### PR TITLE
Add prepublishOnly build steps to all packages

### DIFF
--- a/packages/adapter-cloudflare/package.json
+++ b/packages/adapter-cloudflare/package.json
@@ -15,7 +15,8 @@
     }
   },
   "scripts": {
-    "build": "tsdown"
+    "build": "tsdown",
+    "prepublishOnly": "npm run build"
   },
   "dependencies": {
     "@pracht/core": "workspace:*"

--- a/packages/adapter-node/package.json
+++ b/packages/adapter-node/package.json
@@ -15,7 +15,8 @@
     }
   },
   "scripts": {
-    "build": "tsdown"
+    "build": "tsdown",
+    "prepublishOnly": "npm run build"
   },
   "dependencies": {
     "@pracht/core": "workspace:*"

--- a/packages/adapter-vercel/package.json
+++ b/packages/adapter-vercel/package.json
@@ -15,7 +15,8 @@
     }
   },
   "scripts": {
-    "build": "tsdown"
+    "build": "tsdown",
+    "prepublishOnly": "npm run build"
   },
   "dependencies": {
     "@pracht/core": "workspace:*"

--- a/packages/framework/package.json
+++ b/packages/framework/package.json
@@ -19,7 +19,8 @@
     }
   },
   "scripts": {
-    "build": "tsdown"
+    "build": "tsdown",
+    "prepublishOnly": "npm run build"
   },
   "dependencies": {
     "preact-suspense": "^0.2.0"

--- a/packages/start/package.json
+++ b/packages/start/package.json
@@ -14,6 +14,7 @@
     "provenance": true
   },
   "scripts": {
-    "build": "node -e \"\""
+    "build": "node -e \"\"",
+    "prepublishOnly": "npm run build"
   }
 }

--- a/packages/vite-plugin/package.json
+++ b/packages/vite-plugin/package.json
@@ -19,7 +19,8 @@
     }
   },
   "scripts": {
-    "build": "tsdown"
+    "build": "tsdown",
+    "prepublishOnly": "npm run build"
   },
   "dependencies": {
     "@preact/preset-vite": "^2.10.5",


### PR DESCRIPTION
## Summary
- Adds `"prepublishOnly": "npm run build"` to all 6 packages that have a build script
- Ensures `dist/` is always fresh before publishing to npm
- Skipped `cli` package since it ships source directly via `bin/`

## Test plan
- [ ] Verify `npm publish --dry-run` triggers the build in each package

🤖 Generated with [Claude Code](https://claude.com/claude-code)