### PR TITLE
docs: recommend CSS Modules/Tailwind over CSS-in-JS

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ The starter gives you:
 - `docs/ROUTING.md` for the manifest and matching model
 - `docs/RENDERING_MODES.md` for SSR, SSG, ISG, and SPA behavior
 - `docs/DATA_LOADING.md` for loaders, actions, forms, and client hooks
+- `docs/STYLING.md` for the recommended styling approaches (CSS Modules, Tailwind) and current CSS-in-JS limitations
 - `docs/ADAPTERS.md` for Node, Cloudflare, and Vercel deployment paths
 - `packages/start/README.md` for starter CLI details
 - `examples/basic` and `examples/cloudflare` for working apps

--- a/docs/STYLING.md
+++ b/docs/STYLING.md
@@ -33,7 +33,7 @@ Runtime CSS-in-JS libraries (styled-components, Emotion, goober in runtime
 mode, etc.) work, but with caveats:
 
 - On **SPA** / **CSR** routes they are fine — styles are injected by the
-  library on the client after hydration.
+  library on the client during first render.
 - On **SSR** / **SSG** / **ISG** routes the framework currently has no way to
   collect runtime-generated styles and inline them into the critical path.
   Users will see a flash of unstyled content before hydration finishes and the

--- a/docs/STYLING.md
+++ b/docs/STYLING.md
@@ -1,0 +1,57 @@
+# Styling
+
+Pracht does not prescribe a styling solution — any approach that runs through
+Vite will work. That said, the framework can only optimize style loading for
+solutions that emit CSS at build time. This page lays out the recommendation
+and the reasoning behind it.
+
+---
+
+## Recommended
+
+Prefer styling approaches that produce real CSS files:
+
+- **CSS Modules** — co-located, scoped by filename hash
+- **Tailwind CSS** — utility-first, emitted as a single stylesheet via
+  `@tailwindcss/vite`
+- **Plain `.css` / `.scss` imports** — scoped by convention or by being
+  imported from a single module
+- **PostCSS** pipelines (Open Props, Pico, etc.) — anything that ends up as a
+  static stylesheet
+
+These all produce CSS that Vite tracks through its module graph. Pracht's build
+maps each route and shell to its transitive CSS dependencies, then injects only
+the relevant `<link rel="stylesheet">` tags into the server-rendered HTML. See
+[RENDERING_MODES.md](RENDERING_MODES.md) and the per-page CSS section in the
+performance docs.
+
+---
+
+## CSS-in-JS
+
+Runtime CSS-in-JS libraries (styled-components, Emotion, goober in runtime
+mode, etc.) work, but with caveats:
+
+- On **SPA** / **CSR** routes they are fine — styles are injected by the
+  library on the client after hydration.
+- On **SSR** / **SSG** / **ISG** routes the framework currently has no way to
+  collect runtime-generated styles and inline them into the critical path.
+  Users will see a flash of unstyled content before hydration finishes and the
+  library catches up.
+
+Because of that, CSS-in-JS is **not recommended for server-rendered routes**
+today. Pick a build-time approach for anything that needs to render on the
+server, and keep CSS-in-JS for client-only views if you really want it.
+
+---
+
+## Future work
+
+First-class support for CSS-in-JS with server-side extraction is contingent on
+upstream work in Preact tracked in
+[JoviDeCroock/pracht#30](https://github.com/JoviDeCroock/pracht/issues/30).
+Once that lands, pracht can wire the extracted critical styles into the SSR
+HTML the same way it does for build-time CSS, and this recommendation will be
+revisited.
+
+Until then: reach for CSS Modules or Tailwind first.

--- a/examples/docs/src/routes.ts
+++ b/examples/docs/src/routes.ts
@@ -39,6 +39,10 @@ export const app = defineApp({
         id: "shells",
         render: "ssg",
       }),
+      route("/docs/styling", () => import("./routes/docs/styling.md"), {
+        id: "styling",
+        render: "ssg",
+      }),
       route("/docs/cli", () => import("./routes/docs/cli.md"), {
         id: "cli",
         render: "ssg",

--- a/examples/docs/src/routes/docs/cli.md
+++ b/examples/docs/src/routes/docs/cli.md
@@ -3,8 +3,8 @@ title: CLI
 lead: The <code>@pracht/cli</code> package provides development, build, scaffolding, and doctor commands for your app.
 breadcrumb: CLI
 prev:
-  href: /docs/shells
-  title: Shells
+  href: /docs/styling
+  title: Styling
 next:
   href: /docs/deployment
   title: Deployment

--- a/examples/docs/src/routes/docs/shells.md
+++ b/examples/docs/src/routes/docs/shells.md
@@ -6,8 +6,8 @@ prev:
   href: /docs/middleware
   title: Middleware
 next:
-  href: /docs/cli
-  title: CLI
+  href: /docs/styling
+  title: Styling
 ---
 
 ## Defining a Shell

--- a/examples/docs/src/routes/docs/styling.md
+++ b/examples/docs/src/routes/docs/styling.md
@@ -1,0 +1,64 @@
+---
+title: Styling
+lead: Pracht optimizes style loading for CSS that exists at build time. Prefer CSS Modules, Tailwind, or plain stylesheets over runtime CSS-in-JS — especially on server-rendered routes.
+breadcrumb: Styling
+prev:
+  href: /docs/shells
+  title: Shells
+next:
+  href: /docs/cli
+  title: CLI
+---
+
+## Recommended Approaches
+
+Any of these produce real CSS files that Vite tracks through its module graph. Pracht uses that graph to inject only the stylesheets a route actually needs — no unused CSS is sent, and the critical styles ship in the initial HTML.
+
+- **CSS Modules** — co-located, automatically scoped per file
+- **Tailwind CSS** via `@tailwindcss/vite` — utility-first, single generated stylesheet
+- **Plain `.css` / `.scss` imports** — global or module-scoped by convention
+- **PostCSS** pipelines (Open Props, Pico, etc.) — anything emitted as a static stylesheet
+
+```tsx [src/routes/home.tsx]
+import styles from "./home.module.css";
+
+export default function Home() {
+  return <h1 class={styles.title}>Hello</h1>;
+}
+```
+
+```ts [vite.config.ts]
+import { defineConfig } from "vite";
+import { pracht } from "@pracht/vite-plugin";
+import tailwindcss from "@tailwindcss/vite";
+
+export default defineConfig({
+  plugins: [pracht(), tailwindcss()],
+});
+```
+
+See [Performance → CSS Per Page](/docs/performance) for how pracht maps routes to their transitive CSS dependencies.
+
+---
+
+## CSS-in-JS — Use With Care
+
+Runtime CSS-in-JS libraries like **styled-components**, **Emotion**, and **goober** work in a pracht app, but the framework currently cannot collect their runtime-generated styles and inline them into the server-rendered HTML.
+
+| Route mode        | CSS-in-JS support                                                 |
+| ----------------- | ----------------------------------------------------------------- |
+| `spa` (CSR only)  | ✅ Works — styles are injected on the client after mount           |
+| `ssr` / `ssg` / `isg` | ⚠️ Flash of unstyled content until hydration catches up       |
+
+> [!WARNING]
+> On server-rendered routes, runtime CSS-in-JS produces HTML without the matching `<style>` tags. The page paints unstyled, then re-paints after hydration — a noticeable flash, and not good for Core Web Vitals.
+
+**Guidance:** pick a build-time approach (CSS Modules, Tailwind, plain CSS) for any route that runs on the server. Keep CSS-in-JS for SPA-only routes if you really want it.
+
+---
+
+## Future Work
+
+First-class CSS-in-JS support — where pracht extracts critical styles during SSR and inlines them into the HTML — is contingent on upstream work tracked in [pracht#30](https://github.com/JoviDeCroock/pracht/issues/30). Once that lands, runtime CSS-in-JS libraries will have a path to render without a flash on server-rendered routes, and this recommendation will be revisited.
+
+Until then, reach for CSS Modules or Tailwind first.

--- a/examples/docs/src/shells/docs.tsx
+++ b/examples/docs/src/shells/docs.tsx
@@ -9,6 +9,7 @@ import {
   IconPlug,
   IconShield,
   IconLayout,
+  IconPalette,
   IconTerminal2,
   IconCloud,
   IconGauge,
@@ -38,6 +39,7 @@ const NAV = [
       { href: "/docs/api-routes", Icon: IconPlug, title: "API Routes" },
       { href: "/docs/middleware", Icon: IconShield, title: "Middleware" },
       { href: "/docs/shells", Icon: IconLayout, title: "Shells" },
+      { href: "/docs/styling", Icon: IconPalette, title: "Styling" },
     ],
   },
   {


### PR DESCRIPTION
## Summary

- Adds a new **Styling** doc to the repo ([docs/STYLING.md](docs/STYLING.md)) and the live docs site ([`/docs/styling`](examples/docs/src/routes/docs/styling.md)) that recommends CSS Modules, Tailwind, plain CSS, and other build-time approaches.
- Explains that runtime CSS-in-JS (styled-components, Emotion, goober in runtime mode) is currently only safe on SPA/CSR routes — pracht cannot inline runtime-generated critical CSS into SSR/SSG/ISG HTML, so those routes flash unstyled.
- Notes that first-class CSS-in-JS support with SSR critical-style extraction is contingent on upstream work tracked in https://github.com/JoviDeCroock/pracht/issues/30; the recommendation will be revisited once that lands.
- Wires the new page into the docs sidebar (Core Concepts → Styling) between Shells and CLI, and links the repo doc from the README repo map.

## Testing

- [x] `pnpm e2e`
- [x] `pnpm format`
- [x] `pnpm lint`
- [x] `pnpm test`

## Checklist

- [x] Docs updated if needed
- [x] Skills updated if needed — N/A (no behavioral change)
- [x] Changeset added if published packages changed — N/A (docs-only, no package changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)