### PR TITLE
Resolve real npm versions in create-pracht

### DIFF
--- a/.changeset/start-real-versions.md
+++ b/.changeset/start-real-versions.md
@@ -1,0 +1,5 @@
+---
+"create-pracht": patch
+---
+
+Resolve actual latest versions from the npm registry instead of inserting "latest" in scaffolded package.json

--- a/packages/start/src/index.js
+++ b/packages/start/src/index.js
@@ -4,6 +4,19 @@ import { mkdir, readdir, stat, writeFile } from "node:fs/promises";
 import { basename, dirname, resolve } from "node:path";
 import { createInterface } from "node:readline/promises";
 
+async function fetchLatestVersion(packageName) {
+  const res = await fetch(
+    `https://registry.npmjs.org/${packageName}/latest`,
+  );
+  if (!res.ok) {
+    throw new Error(
+      `Failed to fetch version for ${packageName}: ${res.statusText}`,
+    );
+  }
+  const data = await res.json();
+  return data.version;
+}
+
 const ADAPTERS = {
   node: {
     description: "Node.js server with pracht preview",
@@ -77,7 +90,7 @@ export async function run(argv = process.argv.slice(2)) {
 
 export async function scaffoldProject({ adapter, packageManager, targetDir }) {
   const packageName = toPackageName(basename(targetDir));
-  const files = buildProjectFiles({
+  const files = await buildProjectFiles({
     adapter,
     packageManager,
     projectName: packageName,
@@ -215,11 +228,33 @@ function normalizeAdapter(value) {
   return null;
 }
 
-function buildProjectFiles({ adapter, packageManager, projectName }) {
+async function resolveVersions(packageNames) {
+  const entries = await Promise.all(
+    packageNames.map(async (name) => [
+      name,
+      `^${await fetchLatestVersion(name)}`,
+    ]),
+  );
+  return Object.fromEntries(entries);
+}
+
+async function buildProjectFiles({ adapter, packageManager, projectName }) {
+  const packagesToResolve = [
+    "@pracht/cli",
+    "@pracht/vite-plugin",
+    "@pracht/core",
+    adapter.packageName,
+  ];
+  if (adapter.id === "vercel") {
+    packagesToResolve.push("vercel");
+  }
+
+  const versions = await resolveVersions(packagesToResolve);
+
   const files = {
     ".gitignore": "dist\nnode_modules\n.wrangler\n.vercel\n",
     "README.md": createReadme({ adapter, packageManager, projectName }),
-    "package.json": createPackageJson({ adapter, projectName }),
+    "package.json": createPackageJson({ adapter, projectName, versions }),
     "src/api/health.ts": createHealthRoute(adapter),
     "src/routes.ts": createRoutesFile(),
     "src/routes/home.tsx": createHomeRoute(adapter),
@@ -235,7 +270,7 @@ function buildProjectFiles({ adapter, packageManager, projectName }) {
   return files;
 }
 
-function createPackageJson({ adapter, projectName }) {
+function createPackageJson({ adapter, projectName, versions }) {
   const scripts = {
     build: "pracht build",
     dev: "pracht dev",
@@ -243,8 +278,8 @@ function createPackageJson({ adapter, projectName }) {
   };
 
   const devDependencies = {
-    "@pracht/cli": "latest",
-    "@pracht/vite-plugin": "latest",
+    "@pracht/cli": versions["@pracht/cli"],
+    "@pracht/vite-plugin": versions["@pracht/vite-plugin"],
     preact: "^10.26.9",
     "preact-render-to-string": "^6.5.13",
     vite: "^8.0.0",
@@ -257,14 +292,14 @@ function createPackageJson({ adapter, projectName }) {
 
   if (adapter.id === "vercel") {
     scripts.deploy = "pracht build && vercel deploy --prebuilt";
-    devDependencies.vercel = "latest";
+    devDependencies.vercel = versions["vercel"];
   }
 
   return `${JSON.stringify(
     {
       dependencies: {
-        [adapter.packageName]: "latest",
-        "@pracht/core": "latest",
+        [adapter.packageName]: versions[adapter.packageName],
+        "@pracht/core": versions["@pracht/core"],
       },
       devDependencies,
       name: projectName,

--- a/packages/start/test/index.test.js
+++ b/packages/start/test/index.test.js
@@ -34,8 +34,8 @@ describe("create-pracht", () => {
     const packageJson = await readFile(join(targetDir, "package.json"), "utf-8");
     const routes = await readFile(join(targetDir, "src/routes.ts"), "utf-8");
 
-    expect(packageJson).toContain('"@pracht/cli": "latest"');
-    expect(packageJson).toContain('"@pracht/adapter-node": "latest"');
+    expect(packageJson).toMatch(/"@pracht\/cli": "\^\d+\.\d+\.\d+"/);
+    expect(packageJson).toMatch(/"@pracht\/adapter-node": "\^\d+\.\d+\.\d+"/);
     expect(packageJson).not.toContain("wrangler");
     expect(routes).toContain('route("/", "./routes/home.tsx"');
     expect(existsSync(join(targetDir, "wrangler.jsonc"))).toBe(false);
@@ -60,8 +60,9 @@ describe("create-pracht", () => {
     const packageJson = await readFile(join(targetDir, "package.json"), "utf-8");
     const wranglerConfig = await readFile(join(targetDir, "wrangler.jsonc"), "utf-8");
 
-    expect(packageJson).toContain('"@pracht/cli": "latest"');
-    expect(packageJson).toContain('"@pracht/adapter-cloudflare": "latest"');
+    expect(packageJson).toMatch(/"@pracht\/cli": "\^\d+\.\d+\.\d+"/);
+    expect(packageJson).toMatch(/"@pracht\/adapter-cloudflare": "\^\d+\.\d+\.\d+"/);
+
     expect(packageJson).toContain('"wrangler": "^4.81.0"');
     expect(packageJson).not.toContain('"@cloudflare/vite-plugin"');
     expect(wranglerConfig).toContain('"main": "dist/server/server.js"');
@@ -91,8 +92,9 @@ describe("create-pracht", () => {
     const packageJson = await readFile(join(targetDir, "package.json"), "utf-8");
     const readme = await readFile(join(targetDir, "README.md"), "utf-8");
 
-    expect(packageJson).toContain('"@pracht/adapter-vercel": "latest"');
-    expect(packageJson).toContain('"vercel": "latest"');
+    expect(packageJson).toMatch(/"@pracht\/adapter-vercel": "\^\d+\.\d+\.\d+"/);
+    expect(packageJson).toMatch(/"vercel": "\^\d+\.\d+\.\d+"/);
+
     expect(packageJson).toContain('"deploy": "pracht build && vercel deploy --prebuilt"');
     expect(readme).toContain("configured for Vercel");
     expect(readme).toContain("pnpm deploy");


### PR DESCRIPTION
## Summary
- Fetches actual latest versions from the npm registry when scaffolding a new project, instead of inserting `"latest"` as the version specifier
- Versions are pinned with a caret (`^x.y.z`) for semver-compatible updates
- All package versions are resolved in parallel for speed

## Test plan
- [x] Existing tests updated and passing — assert `^x.y.z` pattern instead of `"latest"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)