### PR TITLE
Add full-stack Cloudflare and Vercel recipes to docs

### DIFF
--- a/examples/docs/src/routes.ts
+++ b/examples/docs/src/routes.ts
@@ -73,6 +73,14 @@ export const app = defineApp({
         id: "recipes-testing",
         render: "ssg",
       }),
+      route("/docs/recipes/fullstack-cloudflare", "./routes/docs/recipes-fullstack-cloudflare.md", {
+        id: "recipes-fullstack-cloudflare",
+        render: "ssg",
+      }),
+      route("/docs/recipes/fullstack-vercel", "./routes/docs/recipes-fullstack-vercel.md", {
+        id: "recipes-fullstack-vercel",
+        render: "ssg",
+      }),
       route("/docs/migrate/nextjs", "./routes/docs/migrate-nextjs.md", {
         id: "migrate-nextjs",
         render: "ssg",

--- a/examples/docs/src/routes/docs/migrate-nextjs.md
+++ b/examples/docs/src/routes/docs/migrate-nextjs.md
@@ -3,8 +3,8 @@ title: Migrating from Next.js
 lead: A practical guide to moving your Next.js App Router project to pracht. Covers routing, data loading, rendering modes, middleware, layouts, and API routes — with side-by-side code examples.
 breadcrumb: Migrate from Next.js
 prev:
-  href: /docs/recipes/testing
-  title: Testing
+  href: /docs/recipes/fullstack-vercel
+  title: Full-Stack Vercel
 ---
 
 ## Overview

--- a/examples/docs/src/routes/docs/recipes-fullstack-cloudflare.md
+++ b/examples/docs/src/routes/docs/recipes-fullstack-cloudflare.md
@@ -1,0 +1,272 @@
+---
+title: Full-Stack Cloudflare
+lead: Build a full-stack app on Cloudflare with D1 (SQLite), KV, and R2. This recipe covers project setup, database migrations, and wiring bindings into your loaders and API routes.
+breadcrumb: Full-Stack Cloudflare
+prev:
+  href: /docs/recipes/testing
+  title: Testing
+next:
+  href: /docs/recipes/fullstack-vercel
+  title: Full-Stack Vercel
+---
+
+## What You Get
+
+Cloudflare Workers give you a global edge runtime with built-in storage primitives:
+
+- **D1** — SQLite databases with zero-latency reads at the edge
+- **KV** — Eventually-consistent key-value store for caching and config
+- **R2** — S3-compatible object storage for files and uploads
+
+pracht's Cloudflare adapter passes all bindings through to your loaders, API routes, and middleware via `context.env`.
+
+---
+
+## 1. Project Setup
+
+```sh
+# Create a new pracht app
+pnpm create pracht my-app
+cd my-app
+
+# Install the Cloudflare adapter
+pnpm add @pracht/adapter-cloudflare
+```
+
+```ts [vite.config.ts]
+import { defineConfig } from "vite";
+import { pracht } from "@pracht/vite-plugin";
+import { cloudflareAdapter } from "@pracht/adapter-cloudflare";
+
+export default defineConfig({
+  plugins: [pracht({ adapter: cloudflareAdapter() })],
+});
+```
+
+---
+
+## 2. Configure Bindings
+
+Add your D1 database and any other bindings to `wrangler.jsonc`:
+
+```json [wrangler.jsonc]
+{
+  "name": "my-app",
+  "main": "dist/server/server.js",
+  "assets": { "directory": "dist/client" },
+  "compatibility_date": "2024-12-01",
+  "d1_databases": [
+    {
+      "binding": "DB",
+      "database_name": "my-app-db",
+      "database_id": "<your-database-id>"
+    }
+  ],
+  "kv_namespaces": [
+    {
+      "binding": "CACHE",
+      "id": "<your-kv-namespace-id>"
+    }
+  ]
+}
+```
+
+Create the D1 database:
+
+```sh
+npx wrangler d1 create my-app-db
+# Copy the database_id into wrangler.jsonc
+```
+
+---
+
+## 3. Database Migrations
+
+Create a `migrations/` directory and add your schema:
+
+```sql [migrations/0001_create_posts.sql]
+CREATE TABLE IF NOT EXISTS posts (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  title TEXT NOT NULL,
+  body TEXT NOT NULL,
+  created_at TEXT DEFAULT (datetime('now'))
+);
+```
+
+Apply migrations locally and remotely:
+
+```sh
+# Local development
+npx wrangler d1 migrations apply my-app-db --local
+
+# Production
+npx wrangler d1 migrations apply my-app-db --remote
+```
+
+---
+
+## 4. Type Your Bindings
+
+Create a types file so your loaders and API routes get autocomplete:
+
+```ts [src/env.d.ts]
+interface Env {
+  DB: D1Database;
+  CACHE: KVNamespace;
+}
+
+declare module "pracht" {
+  interface PrachtContext {
+    env: Env;
+    executionContext: ExecutionContext;
+  }
+}
+```
+
+---
+
+## 5. Query D1 in Loaders
+
+```ts [src/routes/posts.tsx]
+import type { LoaderArgs, RouteComponentProps } from "pracht";
+
+interface Post {
+  id: number;
+  title: string;
+  body: string;
+  created_at: string;
+}
+
+export async function loader({ context }: LoaderArgs) {
+  const { results } = await context.env.DB.prepare(
+    "SELECT id, title, body, created_at FROM posts ORDER BY created_at DESC"
+  ).all<Post>();
+
+  return { posts: results };
+}
+
+export function Component({ data }: RouteComponentProps<typeof loader>) {
+  return (
+    <div>
+      <h1>Posts</h1>
+      <ul>
+        {data.posts.map((post) => (
+          <li key={post.id}>
+            <a href={`/posts/${post.id}`}>{post.title}</a>
+            <time>{post.created_at}</time>
+          </li>
+        ))}
+      </ul>
+      <a href="/posts/new">New Post</a>
+    </div>
+  );
+}
+```
+
+---
+
+## 6. Mutations via API Routes
+
+```ts [src/api/posts.ts]
+import type { ApiRouteArgs } from "pracht";
+
+export async function POST({ request, context }: ApiRouteArgs) {
+  const form = await request.formData();
+  const title = String(form.get("title") ?? "");
+  const body = String(form.get("body") ?? "");
+
+  if (!title || !body) {
+    return Response.json({ error: "Title and body are required" }, { status: 400 });
+  }
+
+  const result = await context.env.DB.prepare(
+    "INSERT INTO posts (title, body) VALUES (?, ?)"
+  )
+    .bind(title, body)
+    .run();
+
+  return new Response(null, {
+    status: 302,
+    headers: { location: `/posts/${result.meta.last_row_id}` },
+  });
+}
+```
+
+Use a form to submit:
+
+```tsx [src/routes/posts/new.tsx]
+import { Form } from "pracht";
+
+export function Component() {
+  return (
+    <Form method="post" action="/api/posts">
+      <label>
+        Title
+        <input type="text" name="title" required />
+      </label>
+      <label>
+        Body
+        <textarea name="body" required />
+      </label>
+      <button type="submit">Create Post</button>
+    </Form>
+  );
+}
+```
+
+---
+
+## 7. Use KV for Caching
+
+KV is great for caching expensive queries or storing configuration:
+
+```ts [src/routes/dashboard.tsx]
+import type { LoaderArgs } from "pracht";
+
+export async function loader({ context }: LoaderArgs) {
+  // Check KV cache first
+  const cached = await context.env.CACHE.get("dashboard:stats", "json");
+  if (cached) return cached;
+
+  // Expensive query
+  const stats = await context.env.DB.prepare(
+    "SELECT COUNT(*) as total, MAX(created_at) as latest FROM posts"
+  ).first();
+
+  // Cache for 5 minutes
+  await context.env.CACHE.put("dashboard:stats", JSON.stringify(stats), {
+    expirationTtl: 300,
+  });
+
+  return stats;
+}
+```
+
+---
+
+## 8. Local Development
+
+The pracht dev server with the Cloudflare adapter runs inside `workerd`, so all bindings work locally:
+
+```sh
+pnpm dev
+# D1, KV, and R2 bindings are available via wrangler's local emulation
+```
+
+---
+
+## 9. Deploy
+
+```sh
+pracht build
+npx wrangler deploy
+```
+
+---
+
+## Tips
+
+- Use `render: "ssr"` for any route that reads from D1 — data changes per request.
+- Use parameterized queries (`?` placeholders with `.bind()`) to prevent SQL injection. Never interpolate user input into SQL strings.
+- D1 supports transactions via `context.env.DB.batch([...])` for atomic multi-statement writes.
+- Use `executionContext.waitUntil()` to run background work (analytics, cache warming) without blocking the response.

--- a/examples/docs/src/routes/docs/recipes-fullstack-vercel.md
+++ b/examples/docs/src/routes/docs/recipes-fullstack-vercel.md
@@ -1,0 +1,262 @@
+---
+title: Full-Stack Vercel
+lead: Build a full-stack app on Vercel with Vercel Postgres (Neon), KV (Upstash Redis), and Blob storage. This recipe covers project setup, database provisioning, and accessing services from loaders and API routes.
+breadcrumb: Full-Stack Vercel
+prev:
+  href: /docs/recipes/fullstack-cloudflare
+  title: Full-Stack Cloudflare
+next:
+  href: /docs/migrate/nextjs
+  title: Migrate from Next.js
+---
+
+## What You Get
+
+Vercel provides managed infrastructure you can connect to from Edge Functions:
+
+- **Vercel Postgres** — Serverless Postgres powered by Neon, accessible via `@vercel/postgres`
+- **Vercel KV** — Redis-compatible store powered by Upstash
+- **Vercel Blob** — File storage with a simple upload/download API
+
+pracht's Vercel adapter deploys your app as an Edge Function with SSG pages served from the CDN.
+
+---
+
+## 1. Project Setup
+
+```sh
+# Create a new pracht app
+pnpm create pracht my-app
+cd my-app
+
+# Install the Vercel adapter and storage SDKs
+pnpm add @pracht/adapter-vercel @vercel/postgres @vercel/kv
+```
+
+```ts [vite.config.ts]
+import { defineConfig } from "vite";
+import { pracht } from "@pracht/vite-plugin";
+import { vercelAdapter } from "@pracht/adapter-vercel";
+
+export default defineConfig({
+  plugins: [pracht({ adapter: vercelAdapter() })],
+});
+```
+
+---
+
+## 2. Provision a Database
+
+Create a Postgres database from the Vercel dashboard or CLI:
+
+```sh
+npx vercel link
+npx vercel env pull .env.local
+```
+
+After linking a Vercel Postgres store, your `.env.local` will contain `POSTGRES_URL` and related connection strings. These are automatically available as environment variables in production.
+
+---
+
+## 3. Database Schema
+
+Use any migration tool you like. Here's a simple approach with `@vercel/postgres`:
+
+```ts [scripts/migrate.ts]
+import { sql } from "@vercel/postgres";
+
+async function migrate() {
+  await sql`
+    CREATE TABLE IF NOT EXISTS posts (
+      id SERIAL PRIMARY KEY,
+      title TEXT NOT NULL,
+      body TEXT NOT NULL,
+      created_at TIMESTAMPTZ DEFAULT NOW()
+    )
+  `;
+  console.log("Migration complete");
+}
+
+migrate();
+```
+
+```sh
+# Run locally with .env.local loaded
+npx dotenv -e .env.local -- npx tsx scripts/migrate.ts
+```
+
+---
+
+## 4. Type Your Context
+
+```ts [src/env.d.ts]
+declare module "pracht" {
+  interface PrachtContext {
+    // Vercel's edge context is available here
+    // Add any custom context from createContext
+  }
+}
+```
+
+---
+
+## 5. Query Postgres in Loaders
+
+`@vercel/postgres` reads connection info from environment variables automatically — no binding wiring needed:
+
+```ts [src/routes/posts.tsx]
+import { sql } from "@vercel/postgres";
+import type { LoaderArgs, RouteComponentProps } from "pracht";
+
+interface Post {
+  id: number;
+  title: string;
+  body: string;
+  created_at: string;
+}
+
+export async function loader(_args: LoaderArgs) {
+  const { rows } = await sql<Post>`
+    SELECT id, title, body, created_at
+    FROM posts
+    ORDER BY created_at DESC
+  `;
+
+  return { posts: rows };
+}
+
+export function Component({ data }: RouteComponentProps<typeof loader>) {
+  return (
+    <div>
+      <h1>Posts</h1>
+      <ul>
+        {data.posts.map((post) => (
+          <li key={post.id}>
+            <a href={`/posts/${post.id}`}>{post.title}</a>
+            <time>{post.created_at}</time>
+          </li>
+        ))}
+      </ul>
+      <a href="/posts/new">New Post</a>
+    </div>
+  );
+}
+```
+
+---
+
+## 6. Mutations via API Routes
+
+```ts [src/api/posts.ts]
+import { sql } from "@vercel/postgres";
+import type { ApiRouteArgs } from "pracht";
+
+export async function POST({ request }: ApiRouteArgs) {
+  const form = await request.formData();
+  const title = String(form.get("title") ?? "");
+  const body = String(form.get("body") ?? "");
+
+  if (!title || !body) {
+    return Response.json({ error: "Title and body are required" }, { status: 400 });
+  }
+
+  const { rows } = await sql`
+    INSERT INTO posts (title, body)
+    VALUES (${title}, ${body})
+    RETURNING id
+  `;
+
+  return new Response(null, {
+    status: 302,
+    headers: { location: `/posts/${rows[0].id}` },
+  });
+}
+```
+
+Use a form to submit:
+
+```tsx [src/routes/posts/new.tsx]
+import { Form } from "pracht";
+
+export function Component() {
+  return (
+    <Form method="post" action="/api/posts">
+      <label>
+        Title
+        <input type="text" name="title" required />
+      </label>
+      <label>
+        Body
+        <textarea name="body" required />
+      </label>
+      <button type="submit">Create Post</button>
+    </Form>
+  );
+}
+```
+
+---
+
+## 7. Use Vercel KV for Caching
+
+```sh
+pnpm add @vercel/kv
+```
+
+```ts [src/routes/dashboard.tsx]
+import { kv } from "@vercel/kv";
+import { sql } from "@vercel/postgres";
+import type { LoaderArgs } from "pracht";
+
+export async function loader(_args: LoaderArgs) {
+  // Check Redis cache first
+  const cached = await kv.get("dashboard:stats");
+  if (cached) return cached;
+
+  // Expensive query
+  const { rows } = await sql`
+    SELECT COUNT(*) as total, MAX(created_at) as latest FROM posts
+  `;
+  const stats = rows[0];
+
+  // Cache for 5 minutes
+  await kv.set("dashboard:stats", stats, { ex: 300 });
+
+  return stats;
+}
+```
+
+---
+
+## 8. Local Development
+
+Pull your environment variables and run the dev server:
+
+```sh
+npx vercel env pull .env.local
+pnpm dev
+# Loaders and API routes connect to your Vercel Postgres and KV stores
+```
+
+> [!INFO]
+> Vercel Postgres and KV connect over the network even in development. Your local dev server talks to the same remote databases as production. Use a separate "preview" database for development if you want isolation.
+
+---
+
+## 9. Deploy
+
+```sh
+pracht build
+npx vercel deploy --prebuilt
+```
+
+Or connect your Git repository in the Vercel dashboard for automatic deployments on push.
+
+---
+
+## Tips
+
+- Use `render: "ssr"` for any route that reads from Postgres — data changes per request.
+- The `sql` template tag from `@vercel/postgres` automatically parameterizes queries — it's safe against SQL injection by default.
+- For ISG routes, pracht handles stale-while-revalidate automatically via the Vercel adapter. Use `render: "isg"` with a `revalidate` interval for pages that change infrequently.
+- Vercel Edge Functions have a 25MB size limit and a 30-second execution timeout. Keep loaders fast and move heavy work to background jobs.

--- a/examples/docs/src/routes/docs/recipes-testing.md
+++ b/examples/docs/src/routes/docs/recipes-testing.md
@@ -6,8 +6,8 @@ prev:
   href: /docs/recipes/forms
   title: Forms
 next:
-  href: /docs/migrate/nextjs
-  title: Migrate from Next.js
+  href: /docs/recipes/fullstack-cloudflare
+  title: Full-Stack Cloudflare
 ---
 
 ## Recommended Setup

--- a/examples/docs/src/shells/docs.tsx
+++ b/examples/docs/src/shells/docs.tsx
@@ -41,6 +41,8 @@ const NAV = [
       { href: "/docs/recipes/auth", icon: "🔒", title: "Authentication" },
       { href: "/docs/recipes/forms", icon: "📝", title: "Forms" },
       { href: "/docs/recipes/testing", icon: "🧪", title: "Testing" },
+      { href: "/docs/recipes/fullstack-cloudflare", icon: "☁", title: "Full-Stack Cloudflare" },
+      { href: "/docs/recipes/fullstack-vercel", icon: "▲", title: "Full-Stack Vercel" },
     ],
   },
   {


### PR DESCRIPTION
## Summary

- Adds a **Full-Stack Cloudflare** recipe covering D1 (SQLite), KV caching, wrangler config, migrations, typed bindings, and parameterized queries in loaders/API routes
- Adds a **Full-Stack Vercel** recipe covering Vercel Postgres (Neon), KV (Upstash Redis), environment provisioning, and deployment
- Registers both recipes in the sidebar nav and route manifest
- Updates prev/next navigation links on adjacent docs (Testing, Migrate from Next.js)

## Test plan

- [ ] Verify docs site builds successfully
- [ ] Check both new recipes render at `/docs/recipes/fullstack-cloudflare` and `/docs/recipes/fullstack-vercel`
- [ ] Confirm sidebar shows both new entries under Recipes
- [ ] Verify prev/next navigation works across Testing → Cloudflare → Vercel → Migrate from Next.js

🤖 Generated with [Claude Code](https://claude.com/claude-code)