### PR TITLE
Add exports option to Cloudflare adapter for worker primitives

### DIFF
--- a/.changeset/cf-worker-exports.md
+++ b/.changeset/cf-worker-exports.md
@@ -1,0 +1,5 @@
+---
+"@pracht/adapter-cloudflare": minor
+---
+
+Add `exports` option to re-export Cloudflare primitives (Workflows, Durable Objects, Queues, etc.) from the generated worker entry. Wrangler requires these named exports to discover and register the classes.

--- a/.changeset/cf-worker-exports.md
+++ b/.changeset/cf-worker-exports.md
@@ -4,5 +4,4 @@
 
 Add a `workerExportsFrom` option so Cloudflare primitives (Workflows, Durable
 Objects, Queues, etc.) can be re-exported from a dedicated user-owned module
-instead of duplicating names and file paths in `vite.config.ts`. The older
-`exports` array remains available as a deprecated fallback.
+instead of duplicating names and file paths in `vite.config.ts`.

--- a/.changeset/cf-worker-exports.md
+++ b/.changeset/cf-worker-exports.md
@@ -2,4 +2,7 @@
 "@pracht/adapter-cloudflare": minor
 ---
 
-Add `exports` option to re-export Cloudflare primitives (Workflows, Durable Objects, Queues, etc.) from the generated worker entry. Wrangler requires these named exports to discover and register the classes.
+Add a `workerExportsFrom` option so Cloudflare primitives (Workflows, Durable
+Objects, Queues, etc.) can be re-exported from a dedicated user-owned module
+instead of duplicating names and file paths in `vite.config.ts`. The older
+`exports` array remains available as a deprecated fallback.

--- a/docs/ADAPTERS.md
+++ b/docs/ADAPTERS.md
@@ -185,21 +185,26 @@ the executable production server entry.
 ### Exporting Cloudflare primitives (Workflows, Durable Objects, etc.)
 
 Wrangler requires named exports from the worker entry for Workflows, Durable
-Objects, Queues, and other Cloudflare primitives. Use the `exports` option to
-re-export them from your source files:
+Objects, Queues, and other Cloudflare primitives. Use the
+`workerExportsFrom` option to point the adapter at a dedicated module that
+re-exports them:
 
 ```typescript
 cloudflareAdapter({
-  exports: [
-    { from: "/src/workers/counter.ts", names: ["Counter"] },
-    { from: "/src/workers/my-workflow.ts", names: ["MyWorkflow"] },
-  ],
+  workerExportsFrom: "/src/cloudflare.ts",
 });
 ```
 
-This generates `export { Counter } from "/src/workers/counter.ts"` (etc.) in the
-built worker entry, which is what Wrangler needs to discover and register the
-classes. Pair this with the corresponding `wrangler.jsonc` bindings:
+```typescript
+// src/cloudflare.ts
+export { Counter } from "./workers/counter.ts";
+export { MyWorkflow } from "./workers/my-workflow.ts";
+```
+
+This generates `export * from "/src/cloudflare.ts"` in the built worker entry,
+which is what Wrangler needs to discover and register the classes. Keep the
+module focused on Cloudflare primitives so the generated worker entry stays
+explicit. Pair this with the corresponding `wrangler.jsonc` bindings:
 
 ```jsonc
 {
@@ -208,6 +213,11 @@ classes. Pair this with the corresponding `wrangler.jsonc` bindings:
   },
 }
 ```
+
+The older `exports` array is still accepted as a deprecated fallback, but
+`workerExportsFrom` is the recommended path because it keeps Cloudflare-specific
+exports in one user-owned module instead of duplicating names and file paths in
+`vite.config.ts`.
 
 ### Using Cloudflare bindings in dev
 

--- a/docs/ADAPTERS.md
+++ b/docs/ADAPTERS.md
@@ -182,6 +182,33 @@ the executable production server entry.
   routes and loaders have full access to Cloudflare bindings (KV, D1, R2,
   Queues, etc.) during development.
 
+### Exporting Cloudflare primitives (Workflows, Durable Objects, etc.)
+
+Wrangler requires named exports from the worker entry for Workflows, Durable
+Objects, Queues, and other Cloudflare primitives. Use the `exports` option to
+re-export them from your source files:
+
+```typescript
+cloudflareAdapter({
+  exports: [
+    { from: "/src/workers/counter.ts", names: ["Counter"] },
+    { from: "/src/workers/my-workflow.ts", names: ["MyWorkflow"] },
+  ],
+});
+```
+
+This generates `export { Counter } from "/src/workers/counter.ts"` (etc.) in the
+built worker entry, which is what Wrangler needs to discover and register the
+classes. Pair this with the corresponding `wrangler.jsonc` bindings:
+
+```jsonc
+{
+  "durable_objects": {
+    "bindings": [{ "name": "COUNTER", "class_name": "Counter" }],
+  },
+}
+```
+
 ### Using Cloudflare bindings in dev
 
 The adapter handles everything — just declare bindings in `wrangler.jsonc`:

--- a/docs/ADAPTERS.md
+++ b/docs/ADAPTERS.md
@@ -214,11 +214,6 @@ explicit. Pair this with the corresponding `wrangler.jsonc` bindings:
 }
 ```
 
-The older `exports` array is still accepted as a deprecated fallback, but
-`workerExportsFrom` is the recommended path because it keeps Cloudflare-specific
-exports in one user-owned module instead of duplicating names and file paths in
-`vite.config.ts`.
-
 ### Using Cloudflare bindings in dev
 
 The adapter handles everything — just declare bindings in `wrangler.jsonc`:

--- a/e2e/cloudflare-build.test.ts
+++ b/e2e/cloudflare-build.test.ts
@@ -49,6 +49,9 @@ test("pracht build emits a deployable Cloudflare Worker setup", async () => {
   expect(workerSource).toContain('buildTarget = "cloudflare"');
   expect(workerSource).toContain("_pracht/headers.json");
   expect(workerSource).toContain("server_default as default");
+
+  // Cloudflare primitives configured via `exports` must be re-exported
+  expect(workerSource).toContain("Counter");
 });
 
 test("prerendered SSG pages include client JS and working framework context", async () => {

--- a/e2e/cloudflare-build.test.ts
+++ b/e2e/cloudflare-build.test.ts
@@ -50,7 +50,7 @@ test("pracht build emits a deployable Cloudflare Worker setup", async () => {
   expect(workerSource).toContain("_pracht/headers.json");
   expect(workerSource).toContain("server_default as default");
 
-  // Cloudflare primitives configured via `exports` must be re-exported
+  // Cloudflare primitives configured via `workerExportsFrom` must be re-exported
   expect(workerSource).toContain("Counter");
 });
 

--- a/examples/cloudflare/README.md
+++ b/examples/cloudflare/README.md
@@ -12,7 +12,9 @@ This example is wired to Pracht's Cloudflare build target.
 ## Deploy
 
 The `wrangler.jsonc` in this directory is yours to edit — add KV, D1, R2,
-cron triggers, or any other Cloudflare bindings as needed. After building:
+cron triggers, or any other Cloudflare bindings as needed. Re-export Durable
+Objects, Workflows, or Queues from `src/cloudflare.ts` so Wrangler can discover
+them from the generated Worker entry. After building:
 
 ```bash
 pnpm dlx wrangler deploy

--- a/examples/cloudflare/src/cloudflare.ts
+++ b/examples/cloudflare/src/cloudflare.ts
@@ -1,0 +1,1 @@
+export { Counter } from "./workers/counter.ts";

--- a/examples/cloudflare/src/workers/counter.ts
+++ b/examples/cloudflare/src/workers/counter.ts
@@ -1,0 +1,7 @@
+export class Counter {
+  private value = 0;
+
+  async fetch(): Promise<Response> {
+    return Response.json({ value: ++this.value });
+  }
+}

--- a/examples/cloudflare/vite.config.ts
+++ b/examples/cloudflare/vite.config.ts
@@ -6,7 +6,7 @@ export default defineConfig({
   plugins: [
     pracht({
       adapter: cloudflareAdapter({
-        exports: [{ from: "/src/workers/counter.ts", names: ["Counter"] }],
+        workerExportsFrom: "/src/cloudflare.ts",
       }),
     }),
   ],

--- a/examples/cloudflare/vite.config.ts
+++ b/examples/cloudflare/vite.config.ts
@@ -3,5 +3,11 @@ import { pracht } from "@pracht/vite-plugin";
 import { cloudflareAdapter } from "@pracht/adapter-cloudflare";
 
 export default defineConfig({
-  plugins: [pracht({ adapter: cloudflareAdapter() })],
+  plugins: [
+    pracht({
+      adapter: cloudflareAdapter({
+        exports: [{ from: "/src/workers/counter.ts", names: ["Counter"] }],
+      }),
+    }),
+  ],
 });

--- a/examples/cloudflare/wrangler.jsonc
+++ b/examples/cloudflare/wrangler.jsonc
@@ -9,4 +9,8 @@
     "run_worker_first": true,
   },
   "kv_namespaces": [{ "binding": "MY_KV", "id": "abc123" }],
+  "durable_objects": {
+    "bindings": [{ "name": "COUNTER", "class_name": "Counter" }],
+  },
+  "migrations": [{ "tag": "v1", "new_classes": ["Counter"] }],
 }

--- a/examples/docs/src/routes/docs/adapters.md
+++ b/examples/docs/src/routes/docs/adapters.md
@@ -69,6 +69,34 @@ Prerendered HTML receives document headers from the generated `_pracht/headers.j
 
 Keep your `wrangler.jsonc` in the project root so you can add bindings without the build overwriting them.
 
+### Exporting Durable Objects and other primitives
+
+Wrangler discovers Durable Objects, Workflows, Queues, and similar primitives
+from named exports on the Worker entry. Point the adapter at a dedicated module
+that re-exports them:
+
+```ts [vite.config.ts]
+import { defineConfig } from "vite";
+import { pracht } from "@pracht/vite-plugin";
+import { cloudflareAdapter } from "@pracht/adapter-cloudflare";
+
+export default defineConfig({
+  plugins: [
+    pracht({
+      adapter: cloudflareAdapter({
+        workerExportsFrom: "/src/cloudflare.ts",
+      }),
+    }),
+  ],
+});
+```
+
+```ts [src/cloudflare.ts]
+export { Counter } from "./workers/counter.ts";
+```
+
+Keep the matching bindings and migrations in `wrangler.jsonc`.
+
 ### Accessing Cloudflare bindings
 
 The `env` object is passed through to your loaders and API routes via the context:

--- a/examples/docs/src/routes/docs/deployment.md
+++ b/examples/docs/src/routes/docs/deployment.md
@@ -50,6 +50,9 @@ wrangler deploy
 ```
 
 Configure bindings (KV, D1, R2) in `wrangler.jsonc`. They are available via `context.env` in loaders and API routes.
+For Durable Objects, Workflows, and other worker primitives, re-export them
+from a dedicated module and pass that module via
+`cloudflareAdapter({ workerExportsFrom: "/src/cloudflare.ts" })`.
 
 ---
 

--- a/packages/adapter-cloudflare/README.md
+++ b/packages/adapter-cloudflare/README.md
@@ -22,6 +22,33 @@ Deploy with:
 pracht build && wrangler deploy
 ```
 
+Export Durable Objects, Workflows, Queues, and other Cloudflare primitives from
+a dedicated module:
+
+```ts
+// vite.config.ts
+import { defineConfig } from "vite";
+import { pracht } from "@pracht/vite-plugin";
+import { cloudflareAdapter } from "@pracht/adapter-cloudflare";
+
+export default defineConfig({
+  plugins: [
+    pracht({
+      adapter: cloudflareAdapter({
+        workerExportsFrom: "/src/cloudflare.ts",
+      }),
+    }),
+  ],
+});
+```
+
+```ts
+// src/cloudflare.ts
+export { Counter } from "./workers/counter.ts";
+```
+
+Keep the matching bindings and migrations in `wrangler.jsonc`.
+
 ## Features
 
 - Converts Cloudflare Worker requests to standard Web Requests

--- a/packages/adapter-cloudflare/src/index.ts
+++ b/packages/adapter-cloudflare/src/index.ts
@@ -44,21 +44,9 @@ export interface CloudflareAdapterOptions<
   createContext?: (args: CloudflareContextArgs<TEnv>) => TContext | Promise<TContext>;
 }
 
-/**
- * @deprecated Use `workerExportsFrom` and re-export worker primitives from a dedicated module.
- */
-export interface CloudflareWorkerExport {
-  from: string;
-  names: string[];
-}
-
 export interface CloudflareServerEntryModuleOptions {
   assetsBinding?: string;
   workerExportsFrom?: string;
-  /**
-   * @deprecated Use `workerExportsFrom` and re-export the primitives from a dedicated module instead.
-   */
-  exports?: CloudflareWorkerExport[];
 }
 
 export function createCloudflareFetchHandler<
@@ -105,18 +93,10 @@ export function createCloudflareFetchHandler<
 export function createCloudflareServerEntryModule(
   options: CloudflareServerEntryModuleOptions = {},
 ): string {
-  if (options.workerExportsFrom && options.exports?.length) {
-    throw new Error(
-      '[pracht] cloudflareAdapter options "workerExportsFrom" and "exports" cannot be used together.',
-    );
-  }
-
   const assetsBinding = options.assetsBinding ?? "ASSETS";
   const workerExports = options.workerExportsFrom
     ? [`export * from ${JSON.stringify(options.workerExportsFrom)};`]
-    : (options.exports ?? []).map(
-        (exp) => `export { ${exp.names.join(", ")} } from ${JSON.stringify(exp.from)};`,
-      );
+    : [];
 
   return [
     `export const cloudflareAssetsBinding = ${JSON.stringify(assetsBinding)};`,

--- a/packages/adapter-cloudflare/src/index.ts
+++ b/packages/adapter-cloudflare/src/index.ts
@@ -44,6 +44,9 @@ export interface CloudflareAdapterOptions<
   createContext?: (args: CloudflareContextArgs<TEnv>) => TContext | Promise<TContext>;
 }
 
+/**
+ * @deprecated Use `workerExportsFrom` and re-export worker primitives from a dedicated module.
+ */
 export interface CloudflareWorkerExport {
   from: string;
   names: string[];
@@ -51,6 +54,10 @@ export interface CloudflareWorkerExport {
 
 export interface CloudflareServerEntryModuleOptions {
   assetsBinding?: string;
+  workerExportsFrom?: string;
+  /**
+   * @deprecated Use `workerExportsFrom` and re-export the primitives from a dedicated module instead.
+   */
   exports?: CloudflareWorkerExport[];
 }
 
@@ -98,7 +105,18 @@ export function createCloudflareFetchHandler<
 export function createCloudflareServerEntryModule(
   options: CloudflareServerEntryModuleOptions = {},
 ): string {
+  if (options.workerExportsFrom && options.exports?.length) {
+    throw new Error(
+      '[pracht] cloudflareAdapter options "workerExportsFrom" and "exports" cannot be used together.',
+    );
+  }
+
   const assetsBinding = options.assetsBinding ?? "ASSETS";
+  const workerExports = options.workerExportsFrom
+    ? [`export * from ${JSON.stringify(options.workerExportsFrom)};`]
+    : (options.exports ?? []).map(
+        (exp) => `export { ${exp.names.join(", ")} } from ${JSON.stringify(exp.from)};`,
+      );
 
   return [
     `export const cloudflareAssetsBinding = ${JSON.stringify(assetsBinding)};`,
@@ -172,9 +190,7 @@ export function createCloudflareServerEntryModule(
     "",
     "export default { fetch };",
     "",
-    ...(options.exports ?? []).map(
-      (exp) => `export { ${exp.names.join(", ")} } from ${JSON.stringify(exp.from)};`,
-    ),
+    ...workerExports,
     "",
   ].join("\n");
 }
@@ -240,7 +256,7 @@ function isFetcher(value: unknown): value is CloudflareFetcher {
  *
  * ```ts
  * import { cloudflareAdapter } from "@pracht/adapter-cloudflare";
- * pracht({ adapter: cloudflareAdapter() })
+ * pracht({ adapter: cloudflareAdapter({ workerExportsFrom: "/src/cloudflare.ts" }) })
  * ```
  */
 export function cloudflareAdapter(options: CloudflareServerEntryModuleOptions = {}): PrachtAdapter {

--- a/packages/adapter-cloudflare/src/index.ts
+++ b/packages/adapter-cloudflare/src/index.ts
@@ -44,8 +44,14 @@ export interface CloudflareAdapterOptions<
   createContext?: (args: CloudflareContextArgs<TEnv>) => TContext | Promise<TContext>;
 }
 
+export interface CloudflareWorkerExport {
+  from: string;
+  names: string[];
+}
+
 export interface CloudflareServerEntryModuleOptions {
   assetsBinding?: string;
+  exports?: CloudflareWorkerExport[];
 }
 
 export function createCloudflareFetchHandler<
@@ -165,6 +171,10 @@ export function createCloudflareServerEntryModule(
     "}",
     "",
     "export default { fetch };",
+    "",
+    ...(options.exports ?? []).map(
+      (exp) => `export { ${exp.names.join(", ")} } from ${JSON.stringify(exp.from)};`,
+    ),
     "",
   ].join("\n");
 }

--- a/packages/adapter-cloudflare/test/index.test.ts
+++ b/packages/adapter-cloudflare/test/index.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+
+import { createCloudflareServerEntryModule } from "../src/index.ts";
+
+describe("createCloudflareServerEntryModule", () => {
+  it("re-exports Cloudflare primitives from a dedicated module", () => {
+    const source = createCloudflareServerEntryModule({
+      workerExportsFrom: "/src/cloudflare.ts",
+    });
+
+    expect(source).toContain('export * from "/src/cloudflare.ts";');
+  });
+
+  it("rejects mixing workerExportsFrom with deprecated named exports", () => {
+    expect(() =>
+      createCloudflareServerEntryModule({
+        workerExportsFrom: "/src/cloudflare.ts",
+        exports: [{ from: "/src/workers/counter.ts", names: ["Counter"] }],
+      }),
+    ).toThrow(/workerExportsFrom/);
+  });
+
+  it("keeps deprecated named exports working", () => {
+    const source = createCloudflareServerEntryModule({
+      exports: [{ from: "/src/workers/counter.ts", names: ["Counter"] }],
+    });
+
+    expect(source).toContain('export { Counter } from "/src/workers/counter.ts";');
+  });
+});

--- a/packages/adapter-cloudflare/test/index.test.ts
+++ b/packages/adapter-cloudflare/test/index.test.ts
@@ -11,20 +11,9 @@ describe("createCloudflareServerEntryModule", () => {
     expect(source).toContain('export * from "/src/cloudflare.ts";');
   });
 
-  it("rejects mixing workerExportsFrom with deprecated named exports", () => {
-    expect(() =>
-      createCloudflareServerEntryModule({
-        workerExportsFrom: "/src/cloudflare.ts",
-        exports: [{ from: "/src/workers/counter.ts", names: ["Counter"] }],
-      }),
-    ).toThrow(/workerExportsFrom/);
-  });
+  it("omits worker primitive re-exports when no module is configured", () => {
+    const source = createCloudflareServerEntryModule();
 
-  it("keeps deprecated named exports working", () => {
-    const source = createCloudflareServerEntryModule({
-      exports: [{ from: "/src/workers/counter.ts", names: ["Counter"] }],
-    });
-
-    expect(source).toContain('export { Counter } from "/src/workers/counter.ts";');
+    expect(source).not.toContain("export * from");
   });
 });


### PR DESCRIPTION
## Summary

- Add `exports` option to `cloudflareAdapter()` that re-exports Cloudflare primitives (Workflows, Durable Objects, Queues, etc.) from the generated worker entry — required by Wrangler to discover and register these classes.
- Includes example DurableObject in the CF example app with wrangler bindings configured.
- Closes #50

## Testing

- [x] `pnpm e2e`
- [x] `pnpm format`
- [x] `pnpm lint`
- [x] `pnpm test`

## Checklist

- [x] Docs updated if needed
- [x] Skills updated if needed
- [x] Changeset added if published packages changed