### PR TITLE
Preload route state for SPA routes with loaders

### DIFF
--- a/.changeset/preload-spa-loaders.md
+++ b/.changeset/preload-spa-loaders.md
@@ -1,0 +1,5 @@
+---
+"@pracht/core": patch
+---
+
+Preload route state for SPA routes with loaders via `<link rel="preload">`, reducing the JS-to-data waterfall on initial page load.

--- a/packages/framework/src/router.ts
+++ b/packages/framework/src/router.ts
@@ -358,8 +358,8 @@ export async function initClientRouter(options: InitClientRouterOptions): Promis
     };
 
     if (initialMatch.route.render === "spa" && options.initialState.pending) {
-      // Kick off the data fetch in parallel with shell hydration
-      const dataPromise = fetchPrachtRouteState(initialRequestUrl);
+      // Use query parameter URL to match the <link rel="preload"> tag from SSR
+      const dataPromise = fetchPrachtRouteState(initialRequestUrl, { useDataParam: true });
 
       const pendingState = await resolveSpaPendingState(
         initialMatch,

--- a/packages/framework/src/runtime.ts
+++ b/packages/framework/src/runtime.ts
@@ -302,9 +302,15 @@ export type RouteStateResult =
   | { type: "redirect"; location: string }
   | { type: "error"; error: SerializedRouteError };
 
-export async function fetchPrachtRouteState(url: string): Promise<RouteStateResult> {
-  const response = await fetch(url, {
-    headers: { [ROUTE_STATE_REQUEST_HEADER]: "1", "Cache-Control": "no-cache" },
+export async function fetchPrachtRouteState(
+  url: string,
+  options?: { useDataParam?: boolean },
+): Promise<RouteStateResult> {
+  const fetchUrl = options?.useDataParam ? buildRouteStateUrl(url) : url;
+  const response = await fetch(fetchUrl, {
+    headers: options?.useDataParam
+      ? {}
+      : { [ROUTE_STATE_REQUEST_HEADER]: "1", "Cache-Control": "no-cache" },
     redirect: "manual",
   });
 
@@ -345,13 +351,23 @@ export async function fetchPrachtRouteState(url: string): Promise<RouteStateResu
   };
 }
 
+function buildRouteStateUrl(url: string): string {
+  const separator = url.includes("?") ? "&" : "?";
+  return `${url}${separator}_data=1`;
+}
+
 export async function handlePrachtRequest<TContext>(
   options: HandlePrachtRequestOptions<TContext>,
 ): Promise<Response> {
   const url = new URL(options.request.url);
+  const hasDataParam = url.searchParams.get("_data") === "1";
+  if (hasDataParam) {
+    url.searchParams.delete("_data");
+  }
   const requestPath = getRequestPath(url);
   const registry = options.registry ?? {};
-  const isRouteStateRequest = options.request.headers.get(ROUTE_STATE_REQUEST_HEADER) === "1";
+  const isRouteStateRequest =
+    options.request.headers.get(ROUTE_STATE_REQUEST_HEADER) === "1" || hasDataParam;
   const exposeDiagnostics = shouldExposeServerErrors(options);
 
   // --- API route dispatch (before page routes) ---
@@ -587,6 +603,7 @@ export async function handlePrachtRequest<TContext>(
           clientEntryUrl: options.clientEntryUrl,
           cssUrls,
           modulePreloadUrls,
+          routeStatePreloadUrl: loader ? buildRouteStateUrl(requestPath) : undefined,
         }),
         200,
         documentHeaders,
@@ -1249,6 +1266,7 @@ function buildHtmlDocument(options: {
   clientEntryUrl?: string;
   cssUrls?: string[];
   modulePreloadUrls?: string[];
+  routeStatePreloadUrl?: string;
 }): string {
   const {
     head,
@@ -1257,6 +1275,7 @@ function buildHtmlDocument(options: {
     clientEntryUrl,
     cssUrls = [],
     modulePreloadUrls = [],
+    routeStatePreloadUrl,
   } = options;
 
   const titleTag = head.title ? `<title>${escapeHtml(head.title)}</title>` : "";
@@ -1287,6 +1306,10 @@ function buildHtmlDocument(options: {
     .map((url) => `<link rel="modulepreload" href="${escapeHtml(url)}">`)
     .join("\n    ");
 
+  const routeStatePreloadTag = routeStatePreloadUrl
+    ? `<link rel="preload" as="fetch" href="${escapeHtml(routeStatePreloadUrl)}" crossorigin="anonymous">`
+    : "";
+
   const stateScript = `<script id="${HYDRATION_STATE_ELEMENT_ID}" type="application/json">${serializeJsonForHtml(hydrationState)}</script>`;
   const entryScript = clientEntryUrl
     ? `<script type="module" src="${escapeHtml(clientEntryUrl)}"></script>`
@@ -1301,6 +1324,7 @@ function buildHtmlDocument(options: {
     ${linkTags}
     ${cssTags}
     ${modulePreloadTags}
+    ${routeStatePreloadTag}
   </head>
   <body>
     <div id="pracht-root">${body}</div>

--- a/packages/framework/test/router-client.test.ts
+++ b/packages/framework/test/router-client.test.ts
@@ -82,12 +82,9 @@ describe("initClientRouter", () => {
     });
 
     expect(fetchSpy).toHaveBeenCalledWith(
-      "/settings",
+      "/settings?_data=1",
       expect.objectContaining({
-        headers: expect.objectContaining({
-          "Cache-Control": "no-cache",
-          "x-pracht-route-state-request": "1",
-        }),
+        headers: {},
         redirect: "manual",
       }),
     );

--- a/packages/framework/test/runtime.test.ts
+++ b/packages/framework/test/runtime.test.ts
@@ -367,6 +367,55 @@ describe("handlePrachtRequest cache variance", () => {
     await expect(response.json()).resolves.toEqual({ data: { plan: "MVP" } });
   });
 
+  it("treats _data=1 query parameter as a route-state request", async () => {
+    const app = defineApp({
+      routes: [route("/pricing", "./routes/pricing.tsx", { render: "ssr" })],
+    });
+
+    const response = await handlePrachtRequest({
+      app,
+      registry: {
+        routeModules: {
+          "./routes/pricing.tsx": async () => ({
+            Component: ({ data }) => h("main", null, (data as { plan: string }).plan),
+            loader: async () => ({ plan: "MVP" }),
+          }),
+        },
+      },
+      request: new Request("http://localhost/pricing?_data=1"),
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toContain("application/json");
+    await expect(response.json()).resolves.toEqual({ data: { plan: "MVP" } });
+  });
+
+  it("strips _data param from the URL passed to loaders", async () => {
+    let capturedUrl: URL | undefined;
+    const app = defineApp({
+      routes: [route("/pricing", "./routes/pricing.tsx", { render: "ssr" })],
+    });
+
+    const response = await handlePrachtRequest({
+      app,
+      registry: {
+        routeModules: {
+          "./routes/pricing.tsx": async () => ({
+            Component: () => h("main", null, "test"),
+            loader: async (args: { url: URL }) => {
+              capturedUrl = args.url;
+              return {};
+            },
+          }),
+        },
+      },
+      request: new Request("http://localhost/pricing?_data=1"),
+    });
+
+    expect(response.status).toBe(200);
+    expect(capturedUrl?.searchParams.has("_data")).toBe(false);
+  });
+
   it("encodes middleware redirects as JSON for route-state requests", async () => {
     const app = defineApp({
       middleware: {
@@ -520,6 +569,63 @@ describe("handlePrachtRequest SPA shell fallback", () => {
     expect(html).toContain("Loading settings...");
     expect(html).toContain('"pending":true');
     expect(html).not.toContain("secret-user");
+  });
+
+  it("emits a preload link for route state when an SPA route has a loader", async () => {
+    const app = defineApp({
+      shells: { app: "./shells/app.tsx" },
+      routes: [route("/settings", "./routes/settings.tsx", { render: "spa", shell: "app" })],
+    });
+
+    const response = await handlePrachtRequest({
+      app,
+      registry: {
+        routeModules: {
+          "./routes/settings.tsx": async () => ({
+            Component: ({ data }) => h("main", null, `Hello ${(data as any).user}`),
+            loader: async () => ({ user: "secret-user" }),
+          }),
+        },
+        shellModules: {
+          "./shells/app.tsx": async () => ({
+            Shell: ({ children }) => h("div", { class: "app-shell" }, children),
+          }),
+        },
+      },
+      request: new Request("http://localhost/settings"),
+    });
+
+    const html = await response.text();
+    expect(html).toContain(
+      '<link rel="preload" as="fetch" href="/settings?_data=1" crossorigin="anonymous">',
+    );
+  });
+
+  it("does not emit a preload link for SPA routes without a loader", async () => {
+    const app = defineApp({
+      shells: { app: "./shells/app.tsx" },
+      routes: [route("/settings", "./routes/settings.tsx", { render: "spa", shell: "app" })],
+    });
+
+    const response = await handlePrachtRequest({
+      app,
+      registry: {
+        routeModules: {
+          "./routes/settings.tsx": async () => ({
+            Component: () => h("main", null, "No loader"),
+          }),
+        },
+        shellModules: {
+          "./shells/app.tsx": async () => ({
+            Shell: ({ children }) => h("div", { class: "app-shell" }, children),
+          }),
+        },
+      },
+      request: new Request("http://localhost/settings"),
+    });
+
+    const html = await response.text();
+    expect(html).not.toContain("preload");
   });
 });
 


### PR DESCRIPTION
## Summary

- For SPA routes that define a loader, emit a `<link rel="preload" as="fetch">` tag in the server-rendered HTML so the browser begins downloading route state data while JavaScript is still loading — eliminating the HTML → JS → data fetch waterfall.
- Adds `_data=1` query parameter as an alternative route-state detection mechanism since `<link rel="preload">` cannot set custom headers. The parameter is stripped from the URL before it reaches loaders or route matching.

## Testing

- [x] `pnpm e2e`
- [x] `pnpm format`
- [x] `pnpm lint`
- [x] `pnpm test`

## Checklist

- [ ] Docs updated if needed
- [ ] Skills updated if needed
- [x] Changeset added if published packages changed