### PR TITLE
Add trusted proxy aware request URL construction

### DIFF
--- a/.changeset/trusted-proxy-url.md
+++ b/.changeset/trusted-proxy-url.md
@@ -1,0 +1,15 @@
+---
+"@pracht/adapter-node": minor
+"@pracht/vite-plugin": patch
+---
+
+Add trusted proxy aware request URL construction
+
+The Node adapter now defaults to deriving the request URL from the socket
+(TLS state for protocol, Host header for host) instead of blindly trusting
+X-Forwarded-Proto. A new `trustProxy` option opts into honoring forwarded
+headers (Forwarded RFC 7239, X-Forwarded-Proto, X-Forwarded-Host) when
+the server sits behind a trusted reverse proxy.
+
+The dev SSR middleware no longer reads X-Forwarded-Proto at all, preventing
+host-header poisoning during development.

--- a/docs/ADAPTERS.md
+++ b/docs/ADAPTERS.md
@@ -69,13 +69,42 @@ The adapter factory calls the entry module generator internally to create a virt
 
 ### `createNodeRequestHandler(options)`
 
-| Option          | Type                 | Description                         |
-| --------------- | -------------------- | ----------------------------------- |
-| `app`           | `PrachtApp`          | The resolved app from `defineApp()` |
-| `registry`      | `ModuleRegistry`     | Lazy module importers               |
-| `staticDir`     | `string`             | Path to `dist/client/`              |
-| `viteManifest`  | `ViteManifest`       | Client asset manifest for injection |
-| `createContext` | `(args) => TContext` | App-level context factory           |
+| Option          | Type                 | Description                                                     |
+| --------------- | -------------------- | --------------------------------------------------------------- |
+| `app`           | `PrachtApp`          | The resolved app from `defineApp()`                             |
+| `registry`      | `ModuleRegistry`     | Lazy module importers                                           |
+| `staticDir`     | `string`             | Path to `dist/client/`                                          |
+| `viteManifest`  | `ViteManifest`       | Client asset manifest for injection                             |
+| `createContext` | `(args) => TContext` | App-level context factory                                       |
+| `trustProxy`    | `boolean`            | Honor forwarded headers for URL construction (default: `false`) |
+
+### Trusted proxy configuration
+
+By default the Node adapter derives the request URL from the socket: protocol
+is inferred from TLS state, and host from the `Host` header. Forwarded headers
+(`Forwarded`, `X-Forwarded-Proto`, `X-Forwarded-Host`) are **ignored**.
+
+Set `trustProxy: true` when the Node server sits behind a trusted reverse proxy
+(nginx, Cloudflare, a load balancer, etc.) that sets forwarded headers:
+
+```typescript
+createNodeRequestHandler({
+  app: resolvedApp,
+  registry,
+  staticDir,
+  trustProxy: true,
+});
+```
+
+When enabled, header precedence is:
+
+1. **RFC 7239 `Forwarded`** header (`proto=` and `host=` directives)
+2. **`X-Forwarded-Proto`** / **`X-Forwarded-Host`**
+3. Socket-derived values (fallback)
+
+> **Security note:** enabling `trustProxy` without a proxy that overwrites
+> these headers exposes the app to host-header poisoning — any client can set
+> arbitrary forwarded values. Only enable this when you control the proxy layer.
 
 ### Features
 

--- a/packages/adapter-node/src/index.ts
+++ b/packages/adapter-node/src/index.ts
@@ -69,6 +69,23 @@ export interface NodeAdapterOptions<TContext = unknown> {
   cssManifest?: Record<string, string[]>;
   jsManifest?: Record<string, string[]>;
   createContext?: (args: NodeAdapterContextArgs) => TContext | Promise<TContext>;
+  /**
+   * Whether to trust proxy headers (`Forwarded`, `X-Forwarded-Proto`,
+   * `X-Forwarded-Host`) when constructing the request URL.
+   *
+   * When **false** (the default), the request URL is derived from the socket:
+   * protocol is inferred from TLS state, and host from the `Host` header.
+   * Forwarded headers are ignored, preventing host-header poisoning.
+   *
+   * When **true**, forwarded headers are honored with the following precedence:
+   *   1. RFC 7239 `Forwarded` header (`proto=` and `host=` directives)
+   *   2. `X-Forwarded-Proto` / `X-Forwarded-Host`
+   *   3. Socket-derived values (fallback)
+   *
+   * Enable this only when the Node server sits behind a trusted reverse proxy
+   * (e.g. nginx, Cloudflare, a load balancer) that sets these headers.
+   */
+  trustProxy?: boolean;
 }
 
 export interface NodeServerEntryModuleOptions {
@@ -80,11 +97,12 @@ export function createNodeRequestHandler<TContext = unknown>(
 ) {
   const isgManifest = options.isgManifest ?? {};
   const staticDir = options.staticDir;
+  const trustProxy = options.trustProxy ?? false;
 
   return async (req: IncomingMessage, res: ServerResponse): Promise<void> => {
     let request: Request;
     try {
-      request = await createWebRequest(req);
+      request = await createWebRequest(req, trustProxy);
     } catch (err) {
       if (err instanceof Error && err.message === "Request body too large") {
         res.statusCode = 413;
@@ -263,9 +281,8 @@ export function createNodeServerEntryModule(options: NodeServerEntryModuleOption
   ].join("\n");
 }
 
-async function createWebRequest(req: IncomingMessage): Promise<Request> {
-  const protocol = getFirstHeaderValue(req.headers["x-forwarded-proto"]) ?? "http";
-  const host = getFirstHeaderValue(req.headers.host) ?? "localhost";
+async function createWebRequest(req: IncomingMessage, trustProxy: boolean): Promise<Request> {
+  const { protocol, host } = resolveOrigin(req, trustProxy);
   const url = new URL(req.url ?? "/", `${protocol}://${host}`);
   const method = req.method ?? "GET";
   const headers = createHeaders(req.headers);
@@ -284,6 +301,76 @@ async function createWebRequest(req: IncomingMessage): Promise<Request> {
   }
 
   return new Request(url, init);
+}
+
+/**
+ * Derive the request protocol and host from the incoming message.
+ *
+ * When `trustProxy` is false (default), the protocol is inferred from the
+ * socket's TLS state and the host from the HTTP `Host` header.  Forwarded
+ * headers are ignored entirely.
+ *
+ * When `trustProxy` is true, the following precedence applies:
+ *   1. RFC 7239 `Forwarded` header (`proto=` / `host=` directives)
+ *   2. `X-Forwarded-Proto` / `X-Forwarded-Host`
+ *   3. Socket-derived values (fallback)
+ */
+function resolveOrigin(
+  req: IncomingMessage,
+  trustProxy: boolean,
+): { protocol: string; host: string } {
+  // Socket-derived defaults — always safe regardless of proxy trust.
+  const socketProtocol =
+    "encrypted" in req.socket && (req.socket as { encrypted?: boolean }).encrypted
+      ? "https"
+      : "http";
+  const socketHost = getFirstHeaderValue(req.headers.host) ?? "localhost";
+
+  if (!trustProxy) {
+    return { protocol: socketProtocol, host: socketHost };
+  }
+
+  // --- Trusted proxy path ---
+
+  // 1. RFC 7239 `Forwarded` header (highest precedence)
+  const forwarded = getFirstHeaderValue(req.headers.forwarded);
+  if (forwarded) {
+    const parsed = parseForwardedHeader(forwarded);
+    return {
+      protocol:
+        parsed.proto ?? getFirstHeaderValue(req.headers["x-forwarded-proto"]) ?? socketProtocol,
+      host: parsed.host ?? getFirstHeaderValue(req.headers["x-forwarded-host"]) ?? socketHost,
+    };
+  }
+
+  // 2. De-facto X-Forwarded-* headers
+  const proto = getFirstHeaderValue(req.headers["x-forwarded-proto"]) ?? socketProtocol;
+  const host = getFirstHeaderValue(req.headers["x-forwarded-host"]) ?? socketHost;
+  return { protocol: proto, host };
+}
+
+/**
+ * Parse the first element of an RFC 7239 `Forwarded` header, extracting
+ * `proto` and `host` directives.  Returns `undefined` for directives that
+ * are not present.
+ */
+function parseForwardedHeader(value: string): { proto?: string; host?: string } {
+  // The header may contain multiple comma-separated elements; use the first
+  // (the one closest to the client).
+  const first = value.split(",")[0];
+  const result: { proto?: string; host?: string } = {};
+
+  for (const part of first.split(";")) {
+    const [key, val] = part.trim().split("=");
+    if (!key || !val) continue;
+    const k = key.toLowerCase();
+    // Strip surrounding quotes if present
+    const v = val.replace(/^"|"$/g, "");
+    if (k === "proto") result.proto = v;
+    else if (k === "host") result.host = v;
+  }
+
+  return result;
 }
 
 function createHeaders(headers: IncomingMessage["headers"]): Headers {

--- a/packages/vite-plugin/src/index.ts
+++ b/packages/vite-plugin/src/index.ts
@@ -526,10 +526,10 @@ function createDevSSRMiddleware(
 const BODYLESS_METHODS = new Set(["GET", "HEAD"]);
 
 async function nodeToWebRequest(req: IncomingMessage): Promise<Request> {
-  const protocol =
-    (Array.isArray(req.headers["x-forwarded-proto"])
-      ? req.headers["x-forwarded-proto"][0]
-      : req.headers["x-forwarded-proto"]) ?? "http";
+  // Dev server is always a direct connection — never trust forwarded headers.
+  // Protocol is always plain HTTP (Vite's dev server does not use TLS), and
+  // host comes from the standard Host header which is safe for direct clients.
+  const protocol = "http";
   const host = req.headers.host ?? "localhost";
   const url = new URL(req.url ?? "/", `${protocol}://${host}`);
   const method = req.method ?? "GET";


### PR DESCRIPTION
## Summary

- Default to socket-derived origin (TLS state for protocol, `Host` header for host) instead of blindly trusting `X-Forwarded-Proto` — prevents host-header poisoning when no proxy is configured.
- Add `trustProxy` option to `NodeAdapterOptions` that opts into honoring forwarded headers with precedence: RFC 7239 `Forwarded` > `X-Forwarded-Proto`/`X-Forwarded-Host` > socket fallback.
- Dev SSR middleware no longer reads `X-Forwarded-Proto` at all.
- Closes #39

## Testing

- [x] `pnpm e2e`
- [x] `pnpm format`
- [x] `pnpm lint`
- [x] `pnpm test`

## Checklist

- [x] Docs updated if needed
- [x] Skills updated if needed
- [x] Changeset added if published packages changed