### PR TITLE
Fix excessive build logs in adapter packages

### DIFF
--- a/packages/adapter-cloudflare/tsdown.config.ts
+++ b/packages/adapter-cloudflare/tsdown.config.ts
@@ -4,5 +4,5 @@ export default defineConfig({
   entry: ["src/index.ts"],
   format: "esm",
   dts: true,
-  external: ["viact", /^node:/],
+  external: ["viact", "@viact/vite-plugin", /^node:/],
 });

--- a/packages/adapter-node/tsdown.config.ts
+++ b/packages/adapter-node/tsdown.config.ts
@@ -4,5 +4,5 @@ export default defineConfig({
   entry: ["src/index.ts"],
   format: "esm",
   dts: true,
-  external: ["viact", /^node:/],
+  external: ["viact", "@viact/vite-plugin", /^node:/],
 });

--- a/packages/adapter-vercel/tsdown.config.ts
+++ b/packages/adapter-vercel/tsdown.config.ts
@@ -4,5 +4,5 @@ export default defineConfig({
   entry: ["src/index.ts"],
   format: "esm",
   dts: true,
-  external: ["viact", /^node:/],
+  external: ["viact", "@viact/vite-plugin", /^node:/],
 });


### PR DESCRIPTION
## Summary
- Add `@viact/vite-plugin` to `external` in the tsdown configs for `adapter-node`, `adapter-cloudflare`, and `adapter-vercel`
- The DTS bundler was following the `type { ViactAdapter }` import into vite-plugin's dependency chain (vite → postcss/esbuild), producing 375 MISSING_EXPORT warnings and 1.5MB of build output
- Build output reduced from 3,019 lines to 82 lines

## Test plan
- [x] `pnpm build` completes with 0 MISSING_EXPORT warnings
- [x] Build output is clean and concise

🤖 Generated with [Claude Code](https://claude.com/claude-code)