### PR TITLE
docs: remove unnecessary preset-vite references

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -374,13 +374,12 @@ viact plugin. Add them in `vite.config.ts`:
 
 ```typescript
 import { defineConfig } from "vite";
-import preact from "@preact/preset-vite";
 import { viact } from "@viact/vite-plugin";
 import mdx from "@mdx-js/rollup";
 import tailwindcss from "@tailwindcss/vite";
 
 export default defineConfig({
-  plugins: [preact(), viact(), mdx(), tailwindcss()],
+  plugins: [viact(), mdx(), tailwindcss()],
 });
 ```
 

--- a/examples/basic/package.json
+++ b/examples/basic/package.json
@@ -8,7 +8,6 @@
     "viact": "workspace:*"
   },
   "devDependencies": {
-    "@preact/preset-vite": "^2.9.4",
     "@viact/cli": "workspace:*",
     "@viact/vite-plugin": "workspace:*",
     "preact": "^10.26.9",

--- a/examples/cloudflare/package.json
+++ b/examples/cloudflare/package.json
@@ -8,7 +8,6 @@
     "viact": "workspace:*"
   },
   "devDependencies": {
-    "@preact/preset-vite": "^2.9.4",
     "@viact/cli": "workspace:*",
     "@viact/vite-plugin": "workspace:*",
     "preact": "^10.26.9",

--- a/examples/docs/package.json
+++ b/examples/docs/package.json
@@ -14,7 +14,6 @@
     "wrangler": "^4.80.0"
   },
   "devDependencies": {
-    "@preact/preset-vite": "^2.9.4",
     "@viact/cli": "workspace:*",
     "@viact/vite-plugin": "workspace:*",
     "preact": "^10.26.9",

--- a/examples/docs/src/routes/docs/adapters.tsx
+++ b/examples/docs/src/routes/docs/adapters.tsx
@@ -44,11 +44,10 @@ export function Component() {
       <CodeBlock
         filename="vite.config.ts"
         code={`import { defineConfig } from "vite";
-import preact from "@preact/preset-vite";
 import { viact } from "@viact/vite-plugin";
 
 export default defineConfig({
-  plugins: [preact(), viact({ adapter: "cloudflare" })],
+  plugins: [viact({ adapter: "cloudflare" })],
 });`}
       />
       <CodeBlock

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
     "@changesets/changelog-github": "^0.6.0",
     "@changesets/cli": "^2.30.0",
     "@playwright/test": "^1.52.0",
-    "@preact/preset-vite": "^2.9.4",
     "@types/node": "^22.15.21",
     "oxfmt": "^0.43.0",
     "oxlint": "^1.58.0",

--- a/packages/start/src/index.js
+++ b/packages/start/src/index.js
@@ -230,7 +230,6 @@ function createPackageJson({ adapter, projectName }) {
   };
 
   const devDependencies = {
-    "@preact/preset-vite": "^2.9.4",
     "@viact/cli": "latest",
     "@viact/vite-plugin": "latest",
     preact: "^10.26.9",
@@ -269,11 +268,10 @@ function createViteConfig(adapter) {
 
   return [
     'import { defineConfig } from "vite";',
-    'import preact from "@preact/preset-vite";',
     'import { viact } from "@viact/vite-plugin";',
     "",
     "export default defineConfig({",
-    `  plugins: [preact(), ${viactCall}],`,
+    `  plugins: [${viactCall}],`,
     "});",
     "",
   ].join("\n");

--- a/skills/migrate-nextjs/SKILL.md
+++ b/skills/migrate-nextjs/SKILL.md
@@ -67,7 +67,7 @@ Ask the user to confirm the migration scope if the project is large (>20 routes)
 | `className` | `class` | Preact uses `class` attribute |
 | `React.useState` etc. | `import { useState } from "preact/hooks"` | Preact hooks API is compatible |
 | `React.useEffect` | `import { useEffect } from "preact/hooks"` | Same API |
-| `import React from "react"` | Remove — no import needed | Preact with `@preact/preset-vite` handles JSX |
+| `import React from "react"` | Remove — no import needed | Viact's Vite plugin handles JSX automatically |
 
 ## Migration Procedure
 
@@ -85,17 +85,15 @@ Ask the user to confirm the migration scope if the project is large (>20 routes)
 2. Create `vite.config.ts`:
    ```ts
    import { defineConfig } from "vite";
-   import preact from "@preact/preset-vite";
    import { viact } from "@viact/vite-plugin";
 
    export default defineConfig({
-     plugins: [preact(), viact()],
+     plugins: [viact()],
    });
    ```
 3. Update `package.json`:
    - Replace `react`, `react-dom` → `preact`
    - Replace `next` → `viact`, `@viact/vite-plugin`, `@viact/adapter-node` (or target adapter)
-   - Add `@preact/preset-vite`
    - Update scripts: `dev` → `viact dev`, `build` → `viact build`, `start` → `viact preview` or `node dist/server/server.js`
 4. Remove Next.js config files: `next.config.*`, `next-env.d.ts`, `.next/`
 5. If `tsconfig.json` has `"jsx": "preserve"`, change to `"jsx": "react-jsx"` and add `"jsxImportSource": "preact"`.
@@ -416,7 +414,7 @@ resolve: {
 }
 ```
 
-Note: `@preact/preset-vite` sets these aliases automatically. Only add manual aliases if a dependency doesn't resolve correctly.
+Note: The viact Vite plugin sets these aliases automatically. Only add manual aliases if a dependency doesn't resolve correctly.
 
 ## Rules
 


### PR DESCRIPTION
## Summary
- Remove `@preact/preset-vite` from example `package.json` files (basic, cloudflare, docs) and root `package.json` since it's a transitive dependency of `@viact/vite-plugin`
- Update docs (ARCHITECTURE.md, migrate-nextjs skill) and example code snippets to show `plugins: [viact()]` without a separate `preact()` call
- Update the `create-viact` scaffolder (`packages/start/src/index.js`) to stop generating configs with preset-vite

The `viact()` plugin already bundles `@preact/preset-vite` internally, so users never need to add it separately.

## Test plan
- [ ] Verify `pnpm install` still resolves correctly (preset-vite comes via `@viact/vite-plugin`)
- [ ] Verify `pnpm dev` works in example apps
- [ ] Run the `create-viact` scaffolder and confirm generated config is clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)