### PR TITLE
Add ability for route modules to use a normal default page export

### DIFF
--- a/.changeset/default-page-exports.md
+++ b/.changeset/default-page-exports.md
@@ -1,0 +1,5 @@
+---
+"@pracht/core": patch
+---
+
+Allow route modules to use a function default export as the page component while preserving named route exports.

--- a/VISION_MVP.md
+++ b/VISION_MVP.md
@@ -128,7 +128,7 @@ SSR and SSG, deployed to Node. Thoroughly tested with Playwright E2E tests.
 
 1. **`packages/framework`** — core exports
    - `defineApp()`, `route()`, `group()` — route manifest API
-   - `RouteModule` type — loader, action, head, Component, errorBoundary
+   - `RouteModule` type — loader, action, head, default/Component, errorBoundary
    - `ShellModule` type — layout wrapper with head contribution
    - `MiddlewareModule` type — server-side request interceptor
    - Router: `matchAppRoute()` segment-based matching

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -109,7 +109,7 @@ export function head({ data }: HeadArgs<typeof loader>) {
 }
 
 // Client + SSR: the page component
-export function Component({ data }: RouteComponentProps<typeof loader>) {
+export default function Dashboard({ data }: RouteComponentProps<typeof loader>) {
   const liveData = useRouteData<typeof loader>();
   return <main>{liveData.user.name}</main>;
 }
@@ -139,10 +139,15 @@ export async function loader({ request }: LoaderArgs) {
 
 ```typescript
 // src/routes/dashboard.tsx — pure component, no server code
-export function Component({ data }: RouteComponentProps) {
+export default function Dashboard({ data }: RouteComponentProps) {
   return <main>{data.user.name}</main>;
 }
 ```
+
+A named `Component` export is also supported for compatibility. Function-valued
+default exports are treated as the page component; named exports such as
+`loader`, `head`, `ErrorBoundary`, and `getStaticPaths` keep their framework
+roles.
 
 Wired in the manifest via the `RouteConfig` object form:
 
@@ -400,7 +405,7 @@ export async function loader({ params }: LoaderArgs) {
 }
 
 // LoaderData<typeof loader> = { title: string; count: number }
-export function Component({ data }: RouteComponentProps<typeof loader>) {
+export default function Page({ data }: RouteComponentProps<typeof loader>) {
   // data.title is string, data.count is number — no manual typing
 }
 ```

--- a/docs/DATA_LOADING.md
+++ b/docs/DATA_LOADING.md
@@ -20,11 +20,15 @@ export async function loader({ request, params, context, signal }: LoaderArgs) {
   return { user, projects };
 }
 
-export function Component({ data }: RouteComponentProps<typeof loader>) {
+export default function Dashboard({ data }: RouteComponentProps<typeof loader>) {
   // data is typed as { user: User; projects: Project[] }
   return <h1>Welcome, {data.user.name}</h1>;
 }
 ```
+
+The route component can be a function default export or a named `Component`
+export. Named route exports such as `loader`, `head`, `ErrorBoundary`, and
+`getStaticPaths` remain separate special exports.
 
 ### LoaderArgs
 

--- a/docs/ROUTING.md
+++ b/docs/ROUTING.md
@@ -282,7 +282,7 @@ Page files can export a `RENDER_MODE` constant to set the rendering strategy:
 // src/pages/about.tsx
 export const RENDER_MODE = "ssg";
 
-export function Component() {
+export default function About() {
   return <div>About us</div>;
 }
 ```

--- a/examples/docs/src/routes/docs/data-loading.md
+++ b/examples/docs/src/routes/docs/data-loading.md
@@ -23,7 +23,7 @@ export async function loader({ request, params, context }: LoaderArgs) {
   return { user, projects };
 }
 
-export function Component({ data }: RouteComponentProps<typeof loader>) {
+export default function Dashboard({ data }: RouteComponentProps<typeof loader>) {
   // data is typed: { user: User; projects: Project[] }
   return (
     <div>
@@ -35,6 +35,10 @@ export function Component({ data }: RouteComponentProps<typeof loader>) {
   );
 }
 ```
+
+The route component can be a function default export or a named `Component`
+export. Named route exports such as `loader`, `head`, `ErrorBoundary`, and
+`getStaticPaths` remain separate special exports.
 
 ### LoaderArgs
 

--- a/packages/framework/README.md
+++ b/packages/framework/README.md
@@ -16,6 +16,10 @@ npm install @pracht/core preact preact-render-to-string
 - `route()` — declare a route with path, component, loader, and rendering mode
 - `group()` — group routes under a shared shell or middleware
 
+Route modules may export the page as a function default export or as a named
+`Component` export. Named exports such as `loader`, `head`, `ErrorBoundary`, and
+`getStaticPaths` keep their special route-module behavior.
+
 ### Server
 
 - `handlePrachtRequest()` — server renderer that produces full HTML with hydration markers

--- a/packages/framework/src/router.ts
+++ b/packages/framework/src/router.ts
@@ -87,7 +87,10 @@ export async function initClientRouter(options: InitClientRouterOptions): Promis
       Shell = resolvedShell.Shell;
     }
 
-    const Component = (state.error ? routeMod.ErrorBoundary : routeMod.Component) as any;
+    const DefaultComponent = typeof routeMod.default === "function" ? routeMod.default : undefined;
+    const Component = (
+      state.error ? routeMod.ErrorBoundary : (routeMod.Component ?? DefaultComponent)
+    ) as any;
     if (!Component) return null;
 
     const props: Record<string, unknown> = state.error

--- a/packages/framework/src/runtime.ts
+++ b/packages/framework/src/runtime.ts
@@ -553,13 +553,15 @@ export async function handlePrachtRequest<TContext>(
     }
 
     // --- SSR / SSG / ISG: render Preact tree to string ---
-    if (!routeModule.Component) {
-      throw new Error("Route has no Component export");
+    const DefaultComponent =
+      typeof routeModule.default === "function" ? routeModule.default : undefined;
+    const Component = (routeModule.Component ?? DefaultComponent) as any;
+    if (!Component) {
+      throw new Error("Route has no Component or default export");
     }
 
     const { renderToStringAsync } = await import("preact-render-to-string");
 
-    const Component = routeModule.Component as any;
     const Shell = shellModule?.Shell;
     const componentProps = { data, params: match.params };
 

--- a/packages/framework/src/types.ts
+++ b/packages/framework/src/types.ts
@@ -217,7 +217,8 @@ export type LoaderFn<TContext = any, TData = unknown> = (
 export interface RouteModule<TContext = any, TLoader extends LoaderLike = undefined> {
   loader?: LoaderFn<TContext>;
   head?: (args: HeadArgs<TLoader, TContext>) => MaybePromise<HeadMetadata>;
-  Component: FunctionComponent<RouteComponentProps<TLoader>>;
+  Component?: FunctionComponent<RouteComponentProps<TLoader>>;
+  default?: FunctionComponent<RouteComponentProps<TLoader>>;
   ErrorBoundary?: FunctionComponent<ErrorBoundaryProps>;
   getStaticPaths?: () => MaybePromise<RouteParams[]>;
 }

--- a/packages/framework/test/runtime.test.ts
+++ b/packages/framework/test/runtime.test.ts
@@ -221,6 +221,31 @@ describe("handlePrachtRequest with separate data modules", () => {
   });
 });
 
+describe("handlePrachtRequest route component exports", () => {
+  it("renders a function default export while preserving named loader exports", async () => {
+    const app = defineApp({
+      routes: [route("/home", "./routes/home.tsx", { render: "ssr" })],
+    });
+
+    const response = await handlePrachtRequest({
+      app,
+      registry: {
+        routeModules: {
+          "./routes/home.tsx": async () => ({
+            default: ({ data }) => h("main", null, `Hello ${(data as any).name}`),
+            loader: async () => ({ name: "default export" }),
+          }),
+        },
+      },
+      request: new Request("http://localhost/home"),
+    });
+
+    expect(response.status).toBe(200);
+    const html = await response.text();
+    expect(html).toContain("Hello default export");
+  });
+});
+
 describe("handlePrachtRequest cache variance", () => {
   it("adds a route-state vary header to HTML responses", async () => {
     const app = defineApp({

--- a/skills/migrate-nextjs/SKILL.md
+++ b/skills/migrate-nextjs/SKILL.md
@@ -192,7 +192,7 @@ export function head({ data }: { data: Awaited<ReturnType<typeof loader>> }) {
   return { title: data.title };
 }
 
-export function Component({ data }: RouteComponentProps<typeof loader>) {
+export default function Page({ data }: RouteComponentProps<typeof loader>) {
   return <div class="page">{data.title}</div>;
 }
 ```
@@ -201,7 +201,7 @@ Key transforms:
 
 - Server-side data fetching → `loader()` export
 - `generateMetadata` → `head()` export
-- `export default function Page` → `export function Component`
+- Keep `export default function Page` as the page component
 - `className` → `class`
 - No `async` components — data comes via props from loader
 


### PR DESCRIPTION
## Summary

This change lets route modules use a normal default page export:

```tsx
export async function loader() {
  return { name: "Ada" };
}

export default function Page({ data }) {
  return <h1>{data.name}</h1>;
}
```

## Testing

- [X] `pnpm e2e`
- [X] `pnpm format`
- [X] `pnpm lint`
- [X] `pnpm test`

## Checklist

- [X] Docs updated if needed
- [X] Skills updated if needed
- [X] Changeset added if published packages changed
