### PR TITLE
Add configureClient() to intercept framework fetch requests

### DIFF
--- a/.changeset/client-fetch-interceptor.md
+++ b/.changeset/client-fetch-interceptor.md
@@ -2,4 +2,4 @@
 "@pracht/core": minor
 ---
 
-Add `configureClient({ fetch })` so apps can install a custom fetch implementation for every framework-initiated client request — route-state fetches during navigation, revalidation, and prefetch, as well as `<Form>` submissions. Enables forwarding auth headers (e.g. `Authorization: Bearer …`) to loaders on client-side navigations without losing them after initial SSR.
+Add `configureClient({ fetch })` so apps can install a custom fetch implementation for every framework-initiated client request — route-state fetches during navigation, revalidation, and prefetch, as well as `<Form>` submissions. Enables forwarding auth headers (e.g. `Authorization: Bearer …`) to loaders on client-side navigations without losing them after initial SSR. When a custom fetch is configured, prefetched route-state JSON is not reused during navigation because loader responses may vary by caller-provided headers.

--- a/.changeset/client-fetch-interceptor.md
+++ b/.changeset/client-fetch-interceptor.md
@@ -1,0 +1,5 @@
+---
+"@pracht/core": minor
+---
+
+Add `configureClient({ fetch })` so apps can install a custom fetch implementation for every framework-initiated client request — route-state fetches during navigation, revalidation, and prefetch, as well as `<Form>` submissions. Enables forwarding auth headers (e.g. `Authorization: Bearer …`) to loaders on client-side navigations without losing them after initial SSR.

--- a/docs/DATA_LOADING.md
+++ b/docs/DATA_LOADING.md
@@ -75,6 +75,49 @@ For SPA routes, the initial HTML can still include the matched shell and an
 optional shell `Loading` export so the page is not blank before the route-state
 request resolves.
 
+### Forwarding headers from the client
+
+Pracht's client runtime issues its own fetches for:
+
+- Navigation route-state fetches
+- `useRevalidate()` calls
+- Prefetching (hover / viewport / intent)
+- `<Form>` submissions
+
+By default these fetches only set framework headers (e.g.
+`x-pracht-route-state-request`). If a loader needs to read a header that the
+browser does not attach automatically — most commonly `Authorization: Bearer …`
+from a client-held token — install a custom fetch with `configureClient()`:
+
+```ts
+// src/routes.ts
+import { configureClient, defineApp } from "@pracht/core";
+
+configureClient({
+  fetch: (input, init) =>
+    fetch(input, {
+      ...init,
+      credentials: "include",
+      headers: {
+        ...(init?.headers as Record<string, string> | undefined),
+        Authorization: `Bearer ${getToken()}`,
+      },
+    }),
+});
+
+export const app = defineApp({ /* ... */ });
+```
+
+Because `src/routes.ts` is imported by the generated client entry before
+`initClientRouter` runs, the configuration is in place before the first
+client fetch. On the server, loaders can then read the header from
+`request.headers.get("authorization")` on both the initial SSR request and
+every subsequent client-triggered route-state fetch.
+
+Cookies (used by the session-based auth recipe) continue to flow by default
+for same-origin deployments; set `credentials: "include"` as shown above only
+if you serve loaders from a cross-origin host.
+
 ### Error handling
 
 Throw `PrachtHttpError` for structured error responses:

--- a/docs/DATA_LOADING.md
+++ b/docs/DATA_LOADING.md
@@ -118,6 +118,11 @@ Cookies (used by the session-based auth recipe) continue to flow by default
 for same-origin deployments; set `credentials: "include"` as shown above only
 if you serve loaders from a cross-origin host.
 
+When a custom fetch is configured, link prefetching still warms the route and
+shell modules, but Pracht does not reuse prefetched route-state JSON for later
+navigations. The custom fetch can make loader responses vary by headers such as
+`Authorization`, so navigations always fetch fresh route state.
+
 ### Error handling
 
 Throw `PrachtHttpError` for structured error responses:

--- a/docs/DATA_LOADING.md
+++ b/docs/DATA_LOADING.md
@@ -74,6 +74,49 @@ For SPA routes, the initial HTML can still include the matched shell and an
 optional shell `Loading` export so the page is not blank before the route-state
 request resolves.
 
+### Forwarding headers from the client
+
+Pracht's client runtime issues its own fetches for:
+
+- Navigation route-state fetches
+- `useRevalidate()` calls
+- Prefetching (hover / viewport / intent)
+- `<Form>` submissions
+
+By default these fetches only set framework headers (e.g.
+`x-pracht-route-state-request`). If a loader needs to read a header that the
+browser does not attach automatically — most commonly `Authorization: Bearer …`
+from a client-held token — install a custom fetch with `configureClient()`:
+
+```ts
+// src/routes.ts
+import { configureClient, defineApp } from "@pracht/core";
+
+configureClient({
+  fetch: (input, init) =>
+    fetch(input, {
+      ...init,
+      credentials: "include",
+      headers: {
+        ...(init?.headers as Record<string, string> | undefined),
+        Authorization: `Bearer ${getToken()}`,
+      },
+    }),
+});
+
+export const app = defineApp({ /* ... */ });
+```
+
+Because `src/routes.ts` is imported by the generated client entry before
+`initClientRouter` runs, the configuration is in place before the first
+client fetch. On the server, loaders can then read the header from
+`request.headers.get("authorization")` on both the initial SSR request and
+every subsequent client-triggered route-state fetch.
+
+Cookies (used by the session-based auth recipe) continue to flow by default
+for same-origin deployments; set `credentials: "include"` as shown above only
+if you serve loaders from a cross-origin host.
+
 ### Error handling
 
 Throw `PrachtHttpError` for structured error responses:

--- a/examples/docs/src/routes/docs/recipes-auth.md
+++ b/examples/docs/src/routes/docs/recipes-auth.md
@@ -323,3 +323,44 @@ This is a pure header check — it doesn't issue or validate tokens. Pair it wit
 ### 3. Token-based CSRF
 
 Only reach for per-request CSRF tokens if your cookies must be `SameSite=None` (e.g. you embed the app in a third-party iframe). For first-party apps, the two layers above are sufficient.
+
+---
+
+## Bearer tokens instead of cookies
+
+If your auth uses a short-lived bearer token kept on the client (e.g. returned
+from an OAuth token endpoint) rather than a session cookie, the token must be
+attached to every client-initiated route-state fetch — not just the initial
+SSR request. Use `configureClient()` at the top of `src/routes.ts` so the
+framework's own navigation, revalidation, prefetch, and `<Form>` fetches all
+forward it:
+
+```ts [src/routes.ts]
+import { configureClient, defineApp } from "@pracht/core";
+import { getToken } from "./auth/token";
+
+configureClient({
+  fetch: (input, init) => {
+    const token = getToken();
+    return fetch(input, {
+      ...init,
+      headers: {
+        ...(init?.headers as Record<string, string> | undefined),
+        ...(token ? { Authorization: `Bearer ${token}` } : {}),
+      },
+    });
+  },
+});
+
+export const app = defineApp({ /* ... */ });
+```
+
+Loaders then read the header the same way on either the first SSR render or
+subsequent client navigations:
+
+```ts
+export async function loader({ request }: LoaderArgs) {
+  const token = request.headers.get("authorization")?.replace(/^Bearer /, "");
+  // ...
+}
+```

--- a/examples/docs/src/routes/docs/recipes-auth.md
+++ b/examples/docs/src/routes/docs/recipes-auth.md
@@ -365,3 +365,7 @@ export async function loader({ request }: LoaderArgs) {
   // ...
 }
 ```
+
+With a custom fetch installed, route prefetching still warms modules, but
+prefetched route-state JSON is not reused during navigation. That keeps
+user-specific loader responses from being cached by URL alone.

--- a/examples/docs/src/routes/docs/recipes-auth.md
+++ b/examples/docs/src/routes/docs/recipes-auth.md
@@ -324,3 +324,44 @@ This is a pure header check — it doesn't issue or validate tokens. Pair it wit
 ### 3. Token-based CSRF
 
 Only reach for per-request CSRF tokens if your cookies must be `SameSite=None` (e.g. you embed the app in a third-party iframe). For first-party apps, the two layers above are sufficient.
+
+---
+
+## Bearer tokens instead of cookies
+
+If your auth uses a short-lived bearer token kept on the client (e.g. returned
+from an OAuth token endpoint) rather than a session cookie, the token must be
+attached to every client-initiated route-state fetch — not just the initial
+SSR request. Use `configureClient()` at the top of `src/routes.ts` so the
+framework's own navigation, revalidation, prefetch, and `<Form>` fetches all
+forward it:
+
+```ts [src/routes.ts]
+import { configureClient, defineApp } from "@pracht/core";
+import { getToken } from "./auth/token";
+
+configureClient({
+  fetch: (input, init) => {
+    const token = getToken();
+    return fetch(input, {
+      ...init,
+      headers: {
+        ...(init?.headers as Record<string, string> | undefined),
+        ...(token ? { Authorization: `Bearer ${token}` } : {}),
+      },
+    });
+  },
+});
+
+export const app = defineApp({ /* ... */ });
+```
+
+Loaders then read the header the same way on either the first SSR render or
+subsequent client navigations:
+
+```ts
+export async function loader({ request }: LoaderArgs) {
+  const token = request.headers.get("authorization")?.replace(/^Bearer /, "");
+  // ...
+}
+```

--- a/packages/framework/src/browser.ts
+++ b/packages/framework/src/browser.ts
@@ -25,7 +25,11 @@ export {
   useRouteData,
 } from "./runtime-hooks.ts";
 export { prefetch, type PrefetchFn } from "./prefetch-api.ts";
-export { fetchPrachtRouteState, parseSafeNavigationUrl } from "./runtime-client-fetch.ts";
+export {
+  configureClient,
+  fetchPrachtRouteState,
+  parseSafeNavigationUrl,
+} from "./runtime-client-fetch.ts";
 export { initClientRouter, useNavigate } from "./router.ts";
 export { redirect, type RedirectOptions } from "./runtime-middleware.ts";
 export { PrachtHttpError } from "./types.ts";
@@ -104,6 +108,10 @@ export type {
   PrachtHydrationState,
   StartAppOptions,
 } from "./runtime-hooks.ts";
-export type { RouteStateResult } from "./runtime-client-fetch.ts";
+export type {
+  ConfigureClientOptions,
+  PrachtClientFetch,
+  RouteStateResult,
+} from "./runtime-client-fetch.ts";
 export type { SerializedRouteError } from "./runtime-errors.ts";
 export type { InitClientRouterOptions, NavigateFn } from "./router.ts";

--- a/packages/framework/src/index.ts
+++ b/packages/framework/src/index.ts
@@ -14,6 +14,7 @@ export { useIsHydrated } from "./hydration.ts";
 export { Suspense, lazy } from "preact-suspense";
 export {
   applyDefaultSecurityHeaders,
+  configureClient,
   Form,
   handlePrachtRequest,
   readHydrationState,
@@ -74,9 +75,11 @@ export type {
   PrachtAppConfig,
 } from "./types.ts";
 export type {
+  ConfigureClientOptions,
   FormProps,
   HandlePrachtRequestOptions,
   Location,
+  PrachtClientFetch,
   PrachtRuntimeDiagnosticPhase,
   PrachtRuntimeDiagnostics,
   RouteStateResult,

--- a/packages/framework/src/index.ts
+++ b/packages/framework/src/index.ts
@@ -28,6 +28,7 @@ export { useIsHydrated } from "./hydration.ts";
 export { Suspense, lazy } from "preact-suspense";
 export {
   applyDefaultSecurityHeaders,
+  configureClient,
   Form,
   formatServerTimingHeader,
   Link,
@@ -112,6 +113,7 @@ export type {
   PrachtAppConfig,
 } from "./types.ts";
 export type {
+  ConfigureClientOptions,
   FormProps,
   HandlePrachtRequestOptions,
   LinkProps,
@@ -119,6 +121,7 @@ export type {
   Navigation,
   NavigationLocation,
   PrachtPhaseTimings,
+  PrachtClientFetch,
   PrachtRuntimeDiagnosticPhase,
   PrachtRuntimeDiagnostics,
   RouteStateResult,

--- a/packages/framework/src/prefetch-api.ts
+++ b/packages/framework/src/prefetch-api.ts
@@ -14,7 +14,11 @@ import {
   getCachedRouteState,
   removeCachedRouteState,
 } from "./prefetch-cache.ts";
-import { fetchPrachtRouteState, routeNeedsServerFetch } from "./runtime-client-fetch.ts";
+import {
+  fetchPrachtRouteState,
+  isClientFetchConfigured,
+  routeNeedsServerFetch,
+} from "./runtime-client-fetch.ts";
 import type { RouteStateResult } from "./runtime-client-fetch.ts";
 import type {
   ResolvedPrachtApp,
@@ -48,11 +52,15 @@ export function getPrefetchTarget(): { app: ResolvedPrachtApp; warmModules?: Mod
 /**
  * Fetch (or reuse) the route-state JSON for `url` and store it in the shared
  * bounded prefetch cache so a subsequent client navigation can consume it
- * without a second network request. Rejected fetches are evicted from the
- * cache so a transient network error does not poison later navigations.
+ * without a second network request. When a custom client fetch is configured,
+ * route state can vary by caller-added headers, so prefetches are deliberately
+ * not cached. Rejected fetches are evicted from the cache so a transient
+ * network error does not poison later navigations.
  */
 export function prefetchRouteState(url: string, route?: ResolvedRoute): Promise<RouteStateResult> {
   if (route && !routeNeedsServerFetch(route)) return EMPTY_ROUTE_STATE_PROMISE;
+
+  if (isClientFetchConfigured()) return fetchPrachtRouteState(url);
 
   const cached = getCachedRouteState(url);
   if (cached) return cached;

--- a/packages/framework/src/router.ts
+++ b/packages/framework/src/router.ts
@@ -32,6 +32,7 @@ import type {
 } from "./types.ts";
 import {
   fetchPrachtRouteState,
+  isClientFetchConfigured,
   parseSafeNavigationUrl,
   routeNeedsServerFetch,
 } from "./runtime-client-fetch.ts";
@@ -366,8 +367,11 @@ export async function initClientRouter(options: InitClientRouterOptions): Promis
       // Start route-state fetch and module imports in parallel
       let statePromise: Promise<RouteStateResult>;
       if (routeNeedsServerFetch(match.route)) {
+        const cachedState = isClientFetchConfigured()
+          ? null
+          : getCachedRouteState(target.requestUrl);
         statePromise =
-          getCachedRouteState(target.requestUrl) ??
+          cachedState ??
           fetchPrachtRouteState(target.requestUrl, { signal: abortController.signal });
       } else {
         statePromise = Promise.resolve({ type: "data" as const, data: undefined });

--- a/packages/framework/src/runtime-client-fetch.ts
+++ b/packages/framework/src/runtime-client-fetch.ts
@@ -37,6 +37,65 @@ export function routeNeedsServerFetch(route: ResolvedRoute): boolean {
   return true;
 }
 
+/**
+ * A fetch implementation matching the standard Web fetch signature.
+ *
+ * Provided to {@link configureClient} to customize how the framework's
+ * client runtime (navigation, revalidation, prefetch, `<Form>`) performs
+ * HTTP requests — e.g. to forward an `Authorization` header from a
+ * client-held token into loader requests.
+ */
+export type PrachtClientFetch = typeof fetch;
+
+export interface ConfigureClientOptions {
+  /**
+   * Replacement fetch function used for every framework-initiated client
+   * request: route-state fetches during navigation/revalidation/prefetch,
+   * and `<Form>` submissions.
+   *
+   * The function receives the same `(input, init)` arguments as the
+   * standard `fetch`. The framework sets its own required headers
+   * (e.g. `x-pracht-route-state-request`) on `init.headers`; callers
+   * should merge them when adding their own.
+   */
+  fetch?: PrachtClientFetch;
+}
+
+let configuredClientFetch: PrachtClientFetch | undefined;
+
+/**
+ * Configure the client runtime. Call this once at app startup (e.g. at the
+ * top of your `src/routes.ts`) to install a custom fetch implementation
+ * that every framework-initiated client request will flow through.
+ *
+ * Typical use is forwarding an `Authorization` header on client-side
+ * navigations, revalidations, prefetches, and `<Form>` submissions so
+ * server-side loaders can read it from `request.headers`.
+ *
+ * ```ts
+ * configureClient({
+ *   fetch: (input, init) =>
+ *     fetch(input, {
+ *       ...init,
+ *       credentials: "include",
+ *       headers: {
+ *         ...(init?.headers as Record<string, string> | undefined),
+ *         Authorization: `Bearer ${getToken()}`,
+ *       },
+ *     }),
+ * });
+ * ```
+ *
+ * Passing `undefined` for `fetch` resets to the global `fetch`.
+ */
+export function configureClient(options: ConfigureClientOptions = {}): void {
+  configuredClientFetch = options.fetch;
+}
+
+export function getConfiguredClientFetch(): PrachtClientFetch {
+  return configuredClientFetch ?? fetch;
+}
+
 export function buildRouteStateUrl(url: string): string {
   const separator = url.includes("?") ? "&" : "?";
   return `${url}${separator}_data=1`;
@@ -47,7 +106,8 @@ export async function fetchPrachtRouteState(
   options?: { signal?: AbortSignal; useDataParam?: boolean },
 ): Promise<RouteStateResult> {
   const fetchUrl = options?.useDataParam ? buildRouteStateUrl(url) : url;
-  const response = await fetch(fetchUrl, {
+  const clientFetch = getConfiguredClientFetch();
+  const response = await clientFetch(fetchUrl, {
     headers: options?.useDataParam
       ? {}
       : { [ROUTE_STATE_REQUEST_HEADER]: "1", "Cache-Control": "no-cache" },

--- a/packages/framework/src/runtime-client-fetch.ts
+++ b/packages/framework/src/runtime-client-fetch.ts
@@ -96,6 +96,10 @@ export function getConfiguredClientFetch(): PrachtClientFetch {
   return configuredClientFetch ?? fetch;
 }
 
+export function isClientFetchConfigured(): boolean {
+  return configuredClientFetch !== undefined;
+}
+
 export function buildRouteStateUrl(url: string): string {
   const separator = url.includes("?") ? "&" : "?";
   return `${url}${separator}_data=1`;

--- a/packages/framework/src/runtime-client-fetch.ts
+++ b/packages/framework/src/runtime-client-fetch.ts
@@ -31,6 +31,65 @@ export function parseSafeNavigationUrl(location: string, base: string | URL): UR
   return targetUrl;
 }
 
+/**
+ * A fetch implementation matching the standard Web fetch signature.
+ *
+ * Provided to {@link configureClient} to customize how the framework's
+ * client runtime (navigation, revalidation, prefetch, `<Form>`) performs
+ * HTTP requests — e.g. to forward an `Authorization` header from a
+ * client-held token into loader requests.
+ */
+export type PrachtClientFetch = typeof fetch;
+
+export interface ConfigureClientOptions {
+  /**
+   * Replacement fetch function used for every framework-initiated client
+   * request: route-state fetches during navigation/revalidation/prefetch,
+   * and `<Form>` submissions.
+   *
+   * The function receives the same `(input, init)` arguments as the
+   * standard `fetch`. The framework sets its own required headers
+   * (e.g. `x-pracht-route-state-request`) on `init.headers`; callers
+   * should merge them when adding their own.
+   */
+  fetch?: PrachtClientFetch;
+}
+
+let configuredClientFetch: PrachtClientFetch | undefined;
+
+/**
+ * Configure the client runtime. Call this once at app startup (e.g. at the
+ * top of your `src/routes.ts`) to install a custom fetch implementation
+ * that every framework-initiated client request will flow through.
+ *
+ * Typical use is forwarding an `Authorization` header on client-side
+ * navigations, revalidations, prefetches, and `<Form>` submissions so
+ * server-side loaders can read it from `request.headers`.
+ *
+ * ```ts
+ * configureClient({
+ *   fetch: (input, init) =>
+ *     fetch(input, {
+ *       ...init,
+ *       credentials: "include",
+ *       headers: {
+ *         ...(init?.headers as Record<string, string> | undefined),
+ *         Authorization: `Bearer ${getToken()}`,
+ *       },
+ *     }),
+ * });
+ * ```
+ *
+ * Passing `undefined` for `fetch` resets to the global `fetch`.
+ */
+export function configureClient(options: ConfigureClientOptions = {}): void {
+  configuredClientFetch = options.fetch;
+}
+
+export function getConfiguredClientFetch(): PrachtClientFetch {
+  return configuredClientFetch ?? fetch;
+}
+
 export function buildRouteStateUrl(url: string): string {
   const separator = url.includes("?") ? "&" : "?";
   return `${url}${separator}_data=1`;
@@ -41,7 +100,8 @@ export async function fetchPrachtRouteState(
   options?: { useDataParam?: boolean },
 ): Promise<RouteStateResult> {
   const fetchUrl = options?.useDataParam ? buildRouteStateUrl(url) : url;
-  const response = await fetch(fetchUrl, {
+  const clientFetch = getConfiguredClientFetch();
+  const response = await clientFetch(fetchUrl, {
     headers: options?.useDataParam
       ? {}
       : { [ROUTE_STATE_REQUEST_HEADER]: "1", "Cache-Control": "no-cache" },

--- a/packages/framework/src/runtime-hooks.ts
+++ b/packages/framework/src/runtime-hooks.ts
@@ -8,7 +8,11 @@ import {
   SAFE_METHODS,
 } from "./runtime-constants.ts";
 import { deserializeRouteError, type SerializedRouteError } from "./runtime-errors.ts";
-import { fetchPrachtRouteState, navigateToClientLocation } from "./runtime-client-fetch.ts";
+import {
+  fetchPrachtRouteState,
+  getConfiguredClientFetch,
+  navigateToClientLocation,
+} from "./runtime-client-fetch.ts";
 import type { RouteParams } from "./types.ts";
 
 export interface PrachtHydrationState<TData = unknown> {
@@ -198,7 +202,8 @@ export function Form(props: FormProps) {
       }
 
       event.preventDefault();
-      const response = await fetch(props.action ?? form.action, {
+      const clientFetch = getConfiguredClientFetch();
+      const response = await clientFetch(props.action ?? form.action, {
         method: formMethod,
         body: new FormData(form),
         redirect: "manual",

--- a/packages/framework/src/runtime-hooks.ts
+++ b/packages/framework/src/runtime-hooks.ts
@@ -27,7 +27,11 @@ import {
 } from "./runtime-context.ts";
 import { clearPrefetchCache } from "./prefetch-cache.ts";
 import { deserializeRouteError } from "./runtime-errors.ts";
-import { fetchPrachtRouteState, navigateToClientLocation } from "./runtime-client-fetch.ts";
+import {
+  fetchPrachtRouteState,
+  getConfiguredClientFetch,
+  navigateToClientLocation,
+} from "./runtime-client-fetch.ts";
 import type {
   LinkPrefetchStrategy,
   LoaderData,
@@ -198,7 +202,8 @@ export function Form(props: FormProps) {
         formData,
       );
       try {
-        const response = await fetch(actionUrl, {
+        const clientFetch = getConfiguredClientFetch();
+        const response = await clientFetch(actionUrl, {
           method: formMethod,
           body: formData,
           redirect: "manual",

--- a/packages/framework/src/runtime.ts
+++ b/packages/framework/src/runtime.ts
@@ -637,7 +637,10 @@ export {
   type StartAppOptions,
 } from "./runtime-hooks.ts";
 export {
+  configureClient,
   fetchPrachtRouteState,
   parseSafeNavigationUrl,
+  type ConfigureClientOptions,
+  type PrachtClientFetch,
   type RouteStateResult,
 } from "./runtime-client-fetch.ts";

--- a/packages/framework/src/runtime.ts
+++ b/packages/framework/src/runtime.ts
@@ -445,7 +445,10 @@ export {
   type StartAppOptions,
 } from "./runtime-hooks.ts";
 export {
+  configureClient,
   fetchPrachtRouteState,
   parseSafeNavigationUrl,
+  type ConfigureClientOptions,
+  type PrachtClientFetch,
   type RouteStateResult,
 } from "./runtime-client-fetch.ts";

--- a/packages/framework/test/configure-client.test.ts
+++ b/packages/framework/test/configure-client.test.ts
@@ -2,6 +2,7 @@
 import { h, render } from "preact";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
+import { configureClient as configureBrowserClient } from "../src/browser.ts";
 import { configureClient, Form } from "../src/index.ts";
 import { fetchPrachtRouteState } from "../src/runtime.ts";
 
@@ -41,6 +42,10 @@ describe("configureClient", () => {
       }),
     );
     expect(result).toEqual({ type: "data", data: { hello: "world" } });
+  });
+
+  it("is exported from the browser entry", () => {
+    expect(configureBrowserClient).toBe(configureClient);
   });
 
   it("falls back to the global fetch when no configuration is set", async () => {

--- a/packages/framework/test/configure-client.test.ts
+++ b/packages/framework/test/configure-client.test.ts
@@ -4,6 +4,8 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { configureClient as configureBrowserClient } from "../src/browser.ts";
 import { configureClient, Form } from "../src/index.ts";
+import { clearPrefetchCache, getCachedRouteState } from "../src/prefetch-cache.ts";
+import { prefetchRouteState } from "../src/prefetch-api.ts";
 import { fetchPrachtRouteState } from "../src/runtime.ts";
 
 function createJsonResponse(body: unknown, init?: ResponseInit): Response {
@@ -19,6 +21,7 @@ describe("configureClient", () => {
   afterEach(() => {
     // Reset to default (global fetch) between tests.
     configureClient({ fetch: undefined });
+    clearPrefetchCache();
     vi.unstubAllGlobals();
     vi.restoreAllMocks();
   });
@@ -97,6 +100,27 @@ describe("configureClient", () => {
       "x-pracht-route-state-request": "1",
       "Cache-Control": "no-cache",
     });
+  });
+
+  it("does not cache route-state prefetches when a custom fetch is configured", async () => {
+    const customFetch = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(createJsonResponse({ data: { token: "first" } }))
+      .mockResolvedValueOnce(createJsonResponse({ data: { token: "second" } }));
+
+    configureClient({ fetch: customFetch });
+
+    await expect(prefetchRouteState("/account")).resolves.toEqual({
+      data: { token: "first" },
+      type: "data",
+    });
+    expect(getCachedRouteState("/account")).toBeNull();
+
+    await expect(prefetchRouteState("/account")).resolves.toEqual({
+      data: { token: "second" },
+      type: "data",
+    });
+    expect(customFetch).toHaveBeenCalledTimes(2);
   });
 
   it("routes <Form> submissions through the configured fetch", async () => {

--- a/packages/framework/test/configure-client.test.ts
+++ b/packages/framework/test/configure-client.test.ts
@@ -1,0 +1,131 @@
+// @vitest-environment jsdom
+import { h, render } from "preact";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { configureClient, Form } from "../src/index.ts";
+import { fetchPrachtRouteState } from "../src/runtime.ts";
+
+function createJsonResponse(body: unknown, init?: ResponseInit): Response {
+  return new Response(JSON.stringify(body), {
+    headers: {
+      "content-type": "application/json",
+    },
+    ...init,
+  });
+}
+
+describe("configureClient", () => {
+  afterEach(() => {
+    // Reset to default (global fetch) between tests.
+    configureClient({ fetch: undefined });
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it("routes fetchPrachtRouteState through the configured fetch", async () => {
+    const customFetch = vi.fn(async () => createJsonResponse({ data: { hello: "world" } }));
+
+    configureClient({ fetch: customFetch as unknown as typeof fetch });
+
+    const result = await fetchPrachtRouteState("/foo");
+
+    expect(customFetch).toHaveBeenCalledTimes(1);
+    expect(customFetch).toHaveBeenCalledWith(
+      "/foo",
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          "Cache-Control": "no-cache",
+          "x-pracht-route-state-request": "1",
+        }),
+        redirect: "manual",
+      }),
+    );
+    expect(result).toEqual({ type: "data", data: { hello: "world" } });
+  });
+
+  it("falls back to the global fetch when no configuration is set", async () => {
+    const globalFetch = vi.fn(async () => createJsonResponse({ data: 1 }));
+    vi.stubGlobal("fetch", globalFetch);
+
+    await fetchPrachtRouteState("/bar");
+
+    expect(globalFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("resets to the global fetch when fetch: undefined is passed", async () => {
+    const customFetch = vi.fn(async () => createJsonResponse({ data: 1 }));
+    const globalFetch = vi.fn(async () => createJsonResponse({ data: 2 }));
+    vi.stubGlobal("fetch", globalFetch);
+
+    configureClient({ fetch: customFetch as unknown as typeof fetch });
+    await fetchPrachtRouteState("/a");
+    expect(customFetch).toHaveBeenCalledTimes(1);
+    expect(globalFetch).not.toHaveBeenCalled();
+
+    configureClient({ fetch: undefined });
+    await fetchPrachtRouteState("/b");
+    expect(customFetch).toHaveBeenCalledTimes(1);
+    expect(globalFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("forwards an Authorization header injected by the configured fetch to client navigation fetches", async () => {
+    const seenHeaders: Array<Record<string, string>> = [];
+    const customFetch = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+      seenHeaders.push((init?.headers as Record<string, string>) ?? {});
+      return createJsonResponse({ data: null });
+    });
+
+    configureClient({
+      fetch: (input, init) => {
+        const headers = {
+          ...(init?.headers as Record<string, string> | undefined),
+          Authorization: "Bearer token-123",
+        };
+        return customFetch(input, { ...init, headers });
+      },
+    });
+
+    await fetchPrachtRouteState("/baz");
+
+    expect(seenHeaders[0]).toMatchObject({
+      Authorization: "Bearer token-123",
+      "x-pracht-route-state-request": "1",
+      "Cache-Control": "no-cache",
+    });
+  });
+
+  it("routes <Form> submissions through the configured fetch", async () => {
+    const customFetch = vi.fn<typeof fetch>(async () => new Response(null, { status: 204 }));
+    configureClient({ fetch: customFetch });
+
+    const root = document.createElement("div");
+    document.body.appendChild(root);
+
+    try {
+      render(
+        h(
+          Form,
+          { action: "/api/do", method: "post" },
+          h("input", { name: "x", defaultValue: "y" }),
+          h("button", { type: "submit" }, "Go"),
+        ),
+        root,
+      );
+
+      const form = root.querySelector("form")!;
+      form.dispatchEvent(new Event("submit", { bubbles: true, cancelable: true }));
+      // let the microtask queue settle
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(customFetch).toHaveBeenCalledTimes(1);
+      const [url, init] = customFetch.mock.calls[0]!;
+      expect(url).toBe("/api/do");
+      expect(init?.method).toBe("POST");
+      expect(init?.redirect).toBe("manual");
+    } finally {
+      render(null, root);
+      root.remove();
+    }
+  });
+});

--- a/packages/framework/test/router-client.test.ts
+++ b/packages/framework/test/router-client.test.ts
@@ -7,6 +7,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   Form,
   Link,
+  configureClient,
   defineApp,
   initClientRouter,
   resolveApp,
@@ -15,6 +16,7 @@ import {
   useNavigate,
   useRouteData,
 } from "../src/index.ts";
+import { cacheRouteState, clearPrefetchCache } from "../src/prefetch-cache.ts";
 
 function createJsonResponse(body: unknown, init?: ResponseInit): Response {
   return new Response(JSON.stringify(body), {
@@ -50,6 +52,8 @@ describe("initClientRouter", () => {
     root.remove();
     vi.unstubAllGlobals();
     vi.restoreAllMocks();
+    configureClient({ fetch: undefined });
+    clearPrefetchCache();
     delete window.__PRACHT_NAVIGATE__;
     delete window.__PRACHT_ROUTER_READY__;
     delete globalThis.__PRACHT_ROUTE_DEFINITIONS__;
@@ -158,6 +162,50 @@ describe("initClientRouter", () => {
     );
     expect(window.location.pathname).toBe("/products/2");
     expect(root.textContent).toContain("Product 2");
+  });
+
+  it("ignores cached route state during navigation when a custom fetch is configured", async () => {
+    function Page() {
+      const data = useRouteData<{ label: string }>();
+      return h("main", null, data.label);
+    }
+
+    const app = resolveApp(
+      defineApp({
+        routes: [
+          route("/", "./routes/home.tsx", { id: "home", render: "ssr" }),
+          route("/next", "./routes/next.tsx", { id: "next", render: "ssr" }),
+        ],
+      }),
+    );
+
+    root.innerHTML = "<main>home</main>";
+    cacheRouteState("/next", Promise.resolve({ data: { label: "cached" }, type: "data" }));
+    fetchSpy.mockResolvedValue(createJsonResponse({ data: { label: "fresh" } }));
+    configureClient({ fetch: fetchSpy as unknown as typeof fetch });
+
+    await initClientRouter({
+      app,
+      routeModules: {
+        "./routes/home.tsx": async () => ({ default: Page }),
+        "./routes/next.tsx": async () => ({ default: Page }),
+      },
+      shellModules: {},
+      initialState: {
+        data: { label: "home" },
+        routeId: "home",
+        url: "/",
+      },
+      root,
+      findModuleKey: (_modules, file) => file,
+    });
+
+    await window.__PRACHT_NAVIGATE__!("/next");
+    await flush();
+
+    expect(fetchSpy).toHaveBeenCalledWith("/next", expect.objectContaining({ redirect: "manual" }));
+    expect(root.textContent).toContain("fresh");
+    expect(root.textContent).not.toContain("cached");
   });
 
   it("preserves same-shell instances without exposing stale route data to useRouteData()", async () => {


### PR DESCRIPTION
## Summary

Add `configureClient({ fetch })` API that allows apps to install a custom fetch implementation for all framework-initiated client requests. This enables forwarding auth headers (e.g. `Authorization: Bearer …`) to loaders on client-side navigations, revalidations, prefetches, and `<Form>` submissions without losing them after initial SSR.

The custom fetch is routed through:
- Route-state fetches during navigation/revalidation/prefetch
- `<Form>` submissions

This is particularly useful for bearer token-based auth where the token is stored on the client and must be attached to every request, unlike session cookies which flow automatically.

## Testing

- [x] Added comprehensive test suite (`configure-client.test.ts`) covering:
  - Custom fetch routing for `fetchPrachtRouteState`
  - Fallback to global fetch when unconfigured
  - Reset to global fetch when `fetch: undefined` is passed
  - Header forwarding from custom fetch implementations
  - `<Form>` submission routing through custom fetch
- [x] `pnpm test` passes

## Checklist

- [x] Docs updated (DATA_LOADING.md with header forwarding guide, auth recipe with bearer token example)
- [x] Changeset added
- [x] Exports added to index.ts (`configureClient`, `ConfigureClientOptions`, `PrachtClientFetch`)

https://claude.ai/code/session_0159U8Fz9HjrYH6iFYfJYFpT