### PR TITLE
Parallelize independent work in server request pipeline

### DIFF
--- a/.changeset/parallel-server-pipeline.md
+++ b/.changeset/parallel-server-pipeline.md
@@ -1,0 +1,13 @@
+---
+"@pracht/core": patch
+---
+
+Parallelize independent work in the server request pipeline. Middleware module
+imports now resolve concurrently (execution order is still preserved), and the
+route module, shell module, and separate-file loader module imports are kicked
+off alongside the middleware chain instead of waiting for it. The shell/route
+`head` and `headers` exports also run concurrently inside each merge step.
+
+No API changes. Observable effect: lower TTFB on cold starts where modules
+ship as separate chunks, and lower end-to-end request latency whenever shell
+or head/headers work was previously waiting for the loader.

--- a/docs/REQUEST_FLOWS.md
+++ b/docs/REQUEST_FLOWS.md
@@ -398,6 +398,62 @@ The client updates the component tree in-place.
 
 ---
 
+## Server pipeline parallelism
+
+Every request handled by `handlePrachtRequest` runs through a common pipeline.
+Steps that don't depend on each other are kicked off concurrently so the
+critical path is bounded by the slowest independent step, not their sum.
+
+```
+request arrives
+│
+├─► middleware chain          ──┐
+│     resolve all middleware    │
+│     modules in parallel;      │
+│     execute sequentially      │
+│     (context may chain)       │
+│                               │
+├─► route module import ────────┤   all four kick off together
+│                               │
+├─► shell module import ────────┤
+│                               │
+└─► data-module import ─────────┘   (separate loader file, if any)
+          │
+          ▼
+   await middleware ─► context
+          │
+          ▼
+   await route module + loader
+          │
+          ▼
+   execute loader(args)        ◄── the one serial gate; loader needs
+          │                         the merged context
+          ▼
+   await shell module (usually already resolved)
+          │
+          ▼
+   merge head + headers (run in parallel; shell/route halves also
+   run in parallel inside each merge)
+          │
+          ▼
+   render HTML
+```
+
+**Important properties:**
+
+- Middleware **execution** order is preserved. Only module imports are
+  parallelized — the chain is still left-to-right so context mutations
+  compose deterministically.
+- `head` / `headers` exports on shell and route run concurrently. If both
+  have side effects, both still run even if one throws. The merge order
+  (shell first, then route takes precedence) is unchanged.
+- If middleware short-circuits with a redirect or `Response`, the route /
+  shell / data module imports that were already in flight are discarded.
+  Their rejections are suppressed to avoid unhandled-rejection warnings;
+  real errors still surface when those promises are awaited downstream.
+
+---
+
 ## Module loading during navigation
 
 ```

--- a/packages/framework/src/runtime.ts
+++ b/packages/framework/src/runtime.ts
@@ -490,8 +490,18 @@ export async function handlePrachtRequest<TContext>(
   let currentPhase: PrachtRuntimeDiagnosticPhase = "middleware";
 
   try {
-    // --- Middleware chain ---
-    const middlewareResult = await runMiddlewareChain({
+    // Kick off every piece of the pipeline that doesn't depend on the
+    // middleware chain's result up front, so they run concurrently with
+    // middleware rather than waiting in line:
+    //
+    //   • route module import                          (needs only match.route.file)
+    //   • shell module import                          (needs only match.route.shellFile)
+    //   • data-module resolution (separate loader file) (needs routeModule)
+    //
+    // Only the loader itself still waits for middleware, because it
+    // receives the merged context. This removes one serial await from
+    // every request (typically the shell module load after the loader).
+    const middlewarePromise = runMiddlewareChain({
       context: routeArgs.context,
       middlewareFiles: match.route.middlewareFiles,
       params: match.params,
@@ -500,6 +510,30 @@ export async function handlePrachtRequest<TContext>(
       route: match.route,
       url,
     });
+
+    const routeModulePromise = resolveRegistryModule<RouteModule>(
+      registry.routeModules,
+      match.route.file,
+    );
+
+    const shellModulePromise: Promise<ShellModule | undefined> = match.route.shellFile
+      ? resolveRegistryModule<ShellModule>(registry.shellModules, match.route.shellFile)
+      : Promise.resolve(undefined);
+
+    const dataFunctionsPromise = routeModulePromise.then((mod) =>
+      resolveDataFunctions(match.route, mod, registry),
+    );
+
+    // Suppress unhandled-rejection warnings for in-flight promises that we
+    // may not reach (e.g. middleware short-circuits with a response). Each
+    // promise is still awaited via the original reference below, so real
+    // errors still surface through the existing try/catch.
+    routeModulePromise.catch(() => {});
+    shellModulePromise.catch(() => {});
+    dataFunctionsPromise.catch(() => {});
+
+    // --- Middleware chain ---
+    const middlewareResult = await middlewarePromise;
     if (middlewareResult.response) {
       return normalizePageResponse(middlewareResult.response, { isRouteStateRequest });
     }
@@ -511,18 +545,14 @@ export async function handlePrachtRequest<TContext>(
 
     // --- Load route module ---
     currentPhase = "render";
-    routeModule = await resolveRegistryModule<RouteModule>(registry.routeModules, match.route.file);
+    routeModule = await routeModulePromise;
     if (!routeModule) {
       throw new Error("Route module not found");
     }
 
     // --- Resolve loader from separate data module or route module ---
     currentPhase = "loader";
-    const { loader, loaderFile: resolvedLoaderFile } = await resolveDataFunctions(
-      match.route,
-      routeModule,
-      registry,
-    );
+    const { loader, loaderFile: resolvedLoaderFile } = await dataFunctionsPromise;
     loaderFile = resolvedLoaderFile;
 
     // --- Execute loader ---
@@ -541,14 +571,17 @@ export async function handlePrachtRequest<TContext>(
     }
 
     // --- Load shell module ---
+    // Shell import was kicked off up front; this await is usually already
+    // resolved by the time we get here (it runs in parallel with the loader).
     currentPhase = "render";
-    shellModule = match.route.shellFile
-      ? await resolveRegistryModule<ShellModule>(registry.shellModules, match.route.shellFile)
-      : undefined;
+    shellModule = await shellModulePromise;
 
     // --- Merge document metadata ---
-    const head = await mergeHeadMetadata(shellModule, routeModule, routeArgs, data);
-    const documentHeaders = await mergeDocumentHeaders(shellModule, routeModule, routeArgs, data);
+    // head and document headers are independent; run them concurrently.
+    const [head, documentHeaders] = await Promise.all([
+      mergeHeadMetadata(shellModule, routeModule, routeArgs, data),
+      mergeDocumentHeaders(shellModule, routeModule, routeArgs, data),
+    ]);
 
     const cssUrls = resolvePageCssUrls(options, match.route.shellFile, match.route.file);
     const modulePreloadUrls = resolvePageJsUrls(options, match.route.shellFile, match.route.file);
@@ -1117,11 +1150,23 @@ async function runMiddlewareChain<TContext>(options: {
 > {
   let context = options.context;
 
-  for (const mwFile of options.middlewareFiles) {
-    const mwModule = await resolveRegistryModule<MiddlewareModule>(
-      options.registry.middlewareModules,
-      mwFile,
-    );
+  // Kick off module resolution for every middleware in parallel. Execution
+  // below still runs sequentially — middleware may mutate context and the
+  // ordering is part of the public contract — but the imports themselves
+  // have no inter-dependency, so waiting for them one-by-one is pure
+  // latency for no benefit. On cold starts where middleware ships as its
+  // own chunks this can meaningfully reduce TTFB.
+  const modulePromises = options.middlewareFiles.map((mwFile) =>
+    resolveRegistryModule<MiddlewareModule>(options.registry.middlewareModules, mwFile),
+  );
+  // Suppress unhandled-rejection warnings for promises that may not be
+  // awaited if an earlier middleware short-circuits with a response.
+  for (const p of modulePromises) {
+    p.catch(() => {});
+  }
+
+  for (const modulePromise of modulePromises) {
+    const mwModule = await modulePromise;
     if (!mwModule?.middleware) continue;
 
     const result = await mwModule.middleware({
@@ -1203,8 +1248,14 @@ async function mergeHeadMetadata(
   routeArgs: BaseRouteArgs<unknown>,
   data: unknown,
 ): Promise<HeadMetadata> {
-  const shellHead = shellModule?.head ? await shellModule.head(routeArgs) : {};
-  const routeHead = routeModule?.head ? await routeModule.head({ ...routeArgs, data } as any) : {};
+  // Shell and route `head` exports are independent — run them concurrently.
+  // Merge order (shell first, then route) is preserved below.
+  const [shellHead, routeHead] = await Promise.all([
+    shellModule?.head ? shellModule.head(routeArgs) : Promise.resolve({} as HeadMetadata),
+    routeModule?.head
+      ? routeModule.head({ ...routeArgs, data } as any)
+      : Promise.resolve({} as HeadMetadata),
+  ]);
 
   return {
     title: routeHead.title ?? shellHead.title,
@@ -1221,14 +1272,17 @@ async function mergeDocumentHeaders(
   data: unknown,
 ): Promise<Headers> {
   const headers = new Headers();
-  const shellHeaders = shellModule?.headers ? await shellModule.headers(routeArgs) : undefined;
+  // Shell and route `headers` exports are independent — run concurrently.
+  // Apply order (shell first, then route) still gives route precedence.
+  const [shellHeaders, routeHeaders] = await Promise.all([
+    shellModule?.headers ? shellModule.headers(routeArgs) : Promise.resolve(undefined),
+    routeModule?.headers
+      ? routeModule.headers({ ...routeArgs, data } as any)
+      : Promise.resolve(undefined),
+  ]);
   if (shellHeaders) {
     applyHeaders(headers, shellHeaders);
   }
-
-  const routeHeaders = routeModule?.headers
-    ? await routeModule.headers({ ...routeArgs, data } as any)
-    : undefined;
   if (routeHeaders) {
     applyHeaders(headers, routeHeaders);
   }

--- a/packages/framework/test/runtime.test.ts
+++ b/packages/framework/test/runtime.test.ts
@@ -1140,3 +1140,158 @@ describe("handlePrachtRequest ErrorBoundary", () => {
     });
   });
 });
+
+describe("handlePrachtRequest pipeline parallelism", () => {
+  function defer<T>() {
+    let resolve!: (value: T) => void;
+    const promise = new Promise<T>((r) => {
+      resolve = r;
+    });
+    return { promise, resolve };
+  }
+
+  async function drainMicrotasks() {
+    // Yield to the event loop twice so any already-scheduled promise chains
+    // have a chance to advance to their first await point.
+    await new Promise((r) => setImmediate(r));
+    await new Promise((r) => setImmediate(r));
+  }
+
+  it("resolves middleware module imports in parallel even though execution stays ordered", async () => {
+    const app = defineApp({
+      middleware: {
+        a: "./middleware/a.ts",
+        b: "./middleware/b.ts",
+        c: "./middleware/c.ts",
+      },
+      routes: [
+        route("/", "./routes/home.tsx", {
+          middleware: ["a", "b", "c"],
+          render: "ssr",
+        }),
+      ],
+    });
+
+    const importStarted: Record<string, boolean> = { a: false, b: false, c: false };
+    const gates = {
+      a: defer<void>(),
+      b: defer<void>(),
+      c: defer<void>(),
+    };
+    const executionOrder: string[] = [];
+
+    const makeMiddleware = (id: "a" | "b" | "c") => async () => {
+      importStarted[id] = true;
+      await gates[id].promise;
+      return {
+        middleware: async ({ context }: { context: Record<string, boolean> }) => {
+          executionOrder.push(id);
+          return { context: { ...context, [`${id}-ran`]: true } };
+        },
+      };
+    };
+
+    const responsePromise = handlePrachtRequest({
+      app,
+      registry: {
+        middlewareModules: {
+          "./middleware/a.ts": makeMiddleware("a"),
+          "./middleware/b.ts": makeMiddleware("b"),
+          "./middleware/c.ts": makeMiddleware("c"),
+        },
+        routeModules: {
+          "./routes/home.tsx": async () => ({
+            Component: () => h("main", null, "ok"),
+          }),
+        },
+      },
+      request: new Request("http://localhost/"),
+    });
+
+    await drainMicrotasks();
+
+    // Under the parallelized chain, every middleware's dynamic-import function
+    // has been kicked off before any of them resolve. Under the old serial
+    // code only `a` would have started here.
+    expect(importStarted).toEqual({ a: true, b: true, c: true });
+
+    // Resolve gates out-of-order to prove execution is still left-to-right.
+    gates.c.resolve();
+    gates.b.resolve();
+    gates.a.resolve();
+
+    const response = await responsePromise;
+    expect(response.status).toBe(200);
+    expect(executionOrder).toEqual(["a", "b", "c"]);
+  });
+
+  it("starts route and shell module imports in parallel with the middleware chain", async () => {
+    const app = defineApp({
+      middleware: {
+        auth: "./middleware/auth.ts",
+      },
+      shells: {
+        app: "./shells/app.tsx",
+      },
+      routes: [
+        route("/", "./routes/home.tsx", {
+          middleware: ["auth"],
+          render: "ssr",
+          shell: "app",
+        }),
+      ],
+    });
+
+    let middlewareStarted = false;
+    let routeModuleImportStarted = false;
+    let shellModuleImportStarted = false;
+    const mwGate = defer<void>();
+
+    const response = handlePrachtRequest({
+      app,
+      registry: {
+        middlewareModules: {
+          "./middleware/auth.ts": async () => ({
+            middleware: async ({ context }: { context: Record<string, unknown> }) => {
+              middlewareStarted = true;
+              await mwGate.promise;
+              return { context };
+            },
+          }),
+        },
+        routeModules: {
+          "./routes/home.tsx": async () => {
+            routeModuleImportStarted = true;
+            return {
+              Component: () => h("main", null, "ok"),
+            };
+          },
+        },
+        shellModules: {
+          "./shells/app.tsx": async () => {
+            shellModuleImportStarted = true;
+            return {
+              Shell: ({ children }: { children: unknown }) => h("div", null, children as any),
+            };
+          },
+        },
+      },
+      request: new Request("http://localhost/"),
+    });
+
+    await drainMicrotasks();
+
+    // While middleware is still blocked on its gate, the route and shell
+    // module importers have already been invoked. Under the old serial
+    // pipeline, neither would have been touched yet — the route import
+    // waited for middleware to resolve, and the shell import waited for the
+    // loader.
+    expect(middlewareStarted).toBe(true);
+    expect(routeModuleImportStarted).toBe(true);
+    expect(shellModuleImportStarted).toBe(true);
+
+    mwGate.resolve();
+    const res = await response;
+    expect(res.status).toBe(200);
+  });
+});


### PR DESCRIPTION
## Summary

Optimizes the server request pipeline by parallelizing independent work that was previously executed serially. This reduces the critical path for request handling, particularly benefiting cold starts where modules ship as separate chunks.

**Key changes:**

- **Middleware module imports** now resolve concurrently (execution order is preserved — only imports are parallelized)
- **Route, shell, and data-module imports** are kicked off alongside the middleware chain instead of waiting for it to complete
- **`head` and `headers` exports** on shell and route modules run concurrently within each merge step
- Unhandled rejection warnings are suppressed for in-flight promises that may not be awaited (e.g., when middleware short-circuits with a response)

No API changes. The observable effect is lower TTFB on cold starts and reduced end-to-end request latency when shell or head/headers work was previously waiting for the loader.

## Testing

- [x] Added comprehensive test suite covering:
  - Middleware module imports resolving in parallel with sequential execution
  - Route and shell module imports starting in parallel with middleware chain
- [x] Existing tests continue to pass
- [x] Documentation updated with request flow diagram

## Checklist

- [x] Docs updated (REQUEST_FLOWS.md with server pipeline parallelism section)
- [x] Changeset added

https://claude.ai/code/session_019CJQibXNz3LmjbGUjQhdYy