### PR TITLE
Replace per-navigation render() with stateful RouterRoot

### DIFF
--- a/.changeset/context-values-memoized.md
+++ b/.changeset/context-values-memoized.md
@@ -1,0 +1,5 @@
+---
+"@pracht/core": patch
+---
+
+Memoize client context values more consistently so unchanged route state does not trigger avoidable context fan-out during rerenders.

--- a/.changeset/route-diff-swap.md
+++ b/.changeset/route-diff-swap.md
@@ -1,0 +1,5 @@
+---
+"@pracht/core": patch
+---
+
+Replace per-navigation render() with a stateful RouterRoot component that lets Preact diff the vnode tree naturally across route transitions

--- a/.changeset/router-root-regressions.md
+++ b/.changeset/router-root-regressions.md
@@ -1,5 +1,0 @@
----
-"@pracht/core": patch
----
-
-Fix two client router regressions introduced by the stateful `RouterRoot` navigation flow: shell-less SPA routes now complete their initial pending bootstrap without crashing, and `useRouteData()` no longer exposes stale data for one render during route transitions.

--- a/.changeset/router-root-regressions.md
+++ b/.changeset/router-root-regressions.md
@@ -1,0 +1,5 @@
+---
+"@pracht/core": patch
+---
+
+Fix two client router regressions introduced by the stateful `RouterRoot` navigation flow: shell-less SPA routes now complete their initial pending bootstrap without crashing, and `useRouteData()` no longer exposes stale data for one render during route transitions.

--- a/packages/framework/src/router.ts
+++ b/packages/framework/src/router.ts
@@ -125,6 +125,7 @@ export async function initClientRouter(options: InitClientRouterOptions): Promis
   async function resolveRouteState(
     match: RouteMatch,
     state: { data: unknown; error?: SerializedRouteError | null },
+    currentUrl: string,
     routeModPromise?: Promise<any> | null,
     shellModPromise?: Promise<any> | null,
   ): Promise<RouteRenderState | null> {
@@ -154,13 +155,14 @@ export async function initClientRouter(options: InitClientRouterOptions): Promis
       data: state.data,
       params: match.params,
       routeId: match.route.id ?? "",
-      url: match.pathname,
+      url: currentUrl,
       version: ++routeStateVersion,
     };
   }
 
   async function resolveSpaPendingState(
     match: RouteMatch,
+    currentUrl: string,
     shellModPromise?: Promise<any> | null,
   ): Promise<RouteRenderState | null> {
     const resolvedShell = await (shellModPromise ?? startShellImport(match));
@@ -178,7 +180,7 @@ export async function initClientRouter(options: InitClientRouterOptions): Promis
       data: undefined,
       params: match.params,
       routeId: match.route.id ?? "",
-      url: match.pathname,
+      url: currentUrl,
       version: ++routeStateVersion,
     };
   }
@@ -306,7 +308,13 @@ export async function initClientRouter(options: InitClientRouterOptions): Promis
     }
 
     // Update route state — module imports started above are already in-flight
-    const routeState = await resolveRouteState(match, state, routeModPromise, shellModPromise);
+    const routeState = await resolveRouteState(
+      match,
+      state,
+      target.requestUrl,
+      routeModPromise,
+      shellModPromise,
+    );
     if (routeState) {
       applyRouteState(routeState);
       window.scrollTo(0, 0);
@@ -353,7 +361,11 @@ export async function initClientRouter(options: InitClientRouterOptions): Promis
       // Kick off the data fetch in parallel with shell hydration
       const dataPromise = fetchPrachtRouteState(initialRequestUrl);
 
-      const pendingState = await resolveSpaPendingState(initialMatch, initialShellPromise);
+      const pendingState = await resolveSpaPendingState(
+        initialMatch,
+        initialRequestUrl,
+        initialShellPromise,
+      );
       if (pendingState) {
         hydrate(h(RouterRoot, { initialState: pendingState }), root);
       }
@@ -384,6 +396,7 @@ export async function initClientRouter(options: InitClientRouterOptions): Promis
       const resolvedState = await resolveRouteState(
         initialMatch,
         state,
+        initialRequestUrl,
         undefined,
         initialShellPromise,
       );
@@ -394,6 +407,7 @@ export async function initClientRouter(options: InitClientRouterOptions): Promis
       const initialRouteState = await resolveRouteState(
         initialMatch,
         state,
+        initialRequestUrl,
         undefined,
         initialShellPromise,
       );

--- a/packages/framework/src/router.ts
+++ b/packages/framework/src/router.ts
@@ -1,15 +1,26 @@
 import { createContext, h } from "preact";
 import { hydrate, render } from "preact";
-import { useContext } from "preact/hooks";
-import type { VNode } from "preact";
+import { useContext, useMemo, useState } from "preact/hooks";
+import type { FunctionComponent, VNode } from "preact";
 
 import { matchAppRoute } from "./app.ts";
 import { markHydrating } from "./hydration.ts";
 import { getCachedRouteState, setupPrefetching } from "./prefetch.ts";
 import type { ModuleWarmFn } from "./prefetch.ts";
-import type { ResolvedPrachtApp, RouteMatch } from "./types.ts";
+import type { ResolvedPrachtApp, RouteMatch, RouteParams } from "./types.ts";
 import { fetchPrachtRouteState, PrachtRuntimeProvider } from "./runtime.ts";
 import type { SerializedRouteError, PrachtHydrationState } from "./runtime.ts";
+
+interface RouteRenderState {
+  Shell: FunctionComponent | null;
+  Component: FunctionComponent<any>;
+  componentProps: Record<string, unknown>;
+  data: unknown;
+  params: RouteParams;
+  routeId: string;
+  url: string;
+  version: number;
+}
 
 declare global {
   interface Window {
@@ -75,20 +86,52 @@ export async function initClientRouter(options: InitClientRouterOptions): Promis
   }
 
   // ------------------------------------------------------------------
-  // Build a Preact VNode tree for a matched route
+  // Resolve route state (data object, not VNodes)
   // ------------------------------------------------------------------
 
-  async function buildRouteTree(
+  let updateRouteState: ((state: RouteRenderState) => void) | null = null;
+  let routeStateVersion = 0;
+
+  function RouterRoot({ initialState }: { initialState: RouteRenderState }) {
+    const [routeState, setRouteState] = useState(initialState);
+    updateRouteState = setRouteState;
+    const navigateValue = useMemo(() => navigate, []);
+
+    const { Shell, Component, componentProps, data, params, routeId, url, version } = routeState;
+    const componentTree = Shell
+      ? h(Shell as any, null, h(Component as any, componentProps))
+      : h(Component as any, componentProps);
+
+    return h(
+      NavigateContext.Provider as any,
+      { value: navigateValue },
+      h(
+        PrachtRuntimeProvider as any,
+        { data, params, routeId, stateVersion: version, url },
+        componentTree,
+      ),
+    );
+  }
+
+  function applyRouteState(routeState: RouteRenderState): void {
+    if (updateRouteState) {
+      updateRouteState(routeState);
+      return;
+    }
+
+    render(h(RouterRoot, { initialState: routeState }), root);
+  }
+
+  async function resolveRouteState(
     match: RouteMatch,
     state: { data: unknown; error?: SerializedRouteError | null },
-    currentUrl: string,
     routeModPromise?: Promise<any> | null,
     shellModPromise?: Promise<any> | null,
-  ): Promise<VNode<any> | null> {
+  ): Promise<RouteRenderState | null> {
     const routeMod = await (routeModPromise ?? startRouteImport(match));
     if (!routeMod) return null;
 
-    let Shell: any = null;
+    let Shell: FunctionComponent | null = null;
     const resolvedShell = await (shellModPromise ?? startShellImport(match));
     if (resolvedShell) {
       Shell = resolvedShell.Shell;
@@ -97,63 +140,47 @@ export async function initClientRouter(options: InitClientRouterOptions): Promis
     const DefaultComponent = typeof routeMod.default === "function" ? routeMod.default : undefined;
     const Component = (
       state.error ? routeMod.ErrorBoundary : (routeMod.Component ?? DefaultComponent)
-    ) as any;
+    ) as FunctionComponent<any>;
     if (!Component) return null;
 
-    const props: Record<string, unknown> = state.error
+    const componentProps: Record<string, unknown> = state.error
       ? { error: deserializeRouteError(state.error) }
       : { data: state.data, params: match.params };
-    const componentTree = Shell ? h(Shell, null, h(Component, props)) : h(Component, props);
 
-    return h(
-      NavigateContext.Provider as any,
-      { value: navigate },
-      h(
-        PrachtRuntimeProvider as any,
-        {
-          data: state.data,
-          params: match.params,
-          routeId: match.route.id ?? "",
-          url: currentUrl,
-        },
-        componentTree,
-      ),
-    );
+    return {
+      Shell,
+      Component,
+      componentProps,
+      data: state.data,
+      params: match.params,
+      routeId: match.route.id ?? "",
+      url: match.pathname,
+      version: ++routeStateVersion,
+    };
   }
 
-  async function buildSpaPendingTree(
+  async function resolveSpaPendingState(
     match: RouteMatch,
-    currentUrl: string,
     shellModPromise?: Promise<any> | null,
-  ): Promise<VNode<any> | null> {
+  ): Promise<RouteRenderState | null> {
     const resolvedShell = await (shellModPromise ?? startShellImport(match));
     if (!resolvedShell) return null;
 
-    const Shell = resolvedShell.Shell as any;
-    const Loading = resolvedShell.Loading as any;
-    const componentTree =
-      Shell != null
-        ? h(Shell, null, Loading ? h(Loading, null) : null)
-        : Loading
-          ? h(Loading, null)
-          : null;
+    const Shell = (resolvedShell.Shell as FunctionComponent) ?? null;
+    const Loading = resolvedShell.Loading as FunctionComponent | null;
 
-    if (!componentTree) return null;
+    if (!Shell && !Loading) return null;
 
-    return h(
-      NavigateContext.Provider as any,
-      { value: navigate },
-      h(
-        PrachtRuntimeProvider as any,
-        {
-          data: undefined,
-          params: match.params,
-          routeId: match.route.id ?? "",
-          url: currentUrl,
-        },
-        componentTree,
-      ),
-    );
+    return {
+      Shell,
+      Component: Loading ?? (() => null),
+      componentProps: {},
+      data: undefined,
+      params: match.params,
+      routeId: match.route.id ?? "",
+      url: match.pathname,
+      version: ++routeStateVersion,
+    };
   }
 
   function resolveRedirectTarget(location: string): {
@@ -278,16 +305,10 @@ export async function initClientRouter(options: InitClientRouterOptions): Promis
       }
     }
 
-    // Render — module imports started above are already in-flight
-    const tree = await buildRouteTree(
-      match,
-      state,
-      target.requestUrl,
-      routeModPromise,
-      shellModPromise,
-    );
-    if (tree) {
-      render(tree, root);
+    // Update route state — module imports started above are already in-flight
+    const routeState = await resolveRouteState(match, state, routeModPromise, shellModPromise);
+    if (routeState) {
+      applyRouteState(routeState);
       window.scrollTo(0, 0);
     } else {
       window.location.href = target.browserUrl;
@@ -332,13 +353,9 @@ export async function initClientRouter(options: InitClientRouterOptions): Promis
       // Kick off the data fetch in parallel with shell hydration
       const dataPromise = fetchPrachtRouteState(initialRequestUrl);
 
-      const pendingTree = await buildSpaPendingTree(
-        initialMatch,
-        initialRequestUrl,
-        initialShellPromise,
-      );
-      if (pendingTree) {
-        hydrate(pendingTree, root);
+      const pendingState = await resolveSpaPendingState(initialMatch, initialShellPromise);
+      if (pendingState) {
+        hydrate(h(RouterRoot, { initialState: pendingState }), root);
       }
 
       try {
@@ -363,21 +380,30 @@ export async function initClientRouter(options: InitClientRouterOptions): Promis
         window.location.href = initialBrowserUrl;
         return;
       }
-    }
 
-    const tree = await buildRouteTree(
-      initialMatch,
-      state,
-      initialRequestUrl,
-      undefined,
-      initialShellPromise,
-    );
-    if (tree) {
-      if (initialMatch.route.render === "spa") {
-        render(tree, root);
-      } else {
-        markHydrating();
-        hydrate(tree, root);
+      const resolvedState = await resolveRouteState(
+        initialMatch,
+        state,
+        undefined,
+        initialShellPromise,
+      );
+      if (resolvedState) {
+        applyRouteState(resolvedState);
+      }
+    } else {
+      const initialRouteState = await resolveRouteState(
+        initialMatch,
+        state,
+        undefined,
+        initialShellPromise,
+      );
+      if (initialRouteState) {
+        if (initialMatch.route.render === "spa") {
+          render(h(RouterRoot, { initialState: initialRouteState }), root);
+        } else {
+          markHydrating();
+          hydrate(h(RouterRoot, { initialState: initialRouteState }), root);
+        }
       }
     }
   }

--- a/packages/framework/src/runtime.ts
+++ b/packages/framework/src/runtime.ts
@@ -93,6 +93,7 @@ const SAFE_METHODS = new Set(["GET", "HEAD"]);
 const HYDRATION_STATE_ELEMENT_ID = "pracht-state";
 const ROUTE_STATE_REQUEST_HEADER = "x-pracht-route-state-request";
 const ROUTE_STATE_CACHE_CONTROL = "no-store";
+const EMPTY_ROUTE_PARAMS = {} as RouteParams;
 
 // Cached dynamic import — keeps preact-render-to-string out of the client bundle
 // while avoiding repeated async resolution on each SSR request.
@@ -119,7 +120,7 @@ const RouteDataContext = createContext<PrachtRuntimeValue | undefined>(undefined
 export function PrachtRuntimeProvider<TData>({
   children,
   data,
-  params = {} as RouteParams,
+  params = EMPTY_ROUTE_PARAMS,
   routeId,
   stateVersion = 0,
   url,

--- a/packages/framework/src/runtime.ts
+++ b/packages/framework/src/runtime.ts
@@ -121,31 +121,44 @@ export function PrachtRuntimeProvider<TData>({
   data,
   params = {} as RouteParams,
   routeId,
+  stateVersion = 0,
   url,
 }: {
   children: ComponentChildren;
   data: TData;
   params?: RouteParams;
   routeId: string;
+  stateVersion?: number;
   url: string;
 }) {
   // TODO: make signal with getter to reduce
   // re-renders caused by the framework itself.
-  const [routeData, setRouteData] = useState<TData>(data);
+  const [routeDataState, setRouteDataState] = useState({
+    data,
+    stateVersion,
+  });
+  const routeData = routeDataState.stateVersion === stateVersion ? routeDataState.data : data;
 
   useEffect(() => {
-    setRouteData(data);
-  }, [data, routeId, url]);
+    setRouteDataState({
+      data,
+      stateVersion,
+    });
+  }, [data, routeId, stateVersion, url]);
 
   const context = useMemo(
     () => ({
       data: routeData,
       params,
       routeId,
-      setData: setRouteData as (data: unknown) => void,
+      setData: (nextData: unknown) =>
+        setRouteDataState({
+          data: nextData as TData,
+          stateVersion,
+        }),
       url,
     }),
-    [routeData, params, routeId, url],
+    [routeData, params, routeId, stateVersion, url],
   );
 
   return h(RouteDataContext.Provider, {

--- a/packages/framework/test/router-client.test.ts
+++ b/packages/framework/test/router-client.test.ts
@@ -1,0 +1,167 @@
+// @vitest-environment jsdom
+import { h, render } from "preact";
+import type { ComponentChildren } from "preact";
+import { useState } from "preact/hooks";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  defineApp,
+  initClientRouter,
+  resolveApp,
+  route,
+  useLocation,
+  useRouteData,
+} from "../src/index.ts";
+
+function createJsonResponse(body: unknown, init?: ResponseInit): Response {
+  return new Response(JSON.stringify(body), {
+    headers: {
+      "content-type": "application/json",
+    },
+    ...init,
+  });
+}
+
+async function flush(): Promise<void> {
+  await Promise.resolve();
+  await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
+  await Promise.resolve();
+}
+
+describe("initClientRouter", () => {
+  let root: HTMLDivElement;
+  let fetchSpy: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    document.body.innerHTML = "";
+    root = document.createElement("div");
+    document.body.appendChild(root);
+    history.replaceState(null, "", "/");
+    window.scrollTo = vi.fn();
+    fetchSpy = vi.fn();
+    vi.stubGlobal("fetch", fetchSpy);
+  });
+
+  afterEach(() => {
+    render(null, root);
+    root.remove();
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+    delete window.__PRACHT_NAVIGATE__;
+    delete window.__PRACHT_ROUTER_READY__;
+  });
+
+  it("renders shell-less SPA routes after the pending bootstrap fetch resolves", async () => {
+    const app = resolveApp(
+      defineApp({
+        routes: [route("/settings", "./routes/settings.tsx", { render: "spa" })],
+      }),
+    );
+
+    fetchSpy.mockResolvedValue(createJsonResponse({ data: { user: "Jovi" } }));
+
+    await initClientRouter({
+      app,
+      routeModules: {
+        "./routes/settings.tsx": async () => ({
+          default: function Settings() {
+            const data = useRouteData<{ user: string }>();
+            return h("main", null, `Hello ${data.user}`);
+          },
+        }),
+      },
+      shellModules: {},
+      initialState: {
+        data: null,
+        pending: true,
+        routeId: "settings",
+        url: "/settings",
+      },
+      root,
+      findModuleKey: (_modules, file) => file,
+    });
+
+    expect(fetchSpy).toHaveBeenCalledWith(
+      "/settings",
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          "Cache-Control": "no-cache",
+          "x-pracht-route-state-request": "1",
+        }),
+        redirect: "manual",
+      }),
+    );
+    expect(root.textContent).toContain("Hello Jovi");
+  });
+
+  it("preserves same-shell instances without exposing stale route data to useRouteData()", async () => {
+    const renderLog: Array<{ label: string; pathname: string }> = [];
+    let shellMountCount = 0;
+
+    function SharedShell({ children }: { children: ComponentChildren }) {
+      const [shellId] = useState(() => ++shellMountCount);
+      return h("section", { "data-shell-id": String(shellId) }, children);
+    }
+
+    function Page() {
+      const data = useRouteData<{ label: string }>();
+      const { pathname } = useLocation();
+      renderLog.push({ label: data.label, pathname });
+      return h("div", { id: "page" }, data.label);
+    }
+
+    const app = resolveApp(
+      defineApp({
+        shells: {
+          app: "./shells/app.tsx",
+        },
+        routes: [
+          route("/", "./routes/home.tsx", { render: "ssr", shell: "app" }),
+          route("/next", "./routes/next.tsx", { render: "ssr", shell: "app" }),
+        ],
+      }),
+    );
+
+    root.innerHTML = '<section data-shell-id="1"><div id="page">start</div></section>';
+    history.replaceState(null, "", "/");
+
+    fetchSpy.mockImplementation(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url === "/next") {
+        return createJsonResponse({ data: { label: "next" } });
+      }
+
+      throw new Error(`Unexpected fetch for ${url}`);
+    });
+
+    await initClientRouter({
+      app,
+      routeModules: {
+        "./routes/home.tsx": async () => ({ default: Page }),
+        "./routes/next.tsx": async () => ({ default: Page }),
+      },
+      shellModules: {
+        "./shells/app.tsx": async () => ({ Shell: SharedShell }),
+      },
+      initialState: {
+        data: { label: "start" },
+        routeId: "home",
+        url: "/",
+      },
+      root,
+      findModuleKey: (_modules, file) => file,
+    });
+
+    renderLog.length = 0;
+    await window.__PRACHT_NAVIGATE__!("/next");
+    await flush();
+
+    expect(root.textContent).toContain("next");
+    expect(root.querySelector("section")?.getAttribute("data-shell-id")).toBe("1");
+    expect(shellMountCount).toBe(1);
+    expect(renderLog).not.toContainEqual({
+      label: "start",
+      pathname: "/next",
+    });
+  });
+});

--- a/packages/framework/test/runtime-context.test.ts
+++ b/packages/framework/test/runtime-context.test.ts
@@ -54,15 +54,12 @@ describe("PrachtRuntimeProvider", () => {
       const [, setTick] = useState(0);
       bump = () => setTick((tick) => tick + 1);
 
-      return h(
-        PrachtRuntimeProvider,
-        {
-          data: { user: "Ada" },
-          routeId: "dashboard",
-          url: "/dashboard",
-        },
-        h(Blocker, null, h(Consumer, null)),
-      );
+      return h(PrachtRuntimeProvider, {
+        children: h(Blocker, null, h(Consumer, null)),
+        data: { user: "Ada" },
+        routeId: "dashboard",
+        url: "/dashboard",
+      });
     }
 
     render(h(App, null), scratch);

--- a/packages/framework/test/runtime-context.test.ts
+++ b/packages/framework/test/runtime-context.test.ts
@@ -1,0 +1,76 @@
+// @vitest-environment jsdom
+import { Component, h, render } from "preact";
+import type { ComponentChildren } from "preact";
+import { useState } from "preact/hooks";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { PrachtRuntimeProvider, useLocation } from "../src/index.ts";
+
+let scratch: HTMLDivElement;
+
+function setupScratch() {
+  scratch = document.createElement("div");
+  document.body.appendChild(scratch);
+  return scratch;
+}
+
+async function flush(): Promise<void> {
+  await Promise.resolve();
+  await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
+  await Promise.resolve();
+}
+
+class Blocker extends Component<{ children: ComponentChildren }> {
+  shouldComponentUpdate() {
+    return false;
+  }
+
+  render(props: { children: ComponentChildren }) {
+    return props.children;
+  }
+}
+
+describe("PrachtRuntimeProvider", () => {
+  beforeEach(() => {
+    setupScratch();
+  });
+
+  afterEach(() => {
+    render(null, scratch);
+    scratch.remove();
+  });
+
+  it("does not fan out a new context value when params are omitted and route state is unchanged", async () => {
+    let bump!: () => void;
+    let consumerRenders = 0;
+
+    function Consumer() {
+      consumerRenders += 1;
+      useLocation();
+      return null;
+    }
+
+    function App() {
+      const [, setTick] = useState(0);
+      bump = () => setTick((tick) => tick + 1);
+
+      return h(
+        PrachtRuntimeProvider,
+        {
+          data: { user: "Ada" },
+          routeId: "dashboard",
+          url: "/dashboard",
+        },
+        h(Blocker, null, h(Consumer, null)),
+      );
+    }
+
+    render(h(App, null), scratch);
+    expect(consumerRenders).toBe(1);
+
+    bump();
+    await flush();
+
+    expect(consumerRenders).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary

- Instead of calling Preact's top-level `render(tree, root)` on every client-side navigation, mount a `RouterRoot` component once and use `useState` updates to swap route content.
- Preact now diffs the vnode tree naturally — shell instances persist across same-shell navigations, and `NavigateContext.Provider`/`PrachtRuntimeProvider` stay mounted rather than being recreated each time.

## Testing

- [x] `pnpm e2e`
- [x] `pnpm format`
- [x] `pnpm lint`
- [x] `pnpm test`

## Checklist

- [ ] Docs updated if needed
- [ ] Skills updated if needed
- [x] Changeset added if published packages changed