### PR TITLE
Add pracht verify for fast app checks

### DIFF
--- a/.changeset/swift-walls-dance.md
+++ b/.changeset/swift-walls-dance.md
@@ -1,0 +1,6 @@
+---
+"@pracht/cli": minor
+---
+
+Add a fast `pracht verify` command with optional `--changed` and `--json`
+output for framework-aware manifest, pages-router, and API route validation.

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ The starter gives you:
 - `pracht dev` for local SSR + HMR
 - `pracht build` for client/server output plus SSG/ISG prerendering
 - `pracht generate route|shell|middleware|api` for framework-native scaffolding
+- `pracht verify` for fast framework-aware checks with `--changed` and `--json`
 - `pracht doctor` for app wiring checks with optional JSON output
 - `dist/server/server.js` as the generated Node server entry when targeting Node
 

--- a/docs/WORKSPACE.md
+++ b/docs/WORKSPACE.md
@@ -12,7 +12,7 @@ described in `VISION_MVP.md`.
 | `packages/adapter-node`       | `@pracht/adapter-node`       | Node `IncomingMessage`/`ServerResponse` bridge, ISG stale-while-revalidate                                   |
 | `packages/adapter-cloudflare` | `@pracht/adapter-cloudflare` | Cloudflare Workers fetch handler and generated worker entry source                                           |
 | `packages/adapter-vercel`     | `@pracht/adapter-vercel`     | Vercel Edge handler and Build Output API entry source                                                        |
-| `packages/cli`                | `@pracht/cli`                | `pracht dev`, `build`, the `generate` subcommands, and `doctor`                                              |
+| `packages/cli`                | `@pracht/cli`                | `pracht dev`, `build`, `verify`, the `generate` subcommands, and `doctor`                                    |
 | `examples/cloudflare`         | `@pracht/example-cloudflare` | Cloudflare-targeted example app with SSG, ISG, SSR, SPA routes, auth middleware, and API routes              |
 | `examples/docs`               | `@pracht/example-docs`       | Documentation website built with pracht + Cloudflare adapter; all routes SSG-prerendered; dark design system |
 
@@ -59,8 +59,10 @@ described in `VISION_MVP.md`.
   client + server builds (with Vite manifest generation, SSG/ISG prerendering,
   ISG manifest output, executable Node server output in `dist/server/server.js`,
   and Vercel `.vercel/output/` generation when the app targets those adapters),
-  `pracht generate route|shell|middleware|api` scaffolds framework-native
-  files, and `pracht doctor` validates app wiring.
+  `pracht verify` runs fast framework-aware checks with optional `--changed`
+  and `--json` output, `pracht generate route|shell|middleware|api` scaffolds
+  framework-native files, and `pracht doctor` validates app wiring across the
+  whole project.
 - **Package builds** — `tsdown` compiles `pracht`, `@pracht/vite-plugin`,
   `@pracht/adapter-node`, `@pracht/adapter-cloudflare`, and
   `@pracht/adapter-vercel` from TypeScript to ESM (`dist/index.mjs` +
@@ -89,9 +91,10 @@ described in `VISION_MVP.md`.
 - **Claude Code skills** — Three repo-local skills in `skills/`:
   - `/scaffold` — wraps `pracht generate route|shell|middleware|api` and only
     falls back to manual wiring when the CLI flags are insufficient.
-  - `/debug` — framework-aware debugging plus `pracht doctor` for fast wiring
-    validation (route matching, loader errors, hydration mismatches,
-    middleware, API routes, build issues).
+  - `/debug` — framework-aware debugging plus `pracht verify` for fast changed
+    scope checks and `pracht doctor` for project-wide wiring validation (route
+    matching, loader errors, hydration mismatches, middleware, API routes,
+    build issues).
   - `/deploy` — guided adapter setup and deployment for Node.js, Cloudflare,
     and Vercel (build, configure, deploy checklist).
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -24,6 +24,18 @@ For Node.js targets, run the built server with:
 node dist/server/server.js
 ```
 
+### `pracht verify`
+
+Run fast framework-aware verification checks without paying for a full build or
+test loop. Use `--changed` to focus on changed manifest-managed files and
+`--json` for machine-readable output.
+
+```bash
+pracht verify
+pracht verify --changed
+pracht verify --json
+```
+
 ### `pracht generate route`
 
 Create a new route module. In manifest apps this also updates `src/routes.ts`.
@@ -58,7 +70,8 @@ pracht generate api --path /health --methods GET,POST
 
 ### `pracht doctor`
 
-Validate the local app wiring. Use `--json` for machine-readable output.
+Validate the local app wiring across the whole project. Use `--json` for
+machine-readable output.
 
 ```bash
 pracht doctor

--- a/packages/cli/bin/pracht.js
+++ b/packages/cli/bin/pracht.js
@@ -4,6 +4,7 @@ import { doctorCommand } from "../lib/commands/doctor.js";
 import { buildCommand } from "../lib/commands/build.js";
 import { devCommand } from "../lib/commands/dev.js";
 import { generateCommand } from "../lib/commands/generate.js";
+import { verifyCommand } from "../lib/commands/verify.js";
 import { handleCliError, printHelp } from "../lib/cli.js";
 import { VERSION } from "../lib/constants.js";
 
@@ -26,6 +27,7 @@ const handlers = {
   dev: devCommand,
   doctor: doctorCommand,
   generate: generateCommand,
+  verify: verifyCommand,
 };
 
 if (!(command in handlers)) {

--- a/packages/cli/lib/cli.js
+++ b/packages/cli/lib/cli.js
@@ -7,6 +7,7 @@ Usage:
   pracht dev [port]                 Start development server with HMR
   pracht build                      Production build (client + server)
   pracht generate <kind> [flags]    Scaffold framework files
+  pracht verify [--changed] [--json] Fast framework-aware verification
   pracht doctor [--json]            Validate app wiring
 
 Generate kinds:

--- a/packages/cli/lib/commands/verify.js
+++ b/packages/cli/lib/commands/verify.js
@@ -1,16 +1,16 @@
 import { parseFlags } from "../cli.js";
-import { runDoctor } from "../verification.js";
+import { runVerification } from "../verification.js";
 
-export async function doctorCommand(args) {
+export async function verifyCommand(args) {
   const options = parseFlags(args);
-  const report = runDoctor(process.cwd());
+  const report = runVerification(process.cwd(), { changed: Boolean(options.changed) });
 
   if (options.json) {
     console.log(JSON.stringify(report, null, 2));
   } else {
-    console.log(`Pracht doctor (${report.mode} mode)`);
+    console.log(`Pracht verify (${report.mode} mode, ${report.scope} scope)`);
     for (const check of report.checks) {
-      console.log(`${check.status.toUpperCase().padEnd(5)} ${check.message}`);
+      console.log(`${check.status.toUpperCase().padEnd(7)} ${check.message}`);
     }
     console.log(report.ok ? "\nNo blocking issues found." : "\nBlocking issues found.");
   }

--- a/packages/cli/lib/manifest.js
+++ b/packages/cli/lib/manifest.js
@@ -54,10 +54,11 @@ export function extractRegistryEntries(source, key) {
   if (!block) return [];
   const inner = source.slice(block.openIndex + 1, block.closeIndex);
   const entries = [];
-  const pattern = /([A-Za-z0-9_-]+)\s*:\s*["'`]([^"'`]+)["'`]/g;
+  const pattern =
+    /([A-Za-z0-9_-]+)\s*:\s*(?:(["'`])([^"'`]+)\2|\(\)\s*=>\s*import\(\s*(["'`])([^"'`]+)\4\s*\))/g;
 
   for (const match of inner.matchAll(pattern)) {
-    entries.push({ name: match[1], path: match[2] });
+    entries.push({ name: match[1], path: match[3] ?? match[5] });
   }
 
   return entries;

--- a/packages/cli/lib/verification.js
+++ b/packages/cli/lib/verification.js
@@ -1,0 +1,641 @@
+import { execFileSync } from "node:child_process";
+import { basename, dirname, relative, resolve } from "node:path";
+import { existsSync, readFileSync } from "node:fs";
+
+import { extractRegistryEntries, extractRelativeModulePaths } from "./manifest.js";
+import {
+  displayPath,
+  hasPagesAppShell,
+  listFilesRecursively,
+  readProjectConfig,
+  resolveProjectPath,
+} from "./project.js";
+
+const CONFIG_FILE_NAMES = new Set([
+  "vite.config.ts",
+  "vite.config.mts",
+  "vite.config.js",
+  "vite.config.mjs",
+  "vite.config.cjs",
+  "vite.config.cts",
+]);
+
+const MODULE_SOURCE_RE = /\.(ts|tsx|js|jsx)$/;
+const PAGE_SOURCE_RE = /\.(ts|tsx|js|jsx|md|mdx)$/;
+
+export function runDoctor(root) {
+  const report = runVerification(root);
+
+  return {
+    checks: report.checks,
+    configFile: report.configFile,
+    mode: report.mode,
+    ok: report.ok,
+  };
+}
+
+export function runVerification(root, options = {}) {
+  const project = readProjectConfig(root);
+  const checks = [];
+  const packageJsonPath = resolve(project.root, "package.json");
+  const configDisplayPath = project.configFile
+    ? displayPath(root, project.configFile)
+    : "vite.config.*";
+  const requestedScope = options.changed ? "changed" : "full";
+
+  collectConfigChecks(project, checks, configDisplayPath);
+
+  let changedInfo = {
+    files: [],
+    warning: null,
+  };
+
+  if (options.changed) {
+    changedInfo = collectChangedFiles(project.root);
+    if (changedInfo.warning) {
+      checks.push(createCheck("warning", changedInfo.warning));
+    }
+  }
+
+  const frameworkFiles = options.changed
+    ? filterFrameworkFiles(project, changedInfo.files, packageJsonPath)
+    : [];
+  const scope =
+    options.changed && !changedInfo.warning && !requiresFullVerification(project, frameworkFiles)
+      ? "changed"
+      : "full";
+
+  if (project.mode === "pages") {
+    collectPagesVerification(project, checks, { changedFiles: frameworkFiles, scope });
+  } else {
+    collectManifestVerification(project, checks, { changedFiles: frameworkFiles, scope });
+  }
+
+  collectApiVerification(project, checks, { changedFiles: frameworkFiles, scope });
+  collectPackageChecks(project, checks, packageJsonPath);
+
+  if (options.changed && frameworkFiles.length === 0 && !changedInfo.warning) {
+    checks.push(
+      createCheck("ok", "No changed framework files were detected in the current project scope."),
+    );
+  }
+
+  return {
+    checks,
+    configFile: project.configFile ? displayPath(root, project.configFile) : null,
+    mode: project.mode,
+    ok: !checks.some((check) => check.status === "error"),
+    requestedScope,
+    scope,
+    changedFiles: changedInfo.files.map((file) => displayPath(project.root, file)),
+    frameworkFiles: frameworkFiles.map((file) => displayPath(project.root, file)),
+  };
+}
+
+function collectConfigChecks(project, checks, configDisplayPath) {
+  if (!project.configFile) {
+    checks.push(createCheck("error", "Missing vite config."));
+  } else {
+    checks.push(createCheck("ok", `Found ${configDisplayPath}.`));
+  }
+
+  if (!project.hasPrachtPlugin) {
+    checks.push(createCheck("error", "vite.config does not appear to register the pracht plugin."));
+  } else {
+    checks.push(createCheck("ok", "Vite config registers the pracht plugin."));
+  }
+}
+
+function collectManifestVerification(project, checks, { changedFiles, scope }) {
+  const manifestPath = resolveProjectPath(project.root, project.appFile);
+  if (!existsSync(manifestPath)) {
+    checks.push(createCheck("error", `App manifest is missing at ${project.appFile}.`));
+    return;
+  }
+
+  const source = readFileSync(manifestPath, "utf-8");
+  const relativeModules = [...extractRelativeModulePaths(source)];
+  const routeCount = (source.match(/\broute\s*\(/g) ?? []).length;
+
+  if (scope === "full") {
+    checks.push(createCheck("ok", `Found app manifest at ${project.appFile}.`));
+
+    if (routeCount === 0) {
+      checks.push(createCheck("warning", "No routes were found in the app manifest."));
+    } else {
+      checks.push(
+        createCheck(
+          "ok",
+          `App manifest defines ${routeCount} route${routeCount === 1 ? "" : "s"}.`,
+        ),
+      );
+    }
+
+    const shellEntries = extractRegistryEntries(source, "shells");
+    const middlewareEntries = extractRegistryEntries(source, "middleware");
+
+    if (shellEntries.length > 0) {
+      checks.push(
+        createCheck(
+          "ok",
+          `Registered ${shellEntries.length} shell${shellEntries.length === 1 ? "" : "s"}.`,
+        ),
+      );
+    }
+
+    if (middlewareEntries.length > 0) {
+      checks.push(
+        createCheck(
+          "ok",
+          `Registered ${middlewareEntries.length} middleware module${middlewareEntries.length === 1 ? "" : "s"}.`,
+        ),
+      );
+    }
+
+    const missingModules = relativeModules
+      .map((modulePath) => ({
+        display: modulePath,
+        exists: existsSync(resolve(dirname(manifestPath), modulePath)),
+      }))
+      .filter((entry) => !entry.exists)
+      .map((entry) => entry.display);
+
+    if (missingModules.length > 0) {
+      checks.push(
+        createCheck(
+          "error",
+          `Manifest references missing files: ${missingModules.map((item) => JSON.stringify(item)).join(", ")}.`,
+        ),
+      );
+    } else {
+      checks.push(
+        createCheck(
+          "ok",
+          `All ${relativeModules.length} manifest module path${relativeModules.length === 1 ? "" : "s"} resolve.`,
+        ),
+      );
+    }
+  } else {
+    collectChangedManifestModuleChecks(
+      project,
+      checks,
+      manifestPath,
+      relativeModules,
+      changedFiles,
+    );
+  }
+}
+
+function collectChangedManifestModuleChecks(
+  project,
+  checks,
+  manifestPath,
+  relativeModules,
+  changedFiles,
+) {
+  const manifestDir = dirname(manifestPath);
+  const referencedModules = new Set(relativeModules.map(normalizePath));
+  const moduleDirectories = [
+    { dir: resolveProjectPath(project.root, project.routesDir), label: "route module" },
+    { dir: resolveProjectPath(project.root, project.shellsDir), label: "shell module" },
+    { dir: resolveProjectPath(project.root, project.middlewareDir), label: "middleware module" },
+    { dir: resolveProjectPath(project.root, project.serverDir), label: "server module" },
+  ];
+
+  for (const file of changedFiles) {
+    const directory = moduleDirectories.find((entry) => isWithinDirectory(file, entry.dir));
+    if (!directory) continue;
+    if (!MODULE_SOURCE_RE.test(file)) continue;
+
+    const display = displayPath(project.root, file);
+    const modulePath = normalizePath(toModuleSpecifier(manifestDir, file));
+    const exists = existsSync(file);
+
+    if (referencedModules.has(modulePath)) {
+      if (exists) {
+        checks.push(
+          createCheck(
+            "ok",
+            `Changed ${directory.label} ${JSON.stringify(display)} is referenced by the app manifest.`,
+          ),
+        );
+      } else {
+        checks.push(
+          createCheck(
+            "error",
+            `Changed ${directory.label} ${JSON.stringify(display)} was removed but is still referenced by the app manifest.`,
+          ),
+        );
+      }
+      continue;
+    }
+
+    if (exists) {
+      checks.push(
+        createCheck(
+          "warning",
+          `Changed ${directory.label} ${JSON.stringify(display)} is not referenced by the app manifest.`,
+        ),
+      );
+    }
+  }
+}
+
+function collectPagesVerification(project, checks, { changedFiles, scope }) {
+  const pagesDir = resolveProjectPath(project.root, project.pagesDir);
+  if (!existsSync(pagesDir)) {
+    checks.push(createCheck("error", `Pages directory is missing at ${project.pagesDir}.`));
+    return;
+  }
+
+  const pages = scanPagesDirectory(pagesDir);
+  const routes = pages.filter((page) => page.kind === "route");
+  const duplicates = collectDuplicateRoutePaths(routes).map((entry) => ({
+    ...entry,
+    files: entry.files.map((file) => displayPath(project.root, file)),
+  }));
+
+  if (scope === "full") {
+    checks.push(createCheck("ok", `Found pages directory at ${project.pagesDir}.`));
+
+    if (routes.length === 0) {
+      checks.push(createCheck("warning", "Pages router app does not contain any route files yet."));
+    } else {
+      checks.push(
+        createCheck("ok", `Found ${routes.length} page route${routes.length === 1 ? "" : "s"}.`),
+      );
+    }
+
+    const hasAppShell = pages.some((page) => page.kind === "shell");
+    if (!hasAppShell) {
+      checks.push(createCheck("warning", "No `_app` shell was found in the pages directory."));
+    } else {
+      checks.push(createCheck("ok", "Found a pages-router `_app` shell."));
+    }
+  } else {
+    collectChangedPagesChecks(project, checks, pagesDir, changedFiles);
+  }
+
+  if (duplicates.length > 0) {
+    checks.push(
+      createCheck(
+        "error",
+        `Pages router resolves duplicate paths: ${duplicates
+          .map(
+            (entry) =>
+              `${JSON.stringify(entry.path)} from ${entry.files.map((file) => JSON.stringify(file)).join(", ")}`,
+          )
+          .join("; ")}.`,
+      ),
+    );
+  } else if (scope === "full" && routes.length > 0) {
+    checks.push(
+      createCheck(
+        "ok",
+        `Pages router resolved ${routes.length} route${routes.length === 1 ? "" : "s"} without path collisions.`,
+      ),
+    );
+  }
+}
+
+function collectChangedPagesChecks(project, checks, pagesDir, changedFiles) {
+  for (const file of changedFiles) {
+    if (!isWithinDirectory(file, pagesDir)) continue;
+    if (!PAGE_SOURCE_RE.test(file)) continue;
+
+    const display = displayPath(project.root, file);
+    if (!existsSync(file)) {
+      checks.push(
+        createCheck(
+          "ok",
+          `Removed page file ${JSON.stringify(display)} is no longer auto-discovered.`,
+        ),
+      );
+      continue;
+    }
+
+    const page = describePagesFile(pagesDir, file);
+    if (page.kind === "shell") {
+      checks.push(
+        createCheck(
+          "ok",
+          `Changed pages shell ${JSON.stringify(display)} will wrap auto-discovered routes.`,
+        ),
+      );
+      continue;
+    }
+
+    if (page.kind === "ignored") {
+      checks.push(
+        createCheck(
+          "warning",
+          `Changed pages file ${JSON.stringify(display)} is ignored by the pages router.`,
+        ),
+      );
+      continue;
+    }
+
+    checks.push(
+      createCheck(
+        "ok",
+        `Changed page route ${JSON.stringify(display)} resolves to ${JSON.stringify(page.routePath)}.`,
+      ),
+    );
+  }
+}
+
+function collectApiVerification(project, checks, { changedFiles, scope }) {
+  const apiDir = resolveProjectPath(project.root, project.apiDir);
+  const changedApiFiles = changedFiles.filter((file) => isWithinDirectory(file, apiDir));
+  if (scope === "changed" && changedApiFiles.length === 0) {
+    return;
+  }
+
+  if (!existsSync(apiDir)) {
+    if (scope === "full") {
+      checks.push(
+        createCheck(
+          "ok",
+          `No API directory was found at ${project.apiDir}; skipping API discovery.`,
+        ),
+      );
+    }
+    return;
+  }
+
+  const apiFiles = listFilesRecursively(apiDir).filter((file) => MODULE_SOURCE_RE.test(file));
+  const routeMap = new Map();
+
+  for (const file of apiFiles) {
+    const routePath = resolveApiRoutePath(apiDir, file);
+    const display = displayPath(project.root, file);
+    const entries = routeMap.get(routePath) ?? [];
+    entries.push(display);
+    routeMap.set(routePath, entries);
+  }
+
+  const duplicates = [...routeMap.entries()]
+    .filter(([, files]) => files.length > 1)
+    .map(([path, files]) => ({ files, path }));
+
+  if (duplicates.length > 0) {
+    checks.push(
+      createCheck(
+        "error",
+        `API route discovery resolves duplicate paths: ${duplicates
+          .map(
+            (entry) =>
+              `${JSON.stringify(entry.path)} from ${entry.files.map((file) => JSON.stringify(file)).join(", ")}`,
+          )
+          .join("; ")}.`,
+      ),
+    );
+  } else if (scope === "full") {
+    checks.push(
+      createCheck(
+        "ok",
+        `API route discovery resolved ${apiFiles.length} route${apiFiles.length === 1 ? "" : "s"}.`,
+      ),
+    );
+  }
+
+  for (const file of changedApiFiles) {
+    if (!MODULE_SOURCE_RE.test(file)) continue;
+
+    const display = displayPath(project.root, file);
+    if (!existsSync(file)) {
+      checks.push(
+        createCheck(
+          "ok",
+          `Removed API route ${JSON.stringify(display)} is no longer auto-discovered.`,
+        ),
+      );
+      continue;
+    }
+
+    checks.push(
+      createCheck(
+        "ok",
+        `Changed API route ${JSON.stringify(display)} resolves to ${JSON.stringify(resolveApiRoutePath(apiDir, file))}.`,
+      ),
+    );
+  }
+}
+
+function collectPackageChecks(project, checks, packageJsonPath) {
+  if (!existsSync(packageJsonPath)) {
+    checks.push(createCheck("warning", "No package.json found in the current app root."));
+    return;
+  }
+
+  const packageJson = JSON.parse(readFileSync(packageJsonPath, "utf-8"));
+  const deps = {
+    ...packageJson.dependencies,
+    ...packageJson.devDependencies,
+  };
+
+  if (!("@pracht/cli" in deps)) {
+    checks.push(
+      createCheck("warning", "`@pracht/cli` is not listed in package.json dependencies."),
+    );
+  }
+
+  const adapterPackages = Object.keys(deps).filter((name) => name.startsWith("@pracht/adapter-"));
+  if (adapterPackages.length === 0) {
+    checks.push(
+      createCheck("warning", "No built-in pracht adapter dependency was found in package.json."),
+    );
+  } else {
+    checks.push(
+      createCheck(
+        "ok",
+        `Found adapter dependency ${adapterPackages.map((name) => JSON.stringify(name)).join(", ")}.`,
+      ),
+    );
+  }
+}
+
+function collectChangedFiles(root) {
+  try {
+    const repoRoot = execFileSync("git", ["rev-parse", "--show-toplevel"], {
+      cwd: root,
+      encoding: "utf-8",
+    }).trim();
+    const prefix = execFileSync("git", ["rev-parse", "--show-prefix"], {
+      cwd: root,
+      encoding: "utf-8",
+    }).trim();
+    const output = execFileSync("git", ["status", "--porcelain", "--untracked-files=all"], {
+      cwd: repoRoot,
+      encoding: "utf-8",
+    });
+    const files = new Set();
+
+    for (const line of output.split(/\r?\n/).filter(Boolean)) {
+      const record = line.slice(3);
+      if (!record) continue;
+
+      if (record.includes(" -> ")) {
+        const [from, to] = record.split(" -> ");
+        addChangedFile(files, repoRoot, prefix, from);
+        addChangedFile(files, repoRoot, prefix, to);
+      } else {
+        addChangedFile(files, repoRoot, prefix, record);
+      }
+    }
+
+    return {
+      files: [...files],
+      warning: null,
+    };
+  } catch {
+    return {
+      files: [],
+      warning: "Unable to determine changed files from git; ran full verification instead.",
+    };
+  }
+}
+
+function addChangedFile(files, repoRoot, prefix, repoRelativePath) {
+  if (prefix && !repoRelativePath.startsWith(prefix)) {
+    return;
+  }
+
+  const projectRelativePath = prefix ? repoRelativePath.slice(prefix.length) : repoRelativePath;
+  if (!projectRelativePath) {
+    return;
+  }
+
+  files.add(resolve(repoRoot, projectRelativePath));
+}
+
+function filterFrameworkFiles(project, files, packageJsonPath) {
+  const appFile = resolveProjectPath(project.root, project.appFile);
+  const routesDir = resolveProjectPath(project.root, project.routesDir);
+  const shellsDir = resolveProjectPath(project.root, project.shellsDir);
+  const middlewareDir = resolveProjectPath(project.root, project.middlewareDir);
+  const serverDir = resolveProjectPath(project.root, project.serverDir);
+  const apiDir = resolveProjectPath(project.root, project.apiDir);
+  const pagesDir = project.pagesDir ? resolveProjectPath(project.root, project.pagesDir) : null;
+
+  return files.filter((file) => {
+    if (CONFIG_FILE_NAMES.has(basename(file))) return true;
+    if (normalizePath(file) === normalizePath(packageJsonPath)) return true;
+    if (project.mode === "manifest" && normalizePath(file) === normalizePath(appFile)) return true;
+    if (isWithinDirectory(file, routesDir) && MODULE_SOURCE_RE.test(file)) return true;
+    if (isWithinDirectory(file, shellsDir) && MODULE_SOURCE_RE.test(file)) return true;
+    if (isWithinDirectory(file, middlewareDir) && MODULE_SOURCE_RE.test(file)) return true;
+    if (isWithinDirectory(file, serverDir) && MODULE_SOURCE_RE.test(file)) return true;
+    if (isWithinDirectory(file, apiDir) && MODULE_SOURCE_RE.test(file)) return true;
+    if (pagesDir && isWithinDirectory(file, pagesDir) && PAGE_SOURCE_RE.test(file)) return true;
+    return false;
+  });
+}
+
+function requiresFullVerification(project, changedFiles) {
+  const packageJsonPath = resolve(project.root, "package.json");
+  const appFile = resolveProjectPath(project.root, project.appFile);
+
+  return changedFiles.some((file) => {
+    const normalized = normalizePath(file);
+    if (CONFIG_FILE_NAMES.has(basename(file))) return true;
+    if (normalized === normalizePath(packageJsonPath)) return true;
+    if (project.mode === "manifest" && normalized === normalizePath(appFile)) return true;
+    return false;
+  });
+}
+
+function scanPagesDirectory(pagesDir) {
+  return listFilesRecursively(pagesDir)
+    .filter((file) => PAGE_SOURCE_RE.test(file))
+    .map((file) => describePagesFile(pagesDir, file));
+}
+
+function describePagesFile(pagesDir, file) {
+  const relativePath = relative(pagesDir, file).replace(/\\/g, "/");
+  const routePath = relativePath.replace(/\.(tsx?|jsx?|mdx?)$/, "");
+  const name = basename(routePath);
+
+  if (hasPagesAppShell(file)) {
+    return { file, kind: "shell" };
+  }
+
+  if (name.startsWith("_")) {
+    return { file, kind: "ignored" };
+  }
+
+  if (routePath === "index") {
+    return { file, kind: "route", routePath: "/" };
+  }
+
+  const withoutIndex = routePath.replace(/\/index$/, "");
+  const normalized = withoutIndex
+    .replace(/\[\.\.\.([^\]]+)\]/g, "*")
+    .replace(/\[([^\].]+)\]/g, ":$1");
+
+  return {
+    file,
+    kind: "route",
+    routePath: normalizeRoutePath(`/${normalized}`),
+  };
+}
+
+function collectDuplicateRoutePaths(routes) {
+  const routeMap = new Map();
+
+  for (const route of routes) {
+    const files = routeMap.get(route.routePath) ?? [];
+    files.push(route.file);
+    routeMap.set(route.routePath, files);
+  }
+
+  return [...routeMap.entries()]
+    .filter(([, files]) => files.length > 1)
+    .map(([path, files]) => ({ files, path }));
+}
+
+function resolveApiRoutePath(apiDir, file) {
+  let relativePath = relative(apiDir, file).replace(/\\/g, "/");
+  relativePath = relativePath.replace(/\.(ts|tsx|js|jsx)$/, "");
+
+  if (relativePath === "index") {
+    relativePath = "";
+  } else {
+    relativePath = relativePath.replace(/\/index$/, "");
+  }
+
+  relativePath = relativePath.replace(/\[([^\]]+)\]/g, ":$1");
+
+  return normalizeRoutePath(relativePath ? `/api/${relativePath}` : "/api");
+}
+
+function toModuleSpecifier(fromDir, filePath) {
+  const relativePath = relative(fromDir, filePath).replace(/\\/g, "/");
+  if (relativePath.startsWith(".")) {
+    return relativePath;
+  }
+  return `./${relativePath}`;
+}
+
+function normalizeRoutePath(path) {
+  if (!path || path === "/") {
+    return "/";
+  }
+
+  const withLeadingSlash = path.startsWith("/") ? path : `/${path}`;
+  const collapsed = withLeadingSlash.replace(/\/{2,}/g, "/");
+  return collapsed.length > 1 && collapsed.endsWith("/") ? collapsed.slice(0, -1) : collapsed;
+}
+
+function isWithinDirectory(filePath, directoryPath) {
+  const relativePath = relative(directoryPath, filePath);
+  return relativePath === "" || (!relativePath.startsWith("..") && !relativePath.startsWith("../"));
+}
+
+function normalizePath(value) {
+  return value.replace(/\\/g, "/");
+}
+
+function createCheck(status, message) {
+  return { message, status };
+}

--- a/packages/cli/test/pracht-cli.test.js
+++ b/packages/cli/test/pracht-cli.test.js
@@ -150,6 +150,122 @@ export const app = defineApp({
     expect(report.checks.some((check) => check.message.includes("missing files"))).toBe(true);
   });
 
+  it("reports a healthy manifest app in verify json output", () => {
+    const appDir = createTempDir("pracht-cli-verify-ok-");
+    writeManifestApp(appDir, {
+      routesSource: `import { defineApp, route } from "@pracht/core";
+
+export const app = defineApp({
+  routes: [route("/dashboard", "./routes/dashboard.tsx", { id: "dashboard", render: "ssr" })],
+});
+`,
+    });
+
+    writeProjectFile(
+      appDir,
+      "src/routes/dashboard.tsx",
+      `export function Component() {
+  return <h1>Dashboard</h1>;
+}
+`,
+    );
+    writeProjectFile(
+      appDir,
+      "src/api/health.ts",
+      `export function GET() {
+  return new Response("ok");
+}
+`,
+    );
+
+    const result = runCli(["verify", "--json"], { cwd: appDir });
+    const report = JSON.parse(result.stdout);
+
+    expect(report.ok).toBe(true);
+    expect(report.scope).toBe("full");
+    expect(report.checks.some((check) => check.message.includes("manifest module path"))).toBe(
+      true,
+    );
+    expect(report.checks.some((check) => check.message.includes("API route discovery"))).toBe(true);
+  });
+
+  it("reports duplicate API discovery failures in verify json output", () => {
+    const appDir = createTempDir("pracht-cli-verify-api-dupe-");
+    writeManifestApp(appDir);
+
+    writeProjectFile(
+      appDir,
+      "src/api/users.ts",
+      `export function GET() {
+  return new Response("users");
+}
+`,
+    );
+    writeProjectFile(
+      appDir,
+      "src/api/users/index.ts",
+      `export function GET() {
+  return new Response("users-index");
+}
+`,
+    );
+
+    const result = runCliStatus(["verify", "--json"], { cwd: appDir });
+    expect(result.status).toBe(1);
+
+    const report = JSON.parse(result.stdout);
+    expect(report.ok).toBe(false);
+    expect(report.checks.some((check) => check.message.includes("duplicate paths"))).toBe(true);
+  });
+
+  it("limits verify --changed to changed framework files", () => {
+    const appDir = createTempDir("pracht-cli-verify-changed-");
+    writeManifestApp(appDir, {
+      routesSource: `import { defineApp, route } from "@pracht/core";
+
+export const app = defineApp({
+  routes: [route("/dashboard", "./routes/dashboard.tsx", { id: "dashboard", render: "ssr" })],
+});
+`,
+    });
+
+    writeProjectFile(
+      appDir,
+      "src/routes/dashboard.tsx",
+      `export function Component() {
+  return <h1>Dashboard</h1>;
+}
+`,
+    );
+
+    initializeGitRepo(appDir);
+
+    writeProjectFile(
+      appDir,
+      "src/routes/dashboard.tsx",
+      `export function Component() {
+  return <h1>Updated dashboard</h1>;
+}
+`,
+    );
+    writeProjectFile(appDir, "notes.txt", "ignored");
+
+    const result = runCli(["verify", "--changed", "--json"], { cwd: appDir });
+    const report = JSON.parse(result.stdout);
+
+    expect(report.ok).toBe(true);
+    expect(report.scope).toBe("changed");
+    expect(report.frameworkFiles).toContain("src/routes/dashboard.tsx");
+    expect(report.frameworkFiles).not.toContain("notes.txt");
+    expect(
+      report.checks.some(
+        (check) =>
+          check.message.includes("Changed route module") &&
+          check.message.includes("src/routes/dashboard.tsx"),
+      ),
+    ).toBe(true);
+  });
+
   it("scaffolds pages-router routes without touching a manifest", () => {
     const appDir = createTempDir("pracht-cli-pages-");
     writePagesApp(appDir);
@@ -190,6 +306,34 @@ function runCliStatus(args, { cwd }) {
     cwd,
     encoding: "utf-8",
     env: process.env,
+  });
+}
+
+function initializeGitRepo(appDir) {
+  execFileSync("git", ["init"], {
+    cwd: appDir,
+    env: process.env,
+    stdio: "ignore",
+  });
+  execFileSync("git", ["config", "user.email", "test@example.com"], {
+    cwd: appDir,
+    env: process.env,
+    stdio: "ignore",
+  });
+  execFileSync("git", ["config", "user.name", "Pracht Tests"], {
+    cwd: appDir,
+    env: process.env,
+    stdio: "ignore",
+  });
+  execFileSync("git", ["add", "."], {
+    cwd: appDir,
+    env: process.env,
+    stdio: "ignore",
+  });
+  execFileSync("git", ["commit", "-m", "initial"], {
+    cwd: appDir,
+    env: process.env,
+    stdio: "ignore",
   });
 }
 

--- a/skills/debug/SKILL.md
+++ b/skills/debug/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: debug
-version: 1.0.0
+version: 1.1.0
 description: |
   Pracht framework-aware debugging. Systematically investigates route matching,
   loader/action errors, rendering issues, middleware, API routes, HMR, and build
@@ -25,7 +25,7 @@ Framework-aware debugging for pracht applications — a full-stack Preact framew
 
 The user will describe a symptom (error, unexpected behavior, blank page, etc.). Investigate systematically using the checklist below, stopping when you find the root cause.
 
-Before deep manual inspection, prefer running `pracht doctor` when the problem could be caused by broken app wiring or missing files.
+Before deep manual inspection, prefer running `pracht verify` for a fast agent loop or `pracht doctor` when the problem could be caused by broader broken app wiring or missing files.
 
 ## Iron Law
 
@@ -37,7 +37,8 @@ Work through these in order, stopping when you find the root cause:
 
 ### 1. Route matching
 
-- Run `pracht doctor` first if the route might be missing, miswired, or pointing at a missing module.
+- Run `pracht verify` first if you want a cheap changed-file confidence check.
+- Run `pracht doctor` if the route might be missing, miswired, or pointing at a missing module across the project.
 - Read `src/routes.ts` — is the route defined? Is the path correct?
 - Check for typos in file paths (the manifest uses relative paths like `"./routes/home.tsx"`).
 - For dynamic segments, verify bracket syntax: `route("/users/:id", ...)` in manifest, `[id].ts` in filenames.
@@ -117,7 +118,7 @@ Work through these in order, stopping when you find the root cause:
 1. Always read the relevant source files before diagnosing.
 2. Start with the most likely cause based on the symptom, not a full audit.
 3. When you find the root cause, explain _why_ it breaks and fix it.
-4. If wiring looks suspicious, run `pracht doctor`. If running the dev server or tests would help, do so (`pracht dev`, `pnpm test`, `pnpm e2e`).
+4. If wiring looks suspicious, run `pracht verify` first, then `pracht doctor` if you need the full-project view. If running the dev server or tests would help, do so (`pracht dev`, `pnpm test`, `pnpm e2e`).
 5. After fixing, verify the fix works (run relevant test or check dev server output).
 6. Never say "this should fix it." Verify and prove it.
 


### PR DESCRIPTION
## Summary

- Add `pracht verify` with `--changed` and `--json` for fast framework-aware manifest, pages-router, and API route validation.
- Refactor `pracht doctor` to reuse the shared verification engine and expand registry parsing for `() => import(...)` entries.
- Closes #47.

## Testing

- [x] `pnpm e2e`
- [x] `pnpm format`
- [x] `pnpm lint`
- [x] `pnpm test`

## Checklist

- [x] Docs updated if needed
- [x] Skills updated if needed
- [x] Changeset added if published packages changed
