### PR TITLE
Remove route action references from public docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ The starter gives you:
 - [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) — framework internals
 - [docs/ROUTING.md](docs/ROUTING.md) — manifest and matching model
 - [docs/RENDERING_MODES.md](docs/RENDERING_MODES.md) — SSR, SSG, ISG, SPA behavior
-- [docs/DATA_LOADING.md](docs/DATA_LOADING.md) — loaders, actions, forms, client hooks
+- [docs/DATA_LOADING.md](docs/DATA_LOADING.md) — loaders, forms, client hooks
 - [docs/STYLING.md](docs/STYLING.md) — CSS Modules, Tailwind, CSS-in-JS limitations
 - [docs/ADAPTERS.md](docs/ADAPTERS.md) — Node, Cloudflare, Vercel deployment paths
 - [packages/start/README.md](packages/start/README.md) — starter CLI details

--- a/VISION_MVP.md
+++ b/VISION_MVP.md
@@ -55,29 +55,27 @@ Two styles, both fully supported — pick whichever fits your mental model:
 
 - **Loaders**: `export function loader(args)` — runs at build (SSG), request (SSR),
   or client navigation time. Returns typed, serializable data.
-- **Form**: A component that allows poting to one of our API-Routes
+- **Form**: A component that allows posting to one of our API routes
 
 **Separate files (manifest-wired):**
 
-- Loader and action live in dedicated server files (e.g. `src/server/`).
+- Loader logic can live in a dedicated server file (e.g. `src/server/`).
 - Wired via the route config object in `routes.ts`:
   ```typescript
   route("/dashboard", {
     component: "./routes/dashboard.tsx",
     loader: "./server/dashboard-loader.ts",
-    action: "./server/dashboard-action.ts",
     render: "ssr",
   });
   ```
 - Route files become pure components — no server code mixed in.
 
-Both styles can coexist in the same app. When a separate `loader`/`action` file
-is specified in the config, it takes precedence over inline exports.
+Both styles can coexist in the same app. When a separate `loader` file is
+specified in the config, it takes precedence over inline exports.
 
 - **Head**: `export function head(args)` — per-route `<head>` metadata merged with
   shell-level head.
-- **Client hooks**: `useRouteData()`, `useRevalidateRoute()`, `useSubmitAction()`,
-  `<Form>` component.
+- **Client hooks**: `useRouteData()`, `useRevalidateRoute()`, `<Form>` component.
 
 ### API Routes
 
@@ -127,13 +125,13 @@ SSR and SSG, deployed to Node. Thoroughly tested with Playwright E2E tests.
 
 1. **`packages/framework`** — core exports
    - `defineApp()`, `route()`, `group()` — route manifest API
-   - `RouteModule` type — loader, action, head, default/Component, errorBoundary
+   - `RouteModule` type — loader, head, default/Component, errorBoundary
    - `ShellModule` type — layout wrapper with head contribution
    - `MiddlewareModule` type — server-side request interceptor
    - Router: `matchAppRoute()` segment-based matching
    - Server renderer: `handlePrachtRequest()` → full HTML with hydration state
    - Client runtime: `startApp()`, hydration, client-side navigation
-   - Hooks: `useRouteData()`, `useRevalidateRoute()`, `useSubmitAction()`, `<Form>`
+   - Hooks: `useRouteData()`, `useRevalidateRoute()`, `<Form>`
 
 2. **`packages/vite-plugin`** — Vite integration
    - Virtual modules: `virtual:pracht/client`, `virtual:pracht/server`
@@ -155,7 +153,7 @@ SSR and SSG, deployed to Node. Thoroughly tested with Playwright E2E tests.
    - Zero config to start — sensible defaults, override when needed
    - Fast feedback loop: save a file → see the change instantly
 
-5. **Example app** — demonstrates SSR + SSG routes, shells, loaders, actions
+5. **Example app** — demonstrates SSR + SSG routes, shells, loaders, and forms
 
 6. **E2E tests** — Playwright tests proving:
    - SSR renders correct HTML on the server

--- a/docs/ADAPTERS.md
+++ b/docs/ADAPTERS.md
@@ -169,8 +169,8 @@ the executable production server entry.
   Prerendered HTML also receives route and shell document headers from
   `dist/client/_pracht/headers.json`.
 - **Default request context**: generated worker entries pass `{ env,
-executionContext }` to pracht so loaders, actions, and middleware can access
-  bindings without extra wiring.
+ executionContext }` to pracht so loaders, API routes, and middleware can
+  access bindings without extra wiring.
 - **Build output**: `pracht({ adapter: cloudflareAdapter() })` makes `pracht build`
   emit a Worker bundle in `dist/server/server.js`. You own a `wrangler.jsonc`
   in your project root that points at the output — this lets you add KV, D1,
@@ -199,7 +199,7 @@ deploys. During dev, the adapter automatically overrides the entry to
 pracht's virtual server module via `@cloudflare/vite-plugin` — no extra
 files needed.
 
-Bindings are available via `context.env` in loaders, actions, and API routes:
+Bindings are available via `context.env` in loaders, middleware, and API routes:
 
 ```typescript
 // src/api/items.ts
@@ -356,8 +356,8 @@ At the runtime level, an adapter also typically needs to:
 
 ### Context factory pattern
 
-The context factory lets adapters inject platform-specific values into loaders
-and actions:
+The context factory lets adapters inject platform-specific values into loaders,
+middleware, and API routes:
 
 ```typescript
 // Node: inject database pool
@@ -374,4 +374,4 @@ createContext: ({ request, env, executionContext }) => ({
 });
 ```
 
-This context is available in every loader, action, and middleware as `args.context`.
+This context is available in every loader, middleware, and API route as `args.context`.

--- a/docs/WORKSPACE.md
+++ b/docs/WORKSPACE.md
@@ -47,9 +47,6 @@ described in `VISION_MVP.md`.
   page.
 - **Middleware** — Named middleware from the manifest runs before loaders and can
   redirect, return a Response, or augment the context.
-- **Actions** — POST/PUT/PATCH/DELETE requests are routed to the route module's
-  `action` export. Action envelopes support JSON results, redirects, custom
-  headers, and client-side revalidation of the current route.
 - **Vite plugin** — Generates `virtual:pracht/client` (hydration entry) and
   `virtual:pracht/server` (resolved app + module registry + API routes +
   adapter-targeted server entry) virtual modules. The `configureServer` hook
@@ -76,8 +73,8 @@ described in `VISION_MVP.md`.
   `handlePrachtRequest()`, and implements ISG stale-while-revalidate with
   background regeneration.
 - **Cloudflare adapter** — Serves `env.ASSETS` when available, falls back to
-  `handlePrachtRequest()`, and gives loaders/actions access to `env` and the
-  `executionContext` through `args.context`.
+  `handlePrachtRequest()`, and gives loaders, API routes, and middleware access
+  to `env` and the `executionContext` through `args.context`.
 - **Vercel adapter** — Emits an Edge-compatible handler, copies the build into
   `.vercel/output/static` and `.vercel/output/functions/render.func`, rewrites
   clean SSG URLs to static HTML, and routes ISG plus dynamic requests to the

--- a/examples/docs/src/routes/docs/migrate-nextjs.md
+++ b/examples/docs/src/routes/docs/migrate-nextjs.md
@@ -17,7 +17,7 @@ Next.js and pracht share many of the same concepts — server rendering, file-ba
 | Bundler         | Turbopack / Webpack                   | Vite                                     |
 | Routing         | File-system conventions               | Explicit manifest (`src/routes.ts`)      |
 | Layouts         | `layout.tsx` nesting                  | Named shells                             |
-| Data fetching   | `async` Server Components, `fetch`    | `loader` / `action` exports              |
+| Data fetching   | `async` Server Components, `fetch`    | `loader` exports + API routes            |
 | Rendering modes | Per-segment (`dynamic`, `revalidate`) | Per-route (`ssg`, `ssr`, `isg`, `spa`)   |
 | Middleware      | Single `middleware.ts` at root        | Named middleware, per-route or per-group |
 | API routes      | `app/api/**/route.ts`                 | `src/api/**/*.ts`                        |
@@ -130,7 +130,7 @@ export function head() {
 
 ---
 
-## Data Fetching → Loaders & Actions
+## Data Fetching → Loaders & API Routes
 
 ### Server Components → Loaders
 
@@ -168,9 +168,10 @@ export default function BlogPost() {
 }
 ```
 
-### Server Actions → Actions
+### Server Actions → API Routes
 
-Next.js Server Actions become pracht `action` exports:
+Next.js Server Actions map cleanly to pracht API routes plus `<Form>` or
+client-side `fetch` calls:
 
 ```tsx
 // Next.js
@@ -181,20 +182,27 @@ async function createPost(formData: FormData) {
 }
 ```
 
-```tsx [src/routes/new-post.tsx]
+```ts [src/api/posts.ts]
 // pracht
-import type { ActionArgs } from "@pracht/core";
-import { Form } from "pracht/client";
+import type { ApiRouteArgs } from "@pracht/core";
 
-export async function action({ request }: ActionArgs) {
+export async function POST({ request }: ApiRouteArgs) {
   const form = await request.formData();
   await db.posts.create({ title: form.get("title") });
-  return { redirect: "/blog" };
+  return new Response(null, {
+    status: 303,
+    headers: { location: "/blog" },
+  });
 }
+```
+
+```tsx [src/routes/new-post.tsx]
+// pracht
+import { Form } from "@pracht/core";
 
 export default function NewPost() {
   return (
-    <Form method="post">
+    <Form method="post" action="/api/posts">
       <input name="title" />
       <button type="submit">Create</button>
     </Form>
@@ -351,7 +359,7 @@ export default {
 3. **Create the route manifest** — Map your `app/` folder structure to `src/routes.ts`
 4. **Convert layouts to shells** — Extract `layout.tsx` files into named shell components
 5. **Extract data fetching into loaders** — Move `async` component logic into `loader` exports
-6. **Convert Server Actions to actions** — Replace `"use server"` functions with `action` exports
+6. **Convert Server Actions to API routes** — Replace `"use server"` functions with API route handlers plus `<Form>` or `fetch`
 7. **Move middleware** — Split your single `middleware.ts` into named middleware files
 8. **Move API routes** — Copy `app/api/` handlers to `src/api/`, replace `NextResponse` with `Response`
 9. **Choose an adapter** — Pick your deployment target in `vite.config.ts`

--- a/packages/framework/README.md
+++ b/packages/framework/README.md
@@ -37,14 +37,13 @@ metadata for the failure phase and matched framework files when available.
 - `startApp()` — client-side hydration and runtime
 - `useRouteData()` — access loader data inside a route component
 - `useRevalidateRoute()` — trigger a revalidation of the current route's data
-- `useSubmitAction()` — submit a form action programmatically
 - `<Form>` — progressive enhancement form component
 
 ### Types
 
 - `LoaderData<T>` — infer the return type of a loader
 - `RouteComponentProps<T>` — props type for route components
-- `LoaderArgs` — argument type passed to loaders and actions
+- `LoaderArgs` — argument type passed to loaders
 
 ## Rendering Modes
 

--- a/skills/debug/SKILL.md
+++ b/skills/debug/SKILL.md
@@ -3,7 +3,7 @@ name: debug
 version: 1.1.0
 description: |
   Pracht framework-aware debugging. Systematically investigates route matching,
-  loader/action errors, rendering issues, middleware, API routes, HMR, and build
+  loader/API route errors, rendering issues, middleware, API routes, HMR, and build
   problems. Uses pracht's architecture knowledge to find root causes fast.
   Use when asked to "debug this", "fix this bug", "why is this broken",
   "blank page", "hydration mismatch", or "404 on my route".
@@ -46,11 +46,11 @@ Work through these in order, stopping when you find the root cause:
 - For dynamic segments, verify bracket syntax: `route("/users/:id", ...)` in manifest, `[id].ts` in filenames.
 - Grep for the route path across the manifest and check `matchAppRoute()` logic if needed.
 
-### 2. Loader / action errors
+### 2. Loader / API route errors
 
-- Read the route module's `loader` or `action` function.
+- Read the route module's `loader` function or the matching API route handler.
 - Check that `loader` returns serializable data (no functions, no circular refs).
-- Check that `action` returns `ActionEnvelope` shape (`{ data, ok, revalidate, redirect }`) or plain data.
+- Check that API route handlers return `Response` objects and branch on `request.method` when using a default export.
 - Look for unhandled promise rejections or thrown errors.
 - Verify `LoaderArgs` destructuring matches what the framework provides: `{ request, params, context, signal, url, route }`.
 
@@ -106,7 +106,7 @@ Work through these in order, stopping when you find the root cause:
 | --------------------- | ----------------------------------------------------- |
 | `src/routes.ts`       | App manifest — all route/shell/middleware definitions |
 | `vite.config.ts`      | Vite config with `pracht()` plugin                    |
-| `src/routes/*.tsx`    | Route modules (loader, action, Component)             |
+| `src/routes/*.tsx`    | Route modules (loader, Component)                     |
 | `src/shells/*.tsx`    | Shell layout components                               |
 | `src/middleware/*.ts` | Server-side middleware                                |
 | `src/api/*.ts`        | API route handlers                                    |

--- a/skills/migrate-nextjs/SKILL.md
+++ b/skills/migrate-nextjs/SKILL.md
@@ -72,7 +72,7 @@ For pages router projects, you can **skip manual manifest wiring entirely** (Pha
 | `generateStaticParams`          | `getStaticPaths()` export                                       | Returns `RouteParams[]` of param objects                              |
 | `generateMetadata`              | `head()` export                                                 | Returns `{ title, meta }`                                             |
 | Server Components               | `loader()` export                                               | Data fetching moves to loader; component is always a Preact component |
-| `"use server"` actions          | `action()` export                                               | Returns data/redirect/revalidation hints                              |
+| `"use server"` actions          | API routes + `<Form>` / `fetch`                                 | Mutations move to `src/api/*`; return `Response` objects              |
 | `useRouter()` (next/navigation) | `useNavigate()` from pracht                                     | Client-side navigation                                                |
 | `useSearchParams()`             | `useRouteData()` or parse from loader args                      | Loaders receive `url` with searchParams                               |
 | `useParams()`                   | `useRouteData()` or `params` in loader                          | Params flow through loader data                                       |
@@ -386,7 +386,7 @@ const navigate = useNavigate();
 navigate("/dashboard");
 ```
 
-#### Server Actions → Pracht actions
+#### Server Actions → API routes
 
 ```tsx
 // Next.js
@@ -396,11 +396,14 @@ async function createPost(formData: FormData) {
   revalidatePath("/posts");
 }
 
-// Pracht — action export in route module
-export async function action({ request }: ActionArgs) {
+// Pracht — API route handler
+export async function POST({ request }: ApiRouteArgs) {
   const form = await request.formData();
   await db.insert({ title: form.get("title") });
-  return { ok: true, revalidate: ["route:self"] };
+  return new Response(null, {
+    status: 303,
+    headers: { location: "/posts" },
+  });
 }
 ```
 


### PR DESCRIPTION
## Summary

- Remove the unsupported route-action API from the public docs surface across the repo docs, package README, and docs-site migration guide.
- Align the repo-local debug and migration skills so they no longer teach `action()`/`useSubmitAction()` as supported framework APIs.
- Relevant issue: N/A

## Testing

- [x] `pnpm e2e`
- [x] `pnpm format`
- [x] `pnpm lint`
- [x] `pnpm test`

## Checklist

- [x] Docs updated if needed
- [x] Skills updated if needed
- [x] Changeset added if published packages changed

N/A: This PR only updates docs and skills, so no package changeset was needed.