### PR TITLE
Fix Node ISG regeneration context

### DIFF
--- a/.changeset/witty-socks-draw.md
+++ b/.changeset/witty-socks-draw.md
@@ -1,0 +1,5 @@
+---
+"@pracht/adapter-node": patch
+---
+
+Fix Node adapter ISG background regeneration so `createContext()` still runs during stale page refreshes.

--- a/packages/adapter-node/README.md
+++ b/packages/adapter-node/README.md
@@ -21,4 +21,4 @@ node dist/server/server.js
 - Converts Node.js HTTP requests to standard Web Requests
 - Serves static files from `dist/client/`
 - Loads the Vite manifest for asset injection
-- Supports ISG time-window revalidation
+- Supports ISG time-window revalidation with background regeneration that reuses `createContext()`

--- a/packages/adapter-node/src/index.ts
+++ b/packages/adapter-node/src/index.ts
@@ -178,7 +178,7 @@ export function createNodeRequestHandler<TContext = unknown>(
 
         // Background regeneration if stale
         if (isStale) {
-          regenerateISGPage(options, url.pathname, htmlPath).catch((err) => {
+          regenerateISGPage(options, url.pathname, htmlPath, { request, req, res }).catch((err) => {
             console.error(`ISG regeneration failed for ${url.pathname}:`, err);
           });
         }
@@ -228,12 +228,17 @@ async function regenerateISGPage<TContext>(
   options: NodeAdapterOptions<TContext>,
   pathname: string,
   htmlPath: string,
+  contextArgs?: NodeAdapterContextArgs,
 ): Promise<void> {
-  const url = new URL(pathname, "http://localhost");
-  const request = new Request(url, { method: "GET" });
+  const request = createISGRegenerationRequest(pathname, contextArgs?.request);
+  const context =
+    options.createContext && contextArgs
+      ? await options.createContext({ ...contextArgs, request })
+      : undefined;
 
   const response = await handlePrachtRequest({
     app: options.app,
+    context,
     registry: options.registry,
     request,
     clientEntryUrl: options.clientEntryUrl,
@@ -246,6 +251,16 @@ async function regenerateISGPage<TContext>(
     await mkdir(dirname(htmlPath), { recursive: true });
     await writeFile(htmlPath, html, "utf-8");
   }
+}
+
+function createISGRegenerationRequest(pathname: string, originalRequest?: Request): Request {
+  const baseUrl = originalRequest ? new URL(originalRequest.url) : new URL("http://localhost");
+  const regenerationUrl = new URL(pathname, baseUrl);
+
+  return new Request(regenerationUrl, {
+    method: "GET",
+    headers: originalRequest ? new Headers(originalRequest.headers) : undefined,
+  });
 }
 
 export function createNodeServerEntryModule(options: NodeServerEntryModuleOptions = {}): string {

--- a/packages/adapter-node/test/index.test.ts
+++ b/packages/adapter-node/test/index.test.ts
@@ -1,0 +1,114 @@
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, utimesSync, writeFileSync } from "node:fs";
+import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { once } from "node:events";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { defineApp, route, timeRevalidate } from "@pracht/core";
+
+import { createNodeRequestHandler } from "../src/index.ts";
+
+const tempDirs: string[] = [];
+const servers = new Set<ReturnType<typeof createServer>>();
+
+function makeTempDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), "pracht-adapter-node-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+async function waitFor(predicate: () => boolean, timeoutMs = 2_000): Promise<void> {
+  const startedAt = Date.now();
+
+  while (!predicate()) {
+    if (Date.now() - startedAt > timeoutMs) {
+      throw new Error("Timed out waiting for condition");
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, 20));
+  }
+}
+
+afterEach(async () => {
+  for (const server of servers) {
+    server.close();
+    await once(server, "close");
+  }
+  servers.clear();
+
+  while (tempDirs.length > 0) {
+    const dir = tempDirs.pop();
+    if (dir) {
+      rmSync(dir, { force: true, recursive: true });
+    }
+  }
+});
+
+describe("createNodeRequestHandler", () => {
+  it("reuses createContext during stale ISG regeneration", async () => {
+    const staticDir = makeTempDir();
+    const htmlDir = join(staticDir, "isg");
+    const htmlPath = join(htmlDir, "index.html");
+    mkdirSync(htmlDir, { recursive: true });
+    writeFileSync(htmlPath, "<html><body>stale</body></html>", "utf-8");
+
+    const staleAt = new Date(Date.now() - 10_000);
+    utimesSync(htmlPath, staleAt, staleAt);
+
+    const createContextCalls: string[] = [];
+    const app = defineApp({
+      routes: [route("/isg", "./routes/isg.tsx", { render: "isg", revalidate: timeRevalidate(1) })],
+    });
+
+    const handler = createNodeRequestHandler({
+      app,
+      createContext: ({ request }) => {
+        const tenant = request.headers.get("x-tenant");
+        createContextCalls.push(tenant ?? "missing");
+        return { tenant };
+      },
+      isgManifest: {
+        "/isg": {
+          revalidate: timeRevalidate(1),
+        },
+      },
+      registry: {
+        routeModules: {
+          "./routes/isg.tsx": async () => ({
+            Component: ({ data }) => `<main>${(data as { tenant: string }).tenant}</main>`,
+            loader: async ({ context }) => ({
+              tenant: (context as { tenant?: string }).tenant ?? "missing",
+            }),
+          }),
+        },
+      },
+      staticDir,
+    });
+
+    const server = createServer((req: IncomingMessage, res: ServerResponse) => {
+      void handler(req, res);
+    });
+    servers.add(server);
+
+    server.listen(0, "127.0.0.1");
+    await once(server, "listening");
+    const address = server.address();
+    if (!address || typeof address === "string") {
+      throw new Error("Expected TCP server address");
+    }
+
+    const response = await fetch(`http://127.0.0.1:${address.port}/isg`, {
+      headers: { "x-tenant": "acme" },
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("x-pracht-isg")).toBe("stale");
+    await expect(response.text()).resolves.toContain("stale");
+
+    await waitFor(() => readFileSync(htmlPath, "utf-8").includes("acme"));
+
+    expect(createContextCalls).toEqual(["acme"]);
+    expect(readFileSync(htmlPath, "utf-8")).toContain("acme");
+  });
+});


### PR DESCRIPTION
## Summary

- Fix the Node adapter's stale ISG regeneration path so background refreshes still run `createContext()`.
- Preserve request-derived headers for regeneration context while keeping the cached HTML keyed to the route pathname.
- Add an integration test that exercises stale ISG serving plus background refresh with request-scoped context.
- Relevant issue: N/A

## Testing

- [x] `pnpm e2e`
- [x] `pnpm format`
- [x] `pnpm lint`
- [x] `pnpm test`

## Checklist

- [x] Docs updated if needed
- [x] Skills updated if needed
- [x] Changeset added if published packages changed

N/A: No skill updates were needed for this fix.