### PR TITLE
Rename core package to @pracht/core

### DIFF
--- a/docs/ADAPTERS.md
+++ b/docs/ADAPTERS.md
@@ -158,7 +158,7 @@ Bindings are available via `context.env` in loaders, actions, and API routes:
 
 ```typescript
 // src/api/items.ts
-import type { BaseRouteArgs } from "pracht";
+import type { BaseRouteArgs } from "@pracht/core";
 
 export async function GET({ context }: BaseRouteArgs) {
   const value = await context.env.MY_KV.get("key");
@@ -170,7 +170,7 @@ export async function GET({ context }: BaseRouteArgs) {
 
 ```javascript
 // virtual:pracht/server (generated in cloudflare mode)
-import { handlePrachtRequest, resolveApp, resolveApiRoutes } from "pracht";
+import { handlePrachtRequest, resolveApp, resolveApiRoutes } from "@pracht/core";
 import { app } from "./src/routes.ts";
 
 const resolvedApp = resolveApp(app);
@@ -222,7 +222,7 @@ export default {
 
 ```javascript
 // virtual:pracht/server (generated in vercel mode)
-import { handlePrachtRequest, resolveApp, resolveApiRoutes } from "pracht";
+import { handlePrachtRequest, resolveApp, resolveApiRoutes } from "@pracht/core";
 import { app } from "./src/routes.ts";
 
 const resolvedApp = resolveApp(app);
@@ -255,7 +255,7 @@ import type { PrachtAdapter } from "@pracht/vite-plugin";
 export function myAdapter(options?: MyOptions): PrachtAdapter {
   return {
     id: "my-platform",
-    serverImports: 'import { handlePrachtRequest, resolveApp, resolveApiRoutes } from "pracht";',
+    serverImports: 'import { handlePrachtRequest, resolveApp, resolveApiRoutes } from "@pracht/core";',
     createServerEntryModule() {
       // Return JavaScript source code that will be appended to the
       // generated virtual:pracht/server module.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -42,7 +42,7 @@ The current repo scaffold and package boundaries are tracked in
 The route manifest is the central configuration. Users define it in `src/routes.ts`:
 
 ```typescript
-import { defineApp, group, route, timeRevalidate } from "pracht";
+import { defineApp, group, route, timeRevalidate } from "@pracht/core";
 
 export const app = defineApp({
   shells: {
@@ -163,7 +163,7 @@ Shells are Preact layout components that wrap route content:
 
 ```typescript
 // src/shells/public.tsx
-import type { ShellProps } from "pracht";
+import type { ShellProps } from "@pracht/core";
 
 export function Shell({ children }: ShellProps) {
   return (
@@ -193,7 +193,7 @@ Server-side functions that run before loaders:
 
 ```typescript
 // src/middleware/auth.ts
-import type { MiddlewareFn } from "pracht";
+import type { MiddlewareFn } from "@pracht/core";
 
 export const middleware: MiddlewareFn = async ({ request }) => {
   const session = await getSession(request);

--- a/docs/DATA_LOADING.md
+++ b/docs/DATA_LOADING.md
@@ -12,7 +12,7 @@ and returns serializable data that flows into the route component.
 
 ```typescript
 // src/routes/dashboard.tsx
-import type { LoaderArgs, RouteComponentProps } from "pracht";
+import type { LoaderArgs, RouteComponentProps } from "@pracht/core";
 
 export async function loader({ request, params, context, signal }: LoaderArgs) {
   const user = await getUser(request);
@@ -119,7 +119,7 @@ export function Component() {
 Declarative form submission:
 
 ```typescript
-import { Form } from "pracht";
+import { Form } from "@pracht/core";
 
 export function Component() {
   return (

--- a/docs/RENDERING_MODES.md
+++ b/docs/RENDERING_MODES.md
@@ -33,7 +33,7 @@ returns the params for each page to generate:
 
 ```typescript
 // src/routes/blog-post.tsx
-import type { LoaderArgs, RouteParams } from "pracht";
+import type { LoaderArgs, RouteParams } from "@pracht/core";
 
 export function getStaticPaths(): RouteParams[] {
   const posts = getAllPosts();
@@ -89,7 +89,7 @@ the stale page is served while a new version is generated in the background.
 ### Time-based revalidation
 
 ```typescript
-import { timeRevalidate } from "pracht";
+import { timeRevalidate } from "@pracht/core";
 
 {
   revalidate: timeRevalidate(3600);
@@ -102,7 +102,7 @@ against the revalidation window. If stale, it triggers regeneration.
 ### Webhook-based revalidation (Phase 2)
 
 ```typescript
-import { webhookRevalidate } from "pracht";
+import { webhookRevalidate } from "@pracht/core";
 
 {
   revalidate: webhookRevalidate({ key: "pricing-update" });

--- a/docs/ROUTING.md
+++ b/docs/ROUTING.md
@@ -11,7 +11,7 @@ shells, middleware, and render modes.
 Define your app's routes in `src/routes.ts`:
 
 ```typescript
-import { defineApp, group, route, timeRevalidate } from "pracht";
+import { defineApp, group, route, timeRevalidate } from "@pracht/core";
 
 export const app = defineApp({
   shells: {
@@ -255,7 +255,7 @@ routes are automatically wrapped in it:
 
 ```tsx
 // src/pages/_app.tsx
-import type { ShellProps } from "pracht";
+import type { ShellProps } from "@pracht/core";
 
 export function Shell({ children }: ShellProps) {
   return (

--- a/examples/basic/package.json
+++ b/examples/basic/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "@pracht/adapter-node": "workspace:*",
     "@pracht/adapter-vercel": "workspace:*",
-    "pracht": "workspace:*"
+    "@pracht/core": "workspace:*"
   },
   "devDependencies": {
     "@pracht/cli": "workspace:*",

--- a/examples/basic/src/api/echo.ts
+++ b/examples/basic/src/api/echo.ts
@@ -1,4 +1,4 @@
-import type { BaseRouteArgs } from "pracht";
+import type { BaseRouteArgs } from "@pracht/core";
 
 export async function POST({ request }: BaseRouteArgs) {
   const body = await request.json();

--- a/examples/basic/src/middleware/auth.ts
+++ b/examples/basic/src/middleware/auth.ts
@@ -1,4 +1,4 @@
-import type { MiddlewareFn } from "pracht";
+import type { MiddlewareFn } from "@pracht/core";
 
 // ⚠️ NOT FOR PRODUCTION — This is a minimal example only.
 // A real implementation should:

--- a/examples/basic/src/routes.ts
+++ b/examples/basic/src/routes.ts
@@ -1,4 +1,4 @@
-import { defineApp, group, route, timeRevalidate } from "pracht";
+import { defineApp, group, route, timeRevalidate } from "@pracht/core";
 
 export const app = defineApp({
   shells: {

--- a/examples/basic/src/routes/dashboard.tsx
+++ b/examples/basic/src/routes/dashboard.tsx
@@ -1,4 +1,4 @@
-import { Form, useRevalidate, type LoaderArgs, type RouteComponentProps } from "pracht";
+import { Form, useRevalidate, type LoaderArgs, type RouteComponentProps } from "@pracht/core";
 
 export async function loader({ request }: LoaderArgs) {
   const hasSession = request.headers.get("cookie")?.includes("session=") ?? false;

--- a/examples/basic/src/routes/home.tsx
+++ b/examples/basic/src/routes/home.tsx
@@ -1,4 +1,4 @@
-import type { LoaderArgs, RouteComponentProps } from "pracht";
+import type { LoaderArgs, RouteComponentProps } from "@pracht/core";
 
 export async function loader(_args: LoaderArgs) {
   return {

--- a/examples/basic/src/routes/pricing.tsx
+++ b/examples/basic/src/routes/pricing.tsx
@@ -1,4 +1,4 @@
-import type { LoaderArgs, RouteComponentProps } from "pracht";
+import type { LoaderArgs, RouteComponentProps } from "@pracht/core";
 
 export async function loader(_args: LoaderArgs) {
   return {

--- a/examples/basic/src/routes/product.tsx
+++ b/examples/basic/src/routes/product.tsx
@@ -1,4 +1,4 @@
-import type { LoaderArgs, RouteComponentProps, RouteParams } from "pracht";
+import type { LoaderArgs, RouteComponentProps, RouteParams } from "@pracht/core";
 
 const PRODUCTS = [
   { id: "1", name: "Widget", price: "$9.99" },

--- a/examples/basic/src/routes/settings.tsx
+++ b/examples/basic/src/routes/settings.tsx
@@ -1,4 +1,4 @@
-import type { LoaderArgs, RouteComponentProps } from "pracht";
+import type { LoaderArgs, RouteComponentProps } from "@pracht/core";
 
 export async function loader(_args: LoaderArgs) {
   return {

--- a/examples/basic/src/shells/app.tsx
+++ b/examples/basic/src/shells/app.tsx
@@ -1,4 +1,4 @@
-import type { ShellProps } from "pracht";
+import type { ShellProps } from "@pracht/core";
 
 export function Shell({ children }: ShellProps) {
   return (

--- a/examples/basic/src/shells/public.tsx
+++ b/examples/basic/src/shells/public.tsx
@@ -1,4 +1,4 @@
-import type { ShellProps } from "pracht";
+import type { ShellProps } from "@pracht/core";
 
 export function Shell({ children }: ShellProps) {
   return (

--- a/examples/cloudflare/package.json
+++ b/examples/cloudflare/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "@pracht/adapter-cloudflare": "workspace:*",
-    "pracht": "workspace:*"
+    "@pracht/core": "workspace:*"
   },
   "devDependencies": {
     "@pracht/cli": "workspace:*",

--- a/examples/cloudflare/src/api/echo.ts
+++ b/examples/cloudflare/src/api/echo.ts
@@ -1,4 +1,4 @@
-import type { BaseRouteArgs } from "pracht";
+import type { BaseRouteArgs } from "@pracht/core";
 
 export async function POST({ request }: BaseRouteArgs) {
   const body = await request.json();

--- a/examples/cloudflare/src/api/health.ts
+++ b/examples/cloudflare/src/api/health.ts
@@ -1,4 +1,4 @@
-import type { BaseRouteArgs } from "pracht";
+import type { BaseRouteArgs } from "@pracht/core";
 
 export async function GET({ context }: BaseRouteArgs) {
   const cached = await context.env.MY_KV.get("health:last-check");

--- a/examples/cloudflare/src/env.d.ts
+++ b/examples/cloudflare/src/env.d.ts
@@ -1,6 +1,6 @@
-import "pracht";
+import "@pracht/core";
 
-declare module "pracht" {
+declare module "@pracht/core" {
   interface Register {
     context: {
       env: Env;

--- a/examples/cloudflare/src/middleware/auth.ts
+++ b/examples/cloudflare/src/middleware/auth.ts
@@ -1,4 +1,4 @@
-import type { MiddlewareFn } from "pracht";
+import type { MiddlewareFn } from "@pracht/core";
 
 export const middleware: MiddlewareFn = async ({ request }) => {
   const hasSession = request.headers.get("cookie")?.includes("session=") ?? false;

--- a/examples/cloudflare/src/routes.ts
+++ b/examples/cloudflare/src/routes.ts
@@ -1,4 +1,4 @@
-import { defineApp, group, route, timeRevalidate } from "pracht";
+import { defineApp, group, route, timeRevalidate } from "@pracht/core";
 
 export const app = defineApp({
   shells: {

--- a/examples/cloudflare/src/routes/dashboard.tsx
+++ b/examples/cloudflare/src/routes/dashboard.tsx
@@ -1,4 +1,4 @@
-import { Form, useRevalidate, type LoaderArgs, type RouteComponentProps } from "pracht";
+import { Form, useRevalidate, type LoaderArgs, type RouteComponentProps } from "@pracht/core";
 
 export async function loader({ request }: LoaderArgs) {
   const hasSession = request.headers.get("cookie")?.includes("session=") ?? false;

--- a/examples/cloudflare/src/routes/home.tsx
+++ b/examples/cloudflare/src/routes/home.tsx
@@ -1,4 +1,4 @@
-import type { LoaderArgs, RouteComponentProps } from "pracht";
+import type { LoaderArgs, RouteComponentProps } from "@pracht/core";
 
 export async function loader(_args: LoaderArgs) {
   return {

--- a/examples/cloudflare/src/routes/pricing.tsx
+++ b/examples/cloudflare/src/routes/pricing.tsx
@@ -1,4 +1,4 @@
-import type { LoaderArgs, RouteComponentProps } from "pracht";
+import type { LoaderArgs, RouteComponentProps } from "@pracht/core";
 
 export async function loader(_args: LoaderArgs) {
   return {

--- a/examples/cloudflare/src/routes/products/[id].tsx
+++ b/examples/cloudflare/src/routes/products/[id].tsx
@@ -1,5 +1,5 @@
-import { useParams } from "pracht";
-import type { LoaderArgs, RouteComponentProps } from "pracht";
+import { useParams } from "@pracht/core";
+import type { LoaderArgs, RouteComponentProps } from "@pracht/core";
 
 const PRODUCTS: Record<string, { name: string; price: number }> = {
   "1": { name: "Widget", price: 9.99 },

--- a/examples/cloudflare/src/routes/settings.tsx
+++ b/examples/cloudflare/src/routes/settings.tsx
@@ -1,4 +1,4 @@
-import type { LoaderArgs, RouteComponentProps } from "pracht";
+import type { LoaderArgs, RouteComponentProps } from "@pracht/core";
 
 export async function loader(_args: LoaderArgs) {
   return {

--- a/examples/cloudflare/src/shells/app.tsx
+++ b/examples/cloudflare/src/shells/app.tsx
@@ -1,4 +1,4 @@
-import type { ShellProps } from "pracht";
+import type { ShellProps } from "@pracht/core";
 
 export function Shell({ children }: ShellProps) {
   return (

--- a/examples/cloudflare/src/shells/public.tsx
+++ b/examples/cloudflare/src/shells/public.tsx
@@ -1,4 +1,4 @@
-import type { ShellProps } from "pracht";
+import type { ShellProps } from "@pracht/core";
 
 export function Shell({ children }: ShellProps) {
   return (

--- a/examples/docs/package.json
+++ b/examples/docs/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "@pracht/adapter-cloudflare": "workspace:*",
-    "pracht": "workspace:*",
+    "@pracht/core": "workspace:*",
     "wrangler": "^4.80.0"
   },
   "devDependencies": {

--- a/examples/docs/src/routes.ts
+++ b/examples/docs/src/routes.ts
@@ -1,4 +1,4 @@
-import { defineApp, group, route } from "pracht";
+import { defineApp, group, route } from "@pracht/core";
 
 export const app = defineApp({
   shells: {

--- a/examples/docs/src/routes/docs/adapters.md
+++ b/examples/docs/src/routes/docs/adapters.md
@@ -44,7 +44,7 @@ export default defineConfig({
 ```json [package.json]
 {
   "dependencies": {
-    "pracht": "*",
+    "@pracht/core": "*",
     "@pracht/adapter-cloudflare": "*"
   }
 }
@@ -183,7 +183,7 @@ import type { PrachtAdapter } from "@pracht/vite-plugin";
 export function myAdapter(): PrachtAdapter {
   return {
     id: "my-platform",
-    serverImports: 'import { handlePrachtRequest, resolveApp, resolveApiRoutes } from "pracht";',
+    serverImports: 'import { handlePrachtRequest, resolveApp, resolveApiRoutes } from "@pracht/core";',
     createServerEntryModule() {
       return `
 export default async function handle(request) {

--- a/examples/docs/src/routes/docs/api-routes.md
+++ b/examples/docs/src/routes/docs/api-routes.md
@@ -27,7 +27,7 @@ API routes live in `src/api/`. The file path maps to the URL:
 Export named functions for each HTTP method you want to handle. Unhandled methods return 405.
 
 ```ts [src/api/users.ts]
-import type { LoaderArgs } from "pracht";
+import type { LoaderArgs } from "@pracht/core";
 
 export function GET({ request }: LoaderArgs) {
   return Response.json([

--- a/examples/docs/src/routes/docs/data-loading.md
+++ b/examples/docs/src/routes/docs/data-loading.md
@@ -15,7 +15,7 @@ next:
 A **loader** is an async function exported from a route module. It runs server-side and returns serializable data that flows into the route component.
 
 ```ts [src/routes/dashboard.tsx]
-import type { LoaderArgs, RouteComponentProps } from "pracht";
+import type { LoaderArgs, RouteComponentProps } from "@pracht/core";
 
 export async function loader({ request, params, context }: LoaderArgs) {
   const user = await getUser(request);
@@ -63,7 +63,7 @@ export function Component({ data }: RouteComponentProps<typeof loader>) {
 ### Error handling
 
 ```ts
-import { PrachtHttpError } from "pracht";
+import { PrachtHttpError } from "@pracht/core";
 
 export async function loader({ params }: LoaderArgs) {
   const post = await getPost(params.slug);
@@ -128,7 +128,7 @@ export function Component() {
 Declarative form submission with progressive enhancement. Use the `action` prop to target an API route:
 
 ```ts
-import { Form } from "pracht";
+import { Form } from "@pracht/core";
 
 export function Component() {
   return (

--- a/examples/docs/src/routes/docs/middleware.md
+++ b/examples/docs/src/routes/docs/middleware.md
@@ -15,7 +15,7 @@ next:
 Middleware modules live in `src/middleware/` and export a `middleware` function:
 
 ```ts [src/middleware/auth.ts]
-import type { MiddlewareFn } from "pracht";
+import type { MiddlewareFn } from "@pracht/core";
 
 export const middleware: MiddlewareFn = async ({ request }) => {
   const session = await getSession(request);

--- a/examples/docs/src/routes/docs/migrate-nextjs.md
+++ b/examples/docs/src/routes/docs/migrate-nextjs.md
@@ -64,7 +64,7 @@ app/
 
 ```ts [src/routes.ts]
 // pracht equivalent
-import { defineApp, group, route } from "pracht";
+import { defineApp, group, route } from "@pracht/core";
 
 export const app = defineApp({
   shells: {
@@ -111,7 +111,7 @@ export default function RootLayout({ children }) {
 
 ```tsx [src/shells/public.tsx]
 // pracht — named shell
-import type { ShellProps } from "pracht";
+import type { ShellProps } from "@pracht/core";
 
 export function Shell({ children }: ShellProps) {
   return (
@@ -150,7 +150,7 @@ export default async function BlogPost({ params }) {
 
 ```tsx [src/routes/blog-post.tsx]
 // pracht
-import type { LoaderArgs, RouteComponentProps } from "pracht";
+import type { LoaderArgs, RouteComponentProps } from "@pracht/core";
 import { useRouteData } from "pracht/client";
 
 export async function loader({ params }: LoaderArgs) {
@@ -183,7 +183,7 @@ async function createPost(formData: FormData) {
 
 ```tsx [src/routes/new-post.tsx]
 // pracht
-import type { ActionArgs } from "pracht";
+import type { ActionArgs } from "@pracht/core";
 import { Form } from "pracht/client";
 
 export async function action({ request }: ActionArgs) {
@@ -219,7 +219,7 @@ export async function generateMetadata({ params }) {
 
 ```tsx [src/routes/about.tsx]
 // pracht
-import type { HeadArgs } from "pracht";
+import type { HeadArgs } from "@pracht/core";
 
 export function head({ data }: HeadArgs) {
   return {
@@ -243,7 +243,7 @@ Next.js controls caching with `export const dynamic` and `revalidate`. pracht se
 | Client component with `"use client"` | `render: "spa"`                          | Client-only UI (dashboards)     |
 
 ```ts [src/routes.ts]
-import { route, timeRevalidate } from "pracht";
+import { route, timeRevalidate } from "@pracht/core";
 
 route("/pricing", "./routes/pricing.tsx", {
   render: "isg",
@@ -271,7 +271,7 @@ export const config = { matcher: ["/dashboard/:path*", "/settings/:path*"] };
 
 ```ts [src/middleware/auth.ts]
 // pracht — named middleware
-import type { MiddlewareFn } from "pracht";
+import type { MiddlewareFn } from "@pracht/core";
 
 export const middleware: MiddlewareFn = async ({ request }) => {
   const session = await getSession(request);

--- a/examples/docs/src/routes/docs/prefetching.md
+++ b/examples/docs/src/routes/docs/prefetching.md
@@ -45,7 +45,7 @@ You don't need to configure anything for most apps. The defaults are:
 Override the default strategy with the `prefetch` field on a route:
 
 ```ts [src/routes.ts]
-import { defineApp, route, group } from "pracht";
+import { defineApp, route, group } from "@pracht/core";
 
 export const app = defineApp({
   routes: [

--- a/examples/docs/src/routes/docs/recipes-auth.md
+++ b/examples/docs/src/routes/docs/recipes-auth.md
@@ -78,7 +78,7 @@ async function sign(data: string): Promise<string> {
 This middleware redirects unauthenticated users to the login page. Apply it to any route group that requires auth.
 
 ```ts [src/middleware/auth.ts]
-import type { MiddlewareFn } from "pracht";
+import type { MiddlewareFn } from "@pracht/core";
 import { getSession } from "../server/session";
 
 export const middleware: MiddlewareFn = async ({ request }) => {
@@ -136,8 +136,8 @@ async function verifyCredentials(email: string, password: string) {
 ```
 
 ```ts [src/routes/login.tsx]
-import type { LoaderArgs, RouteComponentProps } from "pracht";
-import { Form } from "pracht";
+import type { LoaderArgs, RouteComponentProps } from "@pracht/core";
+import { Form } from "@pracht/core";
 
 export async function loader({ url }: LoaderArgs) {
   return { redirect: url.searchParams.get("redirect") ?? "/dashboard" };
@@ -197,7 +197,7 @@ Trigger logout from anywhere with a form:
 Behind the auth middleware, loaders can safely read user info from the headers set by middleware:
 
 ```ts [src/routes/dashboard.tsx]
-import type { LoaderArgs, RouteComponentProps } from "pracht";
+import type { LoaderArgs, RouteComponentProps } from "@pracht/core";
 
 export async function loader({ request }: LoaderArgs) {
   const userId = request.headers.get("x-user-id")!;
@@ -224,7 +224,7 @@ export function Component({ data }: RouteComponentProps<typeof loader>) {
 ## 6. Wire It Up
 
 ```ts [src/routes.ts]
-import { defineApp, group, route } from "pracht";
+import { defineApp, group, route } from "@pracht/core";
 
 export const app = defineApp({
   shells: {

--- a/examples/docs/src/routes/docs/recipes-forms.md
+++ b/examples/docs/src/routes/docs/recipes-forms.md
@@ -36,7 +36,7 @@ export async function POST({ request }: ApiRouteArgs) {
 ```
 
 ```tsx [src/routes/contact.tsx]
-import { Form } from "pracht";
+import { Form } from "@pracht/core";
 import { useState } from "preact/hooks";
 
 export function Component() {
@@ -107,7 +107,7 @@ Use the `action` prop to target any API route:
 Use plain `fetch()` when you need to submit from code rather than a form element:
 
 ```ts
-import { useRevalidate } from "pracht";
+import { useRevalidate } from "@pracht/core";
 
 export function Component() {
   const revalidate = useRevalidate();
@@ -217,7 +217,7 @@ export async function POST({ request }: ApiRouteArgs) {
 After a mutation via an API route, use `useRevalidate()` to refresh the current route's loader data:
 
 ```ts
-import { useRevalidate } from "pracht";
+import { useRevalidate } from "@pracht/core";
 
 export function Component({ data }: RouteComponentProps<typeof loader>) {
   const revalidate = useRevalidate();

--- a/examples/docs/src/routes/docs/recipes-i18n.md
+++ b/examples/docs/src/routes/docs/recipes-i18n.md
@@ -68,7 +68,7 @@ Create middleware that detects the locale and makes it available to loaders. You
 The cleanest approach for SEO — each locale has its own URL namespace like `/fr/about` or `/en/about`.
 
 ```ts [src/middleware/i18n.ts]
-import type { MiddlewareFn } from "pracht";
+import type { MiddlewareFn } from "@pracht/core";
 import { supportedLocales, defaultLocale } from "../i18n";
 
 export const middleware: MiddlewareFn = async ({ request, url }) => {
@@ -101,7 +101,7 @@ export const middleware: MiddlewareFn = async ({ request, url }) => {
 If you prefer clean URLs without a locale prefix, store the preference in a cookie:
 
 ```ts [src/middleware/i18n.ts]
-import type { MiddlewareFn } from "pracht";
+import type { MiddlewareFn } from "@pracht/core";
 import { supportedLocales, defaultLocale } from "../i18n";
 
 export const middleware: MiddlewareFn = async ({ request }) => {
@@ -120,7 +120,7 @@ export const middleware: MiddlewareFn = async ({ request }) => {
 Read the locale set by middleware and return the translated content:
 
 ```ts [src/routes/home.tsx]
-import type { LoaderArgs, RouteComponentProps } from "pracht";
+import type { LoaderArgs, RouteComponentProps } from "@pracht/core";
 import { t } from "../i18n";
 
 export async function loader({ request }: LoaderArgs) {
@@ -157,7 +157,7 @@ export function Component({ data }: RouteComponentProps<typeof loader>) {
 Use `group` with `pathPrefix` to create locale-scoped route groups:
 
 ```ts [src/routes.ts]
-import { defineApp, group, route } from "pracht";
+import { defineApp, group, route } from "@pracht/core";
 
 const localizedRoutes = [
   route("/", "./routes/home.tsx", { render: "ssr" }),
@@ -188,7 +188,7 @@ export const app = defineApp({
 A simple component that links to the same page in a different locale:
 
 ```ts [src/components/LanguageSwitcher.tsx]
-import { useLocation } from "pracht";
+import { useLocation } from "@pracht/core";
 import { supportedLocales } from "../i18n";
 
 const labels: Record<string, string> = { en: "English", fr: "Fran\u00E7ais" };

--- a/examples/docs/src/routes/docs/recipes-testing.md
+++ b/examples/docs/src/routes/docs/recipes-testing.md
@@ -165,7 +165,7 @@ For integration tests, use `handlePrachtRequest()` to test the full server pipel
 
 ```ts [test/integration.test.ts]
 import { describe, it, expect } from "vitest";
-import { handlePrachtRequest, resolveApp } from "pracht";
+import { handlePrachtRequest, resolveApp } from "@pracht/core";
 
 // Build a test app with mock modules
 const app = resolveApp({

--- a/examples/docs/src/routes/docs/rendering.md
+++ b/examples/docs/src/routes/docs/rendering.md
@@ -73,7 +73,7 @@ After the initial load, client-side navigation takes over — subsequent navigat
 ## ISG — Incremental Static Generation
 
 ```ts
-import { timeRevalidate } from "pracht";
+import { timeRevalidate } from "@pracht/core";
 
 route("/pricing", "./routes/pricing.tsx", {
   render: "isg",
@@ -89,7 +89,7 @@ ISG generates HTML at build time (like SSG) but regenerates it after a configura
 ### Webhook revalidation (Phase 2)
 
 ```ts
-import { webhookRevalidate } from "pracht";
+import { webhookRevalidate } from "@pracht/core";
 
 {
   revalidate: webhookRevalidate({ key: "pricing-update" });

--- a/examples/docs/src/routes/docs/routing.md
+++ b/examples/docs/src/routes/docs/routing.md
@@ -15,7 +15,7 @@ next:
 The manifest is the central source of truth for your app's routing. Define it in `src/routes.ts` using `defineApp`, `route`, and `group`:
 
 ```ts [src/routes.ts]
-import { defineApp, group, route, timeRevalidate } from "pracht";
+import { defineApp, group, route, timeRevalidate } from "@pracht/core";
 
 export const app = defineApp({
   shells: {
@@ -114,7 +114,7 @@ route("/docs/*", "./routes/docs.tsx");
 Shells are Preact layout components that wrap route content. They are **decoupled from URL structure** — a flat URL like `/settings` can use the `app` shell without nesting under `/app/settings`.
 
 ```ts [src/shells/app.tsx]
-import type { ShellProps } from "pracht";
+import type { ShellProps } from "@pracht/core";
 
 export function Shell({ children }: ShellProps) {
   return (
@@ -141,7 +141,7 @@ export function head() {
 Middleware runs server-side before the loader. It can redirect, modify context, or throw errors.
 
 ```ts [src/middleware/auth.ts]
-import type { MiddlewareFn } from "pracht";
+import type { MiddlewareFn } from "@pracht/core";
 
 export const middleware: MiddlewareFn = async ({ request }) => {
   const session = await getSession(request);
@@ -202,7 +202,7 @@ When `pagesDir` is set, the `appFile` option is ignored. The plugin scans the pa
 If `pages/_app.tsx` exists, it is registered as a shell named `"pages"` and all discovered routes are automatically wrapped in it:
 
 ```tsx [src/pages/_app.tsx]
-import type { ShellProps } from "pracht";
+import type { ShellProps } from "@pracht/core";
 
 export function Shell({ children }: ShellProps) {
   return (

--- a/examples/docs/src/routes/docs/shells.md
+++ b/examples/docs/src/routes/docs/shells.md
@@ -15,7 +15,7 @@ next:
 Shell modules live in `src/shells/` and export a `Shell` component:
 
 ```ts [src/shells/app.tsx]
-import type { ShellProps } from "pracht";
+import type { ShellProps } from "@pracht/core";
 
 export function Shell({ children }: ShellProps) {
   return (

--- a/examples/docs/src/routes/home.tsx
+++ b/examples/docs/src/routes/home.tsx
@@ -1,4 +1,4 @@
-import type { RouteComponentProps } from "pracht";
+import type { RouteComponentProps } from "@pracht/core";
 import { CodeBlock } from "../components/CodeBlock";
 
 export async function loader() {
@@ -107,7 +107,7 @@ export function Component({ data }: RouteComponentProps<typeof loader>) {
             <p class="hero-code-label">src/routes.ts</p>
             <CodeBlock
               filename="routes.ts"
-              code={`import { defineApp, group, route, timeRevalidate } from "pracht";
+              code={`import { defineApp, group, route, timeRevalidate } from "@pracht/core";
 
 export const app = defineApp({
   shells: {
@@ -201,7 +201,7 @@ export const app = defineApp({
           <div>
             <CodeBlock
               filename="routes/dashboard.tsx"
-              code={`import type { LoaderArgs, RouteComponentProps } from "pracht";
+              code={`import type { LoaderArgs, RouteComponentProps } from "@pracht/core";
 
 export async function loader({ request, context }: LoaderArgs) {
   const user = await getUser(request);

--- a/examples/docs/src/shells/docs.tsx
+++ b/examples/docs/src/shells/docs.tsx
@@ -1,5 +1,5 @@
-import { useLocation } from "pracht";
-import type { ShellProps } from "pracht";
+import { useLocation } from "@pracht/core";
+import type { ShellProps } from "@pracht/core";
 import "../styles/global.css";
 
 const NAV = [

--- a/examples/docs/src/shells/home.tsx
+++ b/examples/docs/src/shells/home.tsx
@@ -1,4 +1,4 @@
-import type { ShellProps } from "pracht";
+import type { ShellProps } from "@pracht/core";
 import "../styles/global.css";
 
 export function Shell({ children }: ShellProps) {

--- a/examples/pages-router/package.json
+++ b/examples/pages-router/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "dependencies": {
     "@pracht/adapter-node": "workspace:*",
-    "pracht": "workspace:*"
+    "@pracht/core": "workspace:*"
   },
   "devDependencies": {
     "@pracht/cli": "workspace:*",

--- a/examples/pages-router/src/pages/_app.tsx
+++ b/examples/pages-router/src/pages/_app.tsx
@@ -1,4 +1,4 @@
-import type { ShellProps } from "pracht";
+import type { ShellProps } from "@pracht/core";
 
 export function Shell({ children }: ShellProps) {
   return (

--- a/examples/pages-router/src/pages/blog/[slug].tsx
+++ b/examples/pages-router/src/pages/blog/[slug].tsx
@@ -1,4 +1,4 @@
-import type { LoaderArgs, RouteComponentProps, RouteParams } from "pracht";
+import type { LoaderArgs, RouteComponentProps, RouteParams } from "@pracht/core";
 
 export const RENDER_MODE = "ssg";
 

--- a/examples/pages-router/src/pages/index.tsx
+++ b/examples/pages-router/src/pages/index.tsx
@@ -1,4 +1,4 @@
-import type { LoaderArgs, RouteComponentProps } from "pracht";
+import type { LoaderArgs, RouteComponentProps } from "@pracht/core";
 
 export const RENDER_MODE = "ssg";
 

--- a/packages/adapter-cloudflare/package.json
+++ b/packages/adapter-cloudflare/package.json
@@ -15,6 +15,6 @@
     "build": "tsdown"
   },
   "dependencies": {
-    "pracht": "workspace:*"
+    "@pracht/core": "workspace:*"
   }
 }

--- a/packages/adapter-cloudflare/src/index.ts
+++ b/packages/adapter-cloudflare/src/index.ts
@@ -5,7 +5,7 @@ import {
   type ModuleRegistry,
   type ResolvedApiRoute,
   type PrachtApp,
-} from "pracht";
+} from "@pracht/core";
 
 export interface CloudflareFetcher {
   fetch(input: Request | URL | string): Promise<Response>;
@@ -179,7 +179,7 @@ function isFetcher(value: unknown): value is CloudflareFetcher {
 export function cloudflareAdapter(options: CloudflareServerEntryModuleOptions = {}): PrachtAdapter {
   return {
     id: "cloudflare",
-    serverImports: 'import { handlePrachtRequest, resolveApp, resolveApiRoutes } from "pracht";',
+    serverImports: 'import { handlePrachtRequest, resolveApp, resolveApiRoutes } from "@pracht/core";',
     createServerEntryModule() {
       return createCloudflareServerEntryModule(options);
     },

--- a/packages/adapter-cloudflare/tsdown.config.ts
+++ b/packages/adapter-cloudflare/tsdown.config.ts
@@ -4,5 +4,5 @@ export default defineConfig({
   entry: ["src/index.ts"],
   format: "esm",
   dts: true,
-  external: ["pracht", "@pracht/vite-plugin", /^node:/],
+  external: ["@pracht/core", "@pracht/vite-plugin", /^node:/],
 });

--- a/packages/adapter-node/package.json
+++ b/packages/adapter-node/package.json
@@ -15,6 +15,6 @@
     "build": "tsdown"
   },
   "dependencies": {
-    "pracht": "workspace:*"
+    "@pracht/core": "workspace:*"
   }
 }

--- a/packages/adapter-node/src/index.ts
+++ b/packages/adapter-node/src/index.ts
@@ -12,7 +12,7 @@ import {
   type ModuleRegistry,
   type ResolvedApiRoute,
   type PrachtApp,
-} from "pracht";
+} from "@pracht/core";
 
 export interface NodeAdapterContextArgs {
   request: Request;
@@ -297,7 +297,7 @@ const BODYLESS_METHODS = new Set(["GET", "HEAD"]);
 export function nodeAdapter(options: NodeServerEntryModuleOptions = {}): PrachtAdapter {
   return {
     id: "node",
-    serverImports: 'import { resolveApp, resolveApiRoutes } from "pracht";',
+    serverImports: 'import { resolveApp, resolveApiRoutes } from "@pracht/core";',
     createServerEntryModule() {
       return createNodeServerEntryModule(options);
     },

--- a/packages/adapter-node/tsdown.config.ts
+++ b/packages/adapter-node/tsdown.config.ts
@@ -4,5 +4,5 @@ export default defineConfig({
   entry: ["src/index.ts"],
   format: "esm",
   dts: true,
-  external: ["pracht", "@pracht/vite-plugin", /^node:/],
+  external: ["@pracht/core", "@pracht/vite-plugin", /^node:/],
 });

--- a/packages/adapter-vercel/package.json
+++ b/packages/adapter-vercel/package.json
@@ -15,6 +15,6 @@
     "build": "tsdown"
   },
   "dependencies": {
-    "pracht": "workspace:*"
+    "@pracht/core": "workspace:*"
   }
 }

--- a/packages/adapter-vercel/src/index.ts
+++ b/packages/adapter-vercel/src/index.ts
@@ -5,7 +5,7 @@ import {
   type ModuleRegistry,
   type ResolvedApiRoute,
   type PrachtApp,
-} from "pracht";
+} from "@pracht/core";
 
 export interface VercelExecutionContext {
   waitUntil?(promise: Promise<unknown>): void;
@@ -96,7 +96,7 @@ export function createVercelServerEntryModule(
 export function vercelAdapter(options: VercelServerEntryModuleOptions = {}): PrachtAdapter {
   return {
     id: "vercel",
-    serverImports: 'import { handlePrachtRequest, resolveApp, resolveApiRoutes } from "pracht";',
+    serverImports: 'import { handlePrachtRequest, resolveApp, resolveApiRoutes } from "@pracht/core";',
     createServerEntryModule() {
       return createVercelServerEntryModule(options);
     },

--- a/packages/adapter-vercel/tsdown.config.ts
+++ b/packages/adapter-vercel/tsdown.config.ts
@@ -4,5 +4,5 @@ export default defineConfig({
   entry: ["src/index.ts"],
   format: "esm",
   dts: true,
-  external: ["pracht", "@pracht/vite-plugin", /^node:/],
+  external: ["@pracht/core", "@pracht/vite-plugin", /^node:/],
 });

--- a/packages/cli/bin/pracht.js
+++ b/packages/cli/bin/pracht.js
@@ -95,7 +95,7 @@ async function build() {
 
   if (existsSync(serverEntry)) {
     const serverMod = await import(serverEntry);
-    const { prerenderApp } = await import("pracht");
+    const { prerenderApp } = await import("@pracht/core");
 
     // Read the Vite manifest for asset URLs
     const manifestPath = resolve(clientDir, ".vite/manifest.json");
@@ -195,7 +195,7 @@ async function preview() {
   }
 
   const serverMod = await import(serverEntry);
-  const { handlePrachtRequest } = await import("pracht");
+  const { handlePrachtRequest } = await import("@pracht/core");
 
   // Load ISG manifest if it exists
   const isgManifestPath = resolve(root, "dist/server/isg-manifest.json");

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -6,6 +6,6 @@
   },
   "type": "module",
   "dependencies": {
-    "pracht": "workspace:*"
+    "@pracht/core": "workspace:*"
   }
 }

--- a/packages/framework/package.json
+++ b/packages/framework/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "pracht",
+  "name": "@pracht/core",
   "version": "0.0.0",
   "files": [
     "dist"

--- a/packages/framework/src/types.ts
+++ b/packages/framework/src/types.ts
@@ -7,7 +7,7 @@ import type { ComponentChildren, FunctionComponent } from "preact";
  *
  * ```ts
  * // src/env.d.ts
- * declare module "pracht" {
+ * declare module "@pracht/core" {
  *   interface Register {
  *     context: { env: Env; executionContext: ExecutionContext };
  *   }

--- a/packages/start/src/index.js
+++ b/packages/start/src/index.js
@@ -301,7 +301,7 @@ function createViteConfig(adapter) {
 
 function createRoutesFile() {
   return [
-    'import { defineApp, route } from "pracht";',
+    'import { defineApp, route } from "@pracht/core";',
     "",
     "export const app = defineApp({",
     "  shells: {",
@@ -317,7 +317,7 @@ function createRoutesFile() {
 
 function createShellFile(projectName) {
   return [
-    'import type { ShellProps } from "pracht";',
+    'import type { ShellProps } from "@pracht/core";',
     "",
     "export function Shell({ children }: ShellProps) {",
     "  return (",
@@ -343,7 +343,7 @@ function createShellFile(projectName) {
 
 function createHomeRoute(adapter) {
   return [
-    'import type { LoaderArgs, RouteComponentProps } from "pracht";',
+    'import type { LoaderArgs, RouteComponentProps } from "@pracht/core";',
     "",
     "export async function loader(_args: LoaderArgs) {",
     "  return {",
@@ -413,8 +413,8 @@ function createWranglerConfig(projectName) {
 
 function createCloudflareEnvDeclaration() {
   return [
-    'import "pracht";',
-    'declare module "pracht" {',
+    'import "@pracht/core";',
+    'declare module "@pracht/core" {',
     "  interface Register {",
     "    context: {",
     "      env: Env;",

--- a/packages/vite-plugin/package.json
+++ b/packages/vite-plugin/package.json
@@ -22,7 +22,7 @@
     "@preact/preset-vite": "^2.10.5",
     "@pracht/adapter-cloudflare": "workspace:*",
     "@pracht/adapter-vercel": "workspace:*",
-    "pracht": "workspace:*"
+    "@pracht/core": "workspace:*"
   },
   "peerDependencies": {
     "@cloudflare/vite-plugin": "^1.0.0",

--- a/packages/vite-plugin/src/index.ts
+++ b/packages/vite-plugin/src/index.ts
@@ -53,7 +53,7 @@ export interface PrachtAdapter {
 function createDefaultNodeAdapter(): PrachtAdapter {
   return {
     id: "node",
-    serverImports: 'import { resolveApp, resolveApiRoutes } from "pracht";',
+    serverImports: 'import { resolveApp, resolveApiRoutes } from "@pracht/core";',
     createServerEntryModule() {
       return [
         'import { existsSync, readFileSync } from "node:fs";',
@@ -275,7 +275,7 @@ export function createPrachtClientModuleSource(
     : `${resolved.shellsDir}/**/*.{ts,tsx,js,jsx,md,mdx}`;
 
   return [
-    'import { resolveApp, initClientRouter, readHydrationState } from "pracht";',
+    'import { resolveApp, initClientRouter, readHydrationState } from "@pracht/core";',
     appImport,
     "",
     `const routeModules = import.meta.glob(${JSON.stringify(routeGlob)});`,
@@ -323,7 +323,7 @@ export function createPrachtServerModuleSource(
   // The adapter tells us what extra imports it needs (e.g. handlePrachtRequest)
   const prachtImports = adapter?.serverImports
     ? adapter.serverImports
-    : 'import { resolveApp, resolveApiRoutes } from "pracht";';
+    : 'import { resolveApp, resolveApiRoutes } from "@pracht/core";';
 
   const appImport = isPagesMode
     ? generatePagesAppInlineSource(resolved, buildOptions.root)
@@ -418,7 +418,7 @@ function createDevSSRMiddleware(
     try {
       // Load the framework and server module through Vite's SSR pipeline
       const [framework, serverMod] = await Promise.all([
-        server.ssrLoadModule("pracht"),
+        server.ssrLoadModule("@pracht/core"),
         server.ssrLoadModule(PRACHT_SERVER_MODULE_ID),
       ]);
 

--- a/packages/vite-plugin/src/pages-router.ts
+++ b/packages/vite-plugin/src/pages-router.ts
@@ -153,7 +153,7 @@ export function generatePagesManifestSource(
     (f) => basename(f, extname(f)) === "_app" && PAGE_EXTENSIONS.has(extname(f)),
   );
 
-  const lines: string[] = ['import { defineApp, group, route } from "pracht";', ""];
+  const lines: string[] = ['import { defineApp, group, route } from "@pracht/core";', ""];
 
   const routeEntries: string[] = [];
 

--- a/packages/vite-plugin/tsdown.config.ts
+++ b/packages/vite-plugin/tsdown.config.ts
@@ -4,5 +4,5 @@ export default defineConfig({
   entry: ["src/index.ts", "src/pages-router.ts"],
   format: "esm",
   dts: true,
-  external: ["vite", "pracht", /^node:/],
+  external: ["vite", "@pracht/core", /^node:/],
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -56,7 +56,7 @@ importers:
       '@pracht/adapter-vercel':
         specifier: workspace:*
         version: link:../../packages/adapter-vercel
-      pracht:
+      '@pracht/core':
         specifier: workspace:*
         version: link:../../packages/framework
     devDependencies:
@@ -81,7 +81,7 @@ importers:
       '@pracht/adapter-cloudflare':
         specifier: workspace:*
         version: link:../../packages/adapter-cloudflare
-      pracht:
+      '@pracht/core':
         specifier: workspace:*
         version: link:../../packages/framework
     devDependencies:
@@ -109,7 +109,7 @@ importers:
       '@pracht/adapter-cloudflare':
         specifier: workspace:*
         version: link:../../packages/adapter-cloudflare
-      pracht:
+      '@pracht/core':
         specifier: workspace:*
         version: link:../../packages/framework
       wrangler:
@@ -140,7 +140,7 @@ importers:
       '@pracht/adapter-node':
         specifier: workspace:*
         version: link:../../packages/adapter-node
-      pracht:
+      '@pracht/core':
         specifier: workspace:*
         version: link:../../packages/framework
     devDependencies:
@@ -162,25 +162,25 @@ importers:
 
   packages/adapter-cloudflare:
     dependencies:
-      pracht:
+      '@pracht/core':
         specifier: workspace:*
         version: link:../framework
 
   packages/adapter-node:
     dependencies:
-      pracht:
+      '@pracht/core':
         specifier: workspace:*
         version: link:../framework
 
   packages/adapter-vercel:
     dependencies:
-      pracht:
+      '@pracht/core':
         specifier: workspace:*
         version: link:../framework
 
   packages/cli:
     dependencies:
-      pracht:
+      '@pracht/core':
         specifier: workspace:*
         version: link:../framework
 
@@ -203,18 +203,18 @@ importers:
       '@cloudflare/vite-plugin':
         specifier: ^1.0.0
         version: 1.31.1(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@22.19.17)(esbuild@0.27.3))(workerd@1.20260405.1)(wrangler@4.81.0)
-      '@preact/preset-vite':
-        specifier: ^2.10.5
-        version: 2.10.5(@babel/core@7.29.0)(preact@10.29.1)(rollup@4.60.1)(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@22.19.17)(esbuild@0.27.3))
       '@pracht/adapter-cloudflare':
         specifier: workspace:*
         version: link:../adapter-cloudflare
       '@pracht/adapter-vercel':
         specifier: workspace:*
         version: link:../adapter-vercel
-      pracht:
+      '@pracht/core':
         specifier: workspace:*
         version: link:../framework
+      '@preact/preset-vite':
+        specifier: ^2.10.5
+        version: 2.10.5(@babel/core@7.29.0)(preact@10.29.1)(rollup@4.60.1)(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@22.19.17)(esbuild@0.27.3))
       vite:
         specifier: ^8.0.0
         version: 8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@22.19.17)(esbuild@0.27.3)

--- a/skills/migrate-nextjs/SKILL.md
+++ b/skills/migrate-nextjs/SKILL.md
@@ -134,7 +134,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
 **Pracht:**
 
 ```tsx
-import type { ShellProps } from "pracht";
+import type { ShellProps } from "@pracht/core";
 
 export function Shell({ children }: ShellProps) {
   return (
@@ -181,7 +181,7 @@ export async function generateMetadata() {
 **Pracht:**
 
 ```tsx
-import type { LoaderArgs, RouteComponentProps } from "pracht";
+import type { LoaderArgs, RouteComponentProps } from "@pracht/core";
 
 export async function loader(_args: LoaderArgs) {
   const res = await fetch("https://api.example.com/data");
@@ -252,7 +252,7 @@ export async function GET(request: NextRequest) {
 **Pracht (`src/api/users.ts`):**
 
 ```ts
-import type { BaseRouteArgs } from "pracht";
+import type { BaseRouteArgs } from "@pracht/core";
 
 export function GET({ request }: BaseRouteArgs) {
   const users = await getUsers();
@@ -287,7 +287,7 @@ export const config = { matcher: ["/dashboard/:path*"] };
 **Pracht (`src/middleware/auth.ts`):**
 
 ```ts
-import type { MiddlewareFn } from "pracht";
+import type { MiddlewareFn } from "@pracht/core";
 
 export const middleware: MiddlewareFn = async ({ request }) => {
   const session = request.headers.get("cookie")?.includes("session");
@@ -315,7 +315,7 @@ Key transforms:
 Build `src/routes.ts` mapping every migrated page:
 
 ```ts
-import { defineApp, group, route } from "pracht";
+import { defineApp, group, route } from "@pracht/core";
 
 export const app = defineApp({
   shells: {
@@ -379,7 +379,7 @@ const router = useRouter();
 router.push("/dashboard");
 
 // Pracht
-import { useNavigate } from "pracht";
+import { useNavigate } from "@pracht/core";
 const navigate = useNavigate();
 navigate("/dashboard");
 ```

--- a/skills/scaffold/SKILL.md
+++ b/skills/scaffold/SKILL.md
@@ -37,7 +37,7 @@ The user will describe what they want to create. Parse their request and generat
 ### Route
 
 ```tsx
-import type { LoaderArgs, RouteComponentProps } from "pracht";
+import type { LoaderArgs, RouteComponentProps } from "@pracht/core";
 
 export async function loader(_args: LoaderArgs) {
   return {
@@ -58,12 +58,12 @@ export function Component({ data }: RouteComponentProps<typeof loader>) {
 - Include `ErrorBoundary` only if requested.
 - Include `getStaticPaths` only for SSG/ISG routes with dynamic segments.
 - Use `RouteComponentProps<typeof loader>` for typed `data` prop.
-- Import `Form` from `"pracht"` when adding actions.
+- Import `Form` from `"@pracht/core"` when adding actions.
 
 ### Shell
 
 ```tsx
-import type { ShellProps } from "pracht";
+import type { ShellProps } from "@pracht/core";
 
 export function Shell({ children }: ShellProps) {
   return (
@@ -82,7 +82,7 @@ export function head() {
 ### Middleware
 
 ```ts
-import type { MiddlewareFn } from "pracht";
+import type { MiddlewareFn } from "@pracht/core";
 
 export const middleware: MiddlewareFn = async ({ request }) => {
   // Return void to continue, { redirect: "/path" } to redirect,
@@ -93,7 +93,7 @@ export const middleware: MiddlewareFn = async ({ request }) => {
 ### API Route
 
 ```ts
-import type { BaseRouteArgs } from "pracht";
+import type { BaseRouteArgs } from "@pracht/core";
 
 export function GET({ params, url }: BaseRouteArgs) {
   return Response.json({
@@ -118,7 +118,7 @@ After creating module files, **always update `src/routes.ts`** to register the n
 
 Available render modes: `"ssr"` (default), `"ssg"` (static at build), `"isg"` (incremental static with `revalidate: timeRevalidate(seconds)`), `"spa"` (client-only).
 
-Import `timeRevalidate` from `"pracht"` when using ISG.
+Import `timeRevalidate` from `"@pracht/core"` when using ISG.
 
 ## Rules
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,7 +14,7 @@
     "jsxImportSource": "preact",
     "baseUrl": ".",
     "paths": {
-      "pracht": ["./packages/framework/src/index.ts"],
+      "@pracht/core": ["./packages/framework/src/index.ts"],
       "@pracht/vite-plugin": ["./packages/vite-plugin/src/index.ts"],
       "@pracht/adapter-node": ["./packages/adapter-node/src/index.ts"],
       "@pracht/adapter-cloudflare": ["./packages/adapter-cloudflare/src/index.ts"],


### PR DESCRIPTION
## Summary
- Rename the main framework package from `pracht` to `@pracht/core` since npm rejects `pracht` as too similar to `preact`
- Updates all imports, dependencies, tsconfig paths, tsdown externals, and documentation across 73 files
- CLI binary name, Vite plugin name, and npm scripts remain `pracht` (these are command/plugin names, not package references)

## Test plan
- [x] `pnpm install` succeeds
- [x] `pnpm build` passes
- [x] All 19 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)