### PR TITLE
feat: use import() expressions in route manifest

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -54,19 +54,19 @@ export const app = defineApp({
   },
   routes: [
     group({ shell: "public" }, [
-      route("/", "./routes/home.tsx", { render: "ssg" }),
-      route("/about", "./routes/about.tsx", { render: "ssg" }),
-      route("/blog/:slug", "./routes/blog-post.tsx", {
+      route("/", () => import("./routes/home.tsx"), { render: "ssg" }),
+      route("/about", () => import("./routes/about.tsx"), { render: "ssg" }),
+      route("/blog/:slug", () => import("./routes/blog-post.tsx"), {
         render: "isg",
         revalidate: timeRevalidate(3600),
       }),
     ]),
     group({ shell: "app", middleware: ["auth"] }, [
       // Inline style: loader/action exported from the route file
-      route("/settings", "./routes/settings.tsx", { render: "spa" }),
+      route("/settings", () => import("./routes/settings.tsx"), { render: "spa" }),
       // Separate files style: server code in dedicated files
       route("/dashboard", {
-        component: "./routes/dashboard.tsx",
+        component: () => import("./routes/dashboard.tsx"),
         loader: "./server/dashboard-loader.ts",
         action: "./server/dashboard-action.ts",
         render: "ssr",
@@ -165,7 +165,7 @@ Wired in the manifest via the `RouteConfig` object form:
 
 ```typescript
 route("/dashboard", {
-  component: "./routes/dashboard.tsx",
+  component: () => import("./routes/dashboard.tsx"),
   loader: "./server/dashboard-loader.ts",
   action: "./server/dashboard-action.ts",
   render: "ssr",

--- a/docs/RENDERING_MODES.md
+++ b/docs/RENDERING_MODES.md
@@ -19,7 +19,7 @@ how and when its HTML is generated.
 ## SSG — Static Site Generation
 
 ```typescript
-route("/about", "./routes/about.tsx", { render: "ssg" });
+route("/about", () => import("./routes/about.tsx"), { render: "ssg" });
 ```
 
 HTML is generated at build time. The loader runs once during the build, and the
@@ -52,7 +52,7 @@ Prerendering runs concurrently (default: 6 parallel renders).
 ## SSR — Server-Side Rendering
 
 ```typescript
-route("/dashboard", "./routes/dashboard.tsx", { render: "ssr" });
+route("/dashboard", () => import("./routes/dashboard.tsx"), { render: "ssr" });
 ```
 
 HTML is generated fresh on every request. The loader runs server-side, the
@@ -72,7 +72,7 @@ fetch only the loader data as JSON, not full HTML.
 ## ISG — Incremental Static Generation
 
 ```typescript
-route("/pricing", "./routes/pricing.tsx", {
+route("/pricing", () => import("./routes/pricing.tsx"), {
   render: "isg",
   revalidate: timeRevalidate(3600), // revalidate every hour
 });
@@ -113,7 +113,7 @@ Useful for CMS-driven content where you know exactly when data changes.
 ## SPA — Single Page Application
 
 ```typescript
-route("/settings", "./routes/settings.tsx", { render: "spa" });
+route("/settings", () => import("./routes/settings.tsx"), { render: "spa" });
 ```
 
 No server-side rendering. The server returns a minimal HTML shell, and the
@@ -140,16 +140,16 @@ export const app = defineApp({
   },
   routes: [
     group({ shell: "public" }, [
-      route("/", "./routes/home.tsx", { render: "ssg" }), // Static
-      route("/pricing", "./routes/pricing.tsx", {
+      route("/", () => import("./routes/home.tsx"), { render: "ssg" }), // Static
+      route("/pricing", () => import("./routes/pricing.tsx"), {
         render: "isg",
         revalidate: timeRevalidate(3600), // Revalidating
       }),
-      route("/login", "./routes/login.tsx", { render: "ssr" }), // Dynamic
+      route("/login", () => import("./routes/login.tsx"), { render: "ssr" }), // Dynamic
     ]),
     group({ shell: "app", middleware: ["auth"] }, [
-      route("/dashboard", "./routes/dashboard.tsx", { render: "ssr" }), // Dynamic
-      route("/settings", "./routes/settings.tsx", { render: "spa" }), // Client-only
+      route("/dashboard", () => import("./routes/dashboard.tsx"), { render: "ssr" }), // Dynamic
+      route("/settings", () => import("./routes/settings.tsx"), { render: "spa" }), // Client-only
     ]),
   ],
 });

--- a/docs/ROUTING.md
+++ b/docs/ROUTING.md
@@ -23,14 +23,14 @@ export const app = defineApp({
   },
   routes: [
     group({ shell: "public" }, [
-      route("/", "./routes/home.tsx", { render: "ssg" }),
-      route("/pricing", "./routes/pricing.tsx", {
+      route("/", () => import("./routes/home.tsx"), { render: "ssg" }),
+      route("/pricing", () => import("./routes/pricing.tsx"), {
         render: "isg",
         revalidate: timeRevalidate(3600),
       }),
     ]),
     group({ shell: "app", middleware: ["auth"] }, [
-      route("/dashboard", "./routes/dashboard.tsx", { render: "ssr" }),
+      route("/dashboard", () => import("./routes/dashboard.tsx"), { render: "ssr" }),
     ]),
   ],
 });
@@ -46,15 +46,19 @@ Top-level configuration:
 | `middleware` | `Record<string, string>`                 | Named middleware modules                               |
 | `routes`     | `(RouteDefinition \| GroupDefinition)[]` | Route tree                                             |
 
-### `route(path, file, meta?)`
+### `route(path, component, meta?)`
 
 Defines a single route:
 
-| Param  | Type        | Description                                            |
-| ------ | ----------- | ------------------------------------------------------ |
-| `path` | `string`    | URL pattern (e.g. `/blog/:slug`)                       |
-| `file` | `string`    | Relative path to route module                          |
-| `meta` | `RouteMeta` | Optional: render mode, shell, middleware, revalidation |
+| Param       | Type                     | Description                                            |
+| ----------- | ------------------------ | ------------------------------------------------------ |
+| `path`      | `string`                 | URL pattern (e.g. `/blog/:slug`)                       |
+| `component` | `() => Promise<any>`     | Lazy import function for the route module              |
+| `meta`      | `RouteMeta`              | Optional: render mode, shell, middleware, revalidation |
+
+The `component` argument is a dynamic `import()` expression, which gives you IDE
+jump-to-definition and TypeScript module resolution. String paths are still
+accepted for backward compatibility.
 
 ### `group(meta, routes)`
 
@@ -88,7 +92,7 @@ interface RouteMeta {
 ### Static paths
 
 ```typescript
-route("/about", "./routes/about.tsx");
+route("/about", () => import("./routes/about.tsx"));
 ```
 
 Matches `/about` exactly.
@@ -96,7 +100,7 @@ Matches `/about` exactly.
 ### Dynamic segments
 
 ```typescript
-route("/blog/:slug", "./routes/blog-post.tsx");
+route("/blog/:slug", () => import("./routes/blog-post.tsx"));
 ```
 
 Matches `/blog/hello-world` with `params.slug = "hello-world"`.
@@ -104,13 +108,13 @@ Matches `/blog/hello-world` with `params.slug = "hello-world"`.
 Multiple dynamic segments:
 
 ```typescript
-route("/users/:userId/posts/:postId", "./routes/user-post.tsx");
+route("/users/:userId/posts/:postId", () => import("./routes/user-post.tsx"));
 ```
 
 ### Catch-all segments
 
 ```typescript
-route("/docs/*", "./routes/docs.tsx");
+route("/docs/*", () => import("./routes/docs.tsx"));
 ```
 
 Matches `/docs/a/b/c` — the catch-all value is available in params.
@@ -124,7 +128,7 @@ of resolved routes. Each resolved route has all inherited properties applied:
 
 ```
 group({ shell: "public" }, [
-  route("/", "./routes/home.tsx", { render: "ssg" })
+  route("/", () => import("./routes/home.tsx"), { render: "ssg" })
 ])
 ```
 
@@ -191,7 +195,7 @@ export const middleware: MiddlewareFn = async ({ request }) => {
 Apply middleware to routes or groups:
 
 ```typescript
-group({ middleware: ["auth"] }, [route("/dashboard", "./routes/dashboard.tsx")]);
+group({ middleware: ["auth"] }, [route("/dashboard", () => import("./routes/dashboard.tsx"))]);
 ```
 
 Middleware from groups stacks — a route inside a group with `["auth"]` that also
@@ -205,8 +209,8 @@ Groups can add a URL prefix to all child routes:
 
 ```typescript
 group({ pathPrefix: "/admin", shell: "admin", middleware: ["auth"] }, [
-  route("/", "./routes/admin/index.tsx"), // → /admin
-  route("/users", "./routes/admin/users.tsx"), // → /admin/users
+  route("/", () => import("./routes/admin/index.tsx")), // → /admin
+  route("/users", () => import("./routes/admin/users.tsx")), // → /admin/users
 ]);
 ```
 

--- a/examples/basic/src/routes.ts
+++ b/examples/basic/src/routes.ts
@@ -10,19 +10,19 @@ export const app = defineApp({
   },
   routes: [
     group({ shell: "public" }, [
-      route("/", "./routes/home.tsx", { id: "home", render: "ssg" }),
-      route("/pricing", "./routes/pricing.tsx", {
+      route("/", () => import("./routes/home.tsx"), { id: "home", render: "ssg" }),
+      route("/pricing", () => import("./routes/pricing.tsx"), {
         id: "pricing",
         render: "isg",
         revalidate: timeRevalidate(3600),
       }),
     ]),
     group({ shell: "app", middleware: ["auth"] }, [
-      route("/dashboard", "./routes/dashboard.tsx", {
+      route("/dashboard", () => import("./routes/dashboard.tsx"), {
         id: "dashboard",
         render: "ssr",
       }),
-      route("/settings", "./routes/settings.tsx", {
+      route("/settings", () => import("./routes/settings.tsx"), {
         id: "settings",
         render: "spa",
       }),

--- a/examples/cloudflare/src/routes.ts
+++ b/examples/cloudflare/src/routes.ts
@@ -10,19 +10,19 @@ export const app = defineApp({
   },
   routes: [
     group({ shell: "public" }, [
-      route("/", "./routes/home.tsx", { id: "home", render: "ssg" }),
-      route("/pricing", "./routes/pricing.tsx", {
+      route("/", () => import("./routes/home.tsx"), { id: "home", render: "ssg" }),
+      route("/pricing", () => import("./routes/pricing.tsx"), {
         id: "pricing",
         render: "isg",
         revalidate: timeRevalidate(3600),
       }),
     ]),
     group({ shell: "app", middleware: ["auth"] }, [
-      route("/dashboard", "./routes/dashboard.tsx", {
+      route("/dashboard", () => import("./routes/dashboard.tsx"), {
         id: "dashboard",
         render: "ssr",
       }),
-      route("/settings", "./routes/settings.tsx", {
+      route("/settings", () => import("./routes/settings.tsx"), {
         id: "settings",
         render: "spa",
       }),

--- a/examples/docs/src/routes.ts
+++ b/examples/docs/src/routes.ts
@@ -6,70 +6,70 @@ export const app = defineApp({
     docs: "./shells/docs.tsx",
   },
   routes: [
-    group({ shell: "home" }, [route("/", "./routes/home.tsx", { id: "home", render: "ssg" })]),
+    group({ shell: "home" }, [route("/", () => import("./routes/home.tsx"), { id: "home", render: "ssg" })]),
     group({ shell: "docs" }, [
-      route("/docs", "./routes/docs/index.tsx", { id: "docs-index", render: "ssr" }),
-      route("/docs/getting-started", "./routes/docs/getting-started.tsx", {
+      route("/docs", () => import("./routes/docs/index.tsx"), { id: "docs-index", render: "ssr" }),
+      route("/docs/getting-started", () => import("./routes/docs/getting-started.tsx"), {
         id: "getting-started",
         render: "ssg",
       }),
-      route("/docs/routing", "./routes/docs/routing.tsx", {
+      route("/docs/routing", () => import("./routes/docs/routing.tsx"), {
         id: "routing",
         render: "ssg",
       }),
-      route("/docs/rendering", "./routes/docs/rendering.tsx", {
+      route("/docs/rendering", () => import("./routes/docs/rendering.tsx"), {
         id: "rendering",
         render: "ssg",
       }),
-      route("/docs/data-loading", "./routes/docs/data-loading.tsx", {
+      route("/docs/data-loading", () => import("./routes/docs/data-loading.tsx"), {
         id: "data-loading",
         render: "ssg",
       }),
-      route("/docs/api-routes", "./routes/docs/api-routes.tsx", {
+      route("/docs/api-routes", () => import("./routes/docs/api-routes.tsx"), {
         id: "api-routes",
         render: "ssg",
       }),
-      route("/docs/middleware", "./routes/docs/middleware.tsx", {
+      route("/docs/middleware", () => import("./routes/docs/middleware.tsx"), {
         id: "middleware",
         render: "ssg",
       }),
-      route("/docs/shells", "./routes/docs/shells.tsx", {
+      route("/docs/shells", () => import("./routes/docs/shells.tsx"), {
         id: "shells",
         render: "ssg",
       }),
-      route("/docs/cli", "./routes/docs/cli.tsx", {
+      route("/docs/cli", () => import("./routes/docs/cli.tsx"), {
         id: "cli",
         render: "ssg",
       }),
-      route("/docs/deployment", "./routes/docs/deployment.tsx", {
+      route("/docs/deployment", () => import("./routes/docs/deployment.tsx"), {
         id: "deployment",
         render: "ssg",
       }),
-      route("/docs/adapters", "./routes/docs/adapters.tsx", {
+      route("/docs/adapters", () => import("./routes/docs/adapters.tsx"), {
         id: "adapters",
         render: "ssg",
       }),
-      route("/docs/prefetching", "./routes/docs/prefetching.tsx", {
+      route("/docs/prefetching", () => import("./routes/docs/prefetching.tsx"), {
         id: "prefetching",
         render: "ssg",
       }),
-      route("/docs/performance", "./routes/docs/performance.tsx", {
+      route("/docs/performance", () => import("./routes/docs/performance.tsx"), {
         id: "performance",
         render: "ssg",
       }),
-      route("/docs/recipes/i18n", "./routes/docs/recipes-i18n.tsx", {
+      route("/docs/recipes/i18n", () => import("./routes/docs/recipes-i18n.tsx"), {
         id: "recipes-i18n",
         render: "ssg",
       }),
-      route("/docs/recipes/auth", "./routes/docs/recipes-auth.tsx", {
+      route("/docs/recipes/auth", () => import("./routes/docs/recipes-auth.tsx"), {
         id: "recipes-auth",
         render: "ssg",
       }),
-      route("/docs/recipes/forms", "./routes/docs/recipes-forms.tsx", {
+      route("/docs/recipes/forms", () => import("./routes/docs/recipes-forms.tsx"), {
         id: "recipes-forms",
         render: "ssg",
       }),
-      route("/docs/recipes/testing", "./routes/docs/recipes-testing.tsx", {
+      route("/docs/recipes/testing", () => import("./routes/docs/recipes-testing.tsx"), {
         id: "recipes-testing",
         render: "ssg",
       }),

--- a/examples/docs/src/routes/docs/middleware.tsx
+++ b/examples/docs/src/routes/docs/middleware.tsx
@@ -57,12 +57,12 @@ export const middleware: MiddlewareFn = async ({ request }) => {
   },
   routes: [
     // Applied to a single route
-    route("/profile", "./routes/profile.tsx", { middleware: ["auth"] }),
+    route("/profile", () => import("./routes/profile.tsx"), { middleware: ["auth"] }),
 
     // Applied to a group — all children inherit
     group({ middleware: ["auth"], shell: "app" }, [
-      route("/dashboard", "./routes/dashboard.tsx"),
-      route("/settings", "./routes/settings.tsx"),
+      route("/dashboard", () => import("./routes/dashboard.tsx")),
+      route("/settings", () => import("./routes/settings.tsx")),
     ]),
   ],
 });`}

--- a/examples/docs/src/routes/docs/prefetching.tsx
+++ b/examples/docs/src/routes/docs/prefetching.tsx
@@ -107,19 +107,19 @@ export function Component() {
 export const app = defineApp({
   routes: [
     // Prefetch when the link enters the viewport
-    route("/pricing", "./routes/pricing.tsx", {
+    route("/pricing", () => import("./routes/pricing.tsx"), {
       render: "isg",
       prefetch: "viewport",
     }),
 
     // Disable prefetching for a rarely visited page
-    route("/terms", "./routes/terms.tsx", {
+    route("/terms", () => import("./routes/terms.tsx"), {
       render: "ssg",
       prefetch: "none",
     }),
 
     // Default: intent-based prefetching (hover/focus)
-    route("/about", "./routes/about.tsx", { render: "ssg" }),
+    route("/about", () => import("./routes/about.tsx"), { render: "ssg" }),
   ],
 });`}
       />

--- a/examples/docs/src/routes/docs/recipes-auth.tsx
+++ b/examples/docs/src/routes/docs/recipes-auth.tsx
@@ -270,15 +270,15 @@ export const app = defineApp({
   routes: [
     // Public routes — no auth
     group({ shell: "public" }, [
-      route("/", "./routes/home.tsx", { render: "ssg" }),
-      route("/login", "./routes/login.tsx", { render: "ssr" }),
-      route("/logout", "./routes/logout.tsx", { render: "ssr" }),
+      route("/", () => import("./routes/home.tsx"), { render: "ssg" }),
+      route("/login", () => import("./routes/login.tsx"), { render: "ssr" }),
+      route("/logout", () => import("./routes/logout.tsx"), { render: "ssr" }),
     ]),
 
     // Protected routes — auth middleware applied
     group({ shell: "app", middleware: ["auth"] }, [
-      route("/dashboard", "./routes/dashboard.tsx", { render: "ssr" }),
-      route("/settings", "./routes/settings.tsx", { render: "ssr" }),
+      route("/dashboard", () => import("./routes/dashboard.tsx"), { render: "ssr" }),
+      route("/settings", () => import("./routes/settings.tsx"), { render: "ssr" }),
     ]),
   ],
 });`}

--- a/examples/docs/src/routes/docs/recipes-i18n.tsx
+++ b/examples/docs/src/routes/docs/recipes-i18n.tsx
@@ -197,9 +197,9 @@ export function Component({ data }: RouteComponentProps<typeof loader>) {
         code={`import { defineApp, group, route } from "viact";
 
 const localizedRoutes = [
-  route("/", "./routes/home.tsx", { render: "ssr" }),
-  route("/about", "./routes/about.tsx", { render: "ssg" }),
-  route("/pricing", "./routes/pricing.tsx", { render: "ssg" }),
+  route("/", () => import("./routes/home.tsx"), { render: "ssr" }),
+  route("/about", () => import("./routes/about.tsx"), { render: "ssg" }),
+  route("/pricing", () => import("./routes/pricing.tsx"), { render: "ssg" }),
 ];
 
 export const app = defineApp({
@@ -212,7 +212,7 @@ export const app = defineApp({
       group({ pathPrefix: "/fr" }, localizedRoutes),
 
       // Root redirects to detected locale
-      route("/", "./routes/locale-redirect.tsx", { render: "ssr" }),
+      route("/", () => import("./routes/locale-redirect.tsx"), { render: "ssr" }),
     ]),
   ],
 });`}

--- a/examples/docs/src/routes/docs/rendering.tsx
+++ b/examples/docs/src/routes/docs/rendering.tsx
@@ -45,7 +45,7 @@ export function Component() {
       <div class="doc-sep" />
 
       <h2>SSG — Static Site Generation</h2>
-      <CodeBlock code={`route("/about", "./routes/about.tsx", { render: "ssg" })`} />
+      <CodeBlock code={`route("/about", () => import("./routes/about.tsx"), { render: "ssg" })`} />
       <p>
         HTML is generated at build time. The loader runs once during the build,
         and the output is written to <code>dist/client/about/index.html</code>.
@@ -82,7 +82,7 @@ export function Component({ data }) {
       <div class="doc-sep" />
 
       <h2>SSR — Server-Side Rendering</h2>
-      <CodeBlock code={`route("/dashboard", "./routes/dashboard.tsx", { render: "ssr" })`} />
+      <CodeBlock code={`route("/dashboard", () => import("./routes/dashboard.tsx"), { render: "ssr" })`} />
       <p>
         HTML is generated fresh on every request. The loader runs server-side,
         the component renders to a string, and the full HTML response includes
@@ -106,7 +106,7 @@ export function Component({ data }) {
       <CodeBlock
         code={`import { timeRevalidate } from "viact";
 
-route("/pricing", "./routes/pricing.tsx", {
+route("/pricing", () => import("./routes/pricing.tsx"), {
   render: "isg",
   revalidate: timeRevalidate(3600), // revalidate every hour
 })`}
@@ -134,7 +134,7 @@ route("/pricing", "./routes/pricing.tsx", {
       <div class="doc-sep" />
 
       <h2>SPA — Single Page Application</h2>
-      <CodeBlock code={`route("/settings", "./routes/settings.tsx", { render: "spa" })`} />
+      <CodeBlock code={`route("/settings", () => import("./routes/settings.tsx"), { render: "spa" })`} />
       <p>
         No server-side rendering. The server returns a minimal HTML shell, and
         the component renders entirely in the browser. The loader runs during
@@ -158,14 +158,14 @@ route("/pricing", "./routes/pricing.tsx", {
       <CodeBlock code={`export const app = defineApp({
   routes: [
     group({ shell: "public" }, [
-      route("/",        "...", { render: "ssg" }),           // Static
-      route("/pricing", "...", { render: "isg",             // Revalidating
+      route("/",        () => import("..."), { render: "ssg" }),           // Static
+      route("/pricing", () => import("..."), { render: "isg",             // Revalidating
         revalidate: timeRevalidate(3600) }),
-      route("/login",   "...", { render: "ssr" }),           // Dynamic
+      route("/login",   () => import("..."), { render: "ssr" }),           // Dynamic
     ]),
     group({ shell: "app", middleware: ["auth"] }, [
-      route("/dashboard", "...", { render: "ssr" }),         // Personalized
-      route("/settings",  "...", { render: "spa" }),         // Client-only
+      route("/dashboard", () => import("..."), { render: "ssr" }),         // Personalized
+      route("/settings",  () => import("..."), { render: "spa" }),         // Client-only
     ]),
   ],
 });`} />

--- a/examples/docs/src/routes/docs/routing.tsx
+++ b/examples/docs/src/routes/docs/routing.tsx
@@ -41,14 +41,14 @@ export const app = defineApp({
   },
   routes: [
     group({ shell: "public" }, [
-      route("/",        "./routes/home.tsx",    { render: "ssg" }),
-      route("/pricing", "./routes/pricing.tsx", {
+      route("/",        () => import("./routes/home.tsx"),    { render: "ssg" }),
+      route("/pricing", () => import("./routes/pricing.tsx"), {
         render: "isg", revalidate: timeRevalidate(3600),
       }),
     ]),
     group({ shell: "app", middleware: ["auth"] }, [
-      route("/dashboard", "./routes/dashboard.tsx", { render: "ssr" }),
-      route("/settings",  "./routes/settings.tsx",  { render: "spa" }),
+      route("/dashboard", () => import("./routes/dashboard.tsx"), { render: "ssr" }),
+      route("/settings",  () => import("./routes/settings.tsx"),  { render: "spa" }),
     ]),
   ],
 });`}
@@ -85,7 +85,7 @@ export const app = defineApp({
         </table>
       </div>
 
-      <h3>route(path, file, meta?)</h3>
+      <h3>route(path, component, meta?)</h3>
       <div class="doc-table-wrap">
         <table class="doc-table">
           <thead>
@@ -93,11 +93,16 @@ export const app = defineApp({
           </thead>
           <tbody>
             <tr><td>path</td><td>string</td><td>URL pattern, e.g. <code>/blog/:slug</code></td></tr>
-            <tr><td>file</td><td>string</td><td>Relative path to the route module</td></tr>
+            <tr><td>component</td><td>{"() => Promise<any>"}</td><td>Lazy import function for the route module</td></tr>
             <tr><td>meta</td><td>RouteMeta</td><td>Optional render mode, shell, middleware, revalidation</td></tr>
           </tbody>
         </table>
       </div>
+      <p>
+        The <code>component</code> argument is a dynamic <code>import()</code>{" "}
+        expression, giving you IDE jump-to-definition and TypeScript module
+        resolution. String paths are still accepted for backward compatibility.
+      </p>
 
       <h3>group(meta, routes)</h3>
       <p>
@@ -121,18 +126,18 @@ export const app = defineApp({
       <h2>Path Patterns</h2>
 
       <h3>Static paths</h3>
-      <CodeBlock code={`route("/about", "./routes/about.tsx")
+      <CodeBlock code={`route("/about", () => import("./routes/about.tsx"))
 // Matches /about exactly`} />
 
       <h3>Dynamic segments</h3>
-      <CodeBlock code={`route("/blog/:slug", "./routes/blog-post.tsx")
+      <CodeBlock code={`route("/blog/:slug", () => import("./routes/blog-post.tsx"))
 // /blog/hello-world → params.slug = "hello-world"
 
-route("/users/:userId/posts/:postId", "./routes/user-post.tsx")
+route("/users/:userId/posts/:postId", () => import("./routes/user-post.tsx"))
 // Multiple dynamic segments`} />
 
       <h3>Catch-all segments</h3>
-      <CodeBlock code={`route("/docs/*", "./routes/docs.tsx")
+      <CodeBlock code={`route("/docs/*", () => import("./routes/docs.tsx"))
 // Matches /docs/a/b/c — catch-all available in params`} />
 
       <div class="doc-sep" />
@@ -202,9 +207,9 @@ export const middleware: MiddlewareFn = async ({ request }) => {
         flat while grouping URLs logically:
       </p>
       <CodeBlock code={`group({ pathPrefix: "/admin", shell: "admin", middleware: ["auth"] }, [
-  route("/",       "./routes/admin/index.tsx"),   // → /admin
-  route("/users",  "./routes/admin/users.tsx"),   // → /admin/users
-  route("/settings", "./routes/admin/settings.tsx"), // → /admin/settings
+  route("/",       () => import("./routes/admin/index.tsx")),   // → /admin
+  route("/users",  () => import("./routes/admin/users.tsx")),   // → /admin/users
+  route("/settings", () => import("./routes/admin/settings.tsx")), // → /admin/settings
 ])`} />
 
       <div class="doc-nav">

--- a/examples/docs/src/routes/docs/shells.tsx
+++ b/examples/docs/src/routes/docs/shells.tsx
@@ -90,12 +90,12 @@ export function head() {
   },
   routes: [
     // Per-route
-    route("/", "./routes/home.tsx", { shell: "public" }),
+    route("/", () => import("./routes/home.tsx"), { shell: "public" }),
 
     // Per-group — all children inherit
     group({ shell: "app" }, [
-      route("/dashboard", "./routes/dashboard.tsx"),
-      route("/settings", "./routes/settings.tsx"),
+      route("/dashboard", () => import("./routes/dashboard.tsx")),
+      route("/settings", () => import("./routes/settings.tsx")),
     ]),
   ],
 });`}

--- a/examples/docs/src/routes/home.tsx
+++ b/examples/docs/src/routes/home.tsx
@@ -119,14 +119,14 @@ export const app = defineApp({
   middleware: { auth: "./middleware/auth.ts" },
   routes: [
     group({ shell: "public" }, [
-      route("/",        "./routes/home.tsx",    { render: "ssg" }),
-      route("/pricing", "./routes/pricing.tsx", {
+      route("/",        () => import("./routes/home.tsx"),    { render: "ssg" }),
+      route("/pricing", () => import("./routes/pricing.tsx"), {
         render: "isg", revalidate: timeRevalidate(3600),
       }),
     ]),
     group({ shell: "app", middleware: ["auth"] }, [
-      route("/dashboard", "./routes/dashboard.tsx", { render: "ssr" }),
-      route("/settings",  "./routes/settings.tsx",  { render: "spa" }),
+      route("/dashboard", () => import("./routes/dashboard.tsx"), { render: "ssr" }),
+      route("/settings",  () => import("./routes/settings.tsx"),  { render: "spa" }),
     ]),
   ],
 });`}

--- a/packages/framework/src/app.ts
+++ b/packages/framework/src/app.ts
@@ -2,6 +2,7 @@ import type {
   ApiRouteMatch,
   GroupDefinition,
   GroupMeta,
+  LazyImport,
   ResolvedApiRoute,
   ResolvedRoute,
   ResolvedViactApp,
@@ -35,27 +36,39 @@ export function timeRevalidate(seconds: number): TimeRevalidatePolicy {
   };
 }
 
+export function route(path: string, component: LazyImport, meta?: RouteMeta): RouteDefinition;
 export function route(path: string, file: string, meta?: RouteMeta): RouteDefinition;
 export function route(path: string, config: RouteConfig): RouteDefinition;
 export function route(
   path: string,
-  fileOrConfig: string | RouteConfig,
+  fileOrConfigOrImport: string | LazyImport | RouteConfig,
   meta: RouteMeta = {},
 ): RouteDefinition {
-  if (typeof fileOrConfig === "string") {
+  if (typeof fileOrConfigOrImport === "function") {
     return {
       kind: "route",
       path: normalizeRoutePath(path),
-      file: fileOrConfig,
+      component: fileOrConfigOrImport,
       ...meta,
     };
   }
 
-  const { component, loader, action, ...routeMeta } = fileOrConfig;
+  if (typeof fileOrConfigOrImport === "string") {
+    return {
+      kind: "route",
+      path: normalizeRoutePath(path),
+      file: fileOrConfigOrImport,
+      ...meta,
+    };
+  }
+
+  const { component, loader, action, ...routeMeta } = fileOrConfigOrImport;
   return {
     kind: "route",
     path: normalizeRoutePath(path),
-    file: component,
+    ...(typeof component === "function"
+      ? { component }
+      : { file: component }),
     loaderFile: loader,
     actionFile: action,
     ...routeMeta,
@@ -150,6 +163,7 @@ function flattenRouteNode(
     id: node.id ?? createRouteId(fullPath),
     path: fullPath,
     file: node.file,
+    component: node.component,
     loaderFile: node.loaderFile,
     actionFile: node.actionFile,
     shell,

--- a/packages/framework/src/index.ts
+++ b/packages/framework/src/index.ts
@@ -43,6 +43,7 @@ export type {
   HttpMethod,
   LoaderArgs,
   LoaderData,
+  LazyImport,
   LoaderFn,
   MiddlewareArgs,
   MiddlewareFn,

--- a/packages/framework/src/router.ts
+++ b/packages/framework/src/router.ts
@@ -46,9 +46,14 @@ export async function initClientRouter(options: InitClientRouterOptions): Promis
     match: RouteMatch,
     state: { data: unknown; error?: SerializedRouteError | null },
   ): Promise<VNode<any> | null> {
-    const routeKey = findModuleKey(routeModules, match.route.file);
-    if (!routeKey) return null;
-    const routeMod = await routeModules[routeKey]();
+    let routeMod: any;
+    if (match.route.component) {
+      routeMod = await match.route.component();
+    } else {
+      const routeKey = findModuleKey(routeModules, match.route.file ?? "");
+      if (!routeKey) return null;
+      routeMod = await routeModules[routeKey]();
+    }
 
     let Shell: any = null;
     if (match.route.shellFile) {

--- a/packages/framework/src/runtime.ts
+++ b/packages/framework/src/runtime.ts
@@ -411,10 +411,12 @@ export async function handleViactRequest<TContext>(
   const context = middlewareResult.context;
 
   // --- Load route module ---
-  const routeModule = await resolveRegistryModule<RouteModule>(
-    registry.routeModules,
-    match.route.file,
-  );
+  const routeModule = match.route.component
+    ? await match.route.component() as RouteModule
+    : await resolveRegistryModule<RouteModule>(
+        registry.routeModules,
+        match.route.file ?? "",
+      );
 
   const routeArgs: BaseRouteArgs<TContext> = {
     request: options.request,
@@ -472,8 +474,8 @@ export async function handleViactRequest<TContext>(
     // --- Merge head metadata ---
     const head = await mergeHeadMetadata(shellModule, routeModule, routeArgs, data);
 
-    const cssUrls = resolvePageCssUrls(options, match.route.shellFile, match.route.file);
-    const modulePreloadUrls = resolvePageJsUrls(options, match.route.shellFile, match.route.file);
+    const cssUrls = resolvePageCssUrls(options, match.route.shellFile, match.route.file ?? "");
+    const modulePreloadUrls = resolvePageJsUrls(options, match.route.shellFile, match.route.file ?? "");
 
     // --- SPA mode: shell HTML with empty body, no SSR ---
     if (match.route.render === "spa") {
@@ -757,8 +759,8 @@ async function renderRouteErrorResponse<TContext>(options: {
         )
       : undefined);
   const head = shellModule?.head ? await shellModule.head(options.routeArgs) : {};
-  const cssUrls = resolvePageCssUrls(options.options, options.shellFile, options.routeArgs.route.file);
-  const modulePreloadUrls = resolvePageJsUrls(options.options, options.shellFile, options.routeArgs.route.file);
+  const cssUrls = resolvePageCssUrls(options.options, options.shellFile, options.routeArgs.route.file ?? "");
+  const modulePreloadUrls = resolvePageJsUrls(options.options, options.shellFile, options.routeArgs.route.file ?? "");
   const { renderToStringAsync } = await import("preact-render-to-string");
 
   const ErrorBoundary = options.routeModule.ErrorBoundary as any;
@@ -1184,7 +1186,9 @@ async function collectSSGPaths(
   }
 
   // Dynamic route — must export prerender() to enumerate paths
-  const routeModule = await resolveRegistryModule<RouteModule>(registry?.routeModules, route.file);
+  const routeModule = route.component
+    ? await route.component() as RouteModule
+    : await resolveRegistryModule<RouteModule>(registry?.routeModules, route.file ?? "");
 
   if (!routeModule?.prerender) {
     console.warn(

--- a/packages/framework/src/types.ts
+++ b/packages/framework/src/types.ts
@@ -62,7 +62,7 @@ export interface ApiConfig {
 }
 
 export interface RouteConfig extends RouteMeta {
-  component: string;
+  component: string | LazyImport;
   loader?: string;
   action?: string;
 }
@@ -70,7 +70,8 @@ export interface RouteConfig extends RouteMeta {
 export interface RouteDefinition extends RouteMeta {
   kind: "route";
   path: string;
-  file: string;
+  file?: string;
+  component?: LazyImport;
   loaderFile?: string;
   actionFile?: string;
 }
@@ -116,7 +117,8 @@ export type RouteSegment = StaticRouteSegment | ParamRouteSegment | CatchAllRout
 
 export interface ResolvedRoute extends Omit<RouteMeta, "middleware"> {
   path: string;
-  file: string;
+  file?: string;
+  component?: LazyImport;
   loaderFile?: string;
   actionFile?: string;
   shell?: string;
@@ -235,7 +237,9 @@ export interface MiddlewareModule<TContext = unknown> {
   middleware: MiddlewareFn<TContext>;
 }
 
-export type ModuleImporter<TModule = unknown> = () => Promise<TModule>;
+export type LazyImport<TModule = unknown> = () => Promise<TModule>;
+
+export type ModuleImporter<TModule = unknown> = LazyImport<TModule>;
 
 export interface DataModule<TContext = unknown> {
   loader?: LoaderFn<TContext>;

--- a/packages/start/src/index.js
+++ b/packages/start/src/index.js
@@ -288,7 +288,7 @@ function createRoutesFile() {
     '    public: "./shells/public.tsx",',
     "  },",
     "  routes: [",
-    '    route("/", "./routes/home.tsx", { id: "home", render: "ssg", shell: "public" }),',
+    '    route("/", () => import("./routes/home.tsx"), { id: "home", render: "ssg", shell: "public" }),',
     "  ],",
     "});",
     "",

--- a/packages/start/test/index.test.js
+++ b/packages/start/test/index.test.js
@@ -37,7 +37,7 @@ describe("create-viact", () => {
     expect(packageJson).toContain('"@viact/cli": "latest"');
     expect(packageJson).toContain('"@viact/adapter-node": "latest"');
     expect(packageJson).not.toContain("wrangler");
-    expect(routes).toContain('route("/", "./routes/home.tsx"');
+    expect(routes).toContain('route("/", () => import("./routes/home.tsx")');
     expect(existsSync(join(targetDir, "wrangler.jsonc"))).toBe(false);
   });
 

--- a/skills/migrate-nextjs/SKILL.md
+++ b/skills/migrate-nextjs/SKILL.md
@@ -51,7 +51,7 @@ Ask the user to confirm the migration scope if the project is large (>20 routes)
 | `app/layout.tsx` | `src/shells/*.tsx` + `shells` in `defineApp` | Shells are named, not directory-nested |
 | `app/loading.tsx` | No direct equivalent | Use Suspense in component if needed |
 | `app/error.tsx` | `ErrorBoundary` export in route module | Same concept, different wiring |
-| `app/not-found.tsx` | 404 route: `route("*", "./routes/not-found.tsx")` | Catch-all at end of routes array |
+| `app/not-found.tsx` | 404 route: `route("*", () => import("./routes/not-found.tsx"))` | Catch-all at end of routes array |
 | `middleware.ts` | `src/middleware/*.ts` + `middleware` in `defineApp` | Named, applied per route/group |
 | `app/api/*/route.ts` | `src/api/*.ts` with `GET`/`POST` exports | Auto-discovered, no manifest entry |
 | `generateStaticParams` | `prerender()` export | Returns `string[]` of paths |
@@ -270,7 +270,7 @@ export const middleware: MiddlewareFn = async ({ request }) => {
 Then apply it in the manifest:
 ```ts
 group({ middleware: ["auth"] }, [
-  route("/dashboard", "./routes/dashboard.tsx", { render: "ssr" }),
+  route("/dashboard", () => import("./routes/dashboard.tsx"), { render: "ssr" }),
 ])
 ```
 
@@ -295,14 +295,14 @@ export const app = defineApp({
   },
   routes: [
     group({ shell: "main" }, [
-      route("/", "./routes/home.tsx", { render: "ssg" }),
-      route("/about", "./routes/about.tsx", { render: "ssg" }),
-      route("/dashboard", "./routes/dashboard.tsx", {
+      route("/", () => import("./routes/home.tsx"), { render: "ssg" }),
+      route("/about", () => import("./routes/about.tsx"), { render: "ssg" }),
+      route("/dashboard", () => import("./routes/dashboard.tsx"), {
         render: "ssr",
         middleware: ["auth"],
       }),
-      route("/blog/:slug", "./routes/blog-post.tsx", { render: "isg" }),
-      route("*", "./routes/not-found.tsx", { render: "ssr" }),
+      route("/blog/:slug", () => import("./routes/blog-post.tsx"), { render: "isg" }),
+      route("*", () => import("./routes/not-found.tsx"), { render: "ssr" }),
     ]),
   ],
 });

--- a/skills/scaffold/SKILL.md
+++ b/skills/scaffold/SKILL.md
@@ -107,7 +107,7 @@ export function GET({ params, url }: BaseRouteArgs) {
 
 After creating module files, **always update `src/routes.ts`** to register the new module:
 
-- **Routes**: Add a `route("/path", "./routes/filename.tsx", { id: "name", render: "ssr" })` call inside the appropriate group or at the top level.
+- **Routes**: Add a `route("/path", () => import("./routes/filename.tsx"), { id: "name", render: "ssr" })` call inside the appropriate group or at the top level.
 - **Shells**: Add to the `shells` record: `shellName: "./shells/filename.tsx"`.
 - **Middleware**: Add to the `middleware` record: `mwName: "./middleware/filename.ts"`.
 - **API routes**: No manifest change needed — auto-discovered from `src/api/` by the Vite plugin.


### PR DESCRIPTION
## Summary
- Change the `route()` API to accept `() => import("./routes/foo.tsx")` as the component argument, enabling IDE jump-to-definition and TypeScript module resolution
- Add `LazyImport` type and `component` field to `RouteDefinition` / `ResolvedRoute` alongside the existing `file` field for backward compatibility
- Update the runtime and client router to use the import function directly when available, falling back to the `import.meta.glob` registry for string-based routes
- Update all examples, docs, skills, and starter templates to use the new syntax

## Test plan
- [ ] Existing tests pass (string-path routes still work via backward compat)
- [ ] Verify IDE jump-to-definition works on `import("./routes/foo.tsx")` in `routes.ts`
- [ ] `viact dev` serves pages correctly with import-function routes
- [ ] `viact build` produces correct code-split chunks

🤖 Generated with [Claude Code](https://claude.com/claude-code)