### PR TITLE
Document HOF middleware pattern for pages router

### DIFF
--- a/e2e/pages-router.test.ts
+++ b/e2e/pages-router.test.ts
@@ -124,6 +124,36 @@ test("route state request returns JSON for pages", async ({ request }) => {
 });
 
 // ---------------------------------------------------------------------------
+// API routes & HOF middleware
+// ---------------------------------------------------------------------------
+
+test("GET /api/health returns JSON", async ({ request }) => {
+  const response = await request.get("/api/health");
+  expect(response.status()).toBe(200);
+
+  const json = await response.json();
+  expect(json).toMatchObject({ status: "ok" });
+});
+
+test("GET /api/me without session returns 401", async ({ request }) => {
+  const response = await request.get("/api/me");
+  expect(response.status()).toBe(401);
+
+  const json = await response.json();
+  expect(json).toMatchObject({ error: "Unauthorized" });
+});
+
+test("GET /api/me with session cookie returns user", async ({ request }) => {
+  const response = await request.get("/api/me", {
+    headers: { cookie: "session=abc123" },
+  });
+  expect(response.status()).toBe(200);
+
+  const json = await response.json();
+  expect(json).toMatchObject({ user: "Alice" });
+});
+
+// ---------------------------------------------------------------------------
 // 404 handling
 // ---------------------------------------------------------------------------
 

--- a/examples/docs/src/routes/docs/api-routes.md
+++ b/examples/docs/src/routes/docs/api-routes.md
@@ -81,6 +81,50 @@ API middleware runs before the handler, just like page middleware runs before lo
 
 ---
 
+## Middleware Without a Manifest (Higher-Order Functions)
+
+When using the **pages router** or any setup without a `routes.ts` manifest, you can apply middleware to individual API routes with a plain higher-order function — no framework API required:
+
+```ts [src/lib/with-auth.ts]
+import type { ApiRouteArgs, ApiRouteHandler } from "@pracht/core";
+
+export function withAuth(handler: ApiRouteHandler): ApiRouteHandler {
+  return async (args: ApiRouteArgs) => {
+    const session = args.request.headers.get("cookie")?.includes("session=");
+    if (!session) {
+      return Response.json({ error: "Unauthorized" }, { status: 401 });
+    }
+    return handler(args);
+  };
+}
+```
+
+Then wrap any handler export:
+
+```ts [src/api/me.ts]
+import { withAuth } from "../lib/with-auth";
+
+export const GET = withAuth(({ request }) => {
+  return Response.json({ user: "Alice" });
+});
+```
+
+You can compose multiple wrappers for stacking:
+
+```ts [src/api/admin.ts]
+import { withAuth } from "../lib/with-auth";
+import { withRateLimit } from "../lib/with-rate-limit";
+
+export const POST = withAuth(withRateLimit(async ({ request }) => {
+  const body = await request.json();
+  return Response.json({ ok: true });
+}));
+```
+
+This pattern works with both the pages router and the manifest router — it's just JavaScript.
+
+---
+
 ## Full Control
 
 API handlers receive the same `LoaderArgs` context (request, params, context, signal) and return standard `Response` objects. You have full control over status codes, headers, and body format.

--- a/examples/docs/src/routes/docs/middleware.md
+++ b/examples/docs/src/routes/docs/middleware.md
@@ -73,3 +73,33 @@ Middleware from groups and routes is combined. A route inside a group with `["au
 | `undefined` / `void`              | Continue to the next middleware or loader |
 | `{ redirect: "/path" }`           | HTTP 302 redirect                         |
 | `{ response: new Response(...) }` | Short-circuit with a custom response      |
+
+---
+
+## Without a Manifest (Higher-Order Functions)
+
+When using the **pages router** (or any setup without `routes.ts`), there is no manifest to register middleware in. Instead, wrap API handlers with plain higher-order functions:
+
+```ts [src/lib/with-auth.ts]
+import type { ApiRouteArgs, ApiRouteHandler } from "@pracht/core";
+
+export function withAuth(handler: ApiRouteHandler): ApiRouteHandler {
+  return async (args: ApiRouteArgs) => {
+    const session = args.request.headers.get("cookie")?.includes("session=");
+    if (!session) {
+      return Response.json({ error: "Unauthorized" }, { status: 401 });
+    }
+    return handler(args);
+  };
+}
+```
+
+```ts [src/api/me.ts]
+import { withAuth } from "../lib/with-auth";
+
+export const GET = withAuth(({ request }) => {
+  return Response.json({ user: "Alice" });
+});
+```
+
+Multiple wrappers compose naturally: `withAuth(withRateLimit(handler))`. See [API Routes](/docs/api-routes) for more detail and stacking examples.

--- a/examples/pages-router/src/api/health.ts
+++ b/examples/pages-router/src/api/health.ts
@@ -1,0 +1,3 @@
+export function GET() {
+  return Response.json({ status: "ok" });
+}

--- a/examples/pages-router/src/api/me.ts
+++ b/examples/pages-router/src/api/me.ts
@@ -1,0 +1,5 @@
+import { withAuth } from "../lib/with-auth";
+
+export const GET = withAuth(() => {
+  return Response.json({ user: "Alice", email: "alice@example.com" });
+});

--- a/examples/pages-router/src/lib/with-auth.ts
+++ b/examples/pages-router/src/lib/with-auth.ts
@@ -1,0 +1,21 @@
+import type { ApiRouteArgs, ApiRouteHandler } from "@pracht/core";
+
+/**
+ * Higher-order function that checks for a session cookie before calling the
+ * wrapped handler. Use it to protect individual API routes without a manifest:
+ *
+ *   export const GET = withAuth((args) => Response.json({ ok: true }));
+ *
+ * ⚠️ NOT FOR PRODUCTION — a real check should verify a cryptographic signature.
+ */
+export function withAuth(handler: ApiRouteHandler): ApiRouteHandler {
+  return async (args: ApiRouteArgs) => {
+    const hasSession = args.request.headers.get("cookie")?.includes("session=") ?? false;
+
+    if (!hasSession) {
+      return Response.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    return handler(args);
+  };
+}

--- a/examples/pages-router/src/pages/_app.tsx
+++ b/examples/pages-router/src/pages/_app.tsx
@@ -9,6 +9,8 @@ export function Shell({ children }: ShellProps) {
           <a href="/">Home</a>
           <a href="/about">About</a>
           <a href="/blog/hello-world">Blog</a>
+          <a href="/api/health">API: Health</a>
+          <a href="/api/me">API: Me (auth)</a>
         </nav>
       </header>
       <main>{children}</main>


### PR DESCRIPTION
## Summary

- Add a "Middleware Without a Manifest" section to the **API Routes** doc showing how to use higher-order functions (`withAuth`, `withRateLimit`) to wrap API handlers — the natural pattern when there's no `routes.ts` manifest.
- Add a matching cross-reference section to the **Middleware** doc.
- Add working example files to the **pages-router** example: `src/lib/with-auth.ts`, `src/api/health.ts`, `src/api/me.ts`, plus nav links in the shell.

Addresses the gap where middleware docs only covered `defineApp`-based routing, leaving pages-router users without a documented path.

## Testing

- [x] `pnpm e2e` — 38 passed
- [x] `pnpm format`
- [x] `pnpm lint`
- [x] `pnpm test` — 68 passed

## Checklist

- [x] Docs updated if needed
- [ ] Skills updated if needed — N/A
- [ ] Changeset added if published packages changed — N/A (docs + example only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)