### PR TITLE
Expand launch docs and examples

### DIFF
--- a/docs/DATA_LOADING.md
+++ b/docs/DATA_LOADING.md
@@ -67,6 +67,8 @@ request resolves.
 Throw `PrachtHttpError` for structured error responses:
 
 ```typescript
+import { PrachtHttpError } from "@pracht/core";
+
 export async function loader({ params }: LoaderArgs) {
   const post = await getPost(params.slug);
   if (!post) throw new PrachtHttpError(404, "Post not found");
@@ -76,6 +78,64 @@ export async function loader({ params }: LoaderArgs) {
 
 If the route defines an `ErrorBoundary`, it catches the error and renders
 the fallback UI. Otherwise, the error bubbles to the shell or global handler.
+
+#### ErrorBoundary
+
+Export an `ErrorBoundary` from any route module to catch errors from its loader
+or component:
+
+```typescript
+import type { ErrorBoundaryProps } from "@pracht/core";
+
+export function ErrorBoundary({ error }: ErrorBoundaryProps) {
+  return (
+    <div>
+      <h1>{error.status ?? 500}</h1>
+      <p>{error.message}</p>
+    </div>
+  );
+}
+```
+
+Error boundaries compose: a route boundary catches route-level errors, while
+a shell boundary catches errors from any route inside that shell. If a route
+has no boundary, the error bubbles up to the shell, then to the global handler.
+
+#### Custom 404 pages
+
+Throw `PrachtHttpError(404)` in a loader to trigger the route's error boundary
+with a 404 status. For a catch-all 404 page, add a wildcard route at the end
+of your manifest:
+
+```typescript
+export const app = defineApp({
+  routes: [
+    // ... your routes
+    route("/:path*", () => import("./routes/not-found.tsx"), { render: "ssr" }),
+  ],
+});
+```
+
+```typescript
+// src/routes/not-found.tsx
+import { PrachtHttpError } from "@pracht/core";
+
+export function loader() {
+  throw new PrachtHttpError(404, "Page not found");
+}
+
+export function ErrorBoundary() {
+  return (
+    <div>
+      <h1>404</h1>
+      <p>This page doesn't exist.</p>
+      <a href="/">Go home</a>
+    </div>
+  );
+}
+```
+
+#### Error sanitization
 
 Unexpected 5xx errors are sanitized by default in both SSR HTML and
 `x-pracht-route-state-request` JSON responses, including the hydration payload.
@@ -108,6 +168,85 @@ export function head({ data }: HeadArgs<typeof loader>) {
 
 Head metadata merges with the shell's head. Route-level values override shell
 values for `title`. Arrays (`meta`, `link`) are concatenated.
+
+### SEO & Open Graph
+
+Use the `meta` array to set Open Graph and other SEO tags. The `head` export
+has full access to loader data, so these can be dynamic per page:
+
+```typescript
+export function head({ data }: HeadArgs<typeof loader>) {
+  return {
+    title: `${data.product.name} — My Store`,
+    meta: [
+      { name: "description", content: data.product.description },
+      // Open Graph
+      { property: "og:title", content: data.product.name },
+      { property: "og:description", content: data.product.description },
+      { property: "og:image", content: data.product.imageUrl },
+      { property: "og:type", content: "product" },
+      { property: "og:url", content: `https://mystore.com/products/${data.product.slug}` },
+      // Twitter Card
+      { name: "twitter:card", content: "summary_large_image" },
+      { name: "twitter:title", content: data.product.name },
+      { name: "twitter:description", content: data.product.description },
+      { name: "twitter:image", content: data.product.imageUrl },
+    ],
+    link: [
+      { rel: "canonical", href: `https://mystore.com/products/${data.product.slug}` },
+    ],
+  };
+}
+```
+
+### Structured data (JSON-LD)
+
+For structured data, include a `script` entry with `type: "application/ld+json"`:
+
+```typescript
+export function head({ data }: HeadArgs<typeof loader>) {
+  return {
+    title: data.article.title,
+    meta: [
+      { property: "og:type", content: "article" },
+      { property: "og:title", content: data.article.title },
+    ],
+    script: [
+      {
+        type: "application/ld+json",
+        children: JSON.stringify({
+          "@context": "https://schema.org",
+          "@type": "Article",
+          headline: data.article.title,
+          datePublished: data.article.publishedAt,
+          author: { "@type": "Person", name: data.article.author },
+        }),
+      },
+    ],
+  };
+}
+```
+
+### Shell-level defaults
+
+Shells can also export `head` to set site-wide defaults. Route-level `title`
+overrides the shell's `title`; `meta` and `link` arrays are concatenated:
+
+```typescript
+// src/shells/public.tsx
+export function head() {
+  return {
+    title: "My Site",
+    meta: [
+      { name: "description", content: "Default site description" },
+      { property: "og:site_name", content: "My Site" },
+    ],
+    link: [
+      { rel: "icon", href: "/favicon.svg" },
+    ],
+  };
+}
+```
 
 ---
 

--- a/docs/RENDERING_MODES.md
+++ b/docs/RENDERING_MODES.md
@@ -99,7 +99,11 @@ import { timeRevalidate } from "@pracht/core";
 The adapter checks the file's mtime (Node) or cache timestamp (Cloudflare)
 against the revalidation window. If stale, it triggers regeneration.
 
-### Webhook-based revalidation (Phase 2)
+### Webhook-based revalidation
+
+> **Not yet available.** `webhookRevalidate` is planned but not exported from
+> `@pracht/core` today. The API below shows the intended design — it will ship
+> in a future release. Use `timeRevalidate` for now.
 
 ```typescript
 import { webhookRevalidate } from "@pracht/core";

--- a/docs/STYLING.md
+++ b/docs/STYLING.md
@@ -45,6 +45,90 @@ server, and keep CSS-in-JS for client-only views if you really want it.
 
 ---
 
+## CSS Modules walkthrough
+
+CSS Modules scope class names to their file by default. Import the module and
+reference classes from the resulting object:
+
+```css
+/* src/routes/home.module.css */
+.hero {
+  padding: 4rem 2rem;
+  text-align: center;
+}
+
+.title {
+  font-size: 2.5rem;
+  font-weight: 700;
+}
+```
+
+```typescript
+// src/routes/home.tsx
+import styles from "./home.module.css";
+
+export default function Home() {
+  return (
+    <section class={styles.hero}>
+      <h1 class={styles.title}>Welcome</h1>
+    </section>
+  );
+}
+```
+
+Vite generates unique class names at build time (e.g. `_hero_1a2b3`), so
+styles never collide across routes. The framework automatically injects only
+the CSS files used by the current route and its shell.
+
+---
+
+## Tailwind CSS setup
+
+Install Tailwind's Vite plugin and add it alongside the pracht plugin:
+
+```bash
+pnpm add -D @tailwindcss/vite tailwindcss
+```
+
+```typescript
+// vite.config.ts
+import { defineConfig } from "vite";
+import { pracht } from "@pracht/vite-plugin";
+import tailwindcss from "@tailwindcss/vite";
+
+export default defineConfig({
+  plugins: [pracht({ /* ... */ }), tailwindcss()],
+});
+```
+
+Import Tailwind in your global CSS or shell:
+
+```css
+/* src/styles/global.css */
+@import "tailwindcss";
+```
+
+Tailwind classes work in any route regardless of render mode — the generated
+stylesheet is a static asset that the framework includes in the HTML.
+
+---
+
+## CSS-in-JS trade-offs for SSR
+
+Runtime CSS-in-JS libraries (styled-components, Emotion, goober) generate
+styles in JavaScript at render time. This creates a fundamental SSR problem:
+
+1. Server renders HTML without the matching `<style>` tags
+2. Browser paints the unstyled HTML
+3. Client-side JavaScript runs and injects styles
+4. Browser repaints — visible flash of unstyled content (FOUC)
+
+This hurts both Core Web Vitals (CLS) and perceived quality. For SPA routes
+(client-only), CSS-in-JS works fine since there's no server HTML to mismatch.
+For server-rendered routes (SSR/SSG/ISG), use build-time CSS instead.
+
+---
+
 ## Future work
 
 First-class support for CSS-in-JS with server-side extraction is contingent on

--- a/examples/docs/src/routes.ts
+++ b/examples/docs/src/routes.ts
@@ -15,6 +15,10 @@ export const app = defineApp({
         id: "getting-started",
         render: "ssg",
       }),
+      route("/docs/why-pracht", () => import("./routes/docs/why-pracht.md"), {
+        id: "why-pracht",
+        render: "ssg",
+      }),
       route("/docs/routing", () => import("./routes/docs/routing.md"), {
         id: "routing",
         render: "ssg",

--- a/examples/docs/src/routes/docs/data-loading.md
+++ b/examples/docs/src/routes/docs/data-loading.md
@@ -66,8 +66,11 @@ export. Named route exports such as `loader`, `head`, `headers`,
 
 ### Error handling
 
+Throw `PrachtHttpError` for structured error responses. Pair it with an `ErrorBoundary` export to render a fallback UI:
+
 ```ts
 import { PrachtHttpError } from "@pracht/core";
+import type { ErrorBoundaryProps } from "@pracht/core";
 
 export async function loader({ params }: LoaderArgs) {
   const post = await getPost(params.slug);
@@ -75,11 +78,46 @@ export async function loader({ params }: LoaderArgs) {
   return { post };
 }
 
-// Optional: render an error boundary for this route
 export function ErrorBoundary({ error }: ErrorBoundaryProps) {
-  return <p>Error: {error.message}</p>;
+  return (
+    <div>
+      <h1>{error.status ?? 500}</h1>
+      <p>{error.message}</p>
+    </div>
+  );
 }
 ```
+
+Error boundaries compose — a route boundary catches route-level errors, a shell boundary catches errors from any route in that shell, and uncaught errors bubble to the global handler.
+
+#### Custom 404 page
+
+Add a catch-all route at the end of your manifest to handle unmatched URLs:
+
+```ts
+route("/:path*", "./routes/not-found.tsx", { render: "ssr" })
+```
+
+```ts [src/routes/not-found.tsx]
+import { PrachtHttpError } from "@pracht/core";
+
+export function loader() {
+  throw new PrachtHttpError(404, "Page not found");
+}
+
+export function ErrorBoundary() {
+  return (
+    <div>
+      <h1>404</h1>
+      <p>This page doesn't exist.</p>
+      <a href="/">Go home</a>
+    </div>
+  );
+}
+```
+
+> [!NOTE]
+> Unexpected 5xx errors are sanitized by default — only `PrachtHttpError` messages are shown to users. Pass `debugErrors: true` to `handlePrachtRequest()` to see full error details during development.
 
 ---
 
@@ -97,6 +135,72 @@ export function head({ data }: HeadArgs<typeof loader>) {
       { property: "og:image", content: data.post.coverUrl },
     ],
     link: [{ rel: "canonical", href: `https://example.com/blog/${data.post.slug}` }],
+  };
+}
+```
+
+### SEO & Open Graph
+
+Use the `meta` array to set Open Graph, Twitter Card, and other SEO tags. Because `head` receives loader data, every tag can be dynamic per page:
+
+```ts
+export function head({ data }: HeadArgs<typeof loader>) {
+  return {
+    title: `${data.product.name} — My Store`,
+    meta: [
+      { name: "description", content: data.product.description },
+      { property: "og:title", content: data.product.name },
+      { property: "og:description", content: data.product.description },
+      { property: "og:image", content: data.product.imageUrl },
+      { property: "og:type", content: "product" },
+      { property: "og:url", content: `https://mystore.com/products/${data.product.slug}` },
+      { name: "twitter:card", content: "summary_large_image" },
+      { name: "twitter:title", content: data.product.name },
+      { name: "twitter:image", content: data.product.imageUrl },
+    ],
+    link: [
+      { rel: "canonical", href: `https://mystore.com/products/${data.product.slug}` },
+    ],
+  };
+}
+```
+
+### Structured data (JSON-LD)
+
+Include a `script` entry with `type: "application/ld+json"` for search engine structured data:
+
+```ts
+export function head({ data }: HeadArgs<typeof loader>) {
+  return {
+    title: data.article.title,
+    meta: [{ property: "og:type", content: "article" }],
+    script: [
+      {
+        type: "application/ld+json",
+        children: JSON.stringify({
+          "@context": "https://schema.org",
+          "@type": "Article",
+          headline: data.article.title,
+          datePublished: data.article.publishedAt,
+          author: { "@type": "Person", name: data.article.author },
+        }),
+      },
+    ],
+  };
+}
+```
+
+### Shell-level defaults
+
+Shells can also export `head` to set site-wide defaults. Route-level `title` overrides the shell's `title`; `meta` and `link` arrays are concatenated:
+
+```ts
+// src/shells/public.tsx
+export function head() {
+  return {
+    title: "My Site",
+    meta: [{ property: "og:site_name", content: "My Site" }],
+    link: [{ rel: "icon", href: "/favicon.svg" }],
   };
 }
 ```

--- a/examples/docs/src/routes/docs/getting-started.md
+++ b/examples/docs/src/routes/docs/getting-started.md
@@ -3,8 +3,8 @@ title: Getting Started
 lead: Get a pracht app running in under a minute. This guide covers project creation, development, and your first production build.
 breadcrumb: Getting Started
 next:
-  href: /docs/routing
-  title: Routing
+  href: /docs/why-pracht
+  title: Why Pracht?
 ---
 
 ## Create a Project

--- a/examples/docs/src/routes/docs/rendering.md
+++ b/examples/docs/src/routes/docs/rendering.md
@@ -86,7 +86,10 @@ ISG generates HTML at build time (like SSG) but regenerates it after a configura
 > [!INFO]
 > ISG revalidation is implemented at the adapter level. The Node adapter uses file `mtime`; Cloudflare uses a cache timestamp in KV.
 
-### Webhook revalidation (Phase 2)
+### Webhook revalidation
+
+> [!WARNING]
+> `webhookRevalidate` is planned but **not yet exported** from `@pracht/core`. The snippet below shows the intended API — it will ship in a future release. Use `timeRevalidate` for now.
 
 ```ts
 import { webhookRevalidate } from "@pracht/core";

--- a/examples/docs/src/routes/docs/routing.md
+++ b/examples/docs/src/routes/docs/routing.md
@@ -3,8 +3,8 @@ title: Routing
 lead: pracht uses a hybrid routing model: route modules live as files by convention, but their wiring — shells, middleware, render modes, and URL patterns — is declared explicitly in a single <code>src/routes.ts</code> manifest.
 breadcrumb: Routing
 prev:
-  href: /docs/getting-started
-  title: Getting Started
+  href: /docs/why-pracht
+  title: Why Pracht?
 next:
   href: /docs/rendering
   title: Rendering Modes

--- a/examples/docs/src/routes/docs/styling.md
+++ b/examples/docs/src/routes/docs/styling.md
@@ -57,6 +57,79 @@ Runtime CSS-in-JS libraries like **styled-components**, **Emotion**, and **goobe
 
 ---
 
+## CSS Modules Walkthrough
+
+CSS Modules scope class names to their file by default. Import the module and reference classes from the resulting object:
+
+```css [src/routes/home.module.css]
+.hero {
+  padding: 4rem 2rem;
+  text-align: center;
+}
+
+.title {
+  font-size: 2.5rem;
+  font-weight: 700;
+}
+```
+
+```tsx [src/routes/home.tsx]
+import styles from "./home.module.css";
+
+export default function Home() {
+  return (
+    <section class={styles.hero}>
+      <h1 class={styles.title}>Welcome</h1>
+    </section>
+  );
+}
+```
+
+Vite generates unique class names at build time (e.g. `_hero_1a2b3`), so styles never collide across routes. The framework automatically injects only the CSS files used by the current route and its shell.
+
+---
+
+## Tailwind CSS Setup
+
+Install Tailwind's Vite plugin and add it alongside the pracht plugin:
+
+```sh
+pnpm add -D @tailwindcss/vite tailwindcss
+```
+
+```ts [vite.config.ts]
+import { defineConfig } from "vite";
+import { pracht } from "@pracht/vite-plugin";
+import tailwindcss from "@tailwindcss/vite";
+
+export default defineConfig({
+  plugins: [pracht({ /* ... */ }), tailwindcss()],
+});
+```
+
+Import Tailwind in your global CSS or shell:
+
+```css [src/styles/global.css]
+@import "tailwindcss";
+```
+
+Tailwind classes work in any route regardless of render mode — the generated stylesheet is a static asset that the framework includes in the HTML.
+
+---
+
+## CSS-in-JS Trade-offs for SSR
+
+Runtime CSS-in-JS libraries generate styles in JavaScript at render time. This creates a fundamental SSR problem:
+
+1. Server renders HTML without matching `<style>` tags
+2. Browser paints the unstyled HTML
+3. Client-side JavaScript runs and injects styles
+4. Browser repaints — visible flash of unstyled content (FOUC)
+
+This hurts Core Web Vitals (CLS) and perceived quality. For SPA routes (client-only), CSS-in-JS works fine. For server-rendered routes (SSR/SSG/ISG), use build-time CSS instead.
+
+---
+
 ## Future Work
 
 First-class CSS-in-JS support — where pracht extracts critical styles during SSR and inlines them into the HTML — is contingent on upstream work tracked in [pracht#30](https://github.com/JoviDeCroock/pracht/issues/30). Once that lands, runtime CSS-in-JS libraries will have a path to render without a flash on server-rendered routes, and this recommendation will be revisited.

--- a/examples/docs/src/routes/docs/why-pracht.md
+++ b/examples/docs/src/routes/docs/why-pracht.md
@@ -1,0 +1,79 @@
+---
+title: Why Pracht?
+lead: How pracht compares to other full-stack frameworks — and when it's the right fit.
+breadcrumb: Why Pracht?
+prev:
+  href: /docs/getting-started
+  title: Getting Started
+next:
+  href: /docs/routing
+  title: Routing
+---
+
+## Design philosophy
+
+Most full-stack frameworks force a global rendering strategy or use implicit file-system conventions to determine behavior. Pracht takes a different approach:
+
+**Every route declares its own rendering mode.** A marketing page can be SSG, a dashboard can be SSR, a settings page can be SPA, and a product catalog can use ISG — all in the same app, the same build, the same deploy. No separate projects, no framework-specific workarounds.
+
+---
+
+## Core differences
+
+### Preact-first, not React-compatible
+
+Pracht is built on Preact — a 3kB alternative to React with the same API. If you want small bundles and fast hydration without giving up the component model you know, this is the tradeoff: you get a lighter runtime, but you don't get the full React ecosystem (some libraries need a compatibility layer).
+
+### Explicit routing manifest
+
+```ts
+export const app = defineApp({
+  routes: [
+    route("/", "./routes/home.tsx", { render: "ssg" }),
+    route("/dashboard", "./routes/dashboard.tsx", { render: "ssr" }),
+  ],
+});
+```
+
+The manifest tells you exactly which file handles which path, what shell wraps it, which middleware runs, and how it renders. No `"use client"` directives, no folder-name magic, no guessing. If you prefer file-based routing, the [pages router](/docs/routing) is available as an opt-in alternative.
+
+### Per-route render modes
+
+Other frameworks typically default to one mode globally (SSR in Next.js, SSG in Astro) and make you opt out per page. Pracht treats the render mode as a first-class route config — `"ssg"`, `"ssr"`, `"isg"`, or `"spa"` — so the decision is always visible and intentional.
+
+### Multi-adapter deployment
+
+One codebase deploys to Node.js, Cloudflare Workers, or Vercel with a one-line adapter swap. Adapters handle platform-specific concerns (static file serving, ISG cache invalidation, KV/D1/R2 bindings) so your application code stays portable.
+
+---
+
+## Compared to...
+
+### Next.js
+
+Next.js is a React framework with a massive ecosystem. Pracht is smaller and more opinionated: Preact instead of React, an explicit manifest instead of file-system routing (by default), and per-route render modes as a core primitive. If you need the React ecosystem or Vercel-native features like `next/image`, Next.js is the better choice. If you want smaller bundles and explicit control over what runs where, try pracht.
+
+### Remix / React Router
+
+Remix pioneered loader/action patterns for data loading. Pracht adopts a similar loader model but differs in two ways: it uses Preact, and it supports SSG/ISG alongside SSR. Remix is server-first; pracht lets you pick per route.
+
+### Astro
+
+Astro excels at content sites with its island architecture and zero-JS-by-default approach. Pracht is for apps that need interactive Preact components on every page — the framework is built around full hydration, not islands. If your site is mostly static content with a few interactive widgets, Astro is likely better.
+
+### SvelteKit
+
+SvelteKit has great DX and small bundles thanks to Svelte's compiler approach. If you're in the Svelte ecosystem, SvelteKit is the obvious choice. Pracht targets the Preact/React mental model and offers similar adapter-based deployment.
+
+### Fresh (Deno)
+
+Fresh is a Preact framework for Deno with island-based hydration. Pracht runs on Node.js, Cloudflare Workers, and Vercel, uses full hydration, and supports ISG. If you're on Deno and want islands, Fresh is great. If you want broader deployment targets and per-route rendering, pracht fits better.
+
+---
+
+## When to choose pracht
+
+- You want Preact's small footprint for a full-stack app
+- Different pages in your app need different rendering strategies
+- You value seeing route → file → render mode in one place
+- You want to deploy the same codebase to multiple platforms

--- a/examples/docs/src/shells/docs.tsx
+++ b/examples/docs/src/shells/docs.tsx
@@ -20,6 +20,7 @@ import {
   IconTriangle,
   IconRefresh,
   IconBrandGithub,
+  IconSparkles,
 } from "@tabler/icons-preact";
 import "../styles/global.css";
 
@@ -28,6 +29,7 @@ const NAV = [
     label: "Getting Started",
     links: [
       { href: "/docs/getting-started", Icon: IconRocket, title: "Quick Start" },
+      { href: "/docs/why-pracht", Icon: IconSparkles, title: "Why Pracht?" },
       { href: "/docs/routing", Icon: IconSitemap, title: "Routing" },
     ],
   },

--- a/examples/pages-router/README.md
+++ b/examples/pages-router/README.md
@@ -1,0 +1,48 @@
+# Pages Router Example
+
+Demonstrates pracht's file-based routing mode — no route manifest required.
+Routes are derived from the filesystem under `src/pages/`, and API routes live
+in `src/api/`.
+
+## File structure
+
+```
+src/
+  pages/
+    _app.tsx          → Shared shell (wraps all pages)
+    index.tsx         → /
+    about.tsx         → /about
+    blog/[slug].tsx   → /blog/:slug
+  api/
+    health.ts         → GET /api/health
+    me.ts             → GET /api/me
+  lib/
+    with-auth.ts      → Shared auth middleware helper
+```
+
+`_app.tsx` is a special file that acts as the shell for all pages, equivalent
+to registering a shell in the manifest router. Dynamic segments use `[param]`
+bracket syntax in the filename.
+
+## Commands
+
+```sh
+pnpm pracht dev        # Dev server with HMR
+pnpm pracht build      # Production build (client + server)
+node dist/server/server.js  # Run the built server
+```
+
+## Configuration
+
+The Vite config enables pages routing by passing `pagesDir` instead of a route
+manifest:
+
+```ts
+// vite.config.ts
+export default defineConfig({
+  plugins: [pracht({ pagesDir: "/src/pages", adapter: nodeAdapter() })],
+});
+```
+
+All four render modes (SSR, SSG, ISG, SPA) work with the pages router — export
+a `config` object from any page to opt into a specific mode.


### PR DESCRIPTION
## Summary

- Add a new "Why Pracht?" docs page, wire it into the docs navigation, and add a pages-router README example.
- Expand the data-loading and styling docs with clearer guidance around error boundaries, SEO metadata, CSS Modules, Tailwind, and SSR CSS-in-JS trade-offs.
- Clarify that webhook revalidation is planned but not yet shipped.
- Issue: N/A

## Testing

- [x] `pnpm run e2e`
- [x] `pnpm run format`
- [x] `pnpm run lint`
- [x] `pnpm run test`

## Checklist

- [x] Docs updated if needed
- [x] Skills updated if needed
- [x] Changeset added if published packages changed
