### PR TITLE
Add `headers()` exports for page doc responses

### DIFF
--- a/.changeset/page-document-headers.md
+++ b/.changeset/page-document-headers.md
@@ -1,0 +1,8 @@
+---
+"@pracht/adapter-cloudflare": patch
+"@pracht/adapter-node": patch
+"@pracht/cli": patch
+"@pracht/core": patch
+---
+
+Add shell and route `headers()` exports for page document responses. Headers merge like `head()` metadata, are preserved in prerender output, and are applied to static SSG/ISG HTML served by the built-in adapters.

--- a/docs/ADAPTERS.md
+++ b/docs/ADAPTERS.md
@@ -26,6 +26,8 @@ For page routes, adapters must preserve the distinction between document
 requests and route-state fetches (`x-pracht-route-state-request: 1`). Cached or
 prerendered HTML should never satisfy a route-state fetch, and HTML responses
 should vary on that header when both representations can exist for the same URL.
+Prerendered HTML also carries route and shell document headers from the build
+header manifest so static responses match dynamic document responses.
 
 ---
 
@@ -112,6 +114,8 @@ When enabled, header precedence is:
   headers. Hashed assets under `/assets/` get `Cache-Control: public,
 max-age=31536000, immutable`; HTML and other files get `public, max-age=0,
 must-revalidate`. Clean URLs (e.g. `/about`) resolve to `about/index.html`.
+Prerendered HTML receives route and shell document headers from
+`dist/server/headers-manifest.json`.
 - **ISG revalidation**: checks `pracht-isg-manifest.json` for time revalidation
   metadata. Compares file mtime against revalidation window. Regenerates stale
   pages and writes updated HTML to disk. Route-state requests bypass the cached
@@ -133,6 +137,7 @@ export const handler = createNodeRequestHandler({
   registry,
   staticDir,
   isgManifest,
+  headersManifest,
   apiRoutes,
   clientEntryUrl,
   cssManifest,
@@ -161,6 +166,8 @@ the executable production server entry.
 - **Asset serving**: uses `env.ASSETS.fetch()` binding for static files
   (Cloudflare handles caching and CDN distribution). Static responses inherit
   the same default security headers applied to dynamic responses.
+  Prerendered HTML also receives route and shell document headers from
+  `dist/client/_pracht/headers.json`.
 - **Default request context**: generated worker entries pass `{ env,
 executionContext }` to pracht so loaders, actions, and middleware can access
   bindings without extra wiring.
@@ -260,7 +267,8 @@ export default {
   correct even without native Vercel ISR integration yet.
 - **Static security headers**: the generated `config.json` includes a `headers`
   section that applies the same baseline security headers to all responses,
-  including static assets served by Vercel's CDN.
+  including static assets served by Vercel's CDN. Static prerendered routes also
+  get route and shell document headers from the prerender header manifest.
 
 ### Entry module
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -108,6 +108,11 @@ export function head({ data }: HeadArgs<typeof loader>) {
   return { title: `Dashboard — ${data.user.name}` };
 }
 
+// Server: document response headers
+export function headers({ data }: HeadersArgs<typeof loader>) {
+  return { "cache-control": data.isPublic ? "public, max-age=60" : "no-store" };
+}
+
 // Client + SSR: the page component
 export default function Dashboard({ data }: RouteComponentProps<typeof loader>) {
   const liveData = useRouteData<typeof loader>();
@@ -146,8 +151,8 @@ export default function Dashboard({ data }: RouteComponentProps) {
 
 A named `Component` export is also supported for compatibility. Function-valued
 default exports are treated as the page component; named exports such as
-`loader`, `head`, `ErrorBoundary`, and `getStaticPaths` keep their framework
-roles.
+`loader`, `head`, `headers`, `ErrorBoundary`, and `getStaticPaths` keep their
+framework roles.
 
 Wired in the manifest via the `RouteConfig` object form:
 
@@ -184,6 +189,12 @@ export function head() {
   return {
     title: "Pracht App",
     meta: [{ name: "viewport", content: "width=device-width, initial-scale=1" }],
+  };
+}
+
+export function headers() {
+  return {
+    "content-security-policy": "default-src 'self'",
   };
 }
 ```
@@ -249,7 +260,7 @@ Browser request
   → Run middleware chain
   → Execute loader
   → Render Preact component tree to string
-  → Merge head metadata (shell + route)
+  → Merge head metadata and document headers (shell + route)
   → Inject escaped hydration state into a JSON script tag
   → Inject asset tags from Vite manifest
   → Return HTML Response

--- a/docs/DATA_LOADING.md
+++ b/docs/DATA_LOADING.md
@@ -27,8 +27,8 @@ export default function Dashboard({ data }: RouteComponentProps<typeof loader>) 
 ```
 
 The route component can be a function default export or a named `Component`
-export. Named route exports such as `loader`, `head`, `ErrorBoundary`, and
-`getStaticPaths` remain separate special exports.
+export. Named route exports such as `loader`, `head`, `headers`,
+`ErrorBoundary`, and `getStaticPaths` remain separate special exports.
 
 ### LoaderArgs
 
@@ -108,6 +108,26 @@ export function head({ data }: HeadArgs<typeof loader>) {
 
 Head metadata merges with the shell's head. Route-level values override shell
 values for `title`. Arrays (`meta`, `link`) are concatenated.
+
+---
+
+## Document Headers
+
+The `headers` export controls HTTP headers for the route's document response.
+It receives the same data-aware arguments as `head`:
+
+```typescript
+export function headers({ data }: HeadersArgs<typeof loader>) {
+  return {
+    "content-security-policy": `default-src 'self'; img-src 'self' ${data.cdnOrigin}`,
+  };
+}
+```
+
+Headers merge with the shell's `headers` export. Route-level headers override
+shell headers with the same name. They apply to HTML document responses,
+including prerendered SSG/ISG HTML, but not API routes or route-state JSON
+fetches.
 
 ---
 

--- a/docs/ROUTING.md
+++ b/docs/ROUTING.md
@@ -174,10 +174,20 @@ export function Shell({ children }: ShellProps) {
 export function head() {
   return { title: "My App" };
 }
+
+// Optional: shell-level document headers
+export function headers() {
+  return { "content-security-policy": "default-src 'self'" };
+}
 ```
 
 Shell head metadata is merged with route-level head. Route head takes precedence
 for conflicting keys (e.g. `title`).
+
+Shell document headers are merged with route-level `headers` exports. Route
+headers take precedence for matching names. These headers apply to HTML
+document responses, including prerendered SSG/ISG HTML, but not API routes or
+route-state JSON fetches.
 
 ---
 
@@ -271,6 +281,10 @@ export function Shell({ children }: ShellProps) {
       <main>{children}</main>
     </div>
   );
+}
+
+export function headers() {
+  return { "content-security-policy": "default-src 'self'" };
 }
 ```
 

--- a/docs/WORKSPACE.md
+++ b/docs/WORKSPACE.md
@@ -32,7 +32,8 @@ described in `VISION_MVP.md`.
 - **Server rendering** — `handlePrachtRequest()` executes the full request
   lifecycle: API route check → middleware chain → loader → Preact
   `renderToString` → HTML document assembly with hydration state
-  (`window.__PRACHT_STATE__`), head metadata merging, and client entry injection.
+  (`window.__PRACHT_STATE__`), head metadata/header merging, and client entry
+  injection.
 - **Render modes** — SSR, SSG, and ISG routes render server-side; SPA routes
   keep the route component client-only but now render their matched shell
   immediately, optionally with a shell `Loading` fallback. Route-state JSON

--- a/e2e/cloudflare-build.test.ts
+++ b/e2e/cloudflare-build.test.ts
@@ -47,6 +47,7 @@ test("pracht build emits a deployable Cloudflare Worker setup", async () => {
   const workerSource = readFileSync(serverEntryPath, "utf-8");
   expect(workerSource).toContain("cloudflareAssetsBinding");
   expect(workerSource).toContain('buildTarget = "cloudflare"');
+  expect(workerSource).toContain("_pracht/headers.json");
   expect(workerSource).toContain("server_default as default");
 });
 
@@ -59,8 +60,12 @@ test("prerendered SSG pages include client JS and working framework context", as
 
   // The home route is render: "ssg" — it should be prerendered as a static HTML file
   const htmlPath = resolve(distDir, "client/index.html");
+  const headersPath = resolve(distDir, "client/_pracht/headers.json");
   expect(existsSync(htmlPath)).toBe(true);
+  expect(existsSync(headersPath)).toBe(true);
   const html = readFileSync(htmlPath, "utf-8");
+  const headers = JSON.parse(readFileSync(headersPath, "utf-8"));
+  expect(headers["/"]["x-pracht-shell"]).toBe("public");
 
   // Must include the client entry script for hydration
   expect(html).toMatch(/<script type="module" src="\/assets\/client-[^"]+\.js"><\/script>/);

--- a/e2e/node-build.test.ts
+++ b/e2e/node-build.test.ts
@@ -42,6 +42,7 @@ test("pracht build emits a deployable Node server entry", async () => {
 
     const homeResponse = await fetch(`http://127.0.0.1:${port}/`);
     expect(homeResponse.status).toBe(200);
+    expect(homeResponse.headers.get("x-pracht-shell")).toBe("public");
     const homeHtml = await homeResponse.text();
     expect(homeHtml).toContain("Pracht starts with an explicit app manifest.");
     expect(homeHtml).not.toContain("/@pracht/client.js");
@@ -67,6 +68,7 @@ test("pracht build emits a deployable Node server entry", async () => {
       headers: { cookie: "session=1" },
     });
     expect(dashboardResponse.status).toBe(200);
+    expect(dashboardResponse.headers.get("x-pracht-shell")).toBe("app");
     const dashboardHtml = await dashboardResponse.text();
     expect(dashboardHtml).toContain("Ada Lovelace");
     expect(dashboardHtml).not.toContain("/@pracht/client.js");
@@ -77,6 +79,7 @@ test("pracht build emits a deployable Node server entry", async () => {
 
     const pricingResponse = await fetch(`http://127.0.0.1:${port}/pricing`);
     expect(pricingResponse.status).toBe(200);
+    expect(pricingResponse.headers.get("x-pracht-shell")).toBe("public");
     expect(pricingResponse.headers.get("vary")).toContain("x-pracht-route-state-request");
 
     const routeStateResponse = await fetch(`http://127.0.0.1:${port}/pricing`, {
@@ -84,6 +87,7 @@ test("pracht build emits a deployable Node server entry", async () => {
     });
     expect(routeStateResponse.status).toBe(200);
     expect(routeStateResponse.headers.get("content-type")).toContain("application/json");
+    expect(routeStateResponse.headers.get("x-pracht-shell")).toBeNull();
     expect(routeStateResponse.headers.get("vary")).toContain("x-pracht-route-state-request");
     expect(routeStateResponse.headers.get("cache-control")).toBe("no-store");
     await expect(routeStateResponse.json()).resolves.toEqual({

--- a/e2e/pages-router.test.ts
+++ b/e2e/pages-router.test.ts
@@ -8,6 +8,7 @@ test("home page renders with loader data via pages router", async ({ page }) => 
   const response = await page.goto("/");
   expect(response?.status()).toBe(200);
   expect(response?.headers()["content-type"]).toContain("text/html");
+  expect(response?.headers()["x-pracht-router"]).toBe("pages");
 
   // Shell renders
   await expect(page.locator(".pages-shell")).toBeVisible();
@@ -131,6 +132,7 @@ test("route state request returns JSON for pages", async ({ request }) => {
   });
 
   expect(response.status()).toBe(200);
+  expect(response.headers()["x-pracht-router"]).toBeUndefined();
   const json = await response.json();
   expect(json.data.message).toContain("file-system routing");
 });

--- a/e2e/vercel-build.test.ts
+++ b/e2e/vercel-build.test.ts
@@ -49,6 +49,19 @@ test("pracht build emits a deployable Vercel Build Output setup", async () => {
       expect.objectContaining({ src: "/(.*)", dest: "/render" }),
     ]),
   );
+  expect(config.headers).toEqual(
+    expect.arrayContaining([
+      expect.objectContaining({
+        source: "/",
+        headers: expect.arrayContaining([
+          {
+            key: "x-pracht-shell",
+            value: "public",
+          },
+        ]),
+      }),
+    ]),
+  );
 
   const functionConfig = JSON.parse(readFileSync(functionConfigPath, "utf-8"));
   expect(functionConfig).toMatchObject({

--- a/examples/basic/src/shells/app.tsx
+++ b/examples/basic/src/shells/app.tsx
@@ -28,3 +28,9 @@ export function head() {
     title: "Pracht App",
   };
 }
+
+export function headers() {
+  return {
+    "x-pracht-shell": "app",
+  };
+}

--- a/examples/basic/src/shells/public.tsx
+++ b/examples/basic/src/shells/public.tsx
@@ -22,3 +22,9 @@ export function head() {
     title: "Pracht Example",
   };
 }
+
+export function headers() {
+  return {
+    "x-pracht-shell": "public",
+  };
+}

--- a/examples/cloudflare/src/shells/app.tsx
+++ b/examples/cloudflare/src/shells/app.tsx
@@ -28,3 +28,9 @@ export function head() {
     title: "Pracht App",
   };
 }
+
+export function headers() {
+  return {
+    "x-pracht-shell": "app",
+  };
+}

--- a/examples/cloudflare/src/shells/public.tsx
+++ b/examples/cloudflare/src/shells/public.tsx
@@ -22,3 +22,9 @@ export function head() {
     title: "Pracht Example",
   };
 }
+
+export function headers() {
+  return {
+    "x-pracht-shell": "public",
+  };
+}

--- a/examples/docs/src/routes/docs/adapters.md
+++ b/examples/docs/src/routes/docs/adapters.md
@@ -23,6 +23,8 @@ Platform request (Node / CF / Vercel)
   → Convert Web Response back to platform response
 ```
 
+Adapters also preserve route and shell document headers for prerendered HTML so static SSG/ISG responses match dynamic document responses.
+
 ---
 
 ## Cloudflare Workers
@@ -62,6 +64,8 @@ dist/
   server/
     server.js      // Worker bundle
 ```
+
+Prerendered HTML receives document headers from the generated `_pracht/headers.json` asset.
 
 Keep your `wrangler.jsonc` in the project root so you can add bindings without the build overwriting them.
 
@@ -104,6 +108,8 @@ pracht({ adapter: vercelAdapter() })
 "@pracht/adapter-vercel": "*"
 ```
 
+Static prerendered routes receive document headers through the generated Build Output `headers` config.
+
 ### Build output
 
 ```
@@ -127,6 +133,8 @@ npx vercel deploy --prebuilt
 ## Node.js
 
 Run pracht as a standard Node.js HTTP server. The adapter handles static file serving, ISG stale-while-revalidate, request translation, and the generated `dist/server/server.js` entry boots the production server directly.
+
+Prerendered HTML receives document headers from `dist/server/headers-manifest.json`.
 
 ### Setup
 

--- a/examples/docs/src/routes/docs/data-loading.md
+++ b/examples/docs/src/routes/docs/data-loading.md
@@ -37,8 +37,8 @@ export default function Dashboard({ data }: RouteComponentProps<typeof loader>) 
 ```
 
 The route component can be a function default export or a named `Component`
-export. Named route exports such as `loader`, `head`, `ErrorBoundary`, and
-`getStaticPaths` remain separate special exports.
+export. Named route exports such as `loader`, `head`, `headers`,
+`ErrorBoundary`, and `getStaticPaths` remain separate special exports.
 
 ### LoaderArgs
 
@@ -100,6 +100,22 @@ export function head({ data }: HeadArgs<typeof loader>) {
   };
 }
 ```
+
+---
+
+## Document Headers
+
+The `headers` export controls HTTP headers for the route's document response. It receives the same data-aware arguments as `head`:
+
+```ts
+export function headers({ data }: HeadersArgs<typeof loader>) {
+  return {
+    "content-security-policy": `default-src 'self'; img-src 'self' ${data.cdnOrigin}`,
+  };
+}
+```
+
+Headers merge with the shell's `headers` export. Route-level headers override shell headers with the same name. They apply to HTML document responses, including prerendered SSG/ISG HTML, but not API routes or route-state JSON fetches.
 
 ---
 

--- a/examples/docs/src/routes/docs/routing.md
+++ b/examples/docs/src/routes/docs/routing.md
@@ -129,10 +129,17 @@ export function Shell({ children }: ShellProps) {
 export function head() {
   return { title: "My App" };
 }
+
+// Optional: shell-level document headers
+export function headers() {
+  return { "content-security-policy": "default-src 'self'" };
+}
 ```
 
 > [!NOTE]
 > Shell head metadata merges with route-level head. Route head takes precedence for `title`. Arrays like `meta` and `link` are concatenated.
+
+Shell document headers merge with route-level `headers` exports. Route headers take precedence for matching names. These headers apply to HTML document responses, including prerendered SSG/ISG HTML, but not API routes or route-state JSON fetches.
 
 ---
 
@@ -211,6 +218,10 @@ export function Shell({ children }: ShellProps) {
       <main>{children}</main>
     </div>
   );
+}
+
+export function headers() {
+  return { "content-security-policy": "default-src 'self'" };
 }
 ```
 

--- a/examples/docs/src/routes/docs/shells.md
+++ b/examples/docs/src/routes/docs/shells.md
@@ -56,6 +56,22 @@ export function head() {
 
 ---
 
+## Shell Document Headers
+
+Shells can contribute HTTP headers to page documents by exporting a `headers` function:
+
+```ts
+export function headers() {
+  return {
+    "content-security-policy": "default-src 'self'",
+  };
+}
+```
+
+Shell headers merge with route-level `headers` exports. Route headers override shell headers with the same name. These headers apply to HTML document responses and prerendered SSG/ISG HTML, not API routes or route-state JSON fetches.
+
+---
+
 ## Assigning Shells
 
 Register shells by name in `defineApp`, then reference them in routes or groups:

--- a/examples/pages-router/src/pages/_app.tsx
+++ b/examples/pages-router/src/pages/_app.tsx
@@ -25,3 +25,9 @@ export function head() {
     title: "Pracht Pages Router",
   };
 }
+
+export function headers() {
+  return {
+    "x-pracht-router": "pages",
+  };
+}

--- a/packages/adapter-cloudflare/src/index.ts
+++ b/packages/adapter-cloudflare/src/index.ts
@@ -8,6 +8,8 @@ import {
   type PrachtApp,
 } from "@pracht/core";
 
+type HeadersManifest = Record<string, Record<string, string>>;
+
 export interface CloudflareFetcher {
   fetch(input: Request | URL | string): Promise<Response>;
 }
@@ -37,6 +39,7 @@ export interface CloudflareAdapterOptions<
   cssManifest?: Record<string, string[]>;
   jsManifest?: Record<string, string[]>;
   assetsBinding?: string;
+  headersManifest?: HeadersManifest;
   createContext?: (args: CloudflareContextArgs<TEnv>) => TContext | Promise<TContext>;
 }
 
@@ -58,7 +61,12 @@ export function createCloudflareFetchHandler<
     env: TEnv,
     executionContext: CloudflareExecutionContext,
   ): Promise<Response> => {
-    const assetResponse = await maybeServeAsset(request, env, assetsBinding);
+    const assetResponse = await maybeServeAsset(
+      request,
+      env,
+      assetsBinding,
+      options.headersManifest ?? {},
+    );
     if (assetResponse) {
       return assetResponse;
     }
@@ -88,6 +96,28 @@ export function createCloudflareServerEntryModule(
   return [
     `export const cloudflareAssetsBinding = ${JSON.stringify(assetsBinding)};`,
     "",
+    "let headersManifestPromise;",
+    "async function readPrachtHeadersManifest(request, assets) {",
+    "  if (!headersManifestPromise) {",
+    "    const manifestUrl = new URL('/_pracht/headers.json', request.url);",
+    "    headersManifestPromise = assets.fetch(manifestUrl).then(async (response) => {",
+    "      if (!response.ok) return {};",
+    "      return response.json();",
+    "    }).catch(() => ({}));",
+    "  }",
+    "  return headersManifestPromise;",
+    "}",
+    "",
+    "function applyPrachtHeadersManifest(headers, headersManifest, pathname) {",
+    "  const withoutIndex = pathname.replace(/\\/index\\.html$/, '') || '/';",
+    "  const withoutSlash = pathname.replace(/\\/$/, '') || '/';",
+    "  const routeHeaders = headersManifest[pathname] ?? headersManifest[withoutSlash] ?? headersManifest[withoutIndex];",
+    "  if (!routeHeaders) return;",
+    "  for (const [key, value] of Object.entries(routeHeaders)) {",
+    "    headers.set(key, value);",
+    "  }",
+    "}",
+    "",
     "async function maybeServePrachtAsset(request, env) {",
     '  if (request.method !== "GET" && request.method !== "HEAD") {',
     "    return null;",
@@ -109,6 +139,9 @@ export function createCloudflareServerEntryModule(
     "  const headers = new Headers(response.headers);",
     "  headers.append('Vary', 'x-pracht-route-state-request');",
     "  applyDefaultSecurityHeaders(headers);",
+    "  if ((headers.get('content-type') ?? '').includes('text/html')) {",
+    "    applyPrachtHeadersManifest(headers, await readPrachtHeadersManifest(request, assets), new URL(request.url).pathname);",
+    "  }",
     "  return new Response(response.body, { status: response.status, statusText: response.statusText, headers });",
     "}",
     "",
@@ -139,6 +172,7 @@ async function maybeServeAsset(
   request: Request,
   env: Record<string, unknown>,
   assetsBinding: string,
+  headersManifest: HeadersManifest = {},
 ): Promise<Response | null> {
   if (request.method !== "GET" && request.method !== "HEAD") {
     return null;
@@ -160,11 +194,30 @@ async function maybeServeAsset(
   const headers = new Headers(response.headers);
   headers.append("Vary", "x-pracht-route-state-request");
   applyDefaultSecurityHeaders(headers);
+  if ((headers.get("content-type") ?? "").includes("text/html")) {
+    applyHeadersManifest(headers, headersManifest, new URL(request.url).pathname);
+  }
   return new Response(response.body, {
     status: response.status,
     statusText: response.statusText,
     headers,
   });
+}
+
+function applyHeadersManifest(
+  headers: Headers,
+  headersManifest: HeadersManifest,
+  pathname: string,
+): void {
+  const withoutIndex = pathname.replace(/\/index\.html$/, "") || "/";
+  const withoutSlash = pathname.replace(/\/$/, "") || "/";
+  const routeHeaders =
+    headersManifest[pathname] ?? headersManifest[withoutSlash] ?? headersManifest[withoutIndex];
+  if (!routeHeaders) return;
+
+  for (const [key, value] of Object.entries(routeHeaders)) {
+    headers.set(key, value);
+  }
 }
 
 function isFetcher(value: unknown): value is CloudflareFetcher {

--- a/packages/adapter-node/src/index.ts
+++ b/packages/adapter-node/src/index.ts
@@ -15,6 +15,8 @@ import {
 
 const ROUTE_STATE_REQUEST_HEADER = "x-pracht-route-state-request";
 
+type HeadersManifest = Record<string, Record<string, string>>;
+
 const MIME_TYPES: Record<string, string> = {
   ".html": "text/html; charset=utf-8",
   ".js": "application/javascript",
@@ -67,6 +69,7 @@ export interface NodeAdapterOptions<TContext = unknown> {
   cssUrls?: string[];
   cssManifest?: Record<string, string[]>;
   jsManifest?: Record<string, string[]>;
+  headersManifest?: HeadersManifest;
   createContext?: (args: NodeAdapterContextArgs) => TContext | Promise<TContext>;
   /**
    * Whether to trust proxy headers (`Forwarded`, `X-Forwarded-Proto`,
@@ -95,6 +98,7 @@ export function createNodeRequestHandler<TContext = unknown>(
   options: NodeAdapterOptions<TContext>,
 ) {
   const isgManifest = options.isgManifest ?? {};
+  const headersManifest = options.headersManifest ?? {};
   const staticDir = options.staticDir;
   const trustProxy = options.trustProxy ?? false;
 
@@ -126,6 +130,9 @@ export function createNodeRequestHandler<TContext = unknown>(
             "cache-control": staticResult.cacheControl,
           }),
         );
+        if (staticResult.contentType.includes("text/html")) {
+          applyHeadersManifest(headers, headersManifest, url.pathname);
+        }
         headers.forEach((value, key) => {
           res.setHeader(key, value);
         });
@@ -159,10 +166,11 @@ export function createNodeRequestHandler<TContext = unknown>(
           new Headers({
             "content-type": "text/html; charset=utf-8",
             "cache-control": "public, max-age=0, must-revalidate",
-            "x-pracht-isg": isStale ? "stale" : "fresh",
             vary: ROUTE_STATE_REQUEST_HEADER,
           }),
         );
+        applyHeadersManifest(headers, headersManifest, url.pathname);
+        headers.set("x-pracht-isg", isStale ? "stale" : "fresh");
         headers.forEach((value, key) => {
           res.setHeader(key, value);
         });
@@ -256,12 +264,17 @@ export function createNodeServerEntryModule(options: NodeServerEntryModuleOption
     "const isgManifest = existsSync(isgManifestPath)",
     '  ? JSON.parse(readFileSync(isgManifestPath, "utf-8"))',
     "  : {};",
+    'const headersManifestPath = resolve(serverDir, "headers-manifest.json");',
+    "const headersManifest = existsSync(headersManifestPath)",
+    '  ? JSON.parse(readFileSync(headersManifestPath, "utf-8"))',
+    "  : {};",
     "",
     "export const handler = createNodeRequestHandler({",
     "  app: resolvedApp,",
     "  registry,",
     "  staticDir,",
     "  isgManifest,",
+    "  headersManifest,",
     "  apiRoutes,",
     "  clientEntryUrl: clientEntryUrl ?? undefined,",
     "  cssManifest,",
@@ -428,6 +441,34 @@ async function writeWebResponse(res: ServerResponse, response: Response): Promis
 
   const body = Buffer.from(await response.arrayBuffer());
   res.end(body);
+}
+
+function applyHeadersManifest(
+  headers: Headers,
+  headersManifest: HeadersManifest,
+  pathname: string,
+): void {
+  const routeHeaders = getManifestHeaders(headersManifest, pathname);
+  if (!routeHeaders) return;
+
+  for (const [key, value] of Object.entries(routeHeaders)) {
+    headers.set(key, value);
+  }
+}
+
+function getManifestHeaders(
+  headersManifest: HeadersManifest,
+  pathname: string,
+): Record<string, string> | undefined {
+  const withoutIndex = pathname.replace(/\/index\.html$/, "") || "/";
+  const withoutSlash = pathname.replace(/\/$/, "") || "/";
+
+  return (
+    headersManifest[pathname] ??
+    headersManifest[withoutSlash] ??
+    headersManifest[withoutIndex] ??
+    undefined
+  );
 }
 
 function getFirstHeaderValue(value: string | string[] | undefined): string | undefined {

--- a/packages/cli/lib/build-shared.js
+++ b/packages/cli/lib/build-shared.js
@@ -14,7 +14,14 @@ export function setDefaultSecurityHeaders(res, headers = {}) {
   }
 }
 
-export function writeVercelBuildOutput({ functionName, regions, root, staticRoutes, isgRoutes }) {
+export function writeVercelBuildOutput({
+  functionName,
+  headersManifest = {},
+  regions,
+  root,
+  staticRoutes,
+  isgRoutes,
+}) {
   const outputDir = join(root, ".vercel/output");
   const staticDir = join(outputDir, "static");
   const functionDir = join(outputDir, "functions", `${functionName || "render"}.func`);
@@ -26,7 +33,11 @@ export function writeVercelBuildOutput({ functionName, regions, root, staticRout
 
   writeFileSync(
     join(outputDir, "config.json"),
-    `${JSON.stringify(createVercelOutputConfig({ functionName, staticRoutes, isgRoutes }), null, 2)}\n`,
+    `${JSON.stringify(
+      createVercelOutputConfig({ functionName, headersManifest, staticRoutes, isgRoutes }),
+      null,
+      2,
+    )}\n`,
     "utf-8",
   );
   writeFileSync(
@@ -38,7 +49,7 @@ export function writeVercelBuildOutput({ functionName, regions, root, staticRout
   return ".vercel/output";
 }
 
-function createVercelOutputConfig({ functionName, staticRoutes, isgRoutes }) {
+function createVercelOutputConfig({ functionName, headersManifest, staticRoutes, isgRoutes }) {
   const target = `/${functionName || "render"}`;
   const routes = [
     {
@@ -65,22 +76,33 @@ function createVercelOutputConfig({ functionName, staticRoutes, isgRoutes }) {
   routes.push({ handle: "filesystem" });
   routes.push({ dest: target, src: "/(.*)" });
 
+  const headers = [
+    {
+      headers: [
+        {
+          key: "permissions-policy",
+          value:
+            "accelerometer=(), camera=(), geolocation=(), gyroscope=(), magnetometer=(), microphone=(), payment=(), usb=()",
+        },
+        { key: "referrer-policy", value: "strict-origin-when-cross-origin" },
+        { key: "x-content-type-options", value: "nosniff" },
+        { key: "x-frame-options", value: "SAMEORIGIN" },
+      ],
+      source: "/(.*)",
+    },
+  ];
+
+  for (const route of sortStaticRoutes(staticRoutes)) {
+    const routeHeaders = headersManifest[route];
+    if (!routeHeaders) continue;
+    headers.push({
+      headers: Object.entries(routeHeaders).map(([key, value]) => ({ key, value })),
+      source: routeToHeaderSource(route),
+    });
+  }
+
   return {
-    headers: [
-      {
-        headers: [
-          {
-            key: "permissions-policy",
-            value:
-              "accelerometer=(), camera=(), geolocation=(), gyroscope=(), magnetometer=(), microphone=(), payment=(), usb=()",
-          },
-          { key: "referrer-policy", value: "strict-origin-when-cross-origin" },
-          { key: "x-content-type-options", value: "nosniff" },
-          { key: "x-frame-options", value: "SAMEORIGIN" },
-        ],
-        source: "/(.*)",
-      },
-    ],
+    headers,
     framework: {
       version: VERSION,
     },
@@ -120,6 +142,10 @@ function routeToStaticHtmlPath(route) {
   }
 
   return `${route}/index.html`;
+}
+
+function routeToHeaderSource(route) {
+  return route === "/" ? "/" : route;
 }
 
 function escapeRegex(value) {

--- a/packages/cli/lib/commands/build.js
+++ b/packages/cli/lib/commands/build.js
@@ -60,6 +60,9 @@ export async function buildCommand() {
       registry: serverMod.registry,
       withISGManifest: true,
     });
+    const headersManifest = Object.fromEntries(
+      pages.map((page) => [page.path, page.headers ?? {}]),
+    );
 
     if (pages.length > 0) {
       console.log(`\n  Prerendering ${pages.length} SSG/ISG route(s)...\n`);
@@ -73,6 +76,17 @@ export async function buildCommand() {
         writeFileSync(filePath, page.html, "utf-8");
         console.log(`    ${page.path} → ${filePath.replace(root + "/", "")}`);
       }
+    }
+
+    if (Object.keys(headersManifest).length > 0) {
+      const headersManifestJson = `${JSON.stringify(headersManifest, null, 2)}\n`;
+      writeFileSync(
+        resolve(root, "dist/server/headers-manifest.json"),
+        headersManifestJson,
+        "utf-8",
+      );
+      mkdirSync(resolve(clientDir, "_pracht"), { recursive: true });
+      writeFileSync(resolve(clientDir, "_pracht/headers.json"), headersManifestJson, "utf-8");
     }
 
     if (Object.keys(isgManifest).length > 0) {
@@ -92,6 +106,7 @@ export async function buildCommand() {
       const outputPath = writeVercelBuildOutput({
         functionName: serverMod.vercelFunctionName,
         isgRoutes: Object.keys(isgManifest),
+        headersManifest,
         regions: serverMod.vercelRegions,
         root,
         staticRoutes: pages.map((page) => page.path).filter((path) => !(path in isgManifest)),

--- a/packages/framework/src/index.ts
+++ b/packages/framework/src/index.ts
@@ -42,6 +42,7 @@ export type {
   GroupMeta,
   HeadArgs,
   HeadMetadata,
+  HeadersArgs,
   HttpMethod,
   LoaderArgs,
   LoaderData,

--- a/packages/framework/src/runtime.ts
+++ b/packages/framework/src/runtime.ts
@@ -519,8 +519,9 @@ export async function handlePrachtRequest<TContext>(
       ? await resolveRegistryModule<ShellModule>(registry.shellModules, match.route.shellFile)
       : undefined;
 
-    // --- Merge head metadata ---
+    // --- Merge document metadata ---
     const head = await mergeHeadMetadata(shellModule, routeModule, routeArgs, data);
+    const documentHeaders = await mergeDocumentHeaders(shellModule, routeModule, routeArgs, data);
 
     const cssUrls = resolvePageCssUrls(options, match.route.shellFile, match.route.file);
     const modulePreloadUrls = resolvePageJsUrls(options, match.route.shellFile, match.route.file);
@@ -560,6 +561,8 @@ export async function handlePrachtRequest<TContext>(
           cssUrls,
           modulePreloadUrls,
         }),
+        200,
+        documentHeaders,
       );
     }
 
@@ -605,6 +608,8 @@ export async function handlePrachtRequest<TContext>(
         cssUrls,
         modulePreloadUrls,
       }),
+      200,
+      documentHeaders,
     );
   } catch (error: unknown) {
     return renderRouteErrorResponse({
@@ -969,6 +974,12 @@ async function renderRouteErrorResponse<TContext>(options: {
         )
       : undefined);
   const head = shellModule?.head ? await shellModule.head(options.routeArgs) : {};
+  const documentHeaders = await mergeDocumentHeaders(
+    shellModule,
+    undefined,
+    options.routeArgs,
+    undefined,
+  );
   const cssUrls = resolvePageCssUrls(
     options.options,
     options.shellFile,
@@ -1013,6 +1024,7 @@ async function renderRouteErrorResponse<TContext>(options: {
       modulePreloadUrls,
     }),
     routeErrorWithDiagnostics.status,
+    documentHeaders,
   );
 }
 
@@ -1126,6 +1138,34 @@ async function mergeHeadMetadata(
   };
 }
 
+async function mergeDocumentHeaders(
+  shellModule: ShellModule | undefined,
+  routeModule: RouteModule | undefined,
+  routeArgs: BaseRouteArgs<unknown>,
+  data: unknown,
+): Promise<Headers> {
+  const headers = new Headers();
+  const shellHeaders = shellModule?.headers ? await shellModule.headers(routeArgs) : undefined;
+  if (shellHeaders) {
+    applyHeaders(headers, shellHeaders);
+  }
+
+  const routeHeaders = routeModule?.headers
+    ? await routeModule.headers({ ...routeArgs, data } as any)
+    : undefined;
+  if (routeHeaders) {
+    applyHeaders(headers, routeHeaders);
+  }
+
+  return headers;
+}
+
+function applyHeaders(headers: Headers, init: HeadersInit): void {
+  new Headers(init).forEach((value, key) => {
+    headers.set(key, value);
+  });
+}
+
 function buildHtmlDocument(options: {
   head: HeadMetadata;
   body: string;
@@ -1194,11 +1234,12 @@ function buildHtmlDocument(options: {
 </html>`;
 }
 
-function htmlResponse(html: string, status = 200): Response {
-  const headers = applySecurityAndRouteHeaders(
-    new Headers({ "content-type": "text/html; charset=utf-8" }),
-    { isRouteStateRequest: false },
-  );
+function htmlResponse(html: string, status = 200, initHeaders?: HeadersInit): Response {
+  const headers = new Headers({ "content-type": "text/html; charset=utf-8" });
+  if (initHeaders) {
+    applyHeaders(headers, initHeaders);
+  }
+  applySecurityAndRouteHeaders(headers, { isRouteStateRequest: false });
   return new Response(html, { status, headers });
 }
 
@@ -1304,6 +1345,7 @@ function serializeJsonForHtml(value: unknown): string {
 export interface PrerenderResult {
   path: string;
   html: string;
+  headers?: Record<string, string>;
 }
 
 export interface ISGManifestEntry {
@@ -1378,13 +1420,17 @@ export async function prerenderApp(
         }
 
         const html = await response.text();
-        return { item, html };
+        return { headers: Object.fromEntries(response.headers), html, item };
       }),
     );
 
     for (const result of batchResults) {
       if (!result) continue;
-      results.push({ path: result.item.pathname, html: result.html });
+      results.push({
+        path: result.item.pathname,
+        html: result.html,
+        headers: result.headers,
+      });
       if (result.item.render === "isg" && result.item.revalidate) {
         isgManifest[result.item.pathname] = { revalidate: result.item.revalidate };
       }

--- a/packages/framework/src/types.ts
+++ b/packages/framework/src/types.ts
@@ -200,6 +200,13 @@ export interface HeadArgs<
   data: LoaderData<TLoader>;
 }
 
+export interface HeadersArgs<
+  TLoader extends LoaderLike = undefined,
+  TContext = any,
+> extends BaseRouteArgs<TContext> {
+  data: LoaderData<TLoader>;
+}
+
 export interface RouteComponentProps<TLoader extends LoaderLike = undefined> {
   data: LoaderData<TLoader>;
   params: RouteParams;
@@ -220,6 +227,7 @@ export type LoaderFn<TContext = any, TData = unknown> = (
 export interface RouteModule<TContext = any, TLoader extends LoaderLike = undefined> {
   loader?: LoaderFn<TContext>;
   head?: (args: HeadArgs<TLoader, TContext>) => MaybePromise<HeadMetadata>;
+  headers?: (args: HeadersArgs<TLoader, TContext>) => MaybePromise<HeadersInit>;
   Component?: FunctionComponent<RouteComponentProps<TLoader>>;
   default?: FunctionComponent<RouteComponentProps<TLoader>>;
   ErrorBoundary?: FunctionComponent<ErrorBoundaryProps>;
@@ -230,6 +238,7 @@ export interface ShellModule<TContext = any> {
   Shell: FunctionComponent<ShellProps>;
   Loading?: FunctionComponent;
   head?: (args: BaseRouteArgs<TContext>) => MaybePromise<HeadMetadata>;
+  headers?: (args: BaseRouteArgs<TContext>) => MaybePromise<HeadersInit>;
 }
 
 export type MiddlewareResult<TContext = any> =

--- a/packages/framework/test/runtime.test.ts
+++ b/packages/framework/test/runtime.test.ts
@@ -367,6 +367,89 @@ describe("handlePrachtRequest cache variance", () => {
   });
 });
 
+describe("handlePrachtRequest document headers", () => {
+  it("merges shell and route headers for document responses", async () => {
+    const app = defineApp({
+      routes: [route("/pricing", "./routes/pricing.tsx", { render: "ssr", shell: "public" })],
+      shells: {
+        public: "./shells/public.tsx",
+      },
+    });
+
+    const response = await handlePrachtRequest({
+      app,
+      registry: {
+        routeModules: {
+          "./routes/pricing.tsx": async () => ({
+            Component: ({ data }) => h("main", null, (data as { plan: string }).plan),
+            headers: ({ data }) => ({
+              "x-plan": (data as { plan: string }).plan,
+              "x-scope": "route",
+            }),
+            loader: async () => ({ plan: "MVP" }),
+          }),
+        },
+        shellModules: {
+          "./shells/public.tsx": async () => ({
+            headers: () => ({
+              "content-security-policy": "default-src 'self'",
+              "x-scope": "shell",
+              "x-shell": "public",
+            }),
+            Shell: ({ children }) => h("section", null, children),
+          }),
+        },
+      },
+      request: new Request("http://localhost/pricing"),
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-security-policy")).toBe("default-src 'self'");
+    expect(response.headers.get("x-shell")).toBe("public");
+    expect(response.headers.get("x-plan")).toBe("MVP");
+    expect(response.headers.get("x-scope")).toBe("route");
+    expect(response.headers.get("vary")).toContain("x-pracht-route-state-request");
+  });
+
+  it("does not apply document headers to route-state JSON responses", async () => {
+    const app = defineApp({
+      routes: [route("/pricing", "./routes/pricing.tsx", { render: "ssr", shell: "public" })],
+      shells: {
+        public: "./shells/public.tsx",
+      },
+    });
+
+    const response = await handlePrachtRequest({
+      app,
+      registry: {
+        routeModules: {
+          "./routes/pricing.tsx": async () => ({
+            Component: ({ data }) => h("main", null, (data as { plan: string }).plan),
+            headers: () => ({ "x-route": "pricing" }),
+            loader: async () => ({ plan: "MVP" }),
+          }),
+        },
+        shellModules: {
+          "./shells/public.tsx": async () => ({
+            headers: () => ({ "x-shell": "public" }),
+            Shell: ({ children }) => h("section", null, children),
+          }),
+        },
+      },
+      request: new Request("http://localhost/pricing", {
+        headers: {
+          "x-pracht-route-state-request": "1",
+        },
+      }),
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("x-route")).toBeNull();
+    expect(response.headers.get("x-shell")).toBeNull();
+    await expect(response.json()).resolves.toEqual({ data: { plan: "MVP" } });
+  });
+});
+
 describe("handlePrachtRequest SPA shell fallback", () => {
   it("renders shell chrome and loading UI for SPA routes without serializing loader data", async () => {
     const app = defineApp({
@@ -440,6 +523,40 @@ describe("prerenderApp", () => {
     expect(page.html).toContain('<link rel="modulepreload" href="/assets/public-abc123.js">');
     expect(page.html).toContain('<link rel="modulepreload" href="/assets/pricing-abc123.js">');
     expect(page.html).toContain('<link rel="modulepreload" href="/assets/vendor-abc123.js">');
+  });
+
+  it("preserves document headers on prerendered pages", async () => {
+    const app = defineApp({
+      routes: [route("/pricing", "./routes/pricing.tsx", { render: "ssg", shell: "public" })],
+      shells: {
+        public: "./shells/public.tsx",
+      },
+    });
+
+    const [page] = await prerenderApp({
+      app,
+      registry: {
+        routeModules: {
+          "/src/routes/pricing.tsx": async () => ({
+            Component: ({ data }) => h("main", null, (data as { plan: string }).plan),
+            headers: ({ data }) => ({ "x-plan": (data as { plan: string }).plan }),
+            loader: async () => ({ plan: "MVP" }),
+          }),
+        },
+        shellModules: {
+          "/src/shells/public.tsx": async () => ({
+            headers: () => ({ "content-security-policy": "default-src 'self'" }),
+            Shell: ({ children }) => h("section", null, children),
+          }),
+        },
+      },
+    });
+
+    expect(page.path).toBe("/pricing");
+    expect(page.headers).toMatchObject({
+      "content-security-policy": "default-src 'self'",
+      "x-plan": "MVP",
+    });
   });
 
   it("renders multiple static paths concurrently", async () => {


### PR DESCRIPTION
## Summary

- Added typed shell and route `headers()` exports
- Headers merge shell first, route second, so route headers override shell headers by name.
- Headers apply to HTML document responses, including SSG/ISG output, and intentionally do not apply to API routes or route-state JSON.
- Preserved prerendered headers through build manifests and adapter serving paths in Node, Cloudflare, and Vercel output.

## Testing

- [X] `pnpm e2e`
- [X] `pnpm format`
- [X] `pnpm lint`
- [X] `pnpm test`

## Checklist

- [X] Docs updated if needed
- [X] Skills updated if needed
- [X] Changeset added if published packages changed
