### PR TITLE
Add structured runtime diagnostics

### DIFF
--- a/.changeset/structured-runtime-diagnostics.md
+++ b/.changeset/structured-runtime-diagnostics.md
@@ -1,0 +1,10 @@
+---
+"@pracht/core": patch
+---
+
+Add structured runtime diagnostics to debug route-state, SSR, and API failures.
+
+`handlePrachtRequest()` now catches middleware and API exceptions earlier in the
+pipeline and, when `debugErrors: true` is enabled, serializes framework
+diagnostics such as the failure phase, matched route metadata, and relevant
+module files alongside the normalized error payload.

--- a/docs/DATA_LOADING.md
+++ b/docs/DATA_LOADING.md
@@ -78,7 +78,10 @@ Unexpected 5xx errors are sanitized by default in both SSR HTML and
 Throw `PrachtHttpError` for expected client-facing failures; 4xx messages stay
 intact. If you need raw server error details while debugging, pass
 `debugErrors: true` to `handlePrachtRequest()`. `@pracht/core` does not infer
-this from `NODE_ENV` or other environment variables.
+this from `NODE_ENV` or other environment variables. When debug errors are
+enabled, serialized route and API failures also include `error.diagnostics`
+with framework metadata such as `phase`, `routeId`, `routePath`, `routeFile`,
+`loaderFile`, `shellFile`, `middlewareFiles`, and `status`.
 
 ---
 

--- a/packages/framework/README.md
+++ b/packages/framework/README.md
@@ -25,7 +25,8 @@ npm install @pracht/core preact preact-render-to-string
 messages do not leak into SSR HTML or route-state JSON. Explicit
 `PrachtHttpError` 4xx messages are preserved. Pass `debugErrors: true` to expose
 raw details intentionally during debugging; `@pracht/core` does not infer this
-from environment variables.
+from environment variables. Debug responses also attach `error.diagnostics`
+metadata for the failure phase and matched framework files when available.
 
 ### Client
 

--- a/packages/framework/src/index.ts
+++ b/packages/framework/src/index.ts
@@ -76,9 +76,13 @@ export type {
   HandlePrachtRequestOptions,
   ISGManifestEntry,
   Location,
+  PrachtRuntimeDiagnosticPhase,
+  PrachtRuntimeDiagnostics,
   PrerenderAppOptions,
   PrerenderAppResult,
   PrerenderResult,
+  RouteStateResult,
+  SerializedRouteError,
   StartAppOptions,
   PrachtHydrationState,
 } from "./runtime.ts";

--- a/packages/framework/src/router.ts
+++ b/packages/framework/src/router.ts
@@ -410,6 +410,11 @@ function appendHydrationWarning(message: string): void {
 function deserializeRouteError(error: SerializedRouteError): Error {
   const result = new Error(error.message);
   result.name = error.name;
-  (result as Error & { status?: number }).status = error.status;
+  (
+    result as Error & { diagnostics?: SerializedRouteError["diagnostics"]; status?: number }
+  ).status = error.status;
+  (
+    result as Error & { diagnostics?: SerializedRouteError["diagnostics"]; status?: number }
+  ).diagnostics = error.diagnostics;
   return result;
 }

--- a/packages/framework/src/runtime.ts
+++ b/packages/framework/src/runtime.ts
@@ -21,6 +21,25 @@ import type {
   PrachtApp,
 } from "./types.ts";
 
+export type PrachtRuntimeDiagnosticPhase =
+  | "match"
+  | "middleware"
+  | "loader"
+  | "action"
+  | "render"
+  | "api";
+
+export interface PrachtRuntimeDiagnostics {
+  phase: PrachtRuntimeDiagnosticPhase;
+  routeId?: string;
+  routePath?: string;
+  routeFile?: string;
+  loaderFile?: string;
+  shellFile?: string;
+  middlewareFiles?: string[];
+  status: number;
+}
+
 export interface PrachtHydrationState<TData = unknown> {
   url: string;
   routeId: string;
@@ -33,6 +52,7 @@ export interface SerializedRouteError {
   message: string;
   name: string;
   status: number;
+  diagnostics?: PrachtRuntimeDiagnostics;
 }
 
 export interface StartAppOptions<TData = unknown> {
@@ -72,6 +92,8 @@ const SAFE_METHODS = new Set(["GET", "HEAD"]);
 const HYDRATION_STATE_ELEMENT_ID = "pracht-state";
 const ROUTE_STATE_REQUEST_HEADER = "x-pracht-route-state-request";
 const ROUTE_STATE_CACHE_CONTROL = "no-store";
+
+type DiagnosticRoute = ResolvedRoute | ResolvedApiRoute;
 
 interface PrachtRuntimeValue {
   data: unknown;
@@ -291,6 +313,8 @@ export async function handlePrachtRequest<TContext>(
 ): Promise<Response> {
   const url = new URL(options.request.url);
   const registry = options.registry ?? {};
+  const isRouteStateRequest = options.request.headers.get(ROUTE_STATE_REQUEST_HEADER) === "1";
+  const exposeDiagnostics = shouldExposeServerErrors(options);
 
   // --- API route dispatch (before page routes) ---
   if (options.apiRoutes?.length) {
@@ -300,61 +324,83 @@ export async function handlePrachtRequest<TContext>(
         const middlewareFile = options.app.middleware[name];
         return middlewareFile ? [middlewareFile] : [];
       });
-      const middlewareResult = await runMiddlewareChain({
-        context: (options.context ?? {}) as TContext,
-        middlewareFiles: apiMiddlewareFiles,
-        params: apiMatch.params,
-        registry,
-        request: options.request,
-        route: apiMatch.route,
-        url,
-      });
-      if (middlewareResult.response) {
-        return middlewareResult.response;
-      }
+      let currentPhase: PrachtRuntimeDiagnosticPhase = "middleware";
 
-      const apiModule = await resolveRegistryModule<ApiRouteModule>(
-        registry.apiModules,
-        apiMatch.route.file,
-      );
-
-      if (!apiModule) {
-        return withDefaultSecurityHeaders(
-          new Response("API route module not found", {
-            status: 500,
-            headers: { "content-type": "text/plain; charset=utf-8" },
-          }),
-        );
-      }
-
-      const method = options.request.method.toUpperCase() as HttpMethod;
-      const handler = apiModule[method];
-
-      if (!handler) {
-        return withDefaultSecurityHeaders(
-          new Response("Method not allowed", {
-            status: 405,
-            headers: { "content-type": "text/plain; charset=utf-8" },
-          }),
-        );
-      }
-
-      return withDefaultSecurityHeaders(
-        await handler({
-          request: options.request,
+      try {
+        const middlewareResult = await runMiddlewareChain({
+          context: (options.context ?? {}) as TContext,
+          middlewareFiles: apiMiddlewareFiles,
           params: apiMatch.params,
-          context: middlewareResult.context,
-          signal: AbortSignal.timeout(30_000),
+          registry,
+          request: options.request,
+          route: apiMatch.route,
           url,
-          route: apiMatch.route as any,
-        }),
-      );
+        });
+        if (middlewareResult.response) {
+          return middlewareResult.response;
+        }
+
+        currentPhase = "api";
+        const apiModule = await resolveRegistryModule<ApiRouteModule>(
+          registry.apiModules,
+          apiMatch.route.file,
+        );
+
+        if (!apiModule) {
+          throw new Error("API route module not found");
+        }
+
+        const method = options.request.method.toUpperCase() as HttpMethod;
+        const handler = apiModule[method];
+
+        if (!handler) {
+          return withDefaultSecurityHeaders(
+            new Response("Method not allowed", {
+              status: 405,
+              headers: { "content-type": "text/plain; charset=utf-8" },
+            }),
+          );
+        }
+
+        return withDefaultSecurityHeaders(
+          await handler({
+            request: options.request,
+            params: apiMatch.params,
+            context: middlewareResult.context,
+            signal: AbortSignal.timeout(30_000),
+            url,
+            route: apiMatch.route as any,
+          }),
+        );
+      } catch (error: unknown) {
+        return renderApiErrorResponse({
+          error,
+          middlewareFiles: apiMiddlewareFiles,
+          options,
+          phase: currentPhase,
+          route: apiMatch.route,
+        });
+      }
     }
   }
 
   const match = matchAppRoute(options.app, url.pathname);
 
   if (!match) {
+    if (isRouteStateRequest) {
+      return jsonErrorResponse(
+        createSerializedRouteError("Not found", 404, {
+          diagnostics: exposeDiagnostics
+            ? buildRuntimeDiagnostics({
+                phase: "match",
+                status: 404,
+              })
+            : undefined,
+          name: "Error",
+        }),
+      );
+    }
+
     return withDefaultSecurityHeaders(
       new Response("Not found", {
         status: 404,
@@ -363,9 +409,24 @@ export async function handlePrachtRequest<TContext>(
     );
   }
 
-  const isRouteStateRequest = options.request.headers.get(ROUTE_STATE_REQUEST_HEADER) === "1";
-
   if (!SAFE_METHODS.has(options.request.method)) {
+    if (isRouteStateRequest) {
+      return jsonErrorResponse(
+        createSerializedRouteError("Method not allowed", 405, {
+          diagnostics: exposeDiagnostics
+            ? buildRuntimeDiagnostics({
+                middlewareFiles: match.route.middlewareFiles,
+                phase: "action",
+                route: match.route,
+                shellFile: match.route.shellFile,
+                status: 405,
+              })
+            : undefined,
+          name: "Error",
+        }),
+      );
+    }
+
     return withRouteResponseHeaders(
       new Response("Method not allowed", {
         status: 405,
@@ -375,42 +436,55 @@ export async function handlePrachtRequest<TContext>(
     );
   }
 
-  // --- Middleware chain ---
-  const middlewareResult = await runMiddlewareChain({
+  let routeArgs: BaseRouteArgs<TContext> = {
+    request: options.request,
+    params: match.params,
     context: (options.context ?? {}) as TContext,
-    middlewareFiles: match.route.middlewareFiles,
-    params: match.params,
-    registry,
-    request: options.request,
-    route: match.route,
-    url,
-  });
-  if (middlewareResult.response) {
-    return withRouteResponseHeaders(middlewareResult.response, { isRouteStateRequest });
-  }
-  const context = middlewareResult.context;
-
-  // --- Load route module ---
-  const routeModule = await resolveRegistryModule<RouteModule>(
-    registry.routeModules,
-    match.route.file,
-  );
-
-  const routeArgs: BaseRouteArgs<TContext> = {
-    request: options.request,
-    params: match.params,
-    context,
     signal: AbortSignal.timeout(30_000),
     url,
     route: match.route,
   };
-
-  // --- Resolve loader from separate data module or route module ---
-  const { loader } = await resolveDataFunctions(match.route, routeModule, registry);
-
+  let routeModule: RouteModule | undefined;
   let shellModule: ShellModule | undefined;
+  let loaderFile: string | undefined;
+  let currentPhase: PrachtRuntimeDiagnosticPhase = "middleware";
 
   try {
+    // --- Middleware chain ---
+    const middlewareResult = await runMiddlewareChain({
+      context: routeArgs.context,
+      middlewareFiles: match.route.middlewareFiles,
+      params: match.params,
+      registry,
+      request: options.request,
+      route: match.route,
+      url,
+    });
+    if (middlewareResult.response) {
+      return withRouteResponseHeaders(middlewareResult.response, { isRouteStateRequest });
+    }
+
+    routeArgs = {
+      ...routeArgs,
+      context: middlewareResult.context,
+    };
+
+    // --- Load route module ---
+    currentPhase = "render";
+    routeModule = await resolveRegistryModule<RouteModule>(registry.routeModules, match.route.file);
+    if (!routeModule) {
+      throw new Error("Route module not found");
+    }
+
+    // --- Resolve loader from separate data module or route module ---
+    currentPhase = "loader";
+    const { loader, loaderFile: resolvedLoaderFile } = await resolveDataFunctions(
+      match.route,
+      routeModule,
+      registry,
+    );
+    loaderFile = resolvedLoaderFile;
+
     // --- Execute loader ---
     const loaderResult = loader ? await loader(routeArgs) : undefined;
 
@@ -427,6 +501,7 @@ export async function handlePrachtRequest<TContext>(
     }
 
     // --- Load shell module ---
+    currentPhase = "render";
     shellModule = match.route.shellFile
       ? await resolveRegistryModule<ShellModule>(registry.shellModules, match.route.shellFile)
       : undefined;
@@ -476,14 +551,8 @@ export async function handlePrachtRequest<TContext>(
     }
 
     // --- SSR / SSG / ISG: render Preact tree to string ---
-    if (!routeModule?.Component) {
-      return withRouteResponseHeaders(
-        new Response("Route has no Component export", {
-          status: 500,
-          headers: { "content-type": "text/plain; charset=utf-8" },
-        }),
-        { isRouteStateRequest },
-      );
+    if (!routeModule.Component) {
+      throw new Error("Route has no Component export");
     }
 
     const { renderToStringAsync } = await import("preact-render-to-string");
@@ -527,7 +596,9 @@ export async function handlePrachtRequest<TContext>(
     return renderRouteErrorResponse({
       error,
       isRouteStateRequest,
+      loaderFile,
       options,
+      phase: currentPhase,
       routeArgs,
       routeId: match.route.id ?? "",
       routeModule,
@@ -621,6 +692,45 @@ function shouldExposeServerErrors(options: HandlePrachtRequestOptions<unknown>):
   return options.debugErrors === true;
 }
 
+function createSerializedRouteError(
+  message: string,
+  status: number,
+  options: {
+    diagnostics?: PrachtRuntimeDiagnostics;
+    name?: string;
+  } = {},
+): SerializedRouteError {
+  return {
+    message,
+    name: options.name ?? "Error",
+    status,
+    ...(options.diagnostics ? { diagnostics: options.diagnostics } : {}),
+  };
+}
+
+function buildRuntimeDiagnostics(options: {
+  middlewareFiles?: string[];
+  phase: PrachtRuntimeDiagnosticPhase;
+  route?: DiagnosticRoute;
+  loaderFile?: string;
+  shellFile?: string;
+  status: number;
+}): PrachtRuntimeDiagnostics {
+  const route = options.route;
+  const routeId = route && "id" in route ? route.id : undefined;
+
+  return {
+    phase: options.phase,
+    routeId,
+    routePath: route?.path,
+    routeFile: route?.file,
+    loaderFile: options.loaderFile,
+    shellFile: options.shellFile,
+    middlewareFiles: options.middlewareFiles ? [...options.middlewareFiles] : [],
+    status: options.status,
+  };
+}
+
 function normalizeRouteError(
   error: unknown,
   options: { exposeDetails: boolean },
@@ -684,14 +794,72 @@ function normalizeRouteError(
 function deserializeRouteError(error: SerializedRouteError): Error {
   const result = new Error(error.message);
   result.name = error.name;
-  (result as Error & { status?: number }).status = error.status;
+  (result as Error & { diagnostics?: PrachtRuntimeDiagnostics; status?: number }).status =
+    error.status;
+  (result as Error & { diagnostics?: PrachtRuntimeDiagnostics; status?: number }).diagnostics =
+    error.diagnostics;
   return result;
+}
+
+function jsonErrorResponse(
+  routeError: SerializedRouteError,
+  options: { isRouteStateRequest: boolean },
+): Response {
+  const response = new Response(JSON.stringify({ error: routeError }), {
+    status: routeError.status,
+    headers: { "content-type": "application/json; charset=utf-8" },
+  });
+
+  return options.isRouteStateRequest
+    ? withRouteResponseHeaders(response, { isRouteStateRequest: true })
+    : withDefaultSecurityHeaders(response);
+}
+
+function renderApiErrorResponse<TContext>(options: {
+  error: unknown;
+  middlewareFiles: string[];
+  options: HandlePrachtRequestOptions<TContext>;
+  phase: PrachtRuntimeDiagnosticPhase;
+  route: ResolvedApiRoute;
+}): Response {
+  const exposeDetails = shouldExposeServerErrors(options.options);
+  const routeError = normalizeRouteError(options.error, {
+    exposeDetails,
+  });
+  const routeErrorWithDiagnostics = exposeDetails
+    ? {
+        ...routeError,
+        diagnostics: buildRuntimeDiagnostics({
+          middlewareFiles: options.middlewareFiles,
+          phase: options.phase,
+          route: options.route,
+          status: routeError.status,
+        }),
+      }
+    : routeError;
+
+  if (exposeDetails) {
+    return jsonErrorResponse(routeErrorWithDiagnostics, { isRouteStateRequest: false });
+  }
+
+  const message =
+    routeErrorWithDiagnostics.status >= 500
+      ? "Internal Server Error"
+      : routeErrorWithDiagnostics.message;
+  return withDefaultSecurityHeaders(
+    new Response(message, {
+      status: routeErrorWithDiagnostics.status,
+      headers: { "content-type": "text/plain; charset=utf-8" },
+    }),
+  );
 }
 
 async function renderRouteErrorResponse<TContext>(options: {
   error: unknown;
   isRouteStateRequest: boolean;
+  loaderFile: string | undefined;
   options: HandlePrachtRequestOptions<TContext>;
+  phase: PrachtRuntimeDiagnosticPhase;
   routeArgs: BaseRouteArgs<TContext>;
   routeId: string;
   routeModule: RouteModule | undefined;
@@ -699,38 +867,43 @@ async function renderRouteErrorResponse<TContext>(options: {
   shellModule: ShellModule | undefined;
   urlPathname: string;
 }): Promise<Response> {
+  const exposeDetails = shouldExposeServerErrors(options.options);
   const routeError = normalizeRouteError(options.error, {
-    exposeDetails: shouldExposeServerErrors(options.options),
+    exposeDetails,
   });
+  const routeErrorWithDiagnostics = exposeDetails
+    ? {
+        ...routeError,
+        diagnostics: buildRuntimeDiagnostics({
+          loaderFile: options.loaderFile,
+          middlewareFiles: options.routeArgs.route.middlewareFiles,
+          phase: options.phase,
+          route: options.routeArgs.route,
+          shellFile: options.shellFile,
+          status: routeError.status,
+        }),
+      }
+    : routeError;
 
   if (!options.routeModule?.ErrorBoundary) {
     if (options.isRouteStateRequest) {
-      return withRouteResponseHeaders(
-        new Response(JSON.stringify({ error: routeError }), {
-          status: routeError.status,
-          headers: { "content-type": "application/json; charset=utf-8" },
-        }),
-        { isRouteStateRequest: true },
-      );
+      return jsonErrorResponse(routeErrorWithDiagnostics, { isRouteStateRequest: true });
     }
 
-    const message = routeError.status >= 500 ? "Internal Server Error" : routeError.message;
+    const message =
+      routeErrorWithDiagnostics.status >= 500
+        ? "Internal Server Error"
+        : routeErrorWithDiagnostics.message;
     return withDefaultSecurityHeaders(
       new Response(message, {
-        status: routeError.status,
+        status: routeErrorWithDiagnostics.status,
         headers: { "content-type": "text/plain; charset=utf-8" },
       }),
     );
   }
 
   if (options.isRouteStateRequest) {
-    return withRouteResponseHeaders(
-      new Response(JSON.stringify({ error: routeError }), {
-        status: routeError.status,
-        headers: { "content-type": "application/json; charset=utf-8" },
-      }),
-      { isRouteStateRequest: true },
-    );
+    return jsonErrorResponse(routeErrorWithDiagnostics, { isRouteStateRequest: true });
   }
 
   const shellModule =
@@ -756,7 +929,7 @@ async function renderRouteErrorResponse<TContext>(options: {
 
   const ErrorBoundary = options.routeModule.ErrorBoundary as any;
   const Shell = shellModule?.Shell;
-  const errorValue = deserializeRouteError(routeError);
+  const errorValue = deserializeRouteError(routeErrorWithDiagnostics);
   const componentTree = Shell
     ? h(Shell, null, h(ErrorBoundary, { error: errorValue }))
     : h(ErrorBoundary, { error: errorValue });
@@ -779,13 +952,13 @@ async function renderRouteErrorResponse<TContext>(options: {
         url: options.urlPathname,
         routeId: options.routeId,
         data: null,
-        error: routeError,
+        error: routeErrorWithDiagnostics,
       },
       clientEntryUrl: options.options.clientEntryUrl,
       cssUrls,
       modulePreloadUrls,
     }),
-    routeError.status,
+    routeErrorWithDiagnostics.status,
   );
 }
 
@@ -844,18 +1017,22 @@ async function resolveDataFunctions(
   route: ResolvedRoute,
   routeModule: RouteModule | undefined,
   registry: ModuleRegistry,
-): Promise<{ loader: RouteModule["loader"] }> {
+): Promise<{ loader: RouteModule["loader"]; loaderFile?: string }> {
   let loader = routeModule?.loader;
+  let loaderFile = routeModule?.loader ? route.file : undefined;
 
   if (route.loaderFile) {
     const dataModule = await resolveRegistryModule<DataModule>(
       registry.dataModules,
       route.loaderFile,
     );
-    if (dataModule?.loader) loader = dataModule.loader;
+    if (dataModule?.loader) {
+      loader = dataModule.loader;
+      loaderFile = route.loaderFile;
+    }
   }
 
-  return { loader };
+  return { loader, loaderFile };
 }
 
 async function resolveRegistryModule<T>(

--- a/packages/framework/src/runtime.ts
+++ b/packages/framework/src/runtime.ts
@@ -398,6 +398,7 @@ export async function handlePrachtRequest<TContext>(
             : undefined,
           name: "Error",
         }),
+        { isRouteStateRequest: true },
       );
     }
 
@@ -424,6 +425,7 @@ export async function handlePrachtRequest<TContext>(
             : undefined,
           name: "Error",
         }),
+        { isRouteStateRequest: true },
       );
     }
 

--- a/packages/framework/test/runtime.test.ts
+++ b/packages/framework/test/runtime.test.ts
@@ -10,6 +10,24 @@ import {
   useParams,
 } from "../src/index.ts";
 
+function parseHydrationState(html: string) {
+  const match = html.match(
+    /<script id="pracht-state" type="application\/json">([\s\S]*?)<\/script>/,
+  );
+  if (!match) {
+    throw new Error("Hydration state script not found");
+  }
+
+  return JSON.parse(match[1]) as {
+    error?: {
+      diagnostics?: Record<string, unknown>;
+      message: string;
+      name: string;
+      status: number;
+    } | null;
+  };
+}
+
 describe("handlePrachtRequest rejects non-GET on page routes", () => {
   it("returns 405 for POST to a page route", async () => {
     const app = defineApp({
@@ -68,6 +86,46 @@ describe("handlePrachtRequest API middleware", () => {
 
     expect(response.status).toBe(200);
     await expect(response.json()).resolves.toEqual({ allowed: true });
+  });
+});
+
+describe("handlePrachtRequest API errors", () => {
+  it("returns structured api diagnostics when debugErrors is enabled", async () => {
+    const app = defineApp({
+      routes: [route("/", "./routes/home.tsx")],
+    });
+
+    const response = await handlePrachtRequest({
+      apiRoutes: resolveApiRoutes(["/src/api/health.ts"]),
+      app,
+      debugErrors: true,
+      registry: {
+        apiModules: {
+          "/src/api/health.ts": async () => ({
+            GET: async () => {
+              throw new Error("api exploded");
+            },
+          }),
+        },
+      },
+      request: new Request("http://localhost/api/health"),
+    });
+
+    expect(response.status).toBe(500);
+    await expect(response.json()).resolves.toEqual({
+      error: {
+        diagnostics: {
+          middlewareFiles: [],
+          phase: "api",
+          routeFile: "/src/api/health.ts",
+          routePath: "/api/health",
+          status: 500,
+        },
+        message: "api exploded",
+        name: "Error",
+        status: 500,
+      },
+    });
   });
 });
 
@@ -400,6 +458,126 @@ describe("handlePrachtRequest ErrorBoundary", () => {
     });
   });
 
+  it("includes structured loader diagnostics in debug route-state responses", async () => {
+    const app = defineApp({
+      middleware: {
+        auth: "./middleware/auth.ts",
+      },
+      shells: {
+        blog: "./shells/blog.tsx",
+      },
+      routes: [
+        route("/posts/:slug", {
+          component: "./routes/post.tsx",
+          id: "post-show",
+          loader: "./server/post-loader.ts",
+          middleware: ["auth"],
+          render: "ssr",
+          shell: "blog",
+        }),
+      ],
+    });
+
+    const response = await handlePrachtRequest({
+      app,
+      debugErrors: true,
+      registry: {
+        dataModules: {
+          "./server/post-loader.ts": async () => ({
+            loader: async () => {
+              throw new Error("loader exploded");
+            },
+          }),
+        },
+        middlewareModules: {
+          "./middleware/auth.ts": async () => ({
+            middleware: async () => ({ context: { user: "jovi" } }),
+          }),
+        },
+        routeModules: {
+          "./routes/post.tsx": async () => ({
+            Component: () => h("main", null, "post"),
+          }),
+        },
+      },
+      request: new Request("http://localhost/posts/missing", {
+        headers: {
+          "x-pracht-route-state-request": "1",
+        },
+      }),
+    });
+
+    expect(response.status).toBe(500);
+    await expect(response.json()).resolves.toEqual({
+      error: {
+        diagnostics: {
+          loaderFile: "./server/post-loader.ts",
+          middlewareFiles: ["./middleware/auth.ts"],
+          phase: "loader",
+          routeFile: "./routes/post.tsx",
+          routeId: "post-show",
+          routePath: "/posts/:slug",
+          shellFile: "./shells/blog.tsx",
+          status: 500,
+        },
+        message: "loader exploded",
+        name: "Error",
+        status: 500,
+      },
+    });
+  });
+
+  it("catches middleware failures and serializes middleware diagnostics", async () => {
+    const app = defineApp({
+      middleware: {
+        auth: "./middleware/auth.ts",
+      },
+      routes: [
+        route("/posts/:slug", "./routes/post.tsx", {
+          id: "post-show",
+          middleware: ["auth"],
+          render: "ssr",
+        }),
+      ],
+    });
+
+    const response = await handlePrachtRequest({
+      app,
+      debugErrors: true,
+      registry: {
+        middlewareModules: {
+          "./middleware/auth.ts": async () => ({
+            middleware: async () => {
+              throw new Error("auth missing");
+            },
+          }),
+        },
+      },
+      request: new Request("http://localhost/posts/missing", {
+        headers: {
+          "x-pracht-route-state-request": "1",
+        },
+      }),
+    });
+
+    expect(response.status).toBe(500);
+    await expect(response.json()).resolves.toEqual({
+      error: {
+        diagnostics: {
+          middlewareFiles: ["./middleware/auth.ts"],
+          phase: "middleware",
+          routeFile: "./routes/post.tsx",
+          routeId: "post-show",
+          routePath: "/posts/:slug",
+          status: 500,
+        },
+        message: "auth missing",
+        name: "Error",
+        status: 500,
+      },
+    });
+  });
+
   it("sanitizes unexpected 5xx loader failures in route-state responses", async () => {
     const app = defineApp({
       routes: [route("/posts/:slug", "./routes/post.tsx")],
@@ -499,6 +677,15 @@ describe("handlePrachtRequest ErrorBoundary", () => {
     expect(response.status).toBe(500);
     await expect(response.json()).resolves.toEqual({
       error: {
+        diagnostics: {
+          loaderFile: "./routes/post.tsx",
+          middlewareFiles: [],
+          phase: "loader",
+          routeFile: "./routes/post.tsx",
+          routeId: "posts-slug",
+          routePath: "/posts/:slug",
+          status: 500,
+        },
         message: "debug details",
         name: "Error",
         status: 500,
@@ -550,5 +737,62 @@ describe("handlePrachtRequest ErrorBoundary", () => {
         process.env.NODE_ENV = previousNodeEnv;
       }
     }
+  });
+
+  it("stores render diagnostics in SSR hydration state when debugErrors is enabled", async () => {
+    const app = defineApp({
+      shells: {
+        blog: "./shells/blog.tsx",
+      },
+      routes: [
+        route("/posts/:slug", "./routes/post.tsx", {
+          id: "post-show",
+          render: "ssr",
+          shell: "blog",
+        }),
+      ],
+    });
+
+    const response = await handlePrachtRequest({
+      app,
+      debugErrors: true,
+      registry: {
+        routeModules: {
+          "./routes/post.tsx": async () => ({
+            Component: () => h("main", null, "post"),
+            ErrorBoundary: ({ error }) => h("p", null, `Error: ${error.message}`),
+            head: async () => {
+              throw new Error("head exploded");
+            },
+          }),
+        },
+        shellModules: {
+          "./shells/blog.tsx": async () => ({
+            Shell: ({ children }) => h("section", null, children),
+          }),
+        },
+      },
+      request: new Request("http://localhost/posts/missing"),
+    });
+
+    expect(response.status).toBe(500);
+    const html = await response.text();
+    expect(html).toContain("Error: head exploded");
+    expect(parseHydrationState(html)).toMatchObject({
+      error: {
+        diagnostics: {
+          middlewareFiles: [],
+          phase: "render",
+          routeFile: "./routes/post.tsx",
+          routeId: "post-show",
+          routePath: "/posts/:slug",
+          shellFile: "./shells/blog.tsx",
+          status: 500,
+        },
+        message: "head exploded",
+        name: "Error",
+        status: 500,
+      },
+    });
   });
 });


### PR DESCRIPTION
## Summary

- Add structured debug diagnostics to `@pracht/core` route-state, SSR, and API error payloads, including earlier middleware/API failure handling and client-side error deserialization support.
- Add regression tests, docs, and a changeset

Fixes https://github.com/JoviDeCroock/pracht/issues/36.

## Testing

- [x] `pnpm e2e`
- [x] `pnpm format`
- [x] `pnpm lint`
- [x] `pnpm test`

## Checklist

- [x] Docs updated if needed
- N/A (no skills updates were needed)
- [x] Changeset added if published packages changed
