### PR TITLE
Fix useIsHydrated

### DIFF
--- a/.changeset/hydration-commit-root.md
+++ b/.changeset/hydration-commit-root.md
@@ -1,0 +1,25 @@
+---
+"@pracht/core": patch
+---
+
+Two `useIsHydrated` correctness fixes:
+
+1. **Mid-tree sibling race.** Sibling components rendered in the same hydrate
+   call could disagree about whether hydration had finished because the global
+   `_hydrated` flag was flipped from `options.diffed` (per vnode). The earlier
+   sibling's `diffed` would fire before the later sibling's render, so the
+   later sibling read `true` from `useState(_hydrated)` during its very first
+   render. Moved the flip to `options._commit` (commit root), which fires once
+   per commit after the whole tree has diffed. This also handles Suspense
+   resolution transparently — when a lazy boundary settles, its re-render
+   goes through a normal diff→commit cycle and `_commit` catches it at the
+   end.
+
+2. **Non-hydrating suspensions were counted as hydration-suspensions.**
+   `options._catchError` was counting every thrown promise while the global
+   `_hydrating` flag was true, so a parallel `render()` tree (portal, modal
+   root, island) that suspended during the hydration window would pin
+   `_hydrated` at `false` forever. The counter now only increments when the
+   thrown promise originates from a vnode that actually carries
+   `MODE_HYDRATE`, matching the check preact-suspense itself uses to decide
+   whether to preserve server DOM.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -446,10 +446,22 @@ in-flight suspensions so it knows when hydration is truly complete.
 
 - `markHydrating()` is called by the router before `hydrate()` to set a global
   `_hydrating` flag.
-- `options.__e` (\_catchError) intercepts thrown promises during hydration. Each
-  promise increments `_suspensionCount`; settling decrements it.
-- `options.diffed` runs after every render cycle. When `_hydrating` is true and
-  `_suspensionCount` hits zero, it flips `_hydrated = true`.
+- `options.__e` (\_catchError) intercepts thrown promises during hydration and,
+  when the suspending vnode carries the `MODE_HYDRATE` flag, increments
+  `_suspensionCount`; settling decrements it. The `MODE_HYDRATE` check is
+  important: without it, an unrelated `render()` tree (portal, island, modal)
+  that suspends while a hydrate is still in-flight would be mis-counted as a
+  hydration suspension and pin `_hydrated` to `false`. This mirrors the same
+  check preact-suspense uses internally to decide whether to preserve server
+  DOM.
+- `options.__c` (\_commit / commitRoot) runs once per commit root after the whole
+  subtree has finished diffing. When `_hydrating` is true and `_suspensionCount`
+  is zero, it flips `_hydrated = true`. Commit-root granularity (rather than
+  per-vnode `diffed`) is important: otherwise the flag could flip between two
+  sibling components in the same hydrate call, and the later sibling would
+  observe `true` on its first render. It also handles Suspense resolution
+  transparently — when a lazy boundary settles, its re-render runs a normal
+  diff→commit cycle and `__c` catches it at the end.
 
 **`useIsHydrated()` hook**:
 

--- a/packages/framework/src/hydration.ts
+++ b/packages/framework/src/hydration.ts
@@ -1,34 +1,60 @@
 import { options } from "preact";
 import { useEffect, useState } from "preact/hooks";
 
+// Preact internal flag on vnode.__u. Set by the hydrate() diff path on every
+// vnode that is actually hydrating against existing DOM. Fresh mounts and
+// normal re-renders (including Suspense re-renders after a boundary resolves)
+// do NOT carry this bit. Mirrors the check preact-suspense uses.
+const MODE_HYDRATE = 1 << 5;
+
 let _hydrating = false;
 let _suspensionCount = 0;
 let _hydrated = false;
 
-// options.__e (_catchError) — count thrown promises during hydration
+// options.__e (_catchError) — count thrown promises that belong to the
+// initial hydration pass. We must NOT count promises thrown from vnodes that
+// aren't hydrating (e.g. nested client-only lazy components inside a Suspense
+// boundary that re-renders after its own hydration promise settled): those
+// are regular render-cycle suspensions, not hydration suspensions, and
+// blocking the _hydrated flip on them would leave useIsHydrated false
+// forever whenever any nested lazy boundary is still pending.
 const oldCatchError = (options as any).__e;
 (options as any).__e = (err: any, newVNode: any, oldVNode: any, errorInfo?: any) => {
   if (_hydrating && !_hydrated && err && err.then) {
-    _suspensionCount++;
-    let settled = false;
-    const onSettled = () => {
-      if (settled) return;
-      settled = true;
-      _suspensionCount--;
-    };
-    err.then(onSettled, onSettled);
+    const isHydratingVNode =
+      !!(newVNode && newVNode.__u && newVNode.__u & MODE_HYDRATE) ||
+      !!(newVNode && newVNode.__h);
+    if (isHydratingVNode) {
+      _suspensionCount++;
+      let settled = false;
+      const onSettled = () => {
+        if (settled) return;
+        settled = true;
+        _suspensionCount--;
+      };
+      err.then(onSettled, onSettled);
+    }
   }
   if (oldCatchError) oldCatchError(err, newVNode, oldVNode, errorInfo);
 };
 
-// options.diffed — after a full render cycle, if nothing is suspended we're done
-const oldDiffed = (options as any).diffed;
-(options as any).diffed = (vnode: any) => {
+// options.__c (_commit / commitRoot) — fires once per commit root, after the
+// whole subtree has finished diffing. Flip _hydrated=true only if no
+// suspensions are still pending. Using commit-root granularity (rather than
+// the per-vnode `diffed` hook) avoids a mid-tree race where a sibling
+// component rendered later in the same hydrate call could observe the flag
+// already flipped by an earlier sibling's diffed. It also handles the
+// Suspense-resolve case transparently: when a lazy boundary settles and its
+// subtree re-renders, that re-render goes through a normal diff→commit
+// cycle, __c fires at the end with _suspensionCount===0, and the flag flips
+// there.
+const oldCommit = (options as any).__c;
+(options as any).__c = (vnode: any, commitQueue: any) => {
   if (_hydrating && !_hydrated && _suspensionCount <= 0) {
     _hydrated = true;
     _hydrating = false;
   }
-  if (oldDiffed) oldDiffed(vnode);
+  if (oldCommit) oldCommit(vnode, commitQueue);
 };
 
 /**

--- a/packages/framework/src/hydration.ts
+++ b/packages/framework/src/hydration.ts
@@ -22,8 +22,7 @@ const oldCatchError = (options as any).__e;
 (options as any).__e = (err: any, newVNode: any, oldVNode: any, errorInfo?: any) => {
   if (_hydrating && !_hydrated && err && err.then) {
     const isHydratingVNode =
-      !!(newVNode && newVNode.__u && newVNode.__u & MODE_HYDRATE) ||
-      !!(newVNode && newVNode.__h);
+      !!(newVNode && newVNode.__u && newVNode.__u & MODE_HYDRATE) || !!(newVNode && newVNode.__h);
     if (isHydratingVNode) {
       _suspensionCount++;
       let settled = false;

--- a/packages/framework/test/hydration.test.ts
+++ b/packages/framework/test/hydration.test.ts
@@ -106,6 +106,74 @@ describe("useIsHydrated", () => {
     expect(values[0]).toBe(true);
   });
 
+  it("keeps sibling components consistent during the initial hydration render", () => {
+    // Regression: a per-vnode `options.diffed` flip would fire _hydrated=true
+    // after the first sibling's subtree finished diffing, causing the second
+    // sibling to read `true` from `useState(_hydrated)` during its very first
+    // render — mid-tree inconsistency between siblings in the same hydrate
+    // call. Using `options.__c` (commit root) defers the flip to after the
+    // whole tree commits, so both siblings must observe `false` on render 1.
+    scratch.innerHTML = "<div><div>A</div><div>B</div></div>";
+
+    const valuesA: boolean[] = [];
+    const valuesB: boolean[] = [];
+    function A() {
+      valuesA.push(useIsHydrated());
+      return h("div", null, "A");
+    }
+    function B() {
+      valuesB.push(useIsHydrated());
+      return h("div", null, "B");
+    }
+    function Root() {
+      return h("div", null, h(A, null), h(B, null));
+    }
+
+    markHydrating();
+    hydrate(h(Root, null), scratch);
+
+    expect(valuesA[0]).toBe(false);
+    expect(valuesB[0]).toBe(false);
+  });
+
+  it("flips _hydrated exactly once for the whole initial commit", async () => {
+    // Sanity check that deeper nesting doesn't re-trigger the flip. All
+    // descendants in a single hydrate call should see `false` on render 1 and
+    // `true` on render 2 (after useEffect), and a component mounted afterwards
+    // via a subsequent render() should see `true` immediately.
+    scratch.innerHTML = "<div><div><div>leaf</div></div></div>";
+
+    const leafValues: boolean[] = [];
+    function Leaf() {
+      leafValues.push(useIsHydrated());
+      return h("div", null, "leaf");
+    }
+    function Middle() {
+      return h("div", null, h(Leaf, null));
+    }
+    function Root() {
+      return h("div", null, h(Middle, null));
+    }
+
+    markHydrating();
+    hydrate(h(Root, null), scratch);
+
+    expect(leafValues[0]).toBe(false);
+
+    await flush();
+
+    expect(leafValues[leafValues.length - 1]).toBe(true);
+
+    // Subsequent mount picks up the finished state synchronously.
+    const laterValues: boolean[] = [];
+    function Later() {
+      laterValues.push(useIsHydrated());
+      return h("div", null, "later");
+    }
+    render(h(Later, null), scratch);
+    expect(laterValues[0]).toBe(true);
+  });
+
   it("tracks suspension count during hydration", async () => {
     // SSR rendered the *resolved* content — that's what sits in the DOM.
     // During hydration the lazy component throws a promise; Suspense keeps
@@ -160,5 +228,86 @@ describe("useIsHydrated", () => {
     // LazyChild's first render saw _hydrated=false, then useEffect flipped it
     expect(lazyValues[0]).toBe(false);
     expect(lazyValues[lazyValues.length - 1]).toBe(true);
+  });
+
+  it("does not count suspensions thrown from non-hydrating render() trees", async () => {
+    // Regression: while a hydrate is still waiting on a legitimate
+    // hydration-suspension, other parts of the app can mount unrelated
+    // trees via render() — e.g. a portal, a modal root, a parallel
+    // island. If one of those throws a promise, its vnode does NOT carry
+    // MODE_HYDRATE (only hydrate() sets that flag), so it's a regular
+    // render-cycle suspension, not a hydration-suspension. Our __e must
+    // ignore it, otherwise the global `_hydrated` flag would stay
+    // pinned at false even after the real hydration finishes.
+    //
+    // We probe the GLOBAL `_hydrated` flag (not a component's local
+    // useState) by mounting a fresh component after the scenario — its
+    // initial `useState(_hydrated)` reads the global directly.
+    scratch.innerHTML = "<div>hello</div>";
+
+    let hydrateThrew = false;
+    let resolveHydrate!: () => void;
+    const hydratePromise = new Promise<void>((r) => {
+      resolveHydrate = r;
+    });
+    function HydrateLazy() {
+      if (!hydrateThrew) {
+        hydrateThrew = true;
+        throw hydratePromise;
+      }
+      return h("div", null, "hello");
+    }
+
+    markHydrating();
+    hydrate(
+      h(Suspense as any, { fallback: null }, h(HydrateLazy, null)),
+      scratch,
+    );
+    // After this, _hydrating=true, _hydrated=false, _suspensionCount=1
+    // (from HydrateLazy's legitimate hydration throw).
+
+    // Mount an UNRELATED tree via render() that also throws. Its vnodes
+    // have no MODE_HYDRATE flag — if the guard in __e is missing, this
+    // would push _suspensionCount to 2 and `resolveHydrate()` below
+    // would decrement it back to 1 (not 0), so `_hydrated` would never
+    // flip.
+    const otherScratch = document.createElement("div");
+    document.body.appendChild(otherScratch);
+    let otherThrew = false;
+    // Intentionally never resolves — stays pending for the whole test.
+    const otherPromise = new Promise<void>(() => {});
+    function OtherLazy() {
+      if (!otherThrew) {
+        otherThrew = true;
+        throw otherPromise;
+      }
+      return h("div", null, "other");
+    }
+    render(
+      h(Suspense as any, { fallback: null }, h(OtherLazy, null)),
+      otherScratch,
+    );
+
+    // Resolve the real hydration suspension. With the guard working,
+    // count goes 1 → 0 → next commit flips _hydrated=true.
+    resolveHydrate();
+    await flush();
+
+    // Probe the global flag with a third, brand-new mount.
+    const probeScratch = document.createElement("div");
+    document.body.appendChild(probeScratch);
+    try {
+      const probeValues: boolean[] = [];
+      function Probe() {
+        probeValues.push(useIsHydrated());
+        return h("div", null, "probe");
+      }
+      render(h(Probe, null), probeScratch);
+      expect(probeValues[0]).toBe(true);
+    } finally {
+      render(null, otherScratch);
+      otherScratch.remove();
+      probeScratch.remove();
+    }
   });
 });

--- a/packages/framework/test/hydration.test.ts
+++ b/packages/framework/test/hydration.test.ts
@@ -259,10 +259,7 @@ describe("useIsHydrated", () => {
     }
 
     markHydrating();
-    hydrate(
-      h(Suspense as any, { fallback: null }, h(HydrateLazy, null)),
-      scratch,
-    );
+    hydrate(h(Suspense as any, { fallback: null }, h(HydrateLazy, null)), scratch);
     // After this, _hydrating=true, _hydrated=false, _suspensionCount=1
     // (from HydrateLazy's legitimate hydration throw).
 
@@ -283,10 +280,7 @@ describe("useIsHydrated", () => {
       }
       return h("div", null, "other");
     }
-    render(
-      h(Suspense as any, { fallback: null }, h(OtherLazy, null)),
-      otherScratch,
-    );
+    render(h(Suspense as any, { fallback: null }, h(OtherLazy, null)), otherScratch);
 
     // Resolve the real hydration suspension. With the guard working,
     // count goes 1 → 0 → next commit flips _hydrated=true.


### PR DESCRIPTION
1. **Mid-tree sibling race.** Sibling components rendered in the same hydrate
   call could disagree about whether hydration had finished because the global
   `_hydrated` flag was flipped from `options.diffed` (per vnode). The earlier
   sibling's `diffed` would fire before the later sibling's render, so the
   later sibling read `true` from `useState(_hydrated)` during its very first
   render. Moved the flip to `options._commit` (commit root), which fires once
   per commit after the whole tree has diffed. This also handles Suspense
   resolution transparently — when a lazy boundary settles, its re-render
   goes through a normal diff→commit cycle and `_commit` catches it at the
   end.

2. **Non-hydrating suspensions were counted as hydration-suspensions.**
   `options._catchError` was counting every thrown promise while the global
   `_hydrating` flag was true, so a parallel `render()` tree (portal, modal
   root, island) that suspended during the hydration window would pin
   `_hydrated` at `false` forever. The counter now only increments when the
   thrown promise originates from a vnode that actually carries
   `MODE_HYDRATE`, matching the check preact-suspense itself uses to decide
   whether to preserve server DOM.