### PR TITLE
Remove action() export convention from route modules

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -62,13 +62,12 @@ export const app = defineApp({
       }),
     ]),
     group({ shell: "app", middleware: ["auth"] }, [
-      // Inline style: loader/action exported from the route file
+      // Inline style: loader exported from the route file
       route("/settings", "./routes/settings.tsx", { render: "spa" }),
       // Separate files style: server code in dedicated files
       route("/dashboard", {
         component: "./routes/dashboard.tsx",
         loader: "./server/dashboard-loader.ts",
-        action: "./server/dashboard-action.ts",
         render: "ssr",
       }),
     ]),
@@ -92,7 +91,7 @@ assignment implicit via `_middleware.ts` files. Viact's hybrid approach:
 Viact supports two styles for wiring data loading to routes. Both can coexist
 in the same app.
 
-#### Style A: Inline (loader/action in the route file)
+#### Style A: Inline (loader in the route file)
 
 A route module exports some combination of:
 
@@ -102,13 +101,6 @@ A route module exports some combination of:
 // Server: runs on request (SSR) or build (SSG)
 export async function loader({ request, params, context, signal }: LoaderArgs) {
   return { user: await getUser(request) };
-}
-
-// Server: handles POST/PUT/PATCH/DELETE
-export async function action({ request, params, context }: ActionArgs) {
-  const form = await request.formData();
-  await createProject(form.get("name"));
-  return { ok: true, revalidate: ["route:self"] };
 }
 
 // Shared: <head> metadata
@@ -146,15 +138,6 @@ export async function loader({ request }: LoaderArgs) {
 ```
 
 ```typescript
-// src/server/dashboard-action.ts
-export async function action({ request }: ActionArgs) {
-  const form = await request.formData();
-  await createProject(form.get("name"));
-  return { ok: true, revalidate: ["route:self"] };
-}
-```
-
-```typescript
 // src/routes/dashboard.tsx — pure component, no server code
 export function Component({ data }: RouteComponentProps) {
   return <main>{data.user.name}</main>;
@@ -167,7 +150,6 @@ Wired in the manifest via the `RouteConfig` object form:
 route("/dashboard", {
   component: "./routes/dashboard.tsx",
   loader: "./server/dashboard-loader.ts",
-  action: "./server/dashboard-action.ts",
   render: "ssr",
 })
 ```
@@ -295,19 +277,6 @@ User clicks <a> or calls navigate()
 This "server-owned navigation" pattern means loaders never run in the browser.
 Secrets in loader code stay server-side. The client only receives serialized data.
 
-### Action Submission
-
-```
-User submits <Form> or calls submitAction()
-  → POST to current route URL
-  → Server validates same-origin (CSRF)
-  → Run middleware
-  → Execute action function
-  → If revalidate hints: re-run affected loaders
-  → Return JSON response
-  → Client updates data and re-renders
-```
-
 ---
 
 ## Build Pipeline
@@ -325,7 +294,7 @@ Viact uses Vite's multi-environment build:
    - Entry: `virtual:viact/server`
    - Output: `dist/ssr/` or `dist/server/`
    - Produces: route manifest JSON, ISG manifest JSON
-   - Contains: loader/action/shell/middleware code
+   - Contains: loader/shell/middleware code
 
 3. **platform** (adapter-specific) — entry module
    - Entry: `virtual:viact/node-server` or `virtual:viact/cloudflare-worker`

--- a/docs/DATA_LOADING.md
+++ b/docs/DATA_LOADING.md
@@ -1,7 +1,7 @@
 # Data Loading
 
 Viact provides a unified data loading model that works across all rendering modes.
-Loaders fetch data, actions handle mutations, and client hooks provide reactive access.
+Loaders fetch data and client hooks provide reactive access.
 
 ---
 
@@ -67,64 +67,6 @@ the fallback UI. Otherwise, the error bubbles to the shell or global handler.
 
 ---
 
-## Actions
-
-Actions handle form submissions and mutations. They receive POST, PUT, PATCH,
-or DELETE requests.
-
-```typescript
-export async function action({ request, params, context }: ActionArgs) {
-  const form = await request.formData();
-  const name = String(form.get("name") || "").trim();
-
-  if (!name) {
-    return { ok: false, data: { error: "Name is required" } };
-  }
-
-  await db.projects.create({ name });
-  return { ok: true, revalidate: ["route:self"] };
-}
-```
-
-### ActionArgs
-
-Same as `LoaderArgs` — `request`, `params`, `context`, `signal`, `url`, `route`.
-
-### Return values
-
-Actions can return:
-
-| Return                     | Effect                                    |
-| -------------------------- | ----------------------------------------- |
-| Plain data                 | Serialized to client as JSON              |
-| `{ ok, data, revalidate }` | Structured result with revalidation hints |
-| `{ redirect: "/path" }`    | Server-side redirect                      |
-| `{ data, headers }`        | Custom response headers (cookies, cache)  |
-
-### Revalidation hints
-
-After a mutation, tell viact which routes need fresh data:
-
-```typescript
-return {
-  ok: true,
-  revalidate: ["route:self"], // Re-run this route's loader
-  // revalidate: ["route:dashboard"],  // Re-run a specific route by ID
-};
-```
-
-### CSRF protection
-
-Page actions validate same-origin requests automatically. Unsafe requests must
-send an `Origin` or `Referer` header that matches the current route origin or
-they are rejected with `403`.
-
-API routes are separate endpoints. They do not inherit page-route middleware or
-page-action CSRF behavior automatically. If you want shared API policy, declare
-it explicitly with `defineApp({ api: { middleware: ["auth"] } })`.
-
----
-
 ## Head Metadata
 
 The `head` export controls `<head>` content per route:
@@ -161,36 +103,27 @@ export function Component() {
 }
 ```
 
-### `useRevalidateRoute()`
+### `useRevalidate()`
 
 Imperatively re-run the current route's loader:
 
 ```typescript
 export function Component() {
-  const revalidate = useRevalidateRoute();
+  const revalidate = useRevalidate();
   return <button onClick={() => revalidate()}>Refresh</button>;
 }
 ```
 
-### `useSubmitAction()`
-
-Submit an action programmatically:
-
-```typescript
-const submit = useSubmitAction();
-await submit({ method: "POST", body: formData });
-```
-
 ### `<Form>` Component
 
-Declarative form submission that calls the route's action:
+Declarative form submission:
 
 ```typescript
 import { Form } from "viact";
 
 export function Component() {
   return (
-    <Form method="post">
+    <Form method="post" action="/api/projects">
       <input name="title" />
       <button type="submit">Create</button>
     </Form>
@@ -200,8 +133,8 @@ export function Component() {
 
 The `<Form>` component:
 
-- Intercepts submit and sends via fetch (no full page reload)
-- Automatically revalidates based on action response hints
+- Intercepts submit and sends via fetch to the specified action URL (no full page reload)
+- Handles redirects automatically
 - Falls back to native form submission if JavaScript fails
 
 ---

--- a/e2e/basic.test.ts
+++ b/e2e/basic.test.ts
@@ -77,7 +77,7 @@ test("dashboard renders with session cookie", async ({ page, context }) => {
   await expect(page.locator("p")).toContainText("Projects: 3");
 });
 
-test("dashboard form submits in-app and keeps the current route hydrated", async ({
+test("dashboard form posts to API route and keeps the current route hydrated", async ({
   page,
   context,
 }) => {

--- a/examples/basic/src/api/dashboard.ts
+++ b/examples/basic/src/api/dashboard.ts
@@ -1,0 +1,3 @@
+export async function POST() {
+  return Response.json({ saved: true });
+}

--- a/examples/basic/src/routes/dashboard.tsx
+++ b/examples/basic/src/routes/dashboard.tsx
@@ -1,4 +1,4 @@
-import { Form, type LoaderArgs, type RouteComponentProps } from "viact";
+import { Form, useRevalidate, type LoaderArgs, type RouteComponentProps } from "viact";
 
 export async function loader({ request }: LoaderArgs) {
   const hasSession = request.headers.get("cookie")?.includes("session=") ?? false;
@@ -9,20 +9,20 @@ export async function loader({ request }: LoaderArgs) {
   };
 }
 
-export async function action() {
-  return {
-    data: { saved: true },
-    ok: true,
-    revalidate: ["route:self"],
-  };
-}
-
 export function Component({ data }: RouteComponentProps<typeof loader>) {
+  const revalidate = useRevalidate();
+
   return (
     <section>
       <h1>{data.user}</h1>
       <p>Projects: {data.projectCount}</p>
-      <Form method="post">
+      <Form
+        method="post"
+        action="/api/dashboard"
+        onSubmit={async () => {
+          await revalidate();
+        }}
+      >
         <button type="submit">Revalidate dashboard</button>
       </Form>
     </section>

--- a/examples/cloudflare/src/api/dashboard.ts
+++ b/examples/cloudflare/src/api/dashboard.ts
@@ -1,0 +1,3 @@
+export async function POST() {
+  return Response.json({ saved: true });
+}

--- a/examples/cloudflare/src/routes/dashboard.tsx
+++ b/examples/cloudflare/src/routes/dashboard.tsx
@@ -1,4 +1,4 @@
-import { Form, type LoaderArgs, type RouteComponentProps } from "viact";
+import { Form, useRevalidate, type LoaderArgs, type RouteComponentProps } from "viact";
 
 export async function loader({ request }: LoaderArgs) {
   const hasSession = request.headers.get("cookie")?.includes("session=") ?? false;
@@ -9,20 +9,20 @@ export async function loader({ request }: LoaderArgs) {
   };
 }
 
-export async function action() {
-  return {
-    data: { saved: true },
-    ok: true,
-    revalidate: ["route:self"],
-  };
-}
-
 export function Component({ data }: RouteComponentProps<typeof loader>) {
+  const revalidate = useRevalidate();
+
   return (
     <section>
       <h1>{data.user}</h1>
       <p>Projects: {data.projectCount}</p>
-      <Form method="post">
+      <Form
+        method="post"
+        action="/api/dashboard"
+        onSubmit={async () => {
+          await revalidate();
+        }}
+      >
         <button type="submit">Revalidate dashboard</button>
       </Form>
     </section>

--- a/examples/docs/src/routes/docs/adapters.md
+++ b/examples/docs/src/routes/docs/adapters.md
@@ -67,7 +67,7 @@ Keep your `wrangler.jsonc` in the project root so you can add bindings without t
 
 ### Accessing Cloudflare bindings
 
-The `env` object is passed through to your loaders and actions via the context:
+The `env` object is passed through to your loaders and API routes via the context:
 
 ```ts
 // src/routes/dashboard.tsx
@@ -151,7 +151,7 @@ node dist/server/server.js
 
 ## Context Factory
 
-Adapters inject platform-specific values into loaders and actions via a context factory. This is where you connect database clients, environment bindings, and other platform resources:
+Adapters inject platform-specific values into loaders and API routes via a context factory. This is where you connect database clients, environment bindings, and other platform resources:
 
 ```ts
 // Node: inject a database pool
@@ -169,7 +169,7 @@ createContext: ({ request, env, executionContext }) => ({
 })
 ```
 
-The context object is available as `args.context` in every loader, action, middleware, and API route handler.
+The context object is available as `args.context` in every loader, middleware, and API route handler.
 
 ---
 

--- a/examples/docs/src/routes/docs/data-loading.md
+++ b/examples/docs/src/routes/docs/data-loading.md
@@ -1,6 +1,6 @@
 ---
 title: Data Loading
-lead: viact provides a unified data model that works across all rendering modes. Loaders fetch data on the server, actions handle mutations, and client hooks give reactive access to route data — all with full TypeScript inference.
+lead: viact provides a unified data model that works across all rendering modes. Loaders fetch data on the server, API routes handle mutations, and client hooks give reactive access to route data — all with full TypeScript inference.
 breadcrumb: Data Loading
 prev:
   href: /docs/rendering
@@ -79,43 +79,6 @@ export function ErrorBoundary({ error }: ErrorBoundaryProps) {
 
 ---
 
-## Actions
-
-Actions handle form submissions and mutations. They receive POST, PUT, PATCH, or DELETE requests to the current route's URL.
-
-```ts
-export async function action({ request, context }: ActionArgs) {
-  const form = await request.formData();
-  const name = String(form.get("name") || "").trim();
-
-  if (!name) return { ok: false, data: { error: "Name is required" } };
-
-  await context.db.projects.create({ name });
-  return { ok: true, revalidate: ["route:self"] };
-}
-```
-
-### Return values
-
-| Return | Effect |
-|--------|--------|
-| Plain data | Serialized to the client as JSON |
-| `{ ok, data, revalidate }` | Structured result with revalidation hints |
-| `{ redirect: "/path" }` | Server-side redirect after the action |
-| `{ data, headers }` | Custom response headers (cookies, cache-control) |
-
-### Revalidation hints
-
-```ts
-return {
-  ok: true,
-  revalidate: ["route:self"],          // Re-run this route's loader
-  // revalidate: ["route:dashboard"],  // Re-run a specific route by ID
-};
-```
-
----
-
 ## Head Metadata
 
 The `head` export controls `<head>` content for the route. It receives the loader data as its argument:
@@ -151,36 +114,27 @@ export function Component() {
 }
 ```
 
-### useRevalidateRoute()
+### useRevalidate()
 
 Imperatively re-run the current route's loader:
 
 ```ts
 export function Component() {
-  const revalidate = useRevalidateRoute();
+  const revalidate = useRevalidate();
   return <button onClick={() => revalidate()}>Refresh</button>;
 }
 ```
 
-### useSubmitAction()
-
-Submit an action programmatically (without a form element):
-
-```ts
-const submit = useSubmitAction();
-await submit({ method: "POST", body: formData });
-```
-
 ### \<Form\> Component
 
-Declarative form submission that calls the route's action with progressive enhancement:
+Declarative form submission with progressive enhancement. Use the `action` prop to target an API route:
 
 ```ts
 import { Form } from "viact";
 
 export function Component() {
   return (
-    <Form method="post">
+    <Form method="post" action="/api/projects">
       <input name="title" placeholder="Project name" />
       <button type="submit">Create</button>
     </Form>
@@ -188,7 +142,7 @@ export function Component() {
 }
 ```
 
-The `<Form>` component intercepts submit and sends via `fetch` (no full page reload), automatically revalidates based on action response hints, and falls back to native submission if JavaScript fails.
+The `<Form>` component intercepts submit and sends via `fetch` (no full page reload), and falls back to native submission if JavaScript fails.
 
 ---
 

--- a/examples/docs/src/routes/docs/deployment.md
+++ b/examples/docs/src/routes/docs/deployment.md
@@ -49,7 +49,7 @@ viact build
 wrangler deploy
 ```
 
-Configure bindings (KV, D1, R2) in `wrangler.jsonc`. They are available via `context.env` in loaders and actions.
+Configure bindings (KV, D1, R2) in `wrangler.jsonc`. They are available via `context.env` in loaders and API routes.
 
 ---
 
@@ -75,7 +75,7 @@ vercel deploy --prebuilt
 
 ## Custom Context
 
-All adapters support a `createContext` option that enriches the context passed to loaders, actions, and middleware:
+All adapters support a `createContext` option that enriches the context passed to loaders, API routes, and middleware:
 
 ```ts
 createNodeRequestHandler({

--- a/examples/docs/src/routes/docs/getting-started.md
+++ b/examples/docs/src/routes/docs/getting-started.md
@@ -74,5 +74,5 @@ pnpm preview
 
 - **Route manifest** — `src/routes.ts` declares all routes, their shells, middleware, and render modes. See [Routing](/docs/routing).
 - **Render modes** — each route can be SSR, SSG, ISG, or SPA. See [Rendering Modes](/docs/rendering).
-- **Loaders & actions** — server-side data fetching and mutations. See [Data Loading](/docs/data-loading).
+- **Loaders & API routes** — server-side data fetching and mutations. See [Data Loading](/docs/data-loading).
 - **Adapters** — deploy to Node.js, Cloudflare, or Vercel. See [Adapters](/docs/adapters).

--- a/examples/docs/src/routes/docs/middleware.md
+++ b/examples/docs/src/routes/docs/middleware.md
@@ -1,6 +1,6 @@
 ---
 title: Middleware
-lead: Server-side request interceptors that run before loaders and actions. Use them for authentication, redirects, request validation, and context enrichment.
+lead: Server-side request interceptors that run before loaders and API routes. Use them for authentication, redirects, request validation, and context enrichment.
 breadcrumb: Middleware
 prev:
   href: /docs/api-routes
@@ -62,7 +62,7 @@ Middleware from groups and routes is combined. A route inside a group with `["au
 
 1. `auth` (from group)
 2. `rateLimit` (from route)
-3. Loader / action
+3. Loader / API route
 
 ---
 

--- a/examples/docs/src/routes/docs/performance.md
+++ b/examples/docs/src/routes/docs/performance.md
@@ -39,7 +39,7 @@ viact builds a CSS manifest that maps each source file to its transitive CSS dep
 
 ## Error Overlay in Dev
 
-During development, if a loader, action, or component throws an error during server-side rendering, viact renders a framework-aware error overlay instead of a generic Vite error page.
+During development, if a loader or component throws an error during server-side rendering, viact renders a framework-aware error overlay instead of a generic Vite error page.
 
 The overlay shows:
 

--- a/examples/docs/src/routes/docs/recipes-auth.md
+++ b/examples/docs/src/routes/docs/recipes-auth.md
@@ -1,6 +1,6 @@
 ---
 title: Authentication
-lead: Protect routes with session-based auth using middleware, loaders, and actions. This recipe covers login/logout flows, session management, and route guards.
+lead: Protect routes with session-based auth using middleware, loaders, and API routes. This recipe covers login/logout flows, session management, and route guards.
 breadcrumb: Authentication
 prev:
   href: /docs/recipes/i18n
@@ -12,12 +12,12 @@ next:
 
 ## Architecture
 
-Auth in viact follows a simple pattern: middleware checks the session before any loader runs. If there's no valid session, redirect to login. Loaders can read the authenticated user. Actions handle login/logout mutations.
+Auth in viact follows a simple pattern: middleware checks the session before any loader runs. If there's no valid session, redirect to login. Loaders can read the authenticated user. API routes handle login/logout mutations.
 
 - **Middleware** — gate access, redirect unauthenticated users
 - **Loaders** — read session data, pass user to components
-- **Actions** — handle login/logout form submissions
-- **Cookies** — store session tokens (set via action response headers)
+- **API routes** — handle login/logout mutations
+- **Cookies** — store session tokens (set via API route response headers)
 
 ---
 
@@ -98,18 +98,12 @@ export const middleware: MiddlewareFn = async ({ request }) => {
 
 ## 3. Login Page
 
-The login route has an action that validates credentials and sets the session cookie:
+The login page renders the form, while an API route handles credential validation and sets the session cookie:
 
-```ts [src/routes/login.tsx]
-import type { ActionArgs, LoaderArgs, RouteComponentProps } from "viact";
-import { Form } from "viact";
-import { createSessionCookie } from "../server/session";
+```ts [src/api/auth/login.ts]
+import { createSessionCookie } from "../../server/session";
 
-export async function loader({ url }: LoaderArgs) {
-  return { redirect: url.searchParams.get("redirect") ?? "/dashboard" };
-}
-
-export async function action({ request }: ActionArgs) {
+export async function POST({ request }: ApiRouteArgs) {
   const form = await request.formData();
   const email = String(form.get("email") ?? "");
   const password = String(form.get("password") ?? "");
@@ -118,7 +112,7 @@ export async function action({ request }: ActionArgs) {
   // Replace with your actual auth logic
   const user = await verifyCredentials(email, password);
   if (!user) {
-    return { ok: false, data: { error: "Invalid email or password" } };
+    return Response.json({ error: "Invalid email or password" }, { status: 401 });
   }
 
   const cookie = await createSessionCookie({
@@ -126,18 +120,34 @@ export async function action({ request }: ActionArgs) {
     email: user.email,
   });
 
-  return {
-    redirect: redirectTo,
-    headers: { "set-cookie": cookie },
-  };
+  return new Response(null, {
+    status: 302,
+    headers: {
+      location: redirectTo,
+      "set-cookie": cookie,
+    },
+  });
 }
 
-export function Component({ data, actionData }: RouteComponentProps<typeof loader>) {
+async function verifyCredentials(email: string, password: string) {
+  // Your DB lookup here
+  return null as any;
+}
+```
+
+```ts [src/routes/login.tsx]
+import type { LoaderArgs, RouteComponentProps } from "viact";
+import { Form } from "viact";
+
+export async function loader({ url }: LoaderArgs) {
+  return { redirect: url.searchParams.get("redirect") ?? "/dashboard" };
+}
+
+export function Component({ data }: RouteComponentProps<typeof loader>) {
   return (
     <div class="login-page">
       <h1>Log in</h1>
-      {actionData?.error && <p class="error">{actionData.error}</p>}
-      <Form method="post">
+      <Form method="post" action="/api/auth/login">
         <input type="hidden" name="redirect" value={data.redirect} />
         <label>
           Email
@@ -152,37 +162,30 @@ export function Component({ data, actionData }: RouteComponentProps<typeof loade
     </div>
   );
 }
-
-async function verifyCredentials(email: string, password: string) {
-  // Your DB lookup here
-  return null as any;
-}
 ```
 
 ---
 
-## 4. Logout Action
+## 4. Logout
 
-```ts [src/routes/logout.tsx]
-import type { ActionArgs } from "viact";
-import { clearSessionCookie } from "../server/session";
+```ts [src/api/auth/logout.ts]
+import { clearSessionCookie } from "../../server/session";
 
-export async function action(_args: ActionArgs) {
-  return {
-    redirect: "/",
-    headers: { "set-cookie": clearSessionCookie() },
-  };
-}
-
-export function Component() {
-  return null;
+export async function POST(_args: ApiRouteArgs) {
+  return new Response(null, {
+    status: 302,
+    headers: {
+      location: "/",
+      "set-cookie": clearSessionCookie(),
+    },
+  });
 }
 ```
 
 Trigger logout from anywhere with a form:
 
 ```tsx
-<Form method="post" action="/logout">
+<Form method="post" action="/api/auth/logout">
   <button type="submit">Log out</button>
 </Form>
 ```
@@ -236,7 +239,6 @@ export const app = defineApp({
     group({ shell: "public" }, [
       route("/", "./routes/home.tsx", { render: "ssg" }),
       route("/login", "./routes/login.tsx", { render: "ssr" }),
-      route("/logout", "./routes/logout.tsx", { render: "ssr" }),
     ]),
 
     // Protected routes — auth middleware applied

--- a/examples/docs/src/routes/docs/recipes-forms.md
+++ b/examples/docs/src/routes/docs/recipes-forms.md
@@ -1,6 +1,6 @@
 ---
 title: Forms & Validation
-lead: Handle form submissions with progressive enhancement using viact's <code>&lt;Form&gt;</code> component and route actions. Forms work without JavaScript and upgrade to fetch-based submissions when JS is available.
+lead: Handle form submissions with progressive enhancement using viact's <code>&lt;Form&gt;</code> component and API routes. Forms work without JavaScript and upgrade to fetch-based submissions when JS is available.
 breadcrumb: Forms
 prev:
   href: /docs/recipes/auth
@@ -12,13 +12,10 @@ next:
 
 ## Basic Form
 
-The simplest pattern: a `<Form>` that posts to the current route's action, with server-side validation.
+The simplest pattern: a `<Form>` that posts to an API route, with server-side validation.
 
-```ts [src/routes/contact.tsx]
-import type { ActionArgs, RouteComponentProps } from "viact";
-import { Form } from "viact";
-
-export async function action({ request }: ActionArgs) {
+```ts [src/api/contact.ts]
+export async function POST({ request }: ApiRouteArgs) {
   const form = await request.formData();
   const name = String(form.get("name") ?? "").trim();
   const email = String(form.get("email") ?? "").trim();
@@ -30,25 +27,32 @@ export async function action({ request }: ActionArgs) {
   if (!message) errors.message = "Message is required";
 
   if (Object.keys(errors).length > 0) {
-    return { ok: false, data: { errors, values: { name, email, message } } };
+    return Response.json({ ok: false, errors, values: { name, email, message } }, { status: 400 });
   }
 
   await sendContactEmail({ name, email, message });
-  return { ok: true, data: { sent: true } };
+  return Response.json({ ok: true, sent: true });
 }
+```
 
-export function Component({ actionData }: RouteComponentProps) {
-  if (actionData?.sent) {
+```tsx [src/routes/contact.tsx]
+import { Form } from "viact";
+import { useState } from "preact/hooks";
+
+export function Component() {
+  const [result, setResult] = useState<any>(null);
+
+  if (result?.sent) {
     return <p class="success">Thanks! We'll be in touch.</p>;
   }
 
-  const errors = actionData?.errors ?? {};
-  const values = actionData?.values ?? {};
+  const errors = result?.errors ?? {};
+  const values = result?.values ?? {};
 
   return (
     <div>
       <h1>Contact Us</h1>
-      <Form method="post">
+      <Form method="post" action="/api/contact" onResponse={setResult}>
         <label>
           Name
           <input type="text" name="name" value={values.name} />
@@ -78,16 +82,16 @@ export function Component({ actionData }: RouteComponentProps) {
 
 ## How It Works
 
-1. `<Form method="post">` intercepts the submit event and sends data via `fetch` (no full reload).
-2. The route's `action()` runs server-side, validates, and returns data.
-3. The component re-renders with `actionData` containing the action's return value.
+1. `<Form method="post" action="/api/contact">` intercepts the submit event and sends data via `fetch` (no full reload).
+2. The API route handler runs server-side, validates, and returns a `Response`.
+3. The component receives the parsed response and re-renders with the result.
 4. If JavaScript is disabled, the form still works — it falls back to a native form POST.
 
 ---
 
-## Posting to a Different Route
+## Posting to a Different API Route
 
-Use the `action` prop to submit to a different route's action:
+Use the `action` prop to target any API route:
 
 ```tsx
 <Form method="post" action="/api/newsletter">
@@ -100,22 +104,27 @@ Use the `action` prop to submit to a different route's action:
 
 ## Programmatic Submission
 
-Use `useSubmitAction()` when you need to submit from code rather than a form element:
+Use plain `fetch()` when you need to submit from code rather than a form element:
 
 ```ts
-import { useSubmitAction } from "viact";
+import { useRevalidate } from "viact";
 
 export function Component() {
-  const submit = useSubmitAction();
+  const revalidate = useRevalidate();
 
   async function handleDelete(id: string) {
     if (!confirm("Are you sure?")) return;
 
-    const formData = new FormData();
-    formData.set("id", id);
-    formData.set("intent", "delete");
+    const res = await fetch("/api/items", {
+      method: "DELETE",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ id }),
+    });
 
-    await submit({ method: "POST", body: formData });
+    if (res.ok) {
+      // Refresh loader data after the mutation
+      revalidate();
+    }
   }
 
   return <button onClick={() => handleDelete("123")}>Delete</button>;
@@ -124,12 +133,29 @@ export function Component() {
 
 ---
 
-## Multiple Actions with Intent
+## Multiple Actions with Separate API Routes
 
-Use a hidden `intent` field to handle multiple actions in one route:
+You can use separate API routes for different mutations, or handle multiple intents in a single route:
 
-```ts [src/routes/settings.tsx]
-export async function action({ request }: ActionArgs) {
+### Separate API routes
+
+```tsx
+<Form method="post" action="/api/settings/profile">
+  <input name="name" value={data.user.name} />
+  <button type="submit">Save Profile</button>
+</Form>
+
+<Form method="post" action="/api/settings/password">
+  <input type="password" name="current" placeholder="Current password" />
+  <input type="password" name="next" placeholder="New password" />
+  <button type="submit">Change Password</button>
+</Form>
+```
+
+### Single API route with intent
+
+```ts [src/api/settings.ts]
+export async function POST({ request }: ApiRouteArgs) {
   const form = await request.formData();
   const intent = form.get("intent");
 
@@ -137,39 +163,25 @@ export async function action({ request }: ActionArgs) {
     case "update-profile": {
       const name = String(form.get("name"));
       await db.users.update({ name });
-      return { ok: true, revalidate: ["route:self"] };
+      return Response.json({ ok: true });
     }
     case "change-password": {
       const current = String(form.get("current"));
       const next = String(form.get("next"));
       // validate and update...
-      return { ok: true, data: { passwordChanged: true } };
+      return Response.json({ ok: true, passwordChanged: true });
     }
     case "delete-account": {
       await db.users.delete();
-      return { redirect: "/" };
+      return new Response(null, {
+        status: 302,
+        headers: { location: "/" },
+      });
     }
     default:
-      return { ok: false, data: { error: "Unknown action" } };
+      return Response.json({ ok: false, error: "Unknown intent" }, { status: 400 });
   }
 }
-```
-
-In the component, use separate forms for each action:
-
-```tsx
-<Form method="post">
-  <input type="hidden" name="intent" value="update-profile" />
-  <input name="name" value={data.user.name} />
-  <button type="submit">Save Profile</button>
-</Form>
-
-<Form method="post">
-  <input type="hidden" name="intent" value="change-password" />
-  <input type="password" name="current" placeholder="Current password" />
-  <input type="password" name="next" placeholder="New password" />
-  <button type="submit">Change Password</button>
-</Form>
 ```
 
 ---
@@ -177,24 +189,24 @@ In the component, use separate forms for each action:
 ## File Uploads
 
 ```tsx
-<Form method="post" enctype="multipart/form-data">
+<Form method="post" action="/api/avatar" enctype="multipart/form-data">
   <input type="file" name="avatar" accept="image/*" />
   <button type="submit">Upload</button>
 </Form>
 ```
 
-```ts
-export async function action({ request }: ActionArgs) {
+```ts [src/api/avatar.ts]
+export async function POST({ request }: ApiRouteArgs) {
   const form = await request.formData();
   const file = form.get("avatar") as File;
 
   if (!file || file.size === 0) {
-    return { ok: false, data: { error: "No file selected" } };
+    return Response.json({ ok: false, error: "No file selected" }, { status: 400 });
   }
 
   const buffer = await file.arrayBuffer();
   const url = await uploadToStorage(file.name, buffer);
-  return { ok: true, data: { url } };
+  return Response.json({ ok: true, url });
 }
 ```
 
@@ -202,21 +214,34 @@ export async function action({ request }: ActionArgs) {
 
 ## Revalidation After Mutations
 
-When an action modifies data, return `revalidate` hints so the page shows fresh content without a full reload:
+After a mutation via an API route, use `useRevalidate()` to refresh the current route's loader data:
 
 ```ts
-export async function action({ request }: ActionArgs) {
-  const form = await request.formData();
-  await db.todos.create({ text: String(form.get("text")) });
+import { useRevalidate } from "viact";
 
-  return {
-    ok: true,
-    revalidate: ["route:self"],  // Re-runs this route's loader
-  };
+export function Component({ data }: RouteComponentProps<typeof loader>) {
+  const revalidate = useRevalidate();
+
+  async function handleAddTodo(text: string) {
+    const res = await fetch("/api/todos", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ text }),
+    });
+
+    if (res.ok) {
+      revalidate(); // Re-runs this route's loader
+    }
+  }
+
+  return (
+    <div>
+      <ul>{data.todos.map(t => <li key={t.id}>{t.text}</li>)}</ul>
+      <button onClick={() => handleAddTodo("New task")}>Add</button>
+    </div>
+  );
 }
 ```
-
-The `<Form>` component handles this automatically — after the action responds, it re-fetches the loader data and updates the UI.
 
 ---
 
@@ -224,5 +249,5 @@ The `<Form>` component handles this automatically — after the action responds,
 
 - Always validate on the server. Client-side validation is a UX nicety, not a security boundary.
 - Return field values in error responses so users don't lose their input.
-- Use `revalidate: ["route:self"]` after mutations that change the current page's data.
-- Actions have automatic CSRF protection — the framework validates the `Origin` header on non-GET requests.
+- Use `useRevalidate()` after mutations that change the current page's data.
+- Use API routes (`src/api/`) for all mutation endpoints — they return standard `Response` objects and are easy to test independently.

--- a/examples/docs/src/routes/docs/recipes-testing.md
+++ b/examples/docs/src/routes/docs/recipes-testing.md
@@ -1,6 +1,6 @@
 ---
 title: Testing
-lead: Test your viact app at every level — unit test loaders and actions with Vitest, and run full E2E tests with Playwright to verify rendering, navigation, and hydration.
+lead: Test your viact app at every level — unit test loaders and API routes with Vitest, and run full E2E tests with Playwright to verify rendering, navigation, and hydration.
 breadcrumb: Testing
 prev:
   href: /docs/recipes/forms
@@ -18,9 +18,9 @@ pnpm add -D vitest @playwright/test
 
 ---
 
-## Unit Testing Loaders & Actions
+## Unit Testing Loaders & API Routes
 
-Loaders and actions are plain async functions that take a `Request` and return data. Test them directly — no framework bootstrap needed.
+Loaders and API route handlers are plain async functions that take a `Request` and return data. Test them directly — no framework bootstrap needed.
 
 ### Testing a loader
 
@@ -60,51 +60,54 @@ describe("dashboard loader", () => {
 });
 ```
 
-### Testing an action
+### Testing an API route
 
-```ts [src/routes/contact.test.ts]
+```ts [src/api/contact.test.ts]
 import { describe, it, expect } from "vitest";
-import { action } from "./contact";
+import { POST } from "./contact";
 
 function makeFormRequest(fields: Record<string, string>) {
   const form = new FormData();
   for (const [key, value] of Object.entries(fields)) {
     form.set(key, value);
   }
-  return new Request("http://localhost/contact", {
+  return new Request("http://localhost/api/contact", {
     method: "POST",
     body: form,
-    headers: { origin: "http://localhost" },
   });
 }
 
-describe("contact action", () => {
+describe("contact API route", () => {
   it("validates required fields", async () => {
-    const result = await action({
+    const response = await POST({
       request: makeFormRequest({ name: "", email: "", message: "" }),
       params: {},
-      url: new URL("http://localhost/contact"),
+      url: new URL("http://localhost/api/contact"),
       signal: AbortSignal.timeout(5000),
     });
 
-    expect(result.ok).toBe(false);
-    expect(result.data.errors.name).toBeDefined();
-    expect(result.data.errors.email).toBeDefined();
+    expect(response.status).toBe(400);
+    const body = await response.json();
+    expect(body.ok).toBe(false);
+    expect(body.errors.name).toBeDefined();
+    expect(body.errors.email).toBeDefined();
   });
 
   it("succeeds with valid input", async () => {
-    const result = await action({
+    const response = await POST({
       request: makeFormRequest({
         name: "Alice",
         email: "alice@example.com",
         message: "Hello!",
       }),
       params: {},
-      url: new URL("http://localhost/contact"),
+      url: new URL("http://localhost/api/contact"),
       signal: AbortSignal.timeout(5000),
     });
 
-    expect(result.ok).toBe(true);
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.ok).toBe(true);
   });
 });
 ```
@@ -408,6 +411,7 @@ Add these to your `package.json`:
 ## Tips
 
 - **Test loaders directly** — they're plain functions. No need to spin up a server for data logic tests.
+- **Test API routes directly** — they take a `Request` and return a `Response`. Easy to unit test without any framework setup.
 - **Use E2E for hydration** — unit tests can't verify that client-side routing and hydration work correctly. That's what Playwright is for.
 - Check for `(window as any).__VIACT_ROUTER_READY__` in Playwright tests to wait for hydration before interacting with the page.
 - **Test the JSON endpoint** — send `x-viact-route-state-request: 1` to get loader data as JSON. Great for verifying data without parsing HTML.

--- a/packages/framework/src/app.ts
+++ b/packages/framework/src/app.ts
@@ -51,13 +51,12 @@ export function route(
     };
   }
 
-  const { component, loader, action, ...routeMeta } = fileOrConfig;
+  const { component, loader, ...routeMeta } = fileOrConfig;
   return {
     kind: "route",
     path: normalizeRoutePath(path),
     file: component,
     loaderFile: loader,
-    actionFile: action,
     ...routeMeta,
   };
 }
@@ -151,7 +150,6 @@ function flattenRouteNode(
     path: fullPath,
     file: node.file,
     loaderFile: node.loaderFile,
-    actionFile: node.actionFile,
     shell,
     shellFile: shell ? app.shells[shell] : undefined,
     render: node.render ?? inherited.render,

--- a/packages/framework/src/index.ts
+++ b/packages/framework/src/index.ts
@@ -19,18 +19,14 @@ export {
   startApp,
   useLocation,
   useParams,
+  useRevalidate,
   useRevalidateRoute,
   useRouteData,
-  useSubmitAction,
   ViactRuntimeProvider,
 } from "./runtime.ts";
 export { initClientRouter, useNavigate } from "./router.ts";
 export { ViactHttpError } from "./types.ts";
 export type {
-  ActionArgs,
-  ActionEnvelope,
-  ActionFn,
-  ActionResult,
   ApiConfig,
   ApiRouteHandler,
   ApiRouteMatch,
@@ -81,7 +77,6 @@ export type {
   PrerenderAppResult,
   PrerenderResult,
   StartAppOptions,
-  SubmitActionOptions,
   ViactHydrationState,
 } from "./runtime.ts";
 export type { InitClientRouterOptions, NavigateFn } from "./router.ts";

--- a/packages/framework/src/runtime.ts
+++ b/packages/framework/src/runtime.ts
@@ -5,7 +5,6 @@ import { useContext, useEffect, useMemo, useState } from "preact/hooks";
 import { matchApiRoute, matchAppRoute } from "./app.ts";
 import type {
   ApiRouteModule,
-  ActionEnvelope,
   BaseRouteArgs,
   DataModule,
   HeadMetadata,
@@ -52,13 +51,6 @@ export interface HandleViactRequestOptions<TContext = unknown> {
   /** Per-source-file JS chunk map produced by the vite plugin for modulepreload hints. */
   jsManifest?: Record<string, string[]>;
   apiRoutes?: ResolvedApiRoute[];
-}
-
-export interface SubmitActionOptions {
-  action?: string;
-  method?: string;
-  body?: BodyInit | null;
-  headers?: HeadersInit;
 }
 
 export interface FormProps extends Omit<JSX.HTMLAttributes<HTMLFormElement>, "action" | "method"> {
@@ -178,7 +170,7 @@ export function useParams(): RouteParams {
   return useContext(RouteDataContext)?.params ?? {};
 }
 
-export function useRevalidateRoute() {
+export function useRevalidate() {
   const runtime = useContext(RouteDataContext);
 
   return async () => {
@@ -203,52 +195,10 @@ export function useRevalidateRoute() {
   };
 }
 
-export function useSubmitAction() {
-  const runtime = useContext(RouteDataContext);
-
-  return async (options: SubmitActionOptions = {}) => {
-    if (typeof window === "undefined") {
-      throw new Error("useSubmitAction can only be used in the browser.");
-    }
-
-    const response = await fetch(options.action ?? window.location.pathname, {
-      method: options.method ?? "POST",
-      body: options.body ?? null,
-      headers: options.headers,
-      redirect: "manual",
-    });
-
-    if (response.type === "opaqueredirect" || (response.status >= 300 && response.status < 400)) {
-      const location = response.headers.get("location");
-      if (location) {
-        await navigateToClientLocation(location);
-        return undefined;
-      }
-
-      window.location.href = options.action ?? window.location.pathname;
-      return undefined;
-    }
-
-    const result = await readResponseBody(response);
-    if (!isActionEnvelope(result)) {
-      return result;
-    }
-
-    if (result.redirect) {
-      await navigateToClientLocation(result.redirect);
-      return result;
-    }
-
-    if (shouldRevalidateCurrentRoute(result.revalidate, runtime?.routeId)) {
-      await useRevalidateResult(runtime, window.location.pathname + window.location.search);
-    }
-
-    return result;
-  };
-}
+/** @deprecated Use useRevalidate instead. */
+export const useRevalidateRoute = useRevalidate;
 
 export function Form(props: FormProps) {
-  const submitAction = useSubmitAction();
   const { onSubmit, method, ...rest } = props;
 
   return h("form", {
@@ -271,11 +221,20 @@ export function Form(props: FormProps) {
       }
 
       event.preventDefault();
-      await submitAction({
-        action: props.action ?? form.action,
-        body: new FormData(form),
+      const response = await fetch(props.action ?? form.action, {
         method: formMethod,
+        body: new FormData(form),
+        redirect: "manual",
       });
+
+      if (response.type === "opaqueredirect" || (response.status >= 300 && response.status < 400)) {
+        const location = response.headers.get("location");
+        if (location) {
+          await navigateToClientLocation(location);
+          return;
+        }
+        window.location.href = props.action ?? form.action;
+      }
     },
   } as JSX.HTMLAttributes<HTMLFormElement>);
 }
@@ -395,13 +354,14 @@ export async function handleViactRequest<TContext>(
   }
 
   const isRouteStateRequest = options.request.headers.get("x-viact-route-state-request") === "1";
-  const isAction = !SAFE_METHODS.has(options.request.method);
 
-  if (isAction) {
-    const csrfError = validateActionCsrfRequest(options.request, url);
-    if (csrfError) {
-      return csrfError;
-    }
+  if (!SAFE_METHODS.has(options.request.method)) {
+    return withDefaultSecurityHeaders(
+      new Response("Method not allowed", {
+        status: 405,
+        headers: { "content-type": "text/plain; charset=utf-8" },
+      }),
+    );
   }
 
   // --- Middleware chain ---
@@ -434,26 +394,12 @@ export async function handleViactRequest<TContext>(
     route: match.route,
   };
 
-  // --- Resolve loader/action from separate data modules or route module ---
-  const { loader, action } = await resolveDataFunctions(
+  // --- Resolve loader from separate data module or route module ---
+  const { loader } = await resolveDataFunctions(
     match.route,
     routeModule,
     registry,
   );
-
-  // --- Handle actions (POST/PUT/PATCH/DELETE) ---
-  if (isAction) {
-    if (!action) {
-      return withDefaultSecurityHeaders(
-        new Response("Method not allowed", {
-          status: 405,
-          headers: { "content-type": "text/plain; charset=utf-8" },
-        }),
-      );
-    }
-    const actionResult = await action(routeArgs);
-    return actionResultToResponse(actionResult);
-  }
 
   let shellModule: ShellModule | undefined;
 
@@ -617,23 +563,6 @@ function resolvePageJsUrls(
   return [...js];
 }
 
-async function useRevalidateResult(
-  runtime: ViactRuntimeValue | undefined,
-  url: string,
-): Promise<void> {
-  const result = await fetchViactRouteState(url);
-  if (result.type === "redirect") {
-    await navigateToClientLocation(result.location);
-    return;
-  }
-
-  if (result.type === "error") {
-    throw deserializeRouteError(result.error);
-  }
-
-  runtime?.setData(result.data);
-}
-
 async function navigateToClientLocation(
   location: string,
   options?: { replace?: boolean },
@@ -655,31 +584,6 @@ async function navigateToClientLocation(
   }
 
   window.location.href = targetUrl.toString();
-}
-
-function shouldRevalidateCurrentRoute(
-  revalidate: string[] | undefined,
-  routeId: string | undefined,
-): boolean {
-  if (!revalidate?.length) {
-    return false;
-  }
-
-  return revalidate.some((value) => {
-    if (value === "route:self") {
-      return true;
-    }
-
-    return Boolean(routeId) && value === `route:${routeId}`;
-  });
-}
-
-function isActionEnvelope(value: unknown): value is ActionEnvelope {
-  if (typeof value !== "object" || value === null) {
-    return false;
-  }
-
-  return "headers" in value || "ok" in value || "redirect" in value || "revalidate" in value;
 }
 
 function isViactHttpError(error: unknown): error is ViactHttpError {
@@ -806,34 +710,6 @@ async function renderRouteErrorResponse<TContext>(options: {
   );
 }
 
-function actionResultToResponse(actionResult: unknown): Response {
-  if (actionResult instanceof Response) {
-    return withDefaultSecurityHeaders(actionResult);
-  }
-
-  if (isActionEnvelope(actionResult) && actionResult.redirect) {
-    const headers = new Headers(actionResult.headers);
-    headers.set("location", actionResult.redirect);
-    return withDefaultSecurityHeaders(
-      new Response(null, {
-        status: 302,
-        headers,
-      }),
-    );
-  }
-
-  const headers = new Headers(isActionEnvelope(actionResult) ? actionResult.headers : undefined);
-  if (!headers.has("content-type")) {
-    headers.set("content-type", "application/json; charset=utf-8");
-  }
-
-  return withDefaultSecurityHeaders(
-    new Response(JSON.stringify(actionResult), {
-      headers,
-    }),
-  );
-}
-
 async function runMiddlewareChain<TContext>(options: {
   context: TContext;
   middlewareFiles: string[];
@@ -889,9 +765,8 @@ async function resolveDataFunctions(
   route: ResolvedRoute,
   routeModule: RouteModule | undefined,
   registry: ModuleRegistry,
-): Promise<{ loader: RouteModule["loader"]; action: RouteModule["action"] }> {
+): Promise<{ loader: RouteModule["loader"] }> {
   let loader = routeModule?.loader;
-  let action = routeModule?.action;
 
   if (route.loaderFile) {
     const dataModule = await resolveRegistryModule<DataModule>(
@@ -901,15 +776,7 @@ async function resolveDataFunctions(
     if (dataModule?.loader) loader = dataModule.loader;
   }
 
-  if (route.actionFile) {
-    const dataModule = await resolveRegistryModule<DataModule>(
-      registry.dataModules,
-      route.actionFile,
-    );
-    if (dataModule?.action) action = dataModule.action;
-  }
-
-  return { loader, action };
+  return { loader };
 }
 
 async function resolveRegistryModule<T>(
@@ -1070,37 +937,6 @@ function serializeJsonForHtml(value: unknown): string {
     .replace(/\u2029/g, "\\u2029");
 }
 
-function validateActionCsrfRequest(request: Request, url: URL): Response | null {
-  const origin = request.headers.get("origin");
-  if (origin) {
-    return isSameOrigin(origin, url.origin) ? null : createCsrfErrorResponse();
-  }
-
-  const referer = request.headers.get("referer");
-  if (referer) {
-    return isSameOrigin(referer, url.origin) ? null : createCsrfErrorResponse();
-  }
-
-  return createCsrfErrorResponse();
-}
-
-function isSameOrigin(candidate: string, expectedOrigin: string): boolean {
-  try {
-    return new URL(candidate).origin === expectedOrigin;
-  } catch {
-    return false;
-  }
-}
-
-function createCsrfErrorResponse(): Response {
-  return withDefaultSecurityHeaders(
-    new Response("Cross-site action blocked", {
-      status: 403,
-      headers: { "content-type": "text/plain; charset=utf-8" },
-    }),
-  );
-}
-
 // ---------------------------------------------------------------------------
 // SSG Prerendering
 // ---------------------------------------------------------------------------
@@ -1208,11 +1044,3 @@ async function collectSSGPaths(
   return paramSets.map((params) => buildPathFromSegments(route.segments, params));
 }
 
-async function readResponseBody(response: Response): Promise<unknown> {
-  const contentType = response.headers.get("content-type") ?? "";
-  if (contentType.includes("application/json")) {
-    return response.json();
-  }
-
-  return response.text();
-}

--- a/packages/framework/src/types.ts
+++ b/packages/framework/src/types.ts
@@ -64,7 +64,6 @@ export interface ApiConfig {
 export interface RouteConfig extends RouteMeta {
   component: string;
   loader?: string;
-  action?: string;
 }
 
 export interface RouteDefinition extends RouteMeta {
@@ -72,7 +71,6 @@ export interface RouteDefinition extends RouteMeta {
   path: string;
   file: string;
   loaderFile?: string;
-  actionFile?: string;
 }
 
 export interface GroupDefinition {
@@ -118,7 +116,6 @@ export interface ResolvedRoute extends Omit<RouteMeta, "middleware"> {
   path: string;
   file: string;
   loaderFile?: string;
-  actionFile?: string;
   shell?: string;
   shellFile?: string;
   middleware: string[];
@@ -148,7 +145,6 @@ export interface BaseRouteArgs<TContext = unknown> {
 
 export interface LoaderArgs<TContext = unknown> extends BaseRouteArgs<TContext> {}
 
-export interface ActionArgs<TContext = unknown> extends BaseRouteArgs<TContext> {}
 
 export interface MiddlewareArgs<TContext = unknown> extends BaseRouteArgs<TContext> {}
 
@@ -189,27 +185,15 @@ export interface ShellProps {
   children: ComponentChildren;
 }
 
-export interface ActionEnvelope<TData = unknown> {
-  ok?: boolean;
-  data?: TData;
-  revalidate?: string[];
-  redirect?: string;
-  headers?: HeadersInit;
-}
 
-export type ActionResult<TData = unknown> = TData | ActionEnvelope<TData>;
 
 export type LoaderFn<TContext = unknown, TData = unknown> = (
   args: LoaderArgs<TContext>,
 ) => MaybePromise<TData>;
 
-export type ActionFn<TContext = unknown, TData = unknown> = (
-  args: ActionArgs<TContext>,
-) => MaybePromise<ActionResult<TData>>;
 
 export interface RouteModule<TContext = unknown, TLoader extends LoaderLike = undefined> {
   loader?: LoaderFn<TContext>;
-  action?: ActionFn<TContext>;
   head?: (args: HeadArgs<TLoader, TContext>) => MaybePromise<HeadMetadata>;
   Component: FunctionComponent<RouteComponentProps<TLoader>>;
   ErrorBoundary?: FunctionComponent<ErrorBoundaryProps>;
@@ -239,7 +223,6 @@ export type ModuleImporter<TModule = unknown> = () => Promise<TModule>;
 
 export interface DataModule<TContext = unknown> {
   loader?: LoaderFn<TContext>;
-  action?: ActionFn<TContext>;
 }
 
 export interface ModuleRegistry {

--- a/packages/framework/test/router.test.ts
+++ b/packages/framework/test/router.test.ts
@@ -41,13 +41,12 @@ describe("resolveApp", () => {
 });
 
 describe("route() with RouteConfig object", () => {
-  it("accepts an object config with component, loader, and action", () => {
+  it("accepts an object config with component and loader", () => {
     const app = defineApp({
       routes: [
         route("/dashboard", {
           component: "./routes/dashboard.tsx",
           loader: "./server/dashboard-loader.ts",
-          action: "./server/dashboard-action.ts",
           render: "ssr",
         }),
       ],
@@ -59,12 +58,11 @@ describe("route() with RouteConfig object", () => {
     expect(resolved.routes[0]).toMatchObject({
       file: "./routes/dashboard.tsx",
       loaderFile: "./server/dashboard-loader.ts",
-      actionFile: "./server/dashboard-action.ts",
       render: "ssr",
     });
   });
 
-  it("works without loader and action", () => {
+  it("works without loader", () => {
     const app = defineApp({
       routes: [
         route("/about", {
@@ -81,7 +79,6 @@ describe("route() with RouteConfig object", () => {
       render: "ssg",
     });
     expect(resolved.routes[0].loaderFile).toBeUndefined();
-    expect(resolved.routes[0].actionFile).toBeUndefined();
   });
 });
 

--- a/packages/framework/test/runtime.test.ts
+++ b/packages/framework/test/runtime.test.ts
@@ -3,8 +3,8 @@ import { describe, expect, it } from "vitest";
 
 import { ViactHttpError, defineApp, handleViactRequest, resolveApiRoutes, route, useParams } from "../src/index.ts";
 
-describe("handleViactRequest actions", () => {
-  it("translates redirect envelopes into HTTP redirects with headers", async () => {
+describe("handleViactRequest rejects non-GET on page routes", () => {
+  it("returns 405 for POST to a page route", async () => {
     const app = defineApp({
       routes: [route("/", "./routes/home.tsx")],
     });
@@ -15,24 +15,15 @@ describe("handleViactRequest actions", () => {
         routeModules: {
           "./routes/home.tsx": async () => ({
             Component: () => null,
-            action: async () => ({
-              headers: { "set-cookie": "viact=1" },
-              redirect: "/done",
-            }),
           }),
         },
       },
       request: new Request("http://localhost/", {
-        headers: {
-          origin: "http://localhost",
-        },
         method: "POST",
       }),
     });
 
-    expect(response.status).toBe(302);
-    expect(response.headers.get("location")).toBe("/done");
-    expect(response.headers.get("set-cookie")).toBe("viact=1");
+    expect(response.status).toBe(405);
   });
 });
 
@@ -107,12 +98,13 @@ describe("handleViactRequest with separate data modules", () => {
     expect(html).toContain("Hello Jovi");
   });
 
-  it("resolves action from a separate dataModule via actionFile", async () => {
+  it("returns 405 for POST to a page route with separate loader", async () => {
     const app = defineApp({
       routes: [
         route("/dashboard", {
           component: "./routes/dashboard.tsx",
-          action: "./server/dashboard-action.ts",
+          loader: "./server/dashboard-loader.ts",
+          render: "ssr",
         }),
       ],
     });
@@ -126,8 +118,8 @@ describe("handleViactRequest with separate data modules", () => {
           }),
         },
         dataModules: {
-          "./server/dashboard-action.ts": async () => ({
-            action: async () => ({ ok: true, data: { created: true } }),
+          "./server/dashboard-loader.ts": async () => ({
+            loader: async () => ({ user: "Jovi" }),
           }),
         },
       },
@@ -137,9 +129,7 @@ describe("handleViactRequest with separate data modules", () => {
       }),
     });
 
-    expect(response.status).toBe(200);
-    const json = await response.json();
-    expect(json).toEqual({ ok: true, data: { created: true } });
+    expect(response.status).toBe(405);
   });
 
   it("falls back to route module loader when no loaderFile is set", async () => {


### PR DESCRIPTION
## Summary

- Remove the `action()` export convention from route modules — forms now POST to API routes (`src/api/`) directly
- Simplify `<Form>` component to a thin fetch + redirect wrapper (no automatic revalidation, no ActionEnvelope parsing)
- Add `useRevalidate()` hook for manual loader data refresh after mutations (`useRevalidateRoute` kept as deprecated alias)
- Remove `ActionArgs`, `ActionEnvelope`, `ActionFn`, `ActionResult` types, `useSubmitAction` hook, `SubmitActionOptions`, CSRF validation on page routes, action dispatch in `handleViactRequest`, and revalidation hints
- Non-GET requests to page routes now return 405
- Update all examples (basic, cloudflare) and documentation (forms, auth, testing, data-loading, adapters, deployment, middleware, performance, getting-started, architecture)

## Test plan

- [x] `npx vitest run` — 13 unit tests pass (framework)
- [x] `npx tsc --noEmit` — typecheck passes
- [x] `pnpm run build` — all packages build successfully
- [x] `npx playwright test` — 21 E2E basic tests + 3 build tests pass
- [x] Grep for orphaned action references in framework src — none found

🤖 Generated with [Claude Code](https://claude.com/claude-code)