### PR TITLE
Generate AGENTS.md in scaffolded starters

### DIFF
--- a/.changeset/agent-instructions.md
+++ b/.changeset/agent-instructions.md
@@ -1,0 +1,5 @@
+---
+"create-pracht": minor
+---
+
+Generate AGENTS.md and CLAUDE.md symlink in scaffolded projects describing project structure, commands, and scaffolding CLI usage

--- a/packages/start/src/index.js
+++ b/packages/start/src/index.js
@@ -1,6 +1,6 @@
 import { spawn } from "node:child_process";
 import { existsSync } from "node:fs";
-import { mkdir, readdir, stat, writeFile } from "node:fs/promises";
+import { mkdir, readdir, stat, symlink, writeFile } from "node:fs/promises";
 import { basename, dirname, resolve } from "node:path";
 import { createInterface } from "node:readline/promises";
 
@@ -102,6 +102,8 @@ export async function scaffoldProject({ adapter, packageManager, router = "manif
     await mkdir(dirname(filePath), { recursive: true });
     await writeFile(filePath, content, "utf-8");
   }
+
+  await symlink("AGENTS.md", resolve(targetDir, "CLAUDE.md"));
 }
 
 export function getPackageManager(userAgent = process.env.npm_config_user_agent ?? "") {
@@ -291,6 +293,7 @@ async function buildProjectFiles({ adapter, packageManager, projectName, router 
     "src/api/health.ts": createHealthRoute(adapter),
     "vite.config.ts": createViteConfig(adapter, router),
     "tsconfig.json": createBaseTSConfig(adapter),
+    "AGENTS.md": createAgentInstructions({ adapter, packageManager, router }),
   };
 
   if (router === "pages") {
@@ -558,6 +561,67 @@ function createCloudflareEnvDeclaration() {
     "}",
     "",
   ].join("\n");
+}
+
+function createAgentInstructions({ adapter, packageManager, router }) {
+  const runCmd = packageManager === "npm" ? "npm run" : packageManager;
+
+  const lines = [
+    "# Pracht App",
+    "",
+    "## Commands",
+    "",
+    `- \`${runCmd} dev\` — start the dev server`,
+    `- \`${runCmd} build\` — production build`,
+  ];
+
+  if (adapter.id === "node") {
+    lines.push(`- \`${runCmd} start\` — run the built server`);
+  }
+
+  if (adapter.id === "cloudflare" || adapter.id === "vercel") {
+    lines.push(`- \`${runCmd} deploy\` — build and deploy`);
+  }
+
+  lines.push("");
+  lines.push("## Scaffolding");
+  lines.push("");
+  lines.push("Use the CLI to generate new files:");
+  lines.push("");
+  lines.push("- `pracht generate route <name>` — add a route");
+  lines.push("- `pracht generate shell <name>` — add a shell");
+  lines.push("- `pracht generate middleware <name>` — add middleware");
+  lines.push("- `pracht generate api <name>` — add an API route");
+  lines.push("- `pracht doctor` — check project health");
+
+  lines.push("");
+  lines.push("## Project structure");
+  lines.push("");
+
+  if (router === "pages") {
+    lines.push("This app uses **pages routing** (file-system based).");
+    lines.push("");
+    lines.push("- `src/pages/` — file-system routes (each file becomes a route)");
+    lines.push("- `src/pages/_app.tsx` — app shell (layout and head)");
+  } else {
+    lines.push("This app uses **manifest routing**.");
+    lines.push("");
+    lines.push("- `src/routes.ts` — route manifest (defines all routes and shells)");
+    lines.push("- `src/routes/` — route components and loaders");
+    lines.push("- `src/shells/` — shell components (layouts)");
+  }
+
+  lines.push("- `src/api/` — API route handlers");
+  lines.push(`- \`vite.config.ts\` — Vite config with the ${adapter.label} adapter`);
+
+  if (adapter.id === "cloudflare") {
+    lines.push("- `wrangler.jsonc` — Cloudflare Workers configuration");
+    lines.push("- `src/env.d.ts` — TypeScript types for Cloudflare bindings");
+  }
+
+  lines.push("");
+
+  return lines.join("\n");
 }
 
 function createReadme({ adapter, packageManager, projectName, router }) {

--- a/packages/start/test/index.test.js
+++ b/packages/start/test/index.test.js
@@ -1,5 +1,5 @@
 import { existsSync } from "node:fs";
-import { mkdtemp, readFile } from "node:fs/promises";
+import { mkdtemp, readFile, readlink } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 
@@ -40,6 +40,15 @@ describe("create-pracht", () => {
     expect(packageJson).not.toContain("wrangler");
     expect(routes).toContain('route("/", "./routes/home.tsx"');
     expect(existsSync(join(targetDir, "wrangler.jsonc"))).toBe(false);
+
+    const agents = await readFile(join(targetDir, "AGENTS.md"), "utf-8");
+    expect(agents).toContain("manifest routing");
+    expect(agents).toContain("src/routes.ts");
+    expect(agents).toContain("pracht generate route");
+    expect(agents).toContain("pnpm dev");
+
+    const claudeLink = await readlink(join(targetDir, "CLAUDE.md"));
+    expect(claudeLink).toBe("AGENTS.md");
 
     const tsconfig = await readFile(join(targetDir, "tsconfig.json"), "utf-8");
     expect(tsconfig).toMatchInlineSnapshot(`
@@ -98,6 +107,10 @@ describe("create-pracht", () => {
     const envDts = await readFile(join(targetDir, "src/env.d.ts"), "utf-8");
     expect(envDts).toContain("interface Register");
     expect(envDts).toContain("env: Env");
+
+    const agents = await readFile(join(targetDir, "AGENTS.md"), "utf-8");
+    expect(agents).toContain("wrangler.jsonc");
+    expect(agents).toContain("Cloudflare Workers adapter");
   });
 
   it("scaffolds a vercel starter", async () => {
@@ -166,5 +179,9 @@ describe("create-pracht", () => {
     expect(existsSync(join(targetDir, "src/pages/_app.tsx"))).toBe(true);
     expect(existsSync(join(targetDir, "src/routes.ts"))).toBe(false);
     expect(readme).toContain("src/pages/");
+
+    const agents = await readFile(join(targetDir, "AGENTS.md"), "utf-8");
+    expect(agents).toContain("pages routing");
+    expect(agents).toContain("src/pages/");
   });
 });


### PR DESCRIPTION
## Summary

- Have `create-pracht` generate an `AGENTS.md` (with a `CLAUDE.md` symlink) in every scaffolded project, describing commands, scaffolding CLI usage, and project structure tailored to the chosen adapter and router.
- Closes #37

## Testing

- [x] `pnpm e2e`
- [x] `pnpm format`
- [x] `pnpm lint`
- [x] `pnpm test`

## Checklist

- [x] Docs updated if needed
- [x] Skills updated if needed
- [x] Changeset added if published packages changed