### PR TITLE
Support default-export API route handlers

### DIFF
--- a/.changeset/default-api-route-handlers.md
+++ b/.changeset/default-api-route-handlers.md
@@ -1,0 +1,5 @@
+---
+"@pracht/core": patch
+---
+
+Allow API route modules to export a default handler that branches on `request.method`.

--- a/VISION_MVP.md
+++ b/VISION_MVP.md
@@ -84,7 +84,8 @@ is specified in the config, it takes precedence over inline exports.
 Standalone server endpoints independent of the page rendering pipeline:
 
 - Defined in `src/api/` with file-based path mapping (e.g. `src/api/health.ts` → `/api/health`).
-- Export named HTTP method handlers: `export function GET(args)`, `POST(args)`, etc.
+- Export named HTTP method handlers (`export function GET(args)`, `POST(args)`, etc.)
+  or one default handler that branches on `args.request.method`.
 - Receive the same `LoaderArgs`-style context (request, params, context, signal).
 - Return `Response` objects directly — full control over status, headers, body.
 - API routes are independent of page-route middleware by default. Shared API

--- a/docs/DATA_LOADING.md
+++ b/docs/DATA_LOADING.md
@@ -186,10 +186,34 @@ export async function DELETE({ params, context }: ApiRouteArgs) {
 }
 ```
 
+If you want to own method dispatch, export one default handler and branch on
+`request.method`:
+
+```typescript
+// src/api/users/[id].ts
+import type { ApiRouteArgs } from "@pracht/core";
+
+export default async function handler({ params, request, context }: ApiRouteArgs) {
+  if (request.method === "GET") {
+    const user = await context.db.users.find(params.id);
+    if (!user) return new Response("Not found", { status: 404 });
+    return Response.json(user);
+  }
+
+  if (request.method === "DELETE") {
+    await context.db.users.delete(params.id);
+    return new Response(null, { status: 204 });
+  }
+
+  return new Response("Method not allowed", { status: 405 });
+}
+```
+
 API routes:
 
 - Live in `src/api/` with file-based path mapping
 - Export named HTTP method handlers (`GET`, `POST`, `PUT`, `PATCH`, `DELETE`)
+  or one default handler that branches on `args.request.method`
 - Return `Response` objects directly
 - Share the same request context shape as page routes
 - Can opt into app-level API middleware via `defineApp({ api: { middleware } })`

--- a/docs/WORKSPACE.md
+++ b/docs/WORKSPACE.md
@@ -24,9 +24,10 @@ described in `VISION_MVP.md`.
 - **API routes** — File-based auto-discovery from `src/api/`. Files are globbed
   by the Vite plugin and resolved to URL paths (e.g. `src/api/health.ts` →
   `/api/health`, `src/api/users/[id].ts` → `/api/users/:id`). Modules export
-  named HTTP method handlers (`GET`, `POST`, etc.) that return `Response`
-  objects directly. API routes are dispatched before page routes in
-  `handlePrachtRequest()`. Missing method handlers return 405. Shared API policy
+  named HTTP method handlers (`GET`, `POST`, etc.) or one default handler that
+  branches on `request.method` and returns `Response` objects directly. API
+  routes are dispatched before page routes in `handlePrachtRequest()`. Missing
+  method handlers return 405 when no default handler exists. Shared API policy
   can be applied explicitly with `defineApp({ api: { middleware: [...] } })`.
 - **Server rendering** — `handlePrachtRequest()` executes the full request
   lifecycle: API route check → middleware chain → loader → Preact

--- a/examples/docs/src/routes/docs/api-routes.md
+++ b/examples/docs/src/routes/docs/api-routes.md
@@ -1,6 +1,6 @@
 ---
 title: API Routes
-lead: Standalone server endpoints that live alongside your pages. Export named HTTP method handlers and return <code>Response</code> objects directly.
+lead: Standalone server endpoints that live alongside your pages. Export named HTTP method handlers or one default handler, then return <code>Response</code> objects directly.
 breadcrumb: API Routes
 prev:
   href: /docs/data-loading
@@ -27,19 +27,38 @@ API routes live in `src/api/`. The file path maps to the URL:
 Export named functions for each HTTP method you want to handle. Unhandled methods return 405.
 
 ```ts [src/api/users.ts]
-import type { LoaderArgs } from "@pracht/core";
+import type { ApiRouteArgs } from "@pracht/core";
 
-export function GET({ request }: LoaderArgs) {
+export function GET({ request }: ApiRouteArgs) {
   return Response.json([
     { id: 1, name: "Alice" },
     { id: 2, name: "Bob" },
   ]);
 }
 
-export async function POST({ request }: LoaderArgs) {
+export async function POST({ request }: ApiRouteArgs) {
   const body = await request.json();
   // Create user...
   return Response.json({ id: 3, ...body }, { status: 201 });
+}
+```
+
+You can also export one default handler and branch on `request.method` yourself:
+
+```ts [src/api/users.ts]
+import type { ApiRouteArgs } from "@pracht/core";
+
+export default async function handler({ request }: ApiRouteArgs) {
+  if (request.method === "GET") {
+    return Response.json([{ id: 1, name: "Alice" }]);
+  }
+
+  if (request.method === "POST") {
+    const body = await request.json();
+    return Response.json({ id: 2, ...body }, { status: 201 });
+  }
+
+  return new Response("Method not allowed", { status: 405 });
 }
 ```
 

--- a/examples/docs/src/routes/docs/data-loading.md
+++ b/examples/docs/src/routes/docs/data-loading.md
@@ -168,4 +168,4 @@ export async function DELETE({ params, context }: ApiRouteArgs) {
 }
 ```
 
-API routes export named HTTP method handlers, return `Response` objects directly, share the same context system as page routes, and are excluded from client bundles entirely.
+API routes export named HTTP method handlers or one default handler that branches on `request.method`, return `Response` objects directly, share the same context system as page routes, and are excluded from client bundles entirely.

--- a/examples/docs/src/routes/docs/migrate-nextjs.md
+++ b/examples/docs/src/routes/docs/migrate-nextjs.md
@@ -293,7 +293,7 @@ group({ middleware: ["auth"], shell: "app" }, [
 
 ## API Routes
 
-Both frameworks use file-based API routes with named HTTP method exports:
+Both frameworks use file-based API routes. Named HTTP method exports map directly:
 
 ```ts
 // Next.js — app/api/posts/route.ts

--- a/packages/framework/src/index.ts
+++ b/packages/framework/src/index.ts
@@ -30,6 +30,7 @@ export { initClientRouter, useNavigate } from "./router.ts";
 export { PrachtHttpError } from "./types.ts";
 export type {
   ApiConfig,
+  ApiRouteArgs,
   ApiRouteHandler,
   Register,
   ApiRouteMatch,

--- a/packages/framework/src/runtime.ts
+++ b/packages/framework/src/runtime.ts
@@ -4,6 +4,7 @@ import { useContext, useEffect, useMemo, useState } from "preact/hooks";
 
 import { matchApiRoute, matchAppRoute } from "./app.ts";
 import type {
+  ApiRouteArgs,
   ApiRouteModule,
   BaseRouteArgs,
   DataModule,
@@ -351,7 +352,7 @@ export async function handlePrachtRequest<TContext>(
         }
 
         const method = options.request.method.toUpperCase() as HttpMethod;
-        const handler = apiModule[method];
+        const handler = apiModule[method] ?? apiModule.default;
 
         if (!handler) {
           return withDefaultSecurityHeaders(
@@ -362,16 +363,16 @@ export async function handlePrachtRequest<TContext>(
           );
         }
 
-        return withDefaultSecurityHeaders(
-          await handler({
-            request: options.request,
-            params: apiMatch.params,
-            context: middlewareResult.context,
-            signal: AbortSignal.timeout(30_000),
-            url,
-            route: apiMatch.route as any,
-          }),
-        );
+        const apiRouteArgs: ApiRouteArgs<TContext> = {
+          request: options.request,
+          params: apiMatch.params,
+          context: middlewareResult.context,
+          signal: AbortSignal.timeout(30_000),
+          url,
+          route: apiMatch.route as any,
+        };
+
+        return withDefaultSecurityHeaders(await handler(apiRouteArgs));
       } catch (error: unknown) {
         return renderApiErrorResponse({
           error,

--- a/packages/framework/src/types.ts
+++ b/packages/framework/src/types.ts
@@ -39,11 +39,14 @@ export type RouteRevalidate = TimeRevalidatePolicy;
 
 export type HttpMethod = "GET" | "POST" | "PUT" | "PATCH" | "DELETE" | "HEAD" | "OPTIONS";
 
+export type ApiRouteArgs<TContext = RegisteredContext> = BaseRouteArgs<TContext>;
+
 export type ApiRouteHandler<TContext = RegisteredContext> = (
-  args: BaseRouteArgs<TContext>,
+  args: ApiRouteArgs<TContext>,
 ) => MaybePromise<Response>;
 
 export interface ApiRouteModule<TContext = any> {
+  default?: ApiRouteHandler<TContext>;
   GET?: ApiRouteHandler<TContext>;
   POST?: ApiRouteHandler<TContext>;
   PUT?: ApiRouteHandler<TContext>;

--- a/packages/framework/test/runtime.test.ts
+++ b/packages/framework/test/runtime.test.ts
@@ -89,6 +89,72 @@ describe("handlePrachtRequest API middleware", () => {
   });
 });
 
+describe("handlePrachtRequest API default handlers", () => {
+  it("falls back to a default export that branches on request.method", async () => {
+    const app = defineApp({
+      routes: [route("/", "./routes/home.tsx")],
+    });
+
+    const response = await handlePrachtRequest({
+      apiRoutes: resolveApiRoutes(["/src/api/widgets/[id].ts"]),
+      app,
+      context: { traceId: "ctx-1" },
+      registry: {
+        apiModules: {
+          "/src/api/widgets/[id].ts": async () => ({
+            default: async ({ context, params, request, route }) => {
+              if (request.method === "PATCH") {
+                return Response.json({
+                  id: params.id,
+                  method: request.method,
+                  routePath: route.path,
+                  traceId: context.traceId,
+                });
+              }
+
+              return new Response("Method not allowed", { status: 405 });
+            },
+          }),
+        },
+      },
+      request: new Request("http://localhost/api/widgets/42", {
+        method: "PATCH",
+      }),
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      id: "42",
+      method: "PATCH",
+      routePath: "/api/widgets/:id",
+      traceId: "ctx-1",
+    });
+  });
+
+  it("prefers named HTTP method handlers over a default export", async () => {
+    const app = defineApp({
+      routes: [route("/", "./routes/home.tsx")],
+    });
+
+    const response = await handlePrachtRequest({
+      apiRoutes: resolveApiRoutes(["/src/api/health.ts"]),
+      app,
+      registry: {
+        apiModules: {
+          "/src/api/health.ts": async () => ({
+            default: async () => new Response("default"),
+            GET: async () => new Response("named"),
+          }),
+        },
+      },
+      request: new Request("http://localhost/api/health"),
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.text()).resolves.toBe("named");
+  });
+});
+
 describe("handlePrachtRequest API errors", () => {
   it("returns structured api diagnostics when debugErrors is enabled", async () => {
     const app = defineApp({

--- a/skills/debug/SKILL.md
+++ b/skills/debug/SKILL.md
@@ -80,8 +80,9 @@ Work through these in order, stopping when you find the root cause:
 - API routes live in `src/api/` and are auto-discovered (no manifest entry needed).
 - For machine-readable API inventory, run `pracht inspect api --json`.
 - File path maps to URL: `src/api/health.ts` → `/api/health`, `src/api/users/[id].ts` → `/api/users/:id`.
-- Each file exports named HTTP method handlers (`GET`, `POST`, etc.).
-- Missing method handler → 405 response.
+- Each file exports named HTTP method handlers (`GET`, `POST`, etc.) or one default handler.
+- Missing method handler → 405 response when there is no default handler.
+- Default handlers receive the same route args and can branch on `request.method`.
 - Handlers must return `Response` objects.
 
 ### 6. Vite plugin / HMR issues

--- a/skills/scaffold/SKILL.md
+++ b/skills/scaffold/SKILL.md
@@ -47,7 +47,7 @@ The user will describe what they want to create. Parse their request and generat
 | Route      | `src/routes/`     | `loader`, `head`, `Component`, `ErrorBoundary`, `getStaticPaths`     | `src/routes/blog.tsx`          |
 | Shell      | `src/shells/`     | `Shell`, `head`                                                      | `src/shells/marketing.tsx`     |
 | Middleware | `src/middleware/` | `middleware`                                                         | `src/middleware/rate-limit.ts` |
-| API route  | `src/api/`        | Named HTTP method handlers (`GET`, `POST`, `PUT`, `PATCH`, `DELETE`) | `src/api/users/[id].ts`        |
+| API route  | `src/api/`        | Named HTTP method handlers (`GET`, `POST`, `PUT`, `PATCH`, `DELETE`) or one default method dispatcher           | `src/api/users/[id].ts`        |
 
 ## Templates
 
@@ -118,6 +118,7 @@ export function GET({ params, url }: BaseRouteArgs) {
 ```
 
 - Only include the HTTP methods the user needs.
+- Use a default export only when the user wants to branch on `request.method` manually.
 - Use `request.json()`, `request.formData()`, etc. for body parsing.
 - Always return `Response` objects (typically `Response.json()`).
 - Dynamic segments use bracket syntax in filenames: `[id].ts`, `[...slug].ts`.


### PR DESCRIPTION
## Summary

- Allow API route modules to export a default handler that branches on `request.method`.
- Keep named HTTP verb handlers as the first match, so `export function GET()` still wins over `export default`.
- Preserve the existing `405` behavior when no named handler or default handler exists.
- Add runtime coverage, docs, local skill updates, and a patch changeset for `@pracht/core`.


## Testing

- [X] `pnpm e2e`
- [X] `pnpm format`
- [X] `pnpm lint`
- [X] `pnpm test`

## Checklist

- [X] Docs updated if needed
- [X] Skills updated if needed
- [X] Changeset added if published packages changed
