### PR TITLE
Fix API route specificity order

### DIFF
--- a/.changeset/tricky-steaks-bake.md
+++ b/.changeset/tricky-steaks-bake.md
@@ -1,0 +1,5 @@
+---
+"@pracht/core": patch
+---
+
+Fix auto-discovered API route precedence so static routes are matched before dynamic parameter routes.

--- a/packages/framework/src/app.ts
+++ b/packages/framework/src/app.ts
@@ -314,30 +314,32 @@ export function buildPathFromSegments(segments: RouteSegment[], params: RoutePar
 export function resolveApiRoutes(files: string[], apiDir: string = "/src/api"): ResolvedApiRoute[] {
   const normalizedDir = apiDir.replace(/\/$/, "");
 
-  return files.map((file) => {
-    // Strip the apiDir prefix and file extension
-    let relative = file;
-    if (relative.startsWith(normalizedDir)) {
-      relative = relative.slice(normalizedDir.length);
-    }
-    relative = relative.replace(/\.(ts|tsx|js|jsx)$/, "");
+  return files
+    .map((file) => {
+      // Strip the apiDir prefix and file extension
+      let relative = file;
+      if (relative.startsWith(normalizedDir)) {
+        relative = relative.slice(normalizedDir.length);
+      }
+      relative = relative.replace(/\.(ts|tsx|js|jsx)$/, "");
 
-    // index files map to the parent directory
-    if (relative.endsWith("/index")) {
-      relative = relative.slice(0, -"/index".length) || "/";
-    }
+      // index files map to the parent directory
+      if (relative.endsWith("/index")) {
+        relative = relative.slice(0, -"/index".length) || "/";
+      }
 
-    // Convert [param] to :param for consistency with page routes
-    relative = relative.replace(/\[([^\]]+)\]/g, ":$1");
+      // Convert [param] to :param for consistency with page routes
+      relative = relative.replace(/\[([^\]]+)\]/g, ":$1");
 
-    const path = normalizeRoutePath(`/api${relative}`);
+      const path = normalizeRoutePath(`/api${relative}`);
 
-    return {
-      path,
-      file,
-      segments: parseRouteSegments(path),
-    };
-  });
+      return {
+        path,
+        file,
+        segments: parseRouteSegments(path),
+      };
+    })
+    .sort(compareResolvedApiRoutes);
 }
 
 export function matchApiRoute(
@@ -378,4 +380,30 @@ function createRouteId(path: string): string {
     })
     .join("-")
     .replace(/[^a-zA-Z0-9-]/g, "-");
+}
+
+function compareResolvedApiRoutes(left: ResolvedApiRoute, right: ResolvedApiRoute): number {
+  const length = Math.max(left.segments.length, right.segments.length);
+
+  for (let index = 0; index < length; index += 1) {
+    const leftSegment = left.segments[index];
+    const rightSegment = right.segments[index];
+
+    if (!leftSegment) return 1;
+    if (!rightSegment) return -1;
+
+    const leftScore = getRouteSegmentSpecificity(leftSegment);
+    const rightScore = getRouteSegmentSpecificity(rightSegment);
+    if (leftScore !== rightScore) {
+      return rightScore - leftScore;
+    }
+  }
+
+  return left.path.localeCompare(right.path);
+}
+
+function getRouteSegmentSpecificity(segment: RouteSegment): number {
+  if (segment.type === "static") return 3;
+  if (segment.type === "param") return 2;
+  return 1;
 }

--- a/packages/framework/test/router.test.ts
+++ b/packages/framework/test/router.test.ts
@@ -3,7 +3,9 @@ import { describe, expect, it } from "vitest";
 import {
   defineApp,
   group,
+  matchApiRoute,
   matchAppRoute,
+  resolveApiRoutes,
   resolveApp,
   route,
   timeRevalidate,
@@ -126,5 +128,26 @@ describe("matchAppRoute", () => {
 
     expect(match?.route.file).toBe("./routes/post.tsx");
     expect(match?.params).toEqual({ slug: "hello world" });
+  });
+});
+
+describe("API route matching", () => {
+  it("sorts static api routes ahead of dynamic routes", () => {
+    const routes = resolveApiRoutes(["/src/api/users/[id].ts", "/src/api/users/me.ts"]);
+
+    expect(routes[0]?.file).toBe("/src/api/users/me.ts");
+    expect(routes[1]?.file).toBe("/src/api/users/[id].ts");
+  });
+
+  it("prefers static api routes over dynamic params during matching", () => {
+    const routes = resolveApiRoutes(["/src/api/users/[id].ts", "/src/api/users/me.ts"]);
+
+    const staticMatch = matchApiRoute(routes, "/api/users/me");
+    const dynamicMatch = matchApiRoute(routes, "/api/users/42");
+
+    expect(staticMatch?.route.file).toBe("/src/api/users/me.ts");
+    expect(staticMatch?.params).toEqual({});
+    expect(dynamicMatch?.route.file).toBe("/src/api/users/[id].ts");
+    expect(dynamicMatch?.params).toEqual({ id: "42" });
   });
 });


### PR DESCRIPTION
## Summary

- Sort auto-discovered API routes by specificity so static routes win over dynamic parameter routes regardless of discovery order.
- Keep dynamic handlers working for non-static matches and add resolver/matcher tests that cover the shadowing case directly.
- Relevant issue: N/A

## Testing

- [x] `pnpm e2e`
- [x] `pnpm format`
- [x] `pnpm lint`
- [x] `pnpm test`

## Checklist

- [x] Docs updated if needed
- [x] Skills updated if needed
- [x] Changeset added if published packages changed

N/A: No docs or skill updates were needed for this fix.