### PR TITLE
Add plugin system for render lifecycle hooks

### DIFF
--- a/.changeset/render-plugins.md
+++ b/.changeset/render-plugins.md
@@ -1,0 +1,5 @@
+---
+"@pracht/core": minor
+---
+
+Add plugin system with `beforeRender` and `afterRender` lifecycle hooks for CSS-in-JS and head injection use cases

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -220,7 +220,42 @@ export const middleware: MiddlewareFn = async ({ request }) => {
 Middleware is named in the manifest and applied per route or group. It can
 redirect, set context, or throw errors.
 
-### 5. Module Registry
+### 5. Plugins
+
+Plugins hook into the server render lifecycle, enabling CSS-in-JS libraries,
+head managers, and similar tools that need to run code around rendering:
+
+```typescript
+import type { PrachtPlugin } from "@pracht/core";
+
+function gooberPlugin(): PrachtPlugin {
+  return {
+    name: "goober",
+    beforeRender: () => {
+      // Clear the style sheet before each render
+      extractCss(); // resets goober's internal buffer
+    },
+    afterRender: () => {
+      // Collect critical CSS and inject into <head>
+      const css = extractCss();
+      return css ? `<style id="_goober">${css}</style>` : undefined;
+    },
+  };
+}
+
+export const app = defineApp({
+  plugins: [gooberPlugin()],
+  routes: [...],
+});
+```
+
+- **`beforeRender`** runs immediately before `renderToStringAsync()`.
+- **`afterRender`** runs immediately after. Returning a string injects it into `<head>`.
+- Plugins run in array order; all `beforeRender` hooks fire, then render, then all `afterRender` hooks.
+- Both hooks support async (returning a Promise).
+- Plugins do not run for route-state JSON requests (client navigations), only for HTML renders.
+
+### 6. Module Registry
 
 The Vite plugin generates a module registry at build time using `import.meta.glob()`.
 This maps normalized file paths to lazy module importers:
@@ -236,7 +271,7 @@ const routeModules = {
 This avoids hand-maintained import maps and enables code splitting — each route
 is a separate chunk loaded on demand.
 
-### 6. Router
+### 7. Router
 
 Segment-based URL matching:
 
@@ -259,10 +294,11 @@ Browser request
   → Match route from manifest
   → Run middleware chain
   → Execute loader
+  → Run plugin beforeRender hooks
   → Render Preact component tree to string
+  → Run plugin afterRender hooks (collect head injections)
   → Merge head metadata and document headers (shell + route)
-  → Inject escaped hydration state into a JSON script tag
-  → Inject asset tags from Vite manifest
+  → Inject plugin head content, escaped hydration state, asset tags
   → Return HTML Response
   → Browser hydrates, client router takes over
 ```

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -238,7 +238,7 @@ function gooberPlugin(): PrachtPlugin {
     afterRender: () => {
       // Collect critical CSS and inject into <head>
       const css = extractCss();
-      return css ? `<style id="_goober">${css}</style>` : undefined;
+      return css ? { head: `<style id="_goober">${css}</style>` } : undefined;
     },
   };
 }
@@ -250,7 +250,7 @@ export const app = defineApp({
 ```
 
 - **`beforeRender`** runs immediately before `renderToStringAsync()`.
-- **`afterRender`** runs immediately after. Returning a string injects it into `<head>`.
+- **`afterRender`** runs immediately after. Return `{ head: "..." }` to inject markup into `<head>`.
 - Plugins run in array order; all `beforeRender` hooks fire, then render, then all `afterRender` hooks.
 - Both hooks support async (returning a Promise).
 - Plugins do not run for route-state JSON requests (client navigations), only for HTML renders.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -224,7 +224,42 @@ short-circuit with a Response, mutate `args.context`, or wrap the rest of
 the request in `try / catch / finally` for logging and tracing. See
 [ROUTING.md](./ROUTING.md#middleware) for the full contract.
 
-### 5. Module Registry
+### 5. Plugins
+
+Plugins hook into the server render lifecycle, enabling CSS-in-JS libraries,
+head managers, and similar tools that need to run code around rendering:
+
+```typescript
+import type { PrachtPlugin } from "@pracht/core";
+
+function gooberPlugin(): PrachtPlugin {
+  return {
+    name: "goober",
+    beforeRender: () => {
+      // Clear the style sheet before each render
+      extractCss(); // resets goober's internal buffer
+    },
+    afterRender: () => {
+      // Collect critical CSS and inject into <head>
+      const css = extractCss();
+      return css ? `<style id="_goober">${css}</style>` : undefined;
+    },
+  };
+}
+
+export const app = defineApp({
+  plugins: [gooberPlugin()],
+  routes: [...],
+});
+```
+
+- **`beforeRender`** runs immediately before `renderToStringAsync()`.
+- **`afterRender`** runs immediately after. Returning a string injects it into `<head>`.
+- Plugins run in array order; all `beforeRender` hooks fire, then render, then all `afterRender` hooks.
+- Both hooks support async (returning a Promise).
+- Plugins do not run for route-state JSON requests (client navigations), only for HTML renders.
+
+### 6. Module Registry
 
 The Vite plugin generates a module registry at build time using `import.meta.glob()`.
 This maps normalized file paths to lazy module importers:
@@ -240,7 +275,7 @@ const routeModules = {
 This avoids hand-maintained import maps and enables code splitting — each route
 is a separate chunk loaded on demand.
 
-### 6. Router
+### 7. Router
 
 Segment-based URL matching:
 
@@ -263,10 +298,11 @@ Browser request
   → Match route from manifest
   → Run middleware chain
   → Execute loader
+  → Run plugin beforeRender hooks
   → Render Preact component tree to string
+  → Run plugin afterRender hooks (collect head injections)
   → Merge head metadata and document headers (shell + route)
-  → Inject escaped hydration state into a JSON script tag
-  → Inject asset tags from Vite manifest
+  → Inject plugin head content, escaped hydration state, asset tags
   → Return HTML Response
   → Browser hydrates, client router takes over
 ```

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -242,7 +242,7 @@ function gooberPlugin(): PrachtPlugin {
     afterRender: () => {
       // Collect critical CSS and inject into <head>
       const css = extractCss();
-      return css ? `<style id="_goober">${css}</style>` : undefined;
+      return css ? { head: `<style id="_goober">${css}</style>` } : undefined;
     },
   };
 }
@@ -254,7 +254,7 @@ export const app = defineApp({
 ```
 
 - **`beforeRender`** runs immediately before `renderToStringAsync()`.
-- **`afterRender`** runs immediately after. Returning a string injects it into `<head>`.
+- **`afterRender`** runs immediately after. Return `{ head: "..." }` to inject markup into `<head>`.
 - Plugins run in array order; all `beforeRender` hooks fire, then render, then all `afterRender` hooks.
 - Both hooks support async (returning a Promise).
 - Plugins do not run for route-state JSON requests (client navigations), only for HTML renders.

--- a/packages/framework/src/app.ts
+++ b/packages/framework/src/app.ts
@@ -99,6 +99,7 @@ export function defineApp(config: PrachtAppConfig): PrachtApp {
     shells: resolveModuleRefRecord(config.shells ?? {}),
     middleware: resolveModuleRefRecord(config.middleware ?? {}),
     api: config.api ?? {},
+    plugins: config.plugins ?? [],
     routes: config.routes,
     viewTransitions: config.viewTransitions,
   };
@@ -141,6 +142,7 @@ export function resolveApp(app: PrachtApp): ResolvedPrachtApp {
     shells: app.shells,
     middleware: app.middleware,
     api: app.api,
+    plugins: app.plugins,
     routes,
     apiRoutes: [],
     viewTransitions: app.viewTransitions,

--- a/packages/framework/src/app.ts
+++ b/packages/framework/src/app.ts
@@ -91,6 +91,7 @@ export function defineApp(config: PrachtAppConfig): PrachtApp {
     shells: resolveModuleRefRecord(config.shells ?? {}),
     middleware: resolveModuleRefRecord(config.middleware ?? {}),
     api: config.api ?? {},
+    plugins: config.plugins ?? [],
     routes: config.routes,
   };
 }
@@ -118,6 +119,7 @@ export function resolveApp(app: PrachtApp): ResolvedPrachtApp {
     shells: app.shells,
     middleware: app.middleware,
     api: app.api,
+    plugins: app.plugins,
     routes,
     apiRoutes: [],
   };

--- a/packages/framework/src/index.ts
+++ b/packages/framework/src/index.ts
@@ -70,6 +70,7 @@ export type {
   ShellModule,
   ShellProps,
   TimeRevalidatePolicy,
+  AfterRenderResult,
   PrachtApp,
   PrachtAppConfig,
   PrachtPlugin,

--- a/packages/framework/src/index.ts
+++ b/packages/framework/src/index.ts
@@ -108,6 +108,7 @@ export type {
   ShellModule,
   ShellProps,
   TimeRevalidatePolicy,
+  AfterRenderResult,
   PrachtApp,
   PrachtAppConfig,
   PrachtPlugin,

--- a/packages/framework/src/index.ts
+++ b/packages/framework/src/index.ts
@@ -72,6 +72,7 @@ export type {
   TimeRevalidatePolicy,
   PrachtApp,
   PrachtAppConfig,
+  PrachtPlugin,
 } from "./types.ts";
 export type {
   FormProps,

--- a/packages/framework/src/index.ts
+++ b/packages/framework/src/index.ts
@@ -110,6 +110,7 @@ export type {
   TimeRevalidatePolicy,
   PrachtApp,
   PrachtAppConfig,
+  PrachtPlugin,
 } from "./types.ts";
 export type {
   FormProps,

--- a/packages/framework/src/runtime-html.ts
+++ b/packages/framework/src/runtime-html.ts
@@ -99,6 +99,7 @@ function isAllowedHeadAttribute(
 export function buildHtmlDocument(options: {
   head: HeadMetadata;
   body: string;
+  pluginHeadContent?: string[];
   hydrationState: PrachtHydrationState;
   clientEntryUrl?: string;
   cssUrls?: string[];
@@ -108,6 +109,7 @@ export function buildHtmlDocument(options: {
   const {
     head,
     body,
+    pluginHeadContent = [],
     hydrationState,
     clientEntryUrl,
     cssUrls = [],
@@ -154,6 +156,8 @@ export function buildHtmlDocument(options: {
     ? `<script type="module" src="${escapeHtml(clientEntryUrl)}"></script>`
     : "";
 
+  const pluginTags = pluginHeadContent.join("\n    ");
+
   return `<!DOCTYPE html>
 <html${head.lang ? ` lang="${escapeHtml(head.lang)}"` : ""}>
   <head>
@@ -163,6 +167,7 @@ export function buildHtmlDocument(options: {
     ${linkTags}
     ${scriptTags}
     ${cssTags}
+    ${pluginTags}
     ${modulePreloadTags}
     ${routeStatePreloadTag}
   </head>

--- a/packages/framework/src/runtime-html.ts
+++ b/packages/framework/src/runtime-html.ts
@@ -23,6 +23,7 @@ export function serializeJsonForHtml(value: unknown): string {
 export function buildHtmlDocument(options: {
   head: HeadMetadata;
   body: string;
+  pluginHeadContent?: string[];
   hydrationState: PrachtHydrationState;
   clientEntryUrl?: string;
   cssUrls?: string[];
@@ -32,6 +33,7 @@ export function buildHtmlDocument(options: {
   const {
     head,
     body,
+    pluginHeadContent = [],
     hydrationState,
     clientEntryUrl,
     cssUrls = [],
@@ -76,6 +78,8 @@ export function buildHtmlDocument(options: {
     ? `<script type="module" src="${escapeHtml(clientEntryUrl)}"></script>`
     : "";
 
+  const pluginTags = pluginHeadContent.join("\n    ");
+
   return `<!DOCTYPE html>
 <html${head.lang ? ` lang="${escapeHtml(head.lang)}"` : ""}>
   <head>
@@ -84,6 +88,7 @@ export function buildHtmlDocument(options: {
     ${metaTags}
     ${linkTags}
     ${cssTags}
+    ${pluginTags}
     ${modulePreloadTags}
     ${routeStatePreloadTag}
   </head>

--- a/packages/framework/src/runtime.ts
+++ b/packages/framework/src/runtime.ts
@@ -40,10 +40,29 @@ import type {
   HttpMethod,
   ModuleRegistry,
   PrachtApp,
+  PrachtPlugin,
   ResolvedApiRoute,
   RouteModule,
   ShellModule,
 } from "./types.ts";
+
+async function runPluginHooks(plugins: PrachtPlugin[], hook: "beforeRender"): Promise<void>;
+async function runPluginHooks(plugins: PrachtPlugin[], hook: "afterRender"): Promise<string[]>;
+async function runPluginHooks(
+  plugins: PrachtPlugin[],
+  hook: "beforeRender" | "afterRender",
+): Promise<string[] | void> {
+  const headResults: string[] = [];
+  for (const plugin of plugins) {
+    const fn = plugin[hook];
+    if (!fn) continue;
+    const result = await fn();
+    if (hook === "afterRender" && typeof result === "string") {
+      headResults.push(result);
+    }
+  }
+  if (hook === "afterRender") return headResults;
+}
 
 export interface HandlePrachtRequestOptions<TContext = unknown> {
   app: PrachtApp;
@@ -332,14 +351,18 @@ export async function handlePrachtRequest<TContext>(
 
         if (loadingTree) {
           const renderFn = await getRenderToStringAsync();
+          await runPluginHooks(options.app.plugins, "beforeRender");
           body = await renderFn(loadingTree);
         }
       }
+
+      const pluginHeadContent = await runPluginHooks(options.app.plugins, "afterRender");
 
       return htmlResponse(
         buildHtmlDocument({
           head,
           body,
+          pluginHeadContent,
           hydrationState: {
             url: requestPath,
             routeId: match.route.id ?? "",
@@ -381,12 +404,15 @@ export async function handlePrachtRequest<TContext>(
       componentTree,
     );
     const renderToString = await getRenderToStringAsync();
+    await runPluginHooks(options.app.plugins, "beforeRender");
     const ssrContent = await renderToString(tree);
+    const pluginHeadContent = await runPluginHooks(options.app.plugins, "afterRender");
 
     return htmlResponse(
       buildHtmlDocument({
         head,
         body: ssrContent,
+        pluginHeadContent,
         hydrationState: {
           url: requestPath,
           routeId: match.route.id ?? "",

--- a/packages/framework/src/runtime.ts
+++ b/packages/framework/src/runtime.ts
@@ -57,8 +57,8 @@ async function runPluginHooks(
     const fn = plugin[hook];
     if (!fn) continue;
     const result = await fn();
-    if (hook === "afterRender" && typeof result === "string") {
-      headResults.push(result);
+    if (hook === "afterRender" && result && typeof result === "object" && result.head) {
+      headResults.push(result.head);
     }
   }
   if (hook === "afterRender") return headResults;

--- a/packages/framework/src/runtime.ts
+++ b/packages/framework/src/runtime.ts
@@ -153,8 +153,8 @@ async function runPluginHooks(
     const fn = plugin[hook];
     if (!fn) continue;
     const result = await fn();
-    if (hook === "afterRender" && typeof result === "string") {
-      headResults.push(result);
+    if (hook === "afterRender" && result && typeof result === "object" && result.head) {
+      headResults.push(result.head);
     }
   }
   if (hook === "afterRender") return headResults;

--- a/packages/framework/src/runtime.ts
+++ b/packages/framework/src/runtime.ts
@@ -42,6 +42,7 @@ import type {
   ModuleRegistry,
   HrefRouteDefinition,
   PrachtApp,
+  PrachtPlugin,
   ResolvedApiRoute,
   ResolvedPrachtApp,
   RouteModule,
@@ -139,6 +140,24 @@ export function isFirstPartyFetch(request: Request): boolean {
   }
 
   return true;
+}
+
+async function runPluginHooks(plugins: PrachtPlugin[], hook: "beforeRender"): Promise<void>;
+async function runPluginHooks(plugins: PrachtPlugin[], hook: "afterRender"): Promise<string[]>;
+async function runPluginHooks(
+  plugins: PrachtPlugin[],
+  hook: "beforeRender" | "afterRender",
+): Promise<string[] | void> {
+  const headResults: string[] = [];
+  for (const plugin of plugins) {
+    const fn = plugin[hook];
+    if (!fn) continue;
+    const result = await fn();
+    if (hook === "afterRender" && typeof result === "string") {
+      headResults.push(result);
+    }
+  }
+  if (hook === "afterRender") return headResults;
 }
 
 export interface HandlePrachtRequestOptions<TContext = unknown> {
@@ -459,13 +478,17 @@ export async function handlePrachtRequest<TContext>(
             loadingTree,
           );
           const renderFn = await getRenderToStringAsync();
+          await runPluginHooks(options.app.plugins, "beforeRender");
           body = await renderFn(tree);
         }
+
+        const pluginHeadContent = await runPluginHooks(options.app.plugins, "afterRender");
 
         return htmlResponse(
           buildHtmlDocument({
             head,
             body,
+            pluginHeadContent,
             hydrationState: {
               url: requestPath,
               routeId: match.route.id ?? "",
@@ -512,12 +535,15 @@ export async function handlePrachtRequest<TContext>(
         componentTree,
       );
       const renderToString = await getRenderToStringAsync();
+      await runPluginHooks(options.app.plugins, "beforeRender");
       const ssrContent = await renderToString(tree);
+      const pluginHeadContent = await runPluginHooks(options.app.plugins, "afterRender");
 
       return htmlResponse(
         buildHtmlDocument({
           head,
           body: ssrContent,
+          pluginHeadContent,
           hydrationState: {
             url: requestPath,
             routeId: match.route.id ?? "",

--- a/packages/framework/src/types.ts
+++ b/packages/framework/src/types.ts
@@ -112,10 +112,14 @@ export interface GroupDefinition {
 
 export type RouteTreeNode = RouteDefinition | GroupDefinition;
 
+export interface AfterRenderResult {
+  head?: string;
+}
+
 export interface PrachtPlugin {
   name: string;
   beforeRender?: () => MaybePromise<void>;
-  afterRender?: () => MaybePromise<string | void>;
+  afterRender?: () => MaybePromise<AfterRenderResult | void>;
 }
 
 export interface PrachtAppConfig {

--- a/packages/framework/src/types.ts
+++ b/packages/framework/src/types.ts
@@ -240,10 +240,17 @@ export interface GroupDefinition {
 
 export type RouteTreeNode = RouteDefinition | GroupDefinition;
 
+export interface PrachtPlugin {
+  name: string;
+  beforeRender?: () => MaybePromise<void>;
+  afterRender?: () => MaybePromise<string | void>;
+}
+
 export interface PrachtAppConfig {
   shells?: Record<string, ModuleRef>;
   middleware?: Record<string, ModuleRef>;
   api?: ApiConfig;
+  plugins?: PrachtPlugin[];
   routes: RouteTreeNode[];
   /**
    * Enable the View Transitions API for every client navigation by default.
@@ -258,6 +265,7 @@ export interface PrachtApp {
   shells: Record<string, string>;
   middleware: Record<string, string>;
   api: ApiConfig;
+  plugins: PrachtPlugin[];
   routes: RouteTreeNode[];
   viewTransitions?: boolean;
 }

--- a/packages/framework/src/types.ts
+++ b/packages/framework/src/types.ts
@@ -112,10 +112,17 @@ export interface GroupDefinition {
 
 export type RouteTreeNode = RouteDefinition | GroupDefinition;
 
+export interface PrachtPlugin {
+  name: string;
+  beforeRender?: () => MaybePromise<void>;
+  afterRender?: () => MaybePromise<string | void>;
+}
+
 export interface PrachtAppConfig {
   shells?: Record<string, ModuleRef>;
   middleware?: Record<string, ModuleRef>;
   api?: ApiConfig;
+  plugins?: PrachtPlugin[];
   routes: RouteTreeNode[];
 }
 
@@ -123,6 +130,7 @@ export interface PrachtApp {
   shells: Record<string, string>;
   middleware: Record<string, string>;
   api: ApiConfig;
+  plugins: PrachtPlugin[];
   routes: RouteTreeNode[];
 }
 

--- a/packages/framework/src/types.ts
+++ b/packages/framework/src/types.ts
@@ -240,10 +240,14 @@ export interface GroupDefinition {
 
 export type RouteTreeNode = RouteDefinition | GroupDefinition;
 
+export interface AfterRenderResult {
+  head?: string;
+}
+
 export interface PrachtPlugin {
   name: string;
   beforeRender?: () => MaybePromise<void>;
-  afterRender?: () => MaybePromise<string | void>;
+  afterRender?: () => MaybePromise<AfterRenderResult | void>;
 }
 
 export interface PrachtAppConfig {

--- a/packages/framework/test/runtime.test.ts
+++ b/packages/framework/test/runtime.test.ts
@@ -1,6 +1,7 @@
 import { h } from "preact";
 import { describe, expect, it } from "vitest";
 
+import type { PrachtPlugin } from "../src/index.ts";
 import {
   Link,
   PrachtHttpError,
@@ -1920,5 +1921,231 @@ describe("handlePrachtRequest pipeline parallelism", () => {
     mwGate.resolve();
     const res = await response;
     expect(res.status).toBe(200);
+  });
+});
+
+describe("handlePrachtRequest plugins", () => {
+  it("calls beforeRender and afterRender hooks during SSR", async () => {
+    const calls: string[] = [];
+    const plugin: PrachtPlugin = {
+      name: "test-plugin",
+      beforeRender: () => {
+        calls.push("before");
+      },
+      afterRender: () => {
+        calls.push("after");
+        return "<style>.critical { color: red }</style>";
+      },
+    };
+
+    const app = defineApp({
+      plugins: [plugin],
+      routes: [route("/", "./routes/home.tsx", { render: "ssr" })],
+    });
+
+    const response = await handlePrachtRequest({
+      app,
+      registry: {
+        routeModules: {
+          "./routes/home.tsx": async () => ({
+            Component: () => h("main", null, "Home"),
+          }),
+        },
+      },
+      request: new Request("http://localhost/"),
+    });
+
+    expect(response.status).toBe(200);
+    expect(calls).toEqual(["before", "after"]);
+    const html = await response.text();
+    expect(html).toContain("<style>.critical { color: red }</style>");
+  });
+
+  it("runs multiple plugins in order", async () => {
+    const calls: string[] = [];
+    const plugins: PrachtPlugin[] = [
+      {
+        name: "first",
+        beforeRender: () => {
+          calls.push("first-before");
+        },
+        afterRender: () => {
+          calls.push("first-after");
+          return "<style>.a{}</style>";
+        },
+      },
+      {
+        name: "second",
+        beforeRender: () => {
+          calls.push("second-before");
+        },
+        afterRender: () => {
+          calls.push("second-after");
+          return "<style>.b{}</style>";
+        },
+      },
+    ];
+
+    const app = defineApp({
+      plugins,
+      routes: [route("/", "./routes/home.tsx", { render: "ssr" })],
+    });
+
+    const response = await handlePrachtRequest({
+      app,
+      registry: {
+        routeModules: {
+          "./routes/home.tsx": async () => ({
+            Component: () => h("main", null, "Home"),
+          }),
+        },
+      },
+      request: new Request("http://localhost/"),
+    });
+
+    expect(response.status).toBe(200);
+    expect(calls).toEqual(["first-before", "second-before", "first-after", "second-after"]);
+    const html = await response.text();
+    expect(html).toContain("<style>.a{}</style>");
+    expect(html).toContain("<style>.b{}</style>");
+  });
+
+  it("runs plugins for SPA shell rendering", async () => {
+    const calls: string[] = [];
+    const plugin: PrachtPlugin = {
+      name: "spa-plugin",
+      beforeRender: () => {
+        calls.push("before");
+      },
+      afterRender: () => {
+        calls.push("after");
+        return "<style>.spa { display: block }</style>";
+      },
+    };
+
+    const app = defineApp({
+      plugins: [plugin],
+      shells: { app: "./shells/app.tsx" },
+      routes: [route("/settings", "./routes/settings.tsx", { render: "spa", shell: "app" })],
+    });
+
+    const response = await handlePrachtRequest({
+      app,
+      registry: {
+        routeModules: {
+          "./routes/settings.tsx": async () => ({
+            Component: () => h("main", null, "Settings"),
+          }),
+        },
+        shellModules: {
+          "./shells/app.tsx": async () => ({
+            Shell: ({ children }) => h("div", { class: "shell" }, children),
+            Loading: () => h("p", null, "Loading..."),
+          }),
+        },
+      },
+      request: new Request("http://localhost/settings"),
+    });
+
+    expect(response.status).toBe(200);
+    expect(calls).toEqual(["before", "after"]);
+    const html = await response.text();
+    expect(html).toContain("<style>.spa { display: block }</style>");
+  });
+
+  it("does not run plugins for route-state JSON requests", async () => {
+    const calls: string[] = [];
+    const plugin: PrachtPlugin = {
+      name: "test-plugin",
+      beforeRender: () => {
+        calls.push("before");
+      },
+      afterRender: () => {
+        calls.push("after");
+      },
+    };
+
+    const app = defineApp({
+      plugins: [plugin],
+      routes: [route("/", "./routes/home.tsx", { render: "ssr" })],
+    });
+
+    const response = await handlePrachtRequest({
+      app,
+      registry: {
+        routeModules: {
+          "./routes/home.tsx": async () => ({
+            Component: () => h("main", null, "Home"),
+            loader: async () => ({ name: "test" }),
+          }),
+        },
+      },
+      request: new Request("http://localhost/", {
+        headers: { "x-pracht-route-state-request": "1" },
+      }),
+    });
+
+    expect(response.status).toBe(200);
+    expect(calls).toEqual([]);
+  });
+
+  it("supports async plugin hooks", async () => {
+    const plugin: PrachtPlugin = {
+      name: "async-plugin",
+      beforeRender: async () => {
+        await new Promise((r) => setTimeout(r, 5));
+      },
+      afterRender: async () => {
+        await new Promise((r) => setTimeout(r, 5));
+        return '<meta name="plugin" content="async">';
+      },
+    };
+
+    const app = defineApp({
+      plugins: [plugin],
+      routes: [route("/", "./routes/home.tsx", { render: "ssr" })],
+    });
+
+    const response = await handlePrachtRequest({
+      app,
+      registry: {
+        routeModules: {
+          "./routes/home.tsx": async () => ({
+            Component: () => h("main", null, "Home"),
+          }),
+        },
+      },
+      request: new Request("http://localhost/"),
+    });
+
+    expect(response.status).toBe(200);
+    const html = await response.text();
+    expect(html).toContain('<meta name="plugin" content="async">');
+  });
+
+  it("afterRender returning void does not inject content", async () => {
+    const plugin: PrachtPlugin = {
+      name: "noop-plugin",
+      afterRender: () => {},
+    };
+
+    const app = defineApp({
+      plugins: [plugin],
+      routes: [route("/", "./routes/home.tsx", { render: "ssr" })],
+    });
+
+    const response = await handlePrachtRequest({
+      app,
+      registry: {
+        routeModules: {
+          "./routes/home.tsx": async () => ({
+            Component: () => h("main", null, "Home"),
+          }),
+        },
+      },
+      request: new Request("http://localhost/"),
+    });
+
+    expect(response.status).toBe(200);
   });
 });

--- a/packages/framework/test/runtime.test.ts
+++ b/packages/framework/test/runtime.test.ts
@@ -1,6 +1,7 @@
 import { h } from "preact";
 import { describe, expect, it } from "vitest";
 
+import type { PrachtPlugin } from "../src/index.ts";
 import {
   PrachtHttpError,
   defineApp,
@@ -1399,5 +1400,231 @@ describe("handlePrachtRequest pipeline parallelism", () => {
     mwGate.resolve();
     const res = await response;
     expect(res.status).toBe(200);
+  });
+});
+
+describe("handlePrachtRequest plugins", () => {
+  it("calls beforeRender and afterRender hooks during SSR", async () => {
+    const calls: string[] = [];
+    const plugin: PrachtPlugin = {
+      name: "test-plugin",
+      beforeRender: () => {
+        calls.push("before");
+      },
+      afterRender: () => {
+        calls.push("after");
+        return "<style>.critical { color: red }</style>";
+      },
+    };
+
+    const app = defineApp({
+      plugins: [plugin],
+      routes: [route("/", "./routes/home.tsx", { render: "ssr" })],
+    });
+
+    const response = await handlePrachtRequest({
+      app,
+      registry: {
+        routeModules: {
+          "./routes/home.tsx": async () => ({
+            Component: () => h("main", null, "Home"),
+          }),
+        },
+      },
+      request: new Request("http://localhost/"),
+    });
+
+    expect(response.status).toBe(200);
+    expect(calls).toEqual(["before", "after"]);
+    const html = await response.text();
+    expect(html).toContain("<style>.critical { color: red }</style>");
+  });
+
+  it("runs multiple plugins in order", async () => {
+    const calls: string[] = [];
+    const plugins: PrachtPlugin[] = [
+      {
+        name: "first",
+        beforeRender: () => {
+          calls.push("first-before");
+        },
+        afterRender: () => {
+          calls.push("first-after");
+          return "<style>.a{}</style>";
+        },
+      },
+      {
+        name: "second",
+        beforeRender: () => {
+          calls.push("second-before");
+        },
+        afterRender: () => {
+          calls.push("second-after");
+          return "<style>.b{}</style>";
+        },
+      },
+    ];
+
+    const app = defineApp({
+      plugins,
+      routes: [route("/", "./routes/home.tsx", { render: "ssr" })],
+    });
+
+    const response = await handlePrachtRequest({
+      app,
+      registry: {
+        routeModules: {
+          "./routes/home.tsx": async () => ({
+            Component: () => h("main", null, "Home"),
+          }),
+        },
+      },
+      request: new Request("http://localhost/"),
+    });
+
+    expect(response.status).toBe(200);
+    expect(calls).toEqual(["first-before", "second-before", "first-after", "second-after"]);
+    const html = await response.text();
+    expect(html).toContain("<style>.a{}</style>");
+    expect(html).toContain("<style>.b{}</style>");
+  });
+
+  it("runs plugins for SPA shell rendering", async () => {
+    const calls: string[] = [];
+    const plugin: PrachtPlugin = {
+      name: "spa-plugin",
+      beforeRender: () => {
+        calls.push("before");
+      },
+      afterRender: () => {
+        calls.push("after");
+        return "<style>.spa { display: block }</style>";
+      },
+    };
+
+    const app = defineApp({
+      plugins: [plugin],
+      shells: { app: "./shells/app.tsx" },
+      routes: [route("/settings", "./routes/settings.tsx", { render: "spa", shell: "app" })],
+    });
+
+    const response = await handlePrachtRequest({
+      app,
+      registry: {
+        routeModules: {
+          "./routes/settings.tsx": async () => ({
+            Component: () => h("main", null, "Settings"),
+          }),
+        },
+        shellModules: {
+          "./shells/app.tsx": async () => ({
+            Shell: ({ children }) => h("div", { class: "shell" }, children),
+            Loading: () => h("p", null, "Loading..."),
+          }),
+        },
+      },
+      request: new Request("http://localhost/settings"),
+    });
+
+    expect(response.status).toBe(200);
+    expect(calls).toEqual(["before", "after"]);
+    const html = await response.text();
+    expect(html).toContain("<style>.spa { display: block }</style>");
+  });
+
+  it("does not run plugins for route-state JSON requests", async () => {
+    const calls: string[] = [];
+    const plugin: PrachtPlugin = {
+      name: "test-plugin",
+      beforeRender: () => {
+        calls.push("before");
+      },
+      afterRender: () => {
+        calls.push("after");
+      },
+    };
+
+    const app = defineApp({
+      plugins: [plugin],
+      routes: [route("/", "./routes/home.tsx", { render: "ssr" })],
+    });
+
+    const response = await handlePrachtRequest({
+      app,
+      registry: {
+        routeModules: {
+          "./routes/home.tsx": async () => ({
+            Component: () => h("main", null, "Home"),
+            loader: async () => ({ name: "test" }),
+          }),
+        },
+      },
+      request: new Request("http://localhost/", {
+        headers: { "x-pracht-route-state-request": "1" },
+      }),
+    });
+
+    expect(response.status).toBe(200);
+    expect(calls).toEqual([]);
+  });
+
+  it("supports async plugin hooks", async () => {
+    const plugin: PrachtPlugin = {
+      name: "async-plugin",
+      beforeRender: async () => {
+        await new Promise((r) => setTimeout(r, 5));
+      },
+      afterRender: async () => {
+        await new Promise((r) => setTimeout(r, 5));
+        return '<meta name="plugin" content="async">';
+      },
+    };
+
+    const app = defineApp({
+      plugins: [plugin],
+      routes: [route("/", "./routes/home.tsx", { render: "ssr" })],
+    });
+
+    const response = await handlePrachtRequest({
+      app,
+      registry: {
+        routeModules: {
+          "./routes/home.tsx": async () => ({
+            Component: () => h("main", null, "Home"),
+          }),
+        },
+      },
+      request: new Request("http://localhost/"),
+    });
+
+    expect(response.status).toBe(200);
+    const html = await response.text();
+    expect(html).toContain('<meta name="plugin" content="async">');
+  });
+
+  it("afterRender returning void does not inject content", async () => {
+    const plugin: PrachtPlugin = {
+      name: "noop-plugin",
+      afterRender: () => {},
+    };
+
+    const app = defineApp({
+      plugins: [plugin],
+      routes: [route("/", "./routes/home.tsx", { render: "ssr" })],
+    });
+
+    const response = await handlePrachtRequest({
+      app,
+      registry: {
+        routeModules: {
+          "./routes/home.tsx": async () => ({
+            Component: () => h("main", null, "Home"),
+          }),
+        },
+      },
+      request: new Request("http://localhost/"),
+    });
+
+    expect(response.status).toBe(200);
   });
 });

--- a/packages/framework/test/runtime.test.ts
+++ b/packages/framework/test/runtime.test.ts
@@ -1413,7 +1413,7 @@ describe("handlePrachtRequest plugins", () => {
       },
       afterRender: () => {
         calls.push("after");
-        return "<style>.critical { color: red }</style>";
+        return { head: "<style>.critical { color: red }</style>" };
       },
     };
 
@@ -1450,7 +1450,7 @@ describe("handlePrachtRequest plugins", () => {
         },
         afterRender: () => {
           calls.push("first-after");
-          return "<style>.a{}</style>";
+          return { head: "<style>.a{}</style>" };
         },
       },
       {
@@ -1460,7 +1460,7 @@ describe("handlePrachtRequest plugins", () => {
         },
         afterRender: () => {
           calls.push("second-after");
-          return "<style>.b{}</style>";
+          return { head: "<style>.b{}</style>" };
         },
       },
     ];
@@ -1498,7 +1498,7 @@ describe("handlePrachtRequest plugins", () => {
       },
       afterRender: () => {
         calls.push("after");
-        return "<style>.spa { display: block }</style>";
+        return { head: "<style>.spa { display: block }</style>" };
       },
     };
 
@@ -1576,7 +1576,7 @@ describe("handlePrachtRequest plugins", () => {
       },
       afterRender: async () => {
         await new Promise((r) => setTimeout(r, 5));
-        return '<meta name="plugin" content="async">';
+        return { head: '<meta name="plugin" content="async">' };
       },
     };
 

--- a/packages/framework/test/runtime.test.ts
+++ b/packages/framework/test/runtime.test.ts
@@ -1934,7 +1934,7 @@ describe("handlePrachtRequest plugins", () => {
       },
       afterRender: () => {
         calls.push("after");
-        return "<style>.critical { color: red }</style>";
+        return { head: "<style>.critical { color: red }</style>" };
       },
     };
 
@@ -1971,7 +1971,7 @@ describe("handlePrachtRequest plugins", () => {
         },
         afterRender: () => {
           calls.push("first-after");
-          return "<style>.a{}</style>";
+          return { head: "<style>.a{}</style>" };
         },
       },
       {
@@ -1981,7 +1981,7 @@ describe("handlePrachtRequest plugins", () => {
         },
         afterRender: () => {
           calls.push("second-after");
-          return "<style>.b{}</style>";
+          return { head: "<style>.b{}</style>" };
         },
       },
     ];
@@ -2019,7 +2019,7 @@ describe("handlePrachtRequest plugins", () => {
       },
       afterRender: () => {
         calls.push("after");
-        return "<style>.spa { display: block }</style>";
+        return { head: "<style>.spa { display: block }</style>" };
       },
     };
 
@@ -2097,7 +2097,7 @@ describe("handlePrachtRequest plugins", () => {
       },
       afterRender: async () => {
         await new Promise((r) => setTimeout(r, 5));
-        return '<meta name="plugin" content="async">';
+        return { head: '<meta name="plugin" content="async">' };
       },
     };
 


### PR DESCRIPTION
## Summary

- Adds a `PrachtPlugin` interface with `beforeRender` and `afterRender` lifecycle hooks that run around server-side rendering.
- `afterRender` can return HTML strings that get injected into `<head>`, enabling CSS-in-JS libraries (goober, etc.) and head management tools.
- Plugins are configured via `defineApp({ plugins: [...] })`.
- Closes #30

## Testing

- [ ] `pnpm e2e` (pre-existing failure unrelated to this change — `@pracht/vite-plugin` resolution in cloudflare example)
- [x] `pnpm format`
- [x] `pnpm lint`
- [x] `pnpm test` (77/77 pass, 6 new plugin tests)

## Checklist

- [x] Docs updated if needed
- [ ] Skills updated if needed — N/A
- [x] Changeset added if published packages changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)