### PR TITLE
chore: move target-specific Vite plugins into adapter packages

### DIFF
--- a/.changeset/adapter-owns-vite-plugins.md
+++ b/.changeset/adapter-owns-vite-plugins.md
@@ -1,0 +1,16 @@
+---
+"@pracht/vite-plugin": minor
+"@pracht/adapter-cloudflare": minor
+---
+
+Adapters can now contribute their own Vite plugins via a new `vitePlugins()`
+hook on `PrachtAdapter`, plus an `ownsDevServer` flag that lets the adapter
+take over dev-server request handling. The `@cloudflare/vite-plugin`
+integration moved out of `@pracht/vite-plugin` and into
+`@pracht/adapter-cloudflare`, so the vite-plugin no longer ships a Cloudflare
+special case or peer-depends on `@cloudflare/vite-plugin` / `wrangler`.
+
+`@pracht/vite-plugin` now depends on `@pracht/adapter-node` directly (the
+default-adapter code path generates an import of it) and no longer lists
+`@pracht/adapter-cloudflare` or `@pracht/adapter-vercel` in dependencies —
+install those only when you use them.

--- a/docs/ADAPTERS.md
+++ b/docs/ADAPTERS.md
@@ -318,6 +318,14 @@ export default async function handle(request) {
 }
 `;
     },
+    // Optional: contribute extra Vite plugins (e.g. a platform-specific runtime).
+    async vitePlugins() {
+      const { myPlatformVitePlugin } = await import("my-platform-vite-plugin");
+      return myPlatformVitePlugin({ entry: "virtual:pracht/server" });
+    },
+    // Optional: set to true when the adapter's Vite plugin runs the dev server
+    // itself (pracht will skip installing its own SSR middleware).
+    ownsDevServer: true,
   };
 }
 ```

--- a/packages/adapter-cloudflare/package.json
+++ b/packages/adapter-cloudflare/package.json
@@ -28,6 +28,11 @@
     "prepublishOnly": "npm run build"
   },
   "dependencies": {
+    "@cloudflare/vite-plugin": "^1.0.0",
     "@pracht/core": "workspace:*"
+  },
+  "peerDependencies": {
+    "vite": "^7.0.0 || ^8.0.0",
+    "wrangler": "^4.81.0"
   }
 }

--- a/packages/adapter-cloudflare/src/index.ts
+++ b/packages/adapter-cloudflare/src/index.ts
@@ -1,4 +1,5 @@
 import type { PrachtAdapter } from "@pracht/vite-plugin";
+import type { Plugin } from "vite";
 import {
   applyDefaultSecurityHeaders,
   handlePrachtRequest,
@@ -182,10 +183,21 @@ function isFetcher(value: unknown): value is CloudflareFetcher {
 export function cloudflareAdapter(options: CloudflareServerEntryModuleOptions = {}): PrachtAdapter {
   return {
     id: "cloudflare",
+    ownsDevServer: true,
     serverImports:
       'import { applyDefaultSecurityHeaders, handlePrachtRequest, resolveApp, resolveApiRoutes } from "@pracht/core";',
     createServerEntryModule() {
       return createCloudflareServerEntryModule(options);
+    },
+    async vitePlugins(): Promise<Plugin[]> {
+      const { cloudflare } = (await import("@cloudflare/vite-plugin")) as {
+        cloudflare: (opts?: { config?: { main?: string } }) => Plugin[];
+      };
+      return cloudflare({
+        config: {
+          main: "virtual:pracht/server",
+        },
+      });
     },
   };
 }

--- a/packages/vite-plugin/README.md
+++ b/packages/vite-plugin/README.md
@@ -29,6 +29,9 @@ export default defineConfig({
 
 ## Peer Dependencies
 
-- `vite@^8.0.0`
-- `@cloudflare/vite-plugin@^1.0.0` (optional, for Cloudflare targets)
-- `wrangler@^4.81.0` (optional, for Cloudflare targets)
+- `vite@^7.0.0 || ^8.0.0`
+
+Target-specific Vite plugins (e.g. `@cloudflare/vite-plugin`) are pulled in by
+the adapter package you install (`@pracht/adapter-cloudflare`,
+`@pracht/adapter-vercel`, etc.). The default path uses `@pracht/adapter-node`,
+which ships as a dependency of this package.

--- a/packages/vite-plugin/package.json
+++ b/packages/vite-plugin/package.json
@@ -32,22 +32,12 @@
     "prepublishOnly": "npm run build"
   },
   "dependencies": {
-    "@pracht/adapter-cloudflare": "workspace:*",
-    "@pracht/adapter-vercel": "workspace:*",
+    "@pracht/adapter-node": "workspace:*",
     "@pracht/core": "workspace:*",
-    "@preact/preset-vite": "^2.10.5"
+    "@preact/preset-vite": "^2.10.5",
+    "@prefresh/vite": "^2.0.0"
   },
   "peerDependencies": {
-    "@cloudflare/vite-plugin": "^1.0.0",
-    "vite": "^8.0.0",
-    "wrangler": "^4.81.0"
-  },
-  "peerDependenciesMeta": {
-    "@cloudflare/vite-plugin": {
-      "optional": true
-    },
-    "wrangler": {
-      "optional": true
-    }
+    "vite": "^7.0.0 || ^8.0.0"
   }
 }

--- a/packages/vite-plugin/src/index.ts
+++ b/packages/vite-plugin/src/index.ts
@@ -48,6 +48,18 @@ export interface PrachtAdapter {
    * request handler or default export.
    */
   createServerEntryModule(): string;
+  /**
+   * Additional Vite plugins the adapter needs (e.g. `@cloudflare/vite-plugin`).
+   * Returned plugins are appended to the plugin array returned by `pracht()`.
+   */
+  vitePlugins?(): Plugin[] | Promise<Plugin[]>;
+  /**
+   * If true, the adapter owns dev-server request handling and the vite-plugin
+   * will not install its own SSR middleware. Used when the adapter contributes
+   * a Vite plugin that runs the dev server in a platform-specific runtime
+   * (e.g. Cloudflare workerd via `@cloudflare/vite-plugin`).
+   */
+  ownsDevServer?: boolean;
 }
 
 function createDefaultNodeAdapter(): PrachtAdapter {
@@ -206,7 +218,7 @@ export async function pracht(options: PrachtPluginOptions = {}): Promise<Plugin[
         });
       }
 
-      if (resolved.adapter.id === "cloudflare") return;
+      if (resolved.adapter.ownsDevServer) return;
       return () => {
         server.middlewares.use(createDevSSRMiddleware(server, resolved));
       };
@@ -250,17 +262,9 @@ export async function pracht(options: PrachtPluginOptions = {}): Promise<Plugin[
 
   const plugins: Plugin[] = [...preact(), prachtPlugin];
 
-  if (resolved.adapter.id === "cloudflare") {
-    const { cloudflare } = (await import("@cloudflare/vite-plugin")) as {
-      cloudflare: (opts?: { config?: { main?: string } }) => Plugin[];
-    };
-    plugins.push(
-      ...cloudflare({
-        config: {
-          main: "virtual:pracht/server",
-        },
-      }),
-    );
+  const adapterPlugins = await resolved.adapter.vitePlugins?.();
+  if (adapterPlugins?.length) {
+    plugins.push(...adapterPlugins);
   }
 
   return plugins;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -168,9 +168,18 @@ importers:
 
   packages/adapter-cloudflare:
     dependencies:
+      '@cloudflare/vite-plugin':
+        specifier: ^1.0.0
+        version: 1.31.1(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@22.19.17)(esbuild@0.27.3))(workerd@1.20260405.1)(wrangler@4.81.0)
       '@pracht/core':
         specifier: workspace:*
         version: link:../framework
+      vite:
+        specifier: ^7.0.0 || ^8.0.0
+        version: 8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@22.19.17)(esbuild@0.27.3)
+      wrangler:
+        specifier: ^4.81.0
+        version: 4.81.0
 
   packages/adapter-node:
     dependencies:
@@ -206,27 +215,21 @@ importers:
 
   packages/vite-plugin:
     dependencies:
-      '@cloudflare/vite-plugin':
-        specifier: ^1.0.0
-        version: 1.31.1(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@22.19.17)(esbuild@0.27.3))(workerd@1.20260405.1)(wrangler@4.81.0)
-      '@pracht/adapter-cloudflare':
+      '@pracht/adapter-node':
         specifier: workspace:*
-        version: link:../adapter-cloudflare
-      '@pracht/adapter-vercel':
-        specifier: workspace:*
-        version: link:../adapter-vercel
+        version: link:../adapter-node
       '@pracht/core':
         specifier: workspace:*
         version: link:../framework
       '@preact/preset-vite':
         specifier: ^2.10.5
         version: 2.10.5(@babel/core@7.29.0)(preact@10.29.1)(rollup@4.60.1)(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@22.19.17)(esbuild@0.27.3))
+      '@prefresh/vite':
+        specifier: ^2.0.0
+        version: 2.4.12(preact@10.29.1)(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@22.19.17)(esbuild@0.27.3))
       vite:
-        specifier: ^8.0.0
+        specifier: ^7.0.0 || ^8.0.0
         version: 8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@22.19.17)(esbuild@0.27.3)
-      wrangler:
-        specifier: ^4.81.0
-        version: 4.81.0
 
 packages:
 


### PR DESCRIPTION
## Summary

- Adapters now declare the Vite plugins they need via an optional `vitePlugins()` hook on `PrachtAdapter`, plus an `ownsDevServer` flag so the adapter can take over dev-server request handling. `@pracht/vite-plugin` no longer hard-codes a Cloudflare branch.
- `@cloudflare/vite-plugin` moved from `@pracht/vite-plugin`'s peer deps into `@pracht/adapter-cloudflare` as a direct dep. `wrangler` stays a peer dep of the adapter (the user still runs it). Vite is now a peer dep of the adapter too.
- `@pracht/vite-plugin` picks up `@pracht/adapter-node` as a regular dep (the default-adapter codegen imports it) and drops the stale `@pracht/adapter-cloudflare` / `@pracht/adapter-vercel` entries from `dependencies` — those packages are opt-in and installed explicitly when used.
- `@prefresh/vite` is pinned to `^2.0.0` for now — v3 has stability issues under rolldown that we want to dodge until upstream settles.
- N/A for breaking API changes: `PrachtAdapter` gains two optional fields, no existing field signatures change.

## Testing

- [x] `pnpm e2e`
- [x] `pnpm format`
- [x] `pnpm lint`
- [x] `pnpm test`

## Checklist

- [x] Docs updated if needed (ADAPTERS.md, vite-plugin README)
- [x] Skills updated if needed — N/A
- [x] Changeset added if published packages changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)