### PR TITLE
Fix pages-router markdown auto-discovery

### DIFF
--- a/.changeset/spotty-cups-yell.md
+++ b/.changeset/spotty-cups-yell.md
@@ -1,0 +1,5 @@
+---
+"@pracht/vite-plugin": patch
+---
+
+Fix pages-router auto-discovery for `.md` and `.mdx` page files and broaden the generated registry globs for script-based server modules.

--- a/docs/ROUTING.md
+++ b/docs/ROUTING.md
@@ -262,8 +262,14 @@ directory and generates the route manifest automatically.
 | `pages/blog/index.tsx`  | `/blog`                |
 | `pages/blog/[slug].tsx` | `/blog/:slug`          |
 | `pages/[...path].tsx`   | `/*`                   |
+| `pages/guide.mdx`       | `/guide`               |
+| `pages/docs/intro.md`   | `/docs/intro`          |
 | `pages/_app.tsx`        | _(shell, not a route)_ |
 | `pages/_anything.tsx`   | _(ignored)_            |
+
+Markdown and MDX pages are routed the same way as `.tsx` pages. If you want to
+render `.mdx` files, add the corresponding Vite transform plugin such as
+`@mdx-js/rollup` alongside `pracht()`.
 
 ### Shell via `_app.tsx`
 

--- a/packages/vite-plugin/src/index.ts
+++ b/packages/vite-plugin/src/index.ts
@@ -382,19 +382,19 @@ export function createPrachtRegistryModuleSource(options: PrachtPluginOptions = 
   const isPagesMode = !!resolved.pagesDir;
 
   const routeGlob = isPagesMode
-    ? `${resolved.pagesDir}/**/*.{ts,tsx,js,jsx,md}`
-    : `${resolved.routesDir}/**/*.{ts,tsx,js,jsx,md}`;
+    ? `${resolved.pagesDir}/**/*.{ts,tsx,js,jsx,md,mdx}`
+    : `${resolved.routesDir}/**/*.{ts,tsx,js,jsx,md,mdx}`;
 
   const shellGlob = isPagesMode
     ? `${resolved.pagesDir}/**/_app.{ts,tsx,js,jsx}`
-    : `${resolved.shellsDir}/**/*.{ts,tsx,js,jsx,md}`;
+    : `${resolved.shellsDir}/**/*.{ts,tsx,js,jsx,md,mdx}`;
 
   return [
     `export const routeModules = import.meta.glob(${JSON.stringify(routeGlob)});`,
     `export const shellModules = import.meta.glob(${JSON.stringify(shellGlob)});`,
-    `export const middlewareModules = import.meta.glob(${JSON.stringify(`${resolved.middlewareDir}/**/*.{ts,tsx,js,jsx,md}`)});`,
-    `export const apiModules = import.meta.glob(${JSON.stringify(`${resolved.apiDir}/**/*.{ts,js}`)});`,
-    `export const dataModules = import.meta.glob(${JSON.stringify(`${resolved.serverDir}/**/*.{ts,js}`)});`,
+    `export const middlewareModules = import.meta.glob(${JSON.stringify(`${resolved.middlewareDir}/**/*.{ts,tsx,js,jsx}`)});`,
+    `export const apiModules = import.meta.glob(${JSON.stringify(`${resolved.apiDir}/**/*.{ts,js,tsx,jsx}`)});`,
+    `export const dataModules = import.meta.glob(${JSON.stringify(`${resolved.serverDir}/**/*.{ts,js,tsx,jsx}`)});`,
     "",
     "export const registry = {",
     "  routeModules,",

--- a/packages/vite-plugin/src/pages-router.ts
+++ b/packages/vite-plugin/src/pages-router.ts
@@ -24,7 +24,8 @@ export interface PagesRouterOptions {
 // Scanner
 // ---------------------------------------------------------------------------
 
-const PAGE_EXTENSIONS = new Set([".tsx", ".ts", ".jsx", ".js"]);
+const PAGE_EXTENSIONS = new Set([".tsx", ".ts", ".jsx", ".js", ".md", ".mdx"]);
+const SHELL_EXTENSIONS = new Set([".tsx", ".ts", ".jsx", ".js"]);
 
 export function scanPagesDirectory(pagesDir: string): ScannedPage[] {
   const pages: ScannedPage[] = [];
@@ -153,7 +154,7 @@ export function generatePagesManifestSource(
   // Check if _app exists by scanning for it
   const allFiles = scanAllFiles(pagesDir);
   const appFile = allFiles.find(
-    (f) => basename(f, extname(f)) === "_app" && PAGE_EXTENSIONS.has(extname(f)),
+    (f) => basename(f, extname(f)) === "_app" && SHELL_EXTENSIONS.has(extname(f)),
   );
 
   const lines: string[] = ['import { defineApp, group, route } from "@pracht/core";', ""];

--- a/packages/vite-plugin/test/pages-router.test.ts
+++ b/packages/vite-plugin/test/pages-router.test.ts
@@ -1,0 +1,76 @@
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { createPrachtRegistryModuleSource } from "../src/index.ts";
+import { generatePagesManifestSource, scanPagesDirectory } from "../src/pages-router.ts";
+
+const tempDirs: string[] = [];
+
+function makeTempPagesDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), "pracht-pages-router-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+afterEach(() => {
+  while (tempDirs.length > 0) {
+    const dir = tempDirs.pop();
+    if (dir) {
+      rmSync(dir, { force: true, recursive: true });
+    }
+  }
+});
+
+describe("scanPagesDirectory", () => {
+  it("includes markdown and mdx pages in the generated route list", () => {
+    const pagesDir = makeTempPagesDir();
+    mkdirSync(join(pagesDir, "docs"), { recursive: true });
+
+    writeFileSync(join(pagesDir, "index.tsx"), "export function Component() { return null; }\n");
+    writeFileSync(join(pagesDir, "guide.mdx"), 'export const RENDER_MODE = "ssg";\n\n# Guide\n');
+    writeFileSync(join(pagesDir, "docs", "getting-started.md"), "# Getting Started\n");
+    writeFileSync(join(pagesDir, "[slug].mdx"), "# Dynamic\n");
+    writeFileSync(join(pagesDir, "_draft.mdx"), "# Draft\n");
+
+    const pages = scanPagesDirectory(pagesDir);
+
+    expect(pages.map((page) => page.routePath)).toEqual([
+      "/",
+      "/docs/getting-started",
+      "/guide",
+      "/:slug",
+    ]);
+    expect(pages.find((page) => page.routePath === "/guide")?.renderMode).toBe("ssg");
+  });
+});
+
+describe("generatePagesManifestSource", () => {
+  it("does not treat markdown _app files as shells", () => {
+    const pagesDir = makeTempPagesDir();
+
+    writeFileSync(join(pagesDir, "index.mdx"), "# Home\n");
+    writeFileSync(join(pagesDir, "_app.mdx"), "# Not a shell\n");
+
+    const source = generatePagesManifestSource(scanPagesDirectory(pagesDir), {
+      pagesDir,
+    });
+
+    expect(source).not.toContain("shells:");
+    expect(source).toContain('route("/", "./index.mdx", { render: "ssr" })');
+  });
+});
+
+describe("createPrachtRegistryModuleSource", () => {
+  it("includes md and mdx pages plus script server module extensions", () => {
+    const source = createPrachtRegistryModuleSource({
+      pagesDir: "/src/pages",
+    });
+
+    expect(source).toContain("/src/pages/**/*.{ts,tsx,js,jsx,md,mdx}");
+    expect(source).toContain("/src/api/**/*.{ts,js,tsx,jsx}");
+    expect(source).toContain("/src/server/**/*.{ts,js,tsx,jsx}");
+    expect(source).toContain("/src/middleware/**/*.{ts,tsx,js,jsx}");
+  });
+});


### PR DESCRIPTION
## Summary

- Fix pages-router scanning so `.md` and `.mdx` files are auto-discovered instead of being silently skipped.
- Extend the generated registry globs to cover the broader markdown/script module inputs and add regression tests for markdown pages plus `_app` shell detection.
- Relevant issue: N/A

## Testing

- [x] `pnpm e2e`
- [x] `pnpm format`
- [x] `pnpm lint`
- [x] `pnpm test`

## Checklist

- [x] Docs updated if needed
- [x] Skills updated if needed
- [x] Changeset added if published packages changed

N/A: No repo-local skill updates were needed for this fix.