### PR TITLE
Add npm provenance to all packages

### DIFF
--- a/packages/adapter-cloudflare/package.json
+++ b/packages/adapter-cloudflare/package.json
@@ -5,6 +5,9 @@
     "dist"
   ],
   "type": "module",
+  "publishConfig": {
+    "provenance": true
+  },
   "exports": {
     ".": {
       "types": "./dist/index.d.mts",

--- a/packages/adapter-node/package.json
+++ b/packages/adapter-node/package.json
@@ -5,6 +5,9 @@
     "dist"
   ],
   "type": "module",
+  "publishConfig": {
+    "provenance": true
+  },
   "exports": {
     ".": {
       "types": "./dist/index.d.mts",

--- a/packages/adapter-vercel/package.json
+++ b/packages/adapter-vercel/package.json
@@ -5,6 +5,9 @@
     "dist"
   ],
   "type": "module",
+  "publishConfig": {
+    "provenance": true
+  },
   "exports": {
     ".": {
       "types": "./dist/index.d.mts",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -5,6 +5,9 @@
     "pracht": "./bin/pracht.js"
   },
   "type": "module",
+  "publishConfig": {
+    "provenance": true
+  },
   "dependencies": {
     "@pracht/core": "workspace:*"
   }

--- a/packages/framework/package.json
+++ b/packages/framework/package.json
@@ -5,6 +5,9 @@
     "dist"
   ],
   "type": "module",
+  "publishConfig": {
+    "provenance": true
+  },
   "exports": {
     ".": {
       "types": "./dist/index.d.mts",

--- a/packages/start/package.json
+++ b/packages/start/package.json
@@ -10,6 +10,9 @@
     "README.md"
   ],
   "type": "module",
+  "publishConfig": {
+    "provenance": true
+  },
   "scripts": {
     "build": "node -e \"\""
   }

--- a/packages/vite-plugin/package.json
+++ b/packages/vite-plugin/package.json
@@ -5,6 +5,9 @@
     "dist"
   ],
   "type": "module",
+  "publishConfig": {
+    "provenance": true
+  },
   "exports": {
     ".": {
       "types": "./dist/index.d.mts",


### PR DESCRIPTION
## Summary

- Adds `publishConfig.provenance: true` to all 7 package.json files
- Enables npm provenance statements when publishing from CI, linking each published package back to its source repo and build

🤖 Generated with [Claude Code](https://claude.com/claude-code)