### PR TITLE
Fix query-string client navigation

### DIFF
--- a/.changeset/gorgeous-radios-fix.md
+++ b/.changeset/gorgeous-radios-fix.md
@@ -1,0 +1,5 @@
+---
+"@pracht/core": patch
+---
+
+Fix client-side query-string navigation so internal links keep using the client router, and expose `search` separately from `pathname` in `useLocation()`.

--- a/e2e/pages-router.test.ts
+++ b/e2e/pages-router.test.ts
@@ -24,7 +24,7 @@ test("about page renders as static page", async ({ page }) => {
 
   await expect(page.locator(".pages-shell")).toBeVisible();
   await expect(page.locator("h1")).toContainText("About");
-  await expect(page.locator("p")).toContainText("static page rendered with SSG");
+  await expect(page.locator("section p").first()).toContainText("static page rendered with SSG");
 });
 
 // ---------------------------------------------------------------------------
@@ -79,6 +79,26 @@ test("client-side navigation works between pages", async ({ page }) => {
   expect(tokenSurvived).toBe(true);
 
   await expect(page.locator("h1")).toContainText("About");
+});
+
+test("client-side navigation preserves query strings and exposes search separately", async ({
+  page,
+}) => {
+  await page.goto("/");
+  await page.waitForFunction(() => (window as any).__PRACHT_ROUTER_READY__);
+
+  await page.evaluate(() => {
+    (window as any).__NAV_TOKEN__ = true;
+  });
+
+  await page.evaluate(() => (window as any).__PRACHT_NAVIGATE__("/about?tab=details"));
+  await page.waitForURL("/about?tab=details");
+
+  const tokenSurvived = await page.evaluate(() => (window as any).__NAV_TOKEN__ === true);
+  expect(tokenSurvived).toBe(true);
+
+  await expect(page.locator(".location-pathname")).toContainText("/about");
+  await expect(page.locator(".location-search")).toContainText("?tab=details");
 });
 
 test("client-side navigation to dynamic route", async ({ page }) => {

--- a/examples/pages-router/src/pages/about.tsx
+++ b/examples/pages-router/src/pages/about.tsx
@@ -1,10 +1,16 @@
+import { useLocation } from "@pracht/core";
+
 export const RENDER_MODE = "ssg";
 
 export function Component() {
+  const { pathname, search } = useLocation();
+
   return (
     <section>
       <h1>About</h1>
       <p>A static page rendered with SSG via the pages router.</p>
+      <p class="location-pathname">Pathname: {pathname}</p>
+      <p class="location-search">Search: {search || "(empty)"}</p>
     </section>
   );
 }

--- a/packages/framework/README.md
+++ b/packages/framework/README.md
@@ -35,6 +35,7 @@ metadata for the failure phase and matched framework files when available.
 ### Client
 
 - `startApp()` — client-side hydration and runtime
+- `useLocation()` — access the current pathname and search string separately
 - `useRouteData()` — access loader data inside a route component
 - `useRevalidateRoute()` — trigger a revalidation of the current route's data
 - `useSubmitAction()` — submit a form action programmatically

--- a/packages/framework/src/prefetch.ts
+++ b/packages/framework/src/prefetch.ts
@@ -36,6 +36,14 @@ export function prefetchRouteState(url: string): Promise<RouteStateResult> {
 export function setupPrefetching(app: ResolvedPrachtApp, warmModules?: ModuleWarmFn): void {
   let hoverTimer: ReturnType<typeof setTimeout> | null = null;
 
+  function getRoutePathname(url: string): string | null {
+    try {
+      return new URL(url, window.location.origin).pathname;
+    } catch {
+      return null;
+    }
+  }
+
   function getInternalHref(anchor: HTMLAnchorElement): string | null {
     const href = anchor.getAttribute("href");
     if (!href || href.startsWith("#")) return null;
@@ -52,7 +60,10 @@ export function setupPrefetching(app: ResolvedPrachtApp, warmModules?: ModuleWar
   }
 
   function getPrefetchStrategy(pathname: string): PrefetchStrategy {
-    const match = matchAppRoute(app, pathname);
+    const routePathname = getRoutePathname(pathname);
+    if (!routePathname) return "none";
+
+    const match = matchAppRoute(app, routePathname);
     if (!match) return "none";
     // Use route-level config, or default based on render mode
     if (match.route.prefetch) return match.route.prefetch;
@@ -78,7 +89,8 @@ export function setupPrefetching(app: ResolvedPrachtApp, warmModules?: ModuleWar
       hoverTimer = setTimeout(() => {
         prefetchRouteState(href);
         if (warmModules) {
-          const m = matchAppRoute(app, href);
+          const pathname = getRoutePathname(href);
+          const m = pathname ? matchAppRoute(app, pathname) : undefined;
           if (m) warmModules(m);
         }
       }, 50);
@@ -113,7 +125,8 @@ export function setupPrefetching(app: ResolvedPrachtApp, warmModules?: ModuleWar
 
       prefetchRouteState(href);
       if (warmModules) {
-        const m = matchAppRoute(app, href);
+        const pathname = getRoutePathname(href);
+        const m = pathname ? matchAppRoute(app, pathname) : undefined;
         if (m) warmModules(m);
       }
     },
@@ -132,7 +145,8 @@ export function setupPrefetching(app: ResolvedPrachtApp, warmModules?: ModuleWar
         if (!href) continue;
         prefetchRouteState(href);
         if (warmModules) {
-          const m = matchAppRoute(app, href);
+          const pathname = getRoutePathname(href);
+          const m = pathname ? matchAppRoute(app, pathname) : undefined;
           if (m) warmModules(m);
         }
         observer.unobserve(anchor);

--- a/packages/framework/src/router.ts
+++ b/packages/framework/src/router.ts
@@ -22,6 +22,12 @@ type ModuleMap = Record<string, () => Promise<any>>;
 
 export type NavigateFn = (to: string, options?: { replace?: boolean }) => Promise<void>;
 
+interface BrowserRouteTarget {
+  browserUrl: string;
+  pathname: string;
+  requestUrl: string;
+}
+
 const NavigateContext = createContext<NavigateFn>(async () => {});
 
 export function useNavigate(): NavigateFn {
@@ -75,6 +81,7 @@ export async function initClientRouter(options: InitClientRouterOptions): Promis
   async function buildRouteTree(
     match: RouteMatch,
     state: { data: unknown; error?: SerializedRouteError | null },
+    currentUrl: string,
     routeModPromise?: Promise<any> | null,
     shellModPromise?: Promise<any> | null,
   ): Promise<VNode<any> | null> {
@@ -107,7 +114,7 @@ export async function initClientRouter(options: InitClientRouterOptions): Promis
           data: state.data,
           params: match.params,
           routeId: match.route.id ?? "",
-          url: match.pathname,
+          url: currentUrl,
         },
         componentTree,
       ),
@@ -116,6 +123,7 @@ export async function initClientRouter(options: InitClientRouterOptions): Promis
 
   async function buildSpaPendingTree(
     match: RouteMatch,
+    currentUrl: string,
     shellModPromise?: Promise<any> | null,
   ): Promise<VNode<any> | null> {
     const resolvedShell = await (shellModPromise ?? startShellImport(match));
@@ -141,7 +149,7 @@ export async function initClientRouter(options: InitClientRouterOptions): Promis
           data: undefined,
           params: match.params,
           routeId: match.route.id ?? "",
-          url: match.pathname,
+          url: currentUrl,
         },
         componentTree,
       ),
@@ -156,15 +164,22 @@ export async function initClientRouter(options: InitClientRouterOptions): Promis
     to: string,
     opts?: { replace?: boolean; _popstate?: boolean },
   ): Promise<void> {
-    const match = matchAppRoute(app, to);
-    if (!match) {
-      // No client route — fall back to full page load
+    const target = resolveBrowserRouteTarget(to);
+    if (!target) {
       window.location.href = to;
       return;
     }
 
+    const match = matchAppRoute(app, target.pathname);
+    if (!match) {
+      // No client route — fall back to full page load
+      window.location.href = target.browserUrl;
+      return;
+    }
+
     // Start route-state fetch and module imports in parallel
-    const statePromise = getCachedRouteState(to) ?? fetchPrachtRouteState(to);
+    const statePromise =
+      getCachedRouteState(target.requestUrl) ?? fetchPrachtRouteState(target.requestUrl);
     const routeModPromise = startRouteImport(match);
     const shellModPromise = startShellImport(match);
 
@@ -180,7 +195,7 @@ export async function initClientRouter(options: InitClientRouterOptions): Promis
           await navigate(result.location, opts);
           return;
         }
-        window.location.href = to;
+        window.location.href = target.browserUrl;
         return;
       }
 
@@ -197,26 +212,32 @@ export async function initClientRouter(options: InitClientRouterOptions): Promis
       }
     } catch {
       // Network error — full page load as fallback
-      window.location.href = to;
+      window.location.href = target.browserUrl;
       return;
     }
 
     // Update browser history
     if (!opts?._popstate) {
       if (opts?.replace) {
-        history.replaceState(null, "", to);
+        history.replaceState(null, "", target.browserUrl);
       } else {
-        history.pushState(null, "", to);
+        history.pushState(null, "", target.browserUrl);
       }
     }
 
     // Render — module imports started above are already in-flight
-    const tree = await buildRouteTree(match, state, routeModPromise, shellModPromise);
+    const tree = await buildRouteTree(
+      match,
+      state,
+      target.requestUrl,
+      routeModPromise,
+      shellModPromise,
+    );
     if (tree) {
       render(tree, root);
       window.scrollTo(0, 0);
     } else {
-      window.location.href = to;
+      window.location.href = target.browserUrl;
     }
   }
 
@@ -240,7 +261,10 @@ export async function initClientRouter(options: InitClientRouterOptions): Promis
   // Initial hydration — includes NavigateContext so useNavigate works
   // ------------------------------------------------------------------
 
-  const initialMatch = matchAppRoute(app, options.initialState.url);
+  const initialTarget = resolveBrowserRouteTarget(options.initialState.url);
+  const initialRequestUrl = initialTarget?.requestUrl ?? options.initialState.url;
+  const initialBrowserUrl = initialTarget?.browserUrl ?? options.initialState.url;
+  const initialMatch = matchAppRoute(app, initialTarget?.pathname ?? options.initialState.url);
   if (initialMatch) {
     const initialShellPromise =
       initialMatch.route.render === "spa" && options.initialState.pending
@@ -253,9 +277,13 @@ export async function initClientRouter(options: InitClientRouterOptions): Promis
 
     if (initialMatch.route.render === "spa" && options.initialState.pending) {
       // Kick off the data fetch in parallel with shell hydration
-      const dataPromise = fetchPrachtRouteState(options.initialState.url);
+      const dataPromise = fetchPrachtRouteState(initialRequestUrl);
 
-      const pendingTree = await buildSpaPendingTree(initialMatch, initialShellPromise);
+      const pendingTree = await buildSpaPendingTree(
+        initialMatch,
+        initialRequestUrl,
+        initialShellPromise,
+      );
       if (pendingTree) {
         hydrate(pendingTree, root);
       }
@@ -279,12 +307,18 @@ export async function initClientRouter(options: InitClientRouterOptions): Promis
           };
         }
       } catch {
-        window.location.href = options.initialState.url;
+        window.location.href = initialBrowserUrl;
         return;
       }
     }
 
-    const tree = await buildRouteTree(initialMatch, state, undefined, initialShellPromise);
+    const tree = await buildRouteTree(
+      initialMatch,
+      state,
+      initialRequestUrl,
+      undefined,
+      initialShellPromise,
+    );
     if (tree) {
       if (initialMatch.route.render === "spa") {
         render(tree, root);
@@ -330,7 +364,7 @@ export async function initClientRouter(options: InitClientRouterOptions): Promis
     if (url.origin !== window.location.origin) return;
 
     e.preventDefault();
-    navigate(url.pathname + url.search);
+    navigate(url.pathname + url.search + url.hash);
   });
 
   // ------------------------------------------------------------------
@@ -338,7 +372,7 @@ export async function initClientRouter(options: InitClientRouterOptions): Promis
   // ------------------------------------------------------------------
 
   window.addEventListener("popstate", () => {
-    navigate(window.location.pathname + window.location.search, {
+    navigate(window.location.pathname + window.location.search + window.location.hash, {
       _popstate: true,
     });
   });
@@ -422,4 +456,25 @@ function deserializeRouteError(error: SerializedRouteError): Error {
     result as Error & { diagnostics?: SerializedRouteError["diagnostics"]; status?: number }
   ).diagnostics = error.diagnostics;
   return result;
+}
+
+function resolveBrowserRouteTarget(to: string): BrowserRouteTarget | null {
+  if (typeof window === "undefined") {
+    return null;
+  }
+
+  try {
+    const url = new URL(to, window.location.href);
+    if (url.origin !== window.location.origin) {
+      return null;
+    }
+
+    return {
+      browserUrl: url.pathname + url.search + url.hash,
+      pathname: url.pathname,
+      requestUrl: url.pathname + url.search,
+    };
+  } catch {
+    return null;
+  }
 }

--- a/packages/framework/src/runtime.ts
+++ b/packages/framework/src/runtime.ts
@@ -200,13 +200,14 @@ export function useRouteData<TData = unknown>(): TData {
 
 export interface Location {
   pathname: string;
+  search: string;
 }
 
 export function useLocation(): Location {
   const url =
     useContext(RouteDataContext)?.url ??
-    (typeof window !== "undefined" ? window.location.pathname : "/");
-  return { pathname: url };
+    (typeof window !== "undefined" ? window.location.pathname + window.location.search : "/");
+  return parseLocation(url);
 }
 
 export function useParams(): RouteParams {
@@ -323,6 +324,7 @@ export async function handlePrachtRequest<TContext>(
   options: HandlePrachtRequestOptions<TContext>,
 ): Promise<Response> {
   const url = new URL(options.request.url);
+  const requestPath = getRequestPath(url);
   const registry = options.registry ?? {};
   const isRouteStateRequest = options.request.headers.get(ROUTE_STATE_REQUEST_HEADER) === "1";
   const exposeDiagnostics = shouldExposeServerErrors(options);
@@ -551,7 +553,7 @@ export async function handlePrachtRequest<TContext>(
           head,
           body,
           hydrationState: {
-            url: url.pathname,
+            url: requestPath,
             routeId: match.route.id ?? "",
             data: null,
             error: null,
@@ -587,7 +589,7 @@ export async function handlePrachtRequest<TContext>(
         data,
         params: match.params,
         routeId: match.route.id ?? "",
-        url: url.pathname,
+        url: requestPath,
       },
       componentTree,
     );
@@ -599,7 +601,7 @@ export async function handlePrachtRequest<TContext>(
         head,
         body: ssrContent,
         hydrationState: {
-          url: url.pathname,
+          url: requestPath,
           routeId: match.route.id ?? "",
           data,
           error: null,
@@ -623,9 +625,28 @@ export async function handlePrachtRequest<TContext>(
       routeModule,
       shellFile: match.route.shellFile,
       shellModule,
-      urlPathname: url.pathname,
+      requestPath,
     });
   }
+}
+
+function parseLocation(value: string): Location {
+  try {
+    const url = new URL(value, "http://pracht.local");
+    return {
+      pathname: url.pathname,
+      search: url.search,
+    };
+  } catch {
+    return {
+      pathname: value || "/",
+      search: "",
+    };
+  }
+}
+
+function getRequestPath(url: URL): string {
+  return `${url.pathname}${url.search}`;
 }
 
 // ---------------------------------------------------------------------------
@@ -924,7 +945,7 @@ async function renderRouteErrorResponse<TContext>(options: {
   routeModule: RouteModule | undefined;
   shellFile: string | undefined;
   shellModule: ShellModule | undefined;
-  urlPathname: string;
+  requestPath: string;
 }): Promise<Response> {
   const exposeDetails = shouldExposeServerErrors(options.options);
   const routeError = normalizeRouteError(options.error, {
@@ -1003,7 +1024,7 @@ async function renderRouteErrorResponse<TContext>(options: {
     {
       data: null,
       routeId: options.routeId,
-      url: options.urlPathname,
+      url: options.requestPath,
     },
     componentTree,
   );
@@ -1014,7 +1035,7 @@ async function renderRouteErrorResponse<TContext>(options: {
       head,
       body,
       hydrationState: {
-        url: options.urlPathname,
+        url: options.requestPath,
         routeId: options.routeId,
         data: null,
         error: routeErrorWithDiagnostics,

--- a/packages/framework/test/runtime.test.ts
+++ b/packages/framework/test/runtime.test.ts
@@ -8,6 +8,7 @@ import {
   prerenderApp,
   resolveApiRoutes,
   route,
+  useLocation,
   useParams,
 } from "../src/index.ts";
 
@@ -646,6 +647,35 @@ describe("useParams", () => {
     expect(response.status).toBe(200);
     const html = await response.text();
     expect(html).toContain("keys:0");
+  });
+});
+
+describe("useLocation", () => {
+  it("provides pathname and search separately during SSR", async () => {
+    const app = defineApp({
+      routes: [route("/about", "./routes/about.tsx", { render: "ssr" })],
+    });
+
+    function LocationDisplay() {
+      const { pathname, search } = useLocation();
+      return h("span", null, `${pathname}|${search}`);
+    }
+
+    const response = await handlePrachtRequest({
+      app,
+      registry: {
+        routeModules: {
+          "./routes/about.tsx": async () => ({
+            Component: () => h("main", null, h(LocationDisplay, null)),
+          }),
+        },
+      },
+      request: new Request("http://localhost/about?tab=team"),
+    });
+
+    expect(response.status).toBe(200);
+    const html = await response.text();
+    expect(html).toContain("/about|?tab=team");
   });
 });
 


### PR DESCRIPTION
## Summary

- Fix client-side navigation for internal URLs with query strings by matching routes on `pathname` while preserving `pathname + search` for fetches and runtime state.
- Expose `search` separately from `pathname` in `useLocation()` and add unit/e2e coverage for the new behavior.
- Relevant issue: N/A

## Testing

- [x] `pnpm e2e`
- [x] `pnpm format`
- [x] `pnpm lint`
- [x] `pnpm test`

## Checklist

- [x] Docs updated if needed
- [x] Skills updated if needed
- [x] Changeset added if published packages changed

N/A: No skill updates were needed for this fix.