### PR TITLE
Route dev SSR requests with dotted query params

### DIFF
--- a/.changeset/route-dotted-query-params.md
+++ b/.changeset/route-dotted-query-params.md
@@ -1,0 +1,5 @@
+---
+"@pracht/vite-plugin": patch
+---
+
+Allow dev SSR page routes to handle dotted query strings by checking only the URL pathname before handing static assets to Vite.

--- a/e2e/pages-router.test.ts
+++ b/e2e/pages-router.test.ts
@@ -109,6 +109,18 @@ test("pages include hydration state", async ({ request }) => {
   expect(html).toContain("Welcome to pracht with file-system routing");
 });
 
+test("page routes tolerate dotted query strings", async ({ request }) => {
+  const response = await request.get(
+    "/?shop=test-shop.myshopify.com&id_token=header.payload.signature",
+  );
+
+  expect(response.status()).toBe(200);
+  expect(response.headers()["content-type"]).toContain("text/html");
+
+  const html = await response.text();
+  expect(html).toContain("Welcome to pracht with file-system routing");
+});
+
 // ---------------------------------------------------------------------------
 // Route state JSON (client-side navigation data)
 // ---------------------------------------------------------------------------

--- a/packages/vite-plugin/src/index.ts
+++ b/packages/vite-plugin/src/index.ts
@@ -430,10 +430,11 @@ function createDevSSRMiddleware(
 ): Connect.NextHandleFunction {
   return async (req: IncomingMessage, res: ServerResponse, next: Connect.NextFunction) => {
     const url = req.url ?? "/";
+    const pathname = new URL(url, "http://localhost").pathname;
 
-    // Let Vite handle assets (have file extensions) and node_modules.
-    // Page routes are clean URLs without dots.
-    if (url.includes(".") || url.startsWith("/node_modules/")) {
+    // Let Vite handle assets by pathname. Query params may contain dotted
+    // domains or tokens, but they should not opt the route out of SSR.
+    if (pathname.includes(".") || pathname.startsWith("/node_modules/")) {
       return next();
     }
 


### PR DESCRIPTION
## Summary

- Update the dev SSR middleware asset check to inspect only the URL pathname
- Allow page routes with dotted query params, such as shop domains or JWT-like tokens, to continue through Pracht SSR
- Add a pages-router regression test for dotted query strings

## Context

This came up while testing a Pracht Shopify app through a Cloudflare tunnel. Shopify loads embedded apps with query params like `shop=test-shop.myshopify.com` and `id_token=...`; because the dev middleware checked the full `req.url` for `.`, those requests were treated like static assets and fell through to Vite’s `Cannot GET /` response instead of SSR.

## Testing

- [X] `pnpm e2e`
- [X] `pnpm format`
- [X] `pnpm lint`
- [X] `pnpm test`