### PR TITLE
Improve first paint for SPA routes

### DIFF
--- a/.changeset/spa-shell-first-paint.md
+++ b/.changeset/spa-shell-first-paint.md
@@ -1,0 +1,5 @@
+---
+"@pracht/core": minor
+---
+
+Improve SPA first paint by rendering the matched shell during the initial HTML response and supporting an optional shell `Loading` export for immediate placeholder UI while route-state data loads on the client.

--- a/docs/DATA_LOADING.md
+++ b/docs/DATA_LOADING.md
@@ -39,13 +39,13 @@ export function Component({ data }: RouteComponentProps<typeof loader>) {
 
 ### When loaders run
 
-| Scenario          | Loader runs on                                              |
-| ----------------- | ----------------------------------------------------------- |
-| SSG build         | Build machine, once per path                                |
-| SSR request       | Server, every request                                       |
-| ISG initial       | Build machine, then server on revalidation                  |
-| SPA               | Server, during client navigation fetch                      |
-| Client navigation | Server (fetched as JSON via `x-pracht-route-state-request`) |
+| Scenario          | Loader runs on                                                    |
+| ----------------- | ----------------------------------------------------------------- |
+| SSG build         | Build machine, once per path                                      |
+| SSR request       | Server, every request                                             |
+| ISG initial       | Build machine, then server on revalidation                        |
+| SPA               | Server, during route-state fetches; initial HTML stays shell-only |
+| Client navigation | Server (fetched as JSON via `x-pracht-route-state-request`)       |
 
 Loaders **never** run in the browser. This keeps server secrets (DB connections,
 API keys) safe.
@@ -53,6 +53,10 @@ API keys) safe.
 Framework-generated route-state responses add `Vary: x-pracht-route-state-request`
 so caches keep HTML and JSON variants separate. Those JSON responses also default
 to `Cache-Control: no-store` unless your app sets a stricter policy explicitly.
+
+For SPA routes, the initial HTML can still include the matched shell and an
+optional shell `Loading` export so the page is not blank before the route-state
+request resolves.
 
 ### Error handling
 

--- a/docs/RENDERING_MODES.md
+++ b/docs/RENDERING_MODES.md
@@ -120,13 +120,31 @@ Useful for CMS-driven content where you know exactly when data changes.
 route("/settings", () => import("./routes/settings.tsx"), { render: "spa" });
 ```
 
-No server-side rendering. The server returns a minimal HTML shell, and the
-route component renders entirely in the browser. The loader runs during
-client-side navigation only.
+The route component is not server-rendered. On the initial document request,
+pracht renders the assigned shell immediately and, if the shell exports
+`Loading`, includes that placeholder in the HTML. The route component still
+renders entirely in the browser after the client router fetches route-state
+JSON.
+
+```typescript
+// src/shells/app.tsx
+import type { ShellProps } from "@pracht/core";
+
+export function Shell({ children }: ShellProps) {
+  return <div class="app-shell">{children}</div>;
+}
+
+export function Loading() {
+  return <p>Loading page...</p>;
+}
+```
+
+This improves first paint for auth-gated apps without serializing loader data
+into the initial document by default.
 
 ### When to use SPA
 
-- Auth-gated pages where SEO doesn't matter
+- Auth-gated pages where SEO doesn't matter, but shell chrome should paint fast
 - Complex interactive UIs (editors, dashboards)
 - Pages where server rendering adds no value
 

--- a/docs/WORKSPACE.md
+++ b/docs/WORKSPACE.md
@@ -33,8 +33,10 @@ described in `VISION_MVP.md`.
   `renderToString` → HTML document assembly with hydration state
   (`window.__PRACHT_STATE__`), head metadata merging, and client entry injection.
 - **Render modes** — SSR, SSG, and ISG routes render server-side; SPA routes
-  return a minimal shell with no SSR content; route-state JSON responses are
-  returned when the `x-pracht-route-state-request` header is present.
+  keep the route component client-only but now render their matched shell
+  immediately, optionally with a shell `Loading` fallback. Route-state JSON
+  responses are returned when the `x-pracht-route-state-request` header is
+  present.
 - **ISG revalidation** — At build time, ISG routes are prerendered alongside SSG
   routes and an `isg-manifest.json` is generated mapping paths to revalidation
   config. At runtime, the Node adapter implements stale-while-revalidate:

--- a/e2e/basic.test.ts
+++ b/e2e/basic.test.ts
@@ -104,15 +104,19 @@ test("dashboard form posts to API route and keeps the current route hydrated", a
 // SPA route: Settings
 // ---------------------------------------------------------------------------
 
-test("settings returns SPA shell without SSR content", async ({ page, context }) => {
+test("settings returns SPA shell chrome and loading UI without SSR route content", async ({
+  page,
+  context,
+}) => {
   await context.addCookies([{ name: "session", value: "abc123", domain: "localhost", path: "/" }]);
 
   const response = await page.goto("/settings");
   expect(response?.status()).toBe(200);
 
-  // SPA mode: pracht-root should be empty in the initial HTML
   const html = await response?.text();
-  expect(html).toContain('<div id="pracht-root"></div>');
+  expect(html).toContain("Loading page...");
+  expect(html).toContain("Back to home");
+  expect(html).not.toContain("<h1>Settings</h1>");
 });
 
 test("settings hydrates correctly on a direct authenticated load", async ({ page, context }) => {

--- a/examples/basic/src/shells/app.tsx
+++ b/examples/basic/src/shells/app.tsx
@@ -15,6 +15,14 @@ export function Shell({ children }: ShellProps) {
   );
 }
 
+export function Loading() {
+  return (
+    <section aria-busy="true">
+      <p>Loading page...</p>
+    </section>
+  );
+}
+
 export function head() {
   return {
     title: "Pracht App",

--- a/examples/cloudflare/src/shells/app.tsx
+++ b/examples/cloudflare/src/shells/app.tsx
@@ -15,6 +15,14 @@ export function Shell({ children }: ShellProps) {
   );
 }
 
+export function Loading() {
+  return (
+    <section aria-busy="true">
+      <p>Loading page...</p>
+    </section>
+  );
+}
+
 export function head() {
   return {
     title: "Pracht App",

--- a/examples/docs/src/routes/docs/rendering.md
+++ b/examples/docs/src/routes/docs/rendering.md
@@ -105,11 +105,25 @@ import { webhookRevalidate } from "@pracht/core";
 route("/settings", "./routes/settings.tsx", { render: "spa" });
 ```
 
-No server-side rendering. The server returns a minimal HTML shell, and the component renders entirely in the browser. The loader runs during client-side navigation only.
+The route component is not server-rendered. On the first document request, pracht renders the assigned shell immediately and includes an optional shell `Loading` export if you provide one. The route component still renders entirely in the browser after the client router fetches route-state JSON.
+
+```ts
+import type { ShellProps } from "@pracht/core";
+
+export function Shell({ children }: ShellProps) {
+  return <div class="app-shell">{children}</div>;
+}
+
+export function Loading() {
+  return <p>Loading page...</p>;
+}
+```
+
+This improves first paint without serializing loader data into the initial document by default.
 
 ### When to use SPA
 
-- Auth-gated pages where SEO doesn't matter
+- Auth-gated pages where SEO doesn't matter, but shell chrome should paint fast
 - Complex interactive UIs (editors, rich dashboards)
 - Pages where server rendering adds no value
 

--- a/packages/framework/README.md
+++ b/packages/framework/README.md
@@ -48,4 +48,4 @@ Each route can specify its rendering mode:
 - `ssr` — server-rendered on every request
 - `ssg` — pre-rendered at build time
 - `isg` — pre-rendered with time-based revalidation
-- `spa` — client-only rendering
+- `spa` — client-only route rendering with optional shell/loading HTML on first paint

--- a/packages/framework/src/router.ts
+++ b/packages/framework/src/router.ts
@@ -248,15 +248,16 @@ export async function initClientRouter(options: InitClientRouterOptions): Promis
     };
 
     if (initialMatch.route.render === "spa" && options.initialState.pending) {
+      // Kick off the data fetch in parallel with shell hydration
+      const dataPromise = fetchPrachtRouteState(options.initialState.url);
+
       const pendingTree = await buildSpaPendingTree(initialMatch, initialShellPromise);
       if (pendingTree) {
         hydrate(pendingTree, root);
       }
-    }
 
-    if (initialMatch.route.render === "spa" && options.initialState.pending) {
       try {
-        const result = await fetchPrachtRouteState(options.initialState.url);
+        const result = await dataPromise;
         if (result.type === "redirect") {
           window.location.href = result.location;
           return;

--- a/packages/framework/src/router.ts
+++ b/packages/framework/src/router.ts
@@ -110,6 +110,40 @@ export async function initClientRouter(options: InitClientRouterOptions): Promis
     );
   }
 
+  async function buildSpaPendingTree(
+    match: RouteMatch,
+    shellModPromise?: Promise<any> | null,
+  ): Promise<VNode<any> | null> {
+    const resolvedShell = await (shellModPromise ?? startShellImport(match));
+    if (!resolvedShell) return null;
+
+    const Shell = resolvedShell.Shell as any;
+    const Loading = resolvedShell.Loading as any;
+    const componentTree =
+      Shell != null
+        ? h(Shell, null, Loading ? h(Loading, null) : null)
+        : Loading
+          ? h(Loading, null)
+          : null;
+
+    if (!componentTree) return null;
+
+    return h(
+      NavigateContext.Provider as any,
+      { value: navigate },
+      h(
+        PrachtRuntimeProvider as any,
+        {
+          data: undefined,
+          params: match.params,
+          routeId: match.route.id ?? "",
+          url: match.pathname,
+        },
+        componentTree,
+      ),
+    );
+  }
+
   // ------------------------------------------------------------------
   // Navigate to a new pathname
   // ------------------------------------------------------------------
@@ -204,12 +238,23 @@ export async function initClientRouter(options: InitClientRouterOptions): Promis
 
   const initialMatch = matchAppRoute(app, options.initialState.url);
   if (initialMatch) {
+    const initialShellPromise =
+      initialMatch.route.render === "spa" && options.initialState.pending
+        ? startShellImport(initialMatch)
+        : null;
     let state = {
       data: options.initialState.data,
       error: options.initialState.error ?? null,
     };
 
-    if (initialMatch.route.render === "spa" && state.data == null && !state.error) {
+    if (initialMatch.route.render === "spa" && options.initialState.pending) {
+      const pendingTree = await buildSpaPendingTree(initialMatch, initialShellPromise);
+      if (pendingTree) {
+        hydrate(pendingTree, root);
+      }
+    }
+
+    if (initialMatch.route.render === "spa" && options.initialState.pending) {
       try {
         const result = await fetchPrachtRouteState(options.initialState.url);
         if (result.type === "redirect") {
@@ -234,7 +279,7 @@ export async function initClientRouter(options: InitClientRouterOptions): Promis
       }
     }
 
-    const tree = await buildRouteTree(initialMatch, state);
+    const tree = await buildRouteTree(initialMatch, state, undefined, initialShellPromise);
     if (tree) {
       if (initialMatch.route.render === "spa") {
         render(tree, root);

--- a/packages/framework/src/runtime.ts
+++ b/packages/framework/src/runtime.ts
@@ -26,6 +26,7 @@ export interface PrachtHydrationState<TData = unknown> {
   routeId: string;
   data: TData;
   error?: SerializedRouteError | null;
+  pending?: boolean;
 }
 
 export interface SerializedRouteError {
@@ -436,17 +437,36 @@ export async function handlePrachtRequest<TContext>(
     const cssUrls = resolvePageCssUrls(options, match.route.shellFile, match.route.file);
     const modulePreloadUrls = resolvePageJsUrls(options, match.route.shellFile, match.route.file);
 
-    // --- SPA mode: shell HTML with empty body, no SSR ---
+    // --- SPA mode: render shell chrome / loading state, but keep route component client-only ---
     if (match.route.render === "spa") {
+      let body = "";
+
+      if (shellModule?.Shell || shellModule?.Loading) {
+        const { renderToStringAsync } = await import("preact-render-to-string");
+        const Shell = shellModule?.Shell as any;
+        const Loading = shellModule?.Loading as any;
+        const loadingTree =
+          Shell != null
+            ? h(Shell, null, Loading ? h(Loading, null) : null)
+            : Loading
+              ? h(Loading, null)
+              : null;
+
+        if (loadingTree) {
+          body = await renderToStringAsync(loadingTree);
+        }
+      }
+
       return htmlResponse(
         buildHtmlDocument({
           head,
-          body: "",
+          body,
           hydrationState: {
             url: url.pathname,
             routeId: match.route.id ?? "",
             data: null,
             error: null,
+            pending: true,
           },
           clientEntryUrl: options.clientEntryUrl,
           cssUrls,

--- a/packages/framework/src/types.ts
+++ b/packages/framework/src/types.ts
@@ -224,6 +224,7 @@ export interface RouteModule<TContext = any, TLoader extends LoaderLike = undefi
 
 export interface ShellModule<TContext = any> {
   Shell: FunctionComponent<ShellProps>;
+  Loading?: FunctionComponent;
   head?: (args: BaseRouteArgs<TContext>) => MaybePromise<HeadMetadata>;
 }
 

--- a/packages/framework/test/runtime.test.ts
+++ b/packages/framework/test/runtime.test.ts
@@ -217,6 +217,43 @@ describe("handlePrachtRequest cache variance", () => {
   });
 });
 
+describe("handlePrachtRequest SPA shell fallback", () => {
+  it("renders shell chrome and loading UI for SPA routes without serializing loader data", async () => {
+    const app = defineApp({
+      shells: {
+        app: "./shells/app.tsx",
+      },
+      routes: [route("/settings", "./routes/settings.tsx", { render: "spa", shell: "app" })],
+    });
+
+    const response = await handlePrachtRequest({
+      app,
+      registry: {
+        routeModules: {
+          "./routes/settings.tsx": async () => ({
+            Component: ({ data }) => h("main", null, `Hello ${(data as any).user}`),
+            loader: async () => ({ user: "secret-user" }),
+          }),
+        },
+        shellModules: {
+          "./shells/app.tsx": async () => ({
+            Shell: ({ children }) => h("div", { class: "app-shell" }, children),
+            Loading: () => h("p", null, "Loading settings..."),
+          }),
+        },
+      },
+      request: new Request("http://localhost/settings"),
+    });
+
+    expect(response.status).toBe(200);
+    const html = await response.text();
+    expect(html).toContain("app-shell");
+    expect(html).toContain("Loading settings...");
+    expect(html).toContain('"pending":true');
+    expect(html).not.toContain("secret-user");
+  });
+});
+
 describe("useParams", () => {
   it("provides route params to nested components during SSR", async () => {
     const app = defineApp({


### PR DESCRIPTION
## Summary
Improve SPA first paint by rendering the matched shell in the initial HTML response and supporting an optional shell  export while route-state loads on the client.
Update the basic and Cloudflare example app shells, add framework unit and e2e coverage, and document the new SPA behavior across the framework docs.

Resolves https://github.com/JoviDeCroock/pracht/issues/45

## Validation
pnpm run e2e && pnpm run format && pnpm run lint && pnpm run test