### PR TITLE
chore: code quality sweep (dedup, types, dead code, weak types, comments)

### DIFF
--- a/.changeset/remove-deprecated-css-urls-and-revalidate-route.md
+++ b/.changeset/remove-deprecated-css-urls-and-revalidate-route.md
@@ -1,0 +1,6 @@
+---
+"pracht": patch
+"@pracht/adapter-node": patch
+---
+
+Remove deprecated `cssUrls` option from `HandlePrachtRequestOptions` and `PrerenderAppOptions` (superseded by `cssManifest`), and remove the deprecated `useRevalidateRoute` alias (use `useRevalidate` instead). The `NodeAdapterOptions.cssUrls` field, which was never forwarded to the framework, is also removed.

--- a/VISION_MVP.md
+++ b/VISION_MVP.md
@@ -75,7 +75,7 @@ specified in the config, it takes precedence over inline exports.
 
 - **Head**: `export function head(args)` — per-route `<head>` metadata merged with
   shell-level head.
-- **Client hooks**: `useRouteData()`, `useRevalidateRoute()`, `<Form>` component.
+- **Client hooks**: `useRouteData()`, `useRevalidate()`, `<Form>` component.
 
 ### API Routes
 
@@ -131,7 +131,7 @@ SSR and SSG, deployed to Node. Thoroughly tested with Playwright E2E tests.
    - Router: `matchAppRoute()` segment-based matching
    - Server renderer: `handlePrachtRequest()` → full HTML with hydration state
    - Client runtime: `startApp()`, hydration, client-side navigation
-   - Hooks: `useRouteData()`, `useRevalidateRoute()`, `<Form>`
+   - Hooks: `useRouteData()`, `useRevalidate()`, `<Form>`
 
 2. **`packages/vite-plugin`** — Vite integration
    - Virtual modules: `virtual:pracht/client`, `virtual:pracht/server`

--- a/docs/ADAPTERS.md
+++ b/docs/ADAPTERS.md
@@ -290,7 +290,7 @@ export default async function handle(request, context) {
     context,
     apiRoutes,
     clientEntryUrl: clientEntryUrl ?? undefined,
-    cssUrls,
+    cssManifest,
   });
 }
 ```

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -406,6 +406,37 @@ details.
 
 ---
 
+## Module Dependency Structure (`packages/framework/src`)
+
+The internal module graph within the framework package is acyclic:
+
+```
+types.ts        — pure types, no internal deps
+    ↑
+app.ts          — route manifest, matching, SSG path building
+    ↑
+runtime.ts      — SSR handler, prerendering, client hooks (static import of app.ts)
+    ↑
+prefetch.ts     — prefetch cache, strategy wiring (imports runtime + app)
+    ↑
+router.ts       — client router, hydration bootstrap (imports runtime + prefetch + hydration)
+
+hydration.ts    — Preact options hooks for tracking hydration (no internal deps)
+forwardRef.ts   — forwardRef helper (no internal deps)
+error-overlay.ts — dev error page HTML (no internal deps)
+```
+
+**Important:** `runtime.ts` imports `resolveApp` and `buildPathFromSegments` directly from
+`app.ts` via a static import. Earlier versions used `await import("./app.ts")` dynamic
+imports inside `prerenderApp` and `collectSSGPaths` — these were a defensive workaround
+against a perceived circular dependency that never actually existed (since `app.ts` only
+imports from `types.ts`). The dynamic imports have been replaced with static imports.
+
+The only intentional dynamic import in `runtime.ts` is `preact-render-to-string`, which
+is lazy-loaded to keep the SSR-only dependency out of the client bundle.
+
+---
+
 ## Type Safety
 
 Pracht provides end-to-end type inference from loader to component:

--- a/packages/adapter-node/src/index.ts
+++ b/packages/adapter-node/src/index.ts
@@ -66,7 +66,6 @@ export interface NodeAdapterOptions<TContext = unknown> {
   isgManifest?: Record<string, ISGManifestEntry>;
   apiRoutes?: ResolvedApiRoute[];
   clientEntryUrl?: string;
-  cssUrls?: string[];
   cssManifest?: Record<string, string[]>;
   jsManifest?: Record<string, string[]>;
   headersManifest?: HeadersManifest;
@@ -117,8 +116,7 @@ export function createNodeRequestHandler<TContext = unknown>(
     const url = new URL(request.url);
     const isRouteStateRequest = request.headers.get(ROUTE_STATE_REQUEST_HEADER) === "1";
 
-    // --- Serve static assets from the client build directory ---
-    // Skip index.html resolution for ISG routes (handled below with staleness logic).
+    // Skip index.html for ISG routes — those go through the staleness check below.
     if (staticDir && request.method === "GET") {
       const staticResult = await resolveStaticFile(staticDir, url.pathname, isgManifest);
       if (staticResult) {
@@ -141,7 +139,6 @@ export function createNodeRequestHandler<TContext = unknown>(
       }
     }
 
-    // --- ISG stale-while-revalidate for GET requests ---
     if (
       staticDir &&
       request.method === "GET" &&
@@ -356,8 +353,6 @@ function resolveOrigin(
   if (!trustProxy) {
     return { protocol: socketProtocol, host: socketHost };
   }
-
-  // --- Trusted proxy path ---
 
   // 1. RFC 7239 `Forwarded` header (highest precedence)
   const forwarded = getFirstHeaderValue(req.headers.forwarded);

--- a/packages/cli/src/build-shared.ts
+++ b/packages/cli/src/build-shared.ts
@@ -1,25 +1,9 @@
 import { cpSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 
-import { DEFAULT_SECURITY_HEADERS, VERSION } from "./constants.js";
+import { VERSION } from "./constants.js";
 
 const ROUTE_STATE_REQUEST_HEADER = "x-pracht-route-state-request";
-
-interface HeaderSettable {
-  setHeader(key: string, value: string): void;
-}
-
-export function setDefaultSecurityHeaders(
-  res: HeaderSettable,
-  headers: Record<string, string> = {},
-): void {
-  for (const [key, value] of Object.entries({
-    ...DEFAULT_SECURITY_HEADERS,
-    ...headers,
-  })) {
-    res.setHeader(key, value);
-  }
-}
 
 interface VercelBuildOutputOptions {
   functionName?: string;

--- a/packages/cli/src/commands/generate.ts
+++ b/packages/cli/src/commands/generate.ts
@@ -361,19 +361,16 @@ function generateApi(args: ApiArgs, project: ProjectConfig): GenerateResult {
   };
 }
 
-function buildManifestRouteModuleSource({
-  includeErrorBoundary,
-  includeLoader,
-  includeStaticPaths,
-  routePath,
-  title,
-}: {
+interface RouteModuleParts {
   includeErrorBoundary: boolean;
   includeLoader: boolean;
   includeStaticPaths: boolean;
   routePath: string;
   title: string;
-}): string {
+}
+
+function buildRouteModuleSections(opts: RouteModuleParts): string[] {
+  const { includeErrorBoundary, includeLoader, includeStaticPaths, routePath, title } = opts;
   const params = dynamicParamNames(routePath);
   const imports: string[] = [];
   const sections: string[] = [];
@@ -408,8 +405,6 @@ function buildManifestRouteModuleSource({
     );
   }
 
-  sections.push("export function head() {", `  return { title: ${quote(title)} };`, "}", "");
-
   if (includeLoader) {
     sections.push(
       "export function Component({ data }: RouteComponentProps<typeof loader>) {",
@@ -441,92 +436,35 @@ function buildManifestRouteModuleSource({
       "}",
     );
   }
+
+  return sections;
+}
+
+function buildManifestRouteModuleSource(opts: RouteModuleParts): string {
+  const sections = buildRouteModuleSections(opts);
+
+  // Insert head() before the Component export (after loader/getStaticPaths)
+  const componentIdx = sections.findIndex((s) => s.startsWith("export function Component"));
+  const insertAt = componentIdx === -1 ? sections.length : componentIdx;
+  sections.splice(
+    insertAt,
+    0,
+    "export function head() {",
+    `  return { title: ${quote(opts.title)} };`,
+    "}",
+    "",
+  );
 
   return `${sections.join("\n")}\n`;
 }
 
-function buildPagesRouteModuleSource({
-  includeErrorBoundary,
-  includeLoader,
-  includeStaticPaths,
-  render,
-  routePath,
-  title,
-}: {
-  includeErrorBoundary: boolean;
-  includeLoader: boolean;
-  includeStaticPaths: boolean;
-  render: string;
-  routePath: string;
-  title: string;
-}): string {
-  const params = dynamicParamNames(routePath);
-  const imports: string[] = [];
-  const sections: string[] = [];
+function buildPagesRouteModuleSource(opts: RouteModuleParts & { render: string }): string {
+  const sections = buildRouteModuleSections(opts);
 
-  if (includeLoader) {
-    imports.push("LoaderArgs", "RouteComponentProps");
-  }
-  if (includeErrorBoundary) {
-    imports.push("ErrorBoundaryProps");
-  }
-
-  if (imports.length > 0) {
-    sections.push(`import type { ${imports.join(", ")} } from "@pracht/core";`);
-    sections.push("");
-  }
-
-  sections.push(`export const RENDER_MODE = ${quote(render)};`, "");
-
-  if (includeLoader) {
-    sections.push(
-      "export async function loader(_args: LoaderArgs) {",
-      `  return { message: ${quote(`Welcome to ${title}.`)} };`,
-      "}",
-      "",
-    );
-  }
-
-  if (includeStaticPaths) {
-    sections.push(
-      "export function getStaticPaths() {",
-      `  return [${buildStaticPathsStub(params)}];`,
-      "}",
-      "",
-    );
-  }
-
-  if (includeLoader) {
-    sections.push(
-      "export function Component({ data }: RouteComponentProps<typeof loader>) {",
-      "  return (",
-      "    <section>",
-      `      <h1>${escapeJsxText(title)}</h1>`,
-      "      <p>{data.message}</p>",
-      "    </section>",
-      "  );",
-      "}",
-    );
-  } else {
-    sections.push(
-      "export function Component() {",
-      "  return (",
-      "    <section>",
-      `      <h1>${escapeJsxText(title)}</h1>`,
-      "    </section>",
-      "  );",
-      "}",
-    );
-  }
-
-  if (includeErrorBoundary) {
-    sections.push(
-      "",
-      "export function ErrorBoundary({ error }: ErrorBoundaryProps) {",
-      "  return <p>{error.message}</p>;",
-      "}",
-    );
-  }
+  // Insert RENDER_MODE before the first exported declaration (after imports)
+  const firstExportIdx = sections.findIndex((s) => s.startsWith("export"));
+  const insertAt = firstExportIdx === -1 ? sections.length : firstExportIdx;
+  sections.splice(insertAt, 0, `export const RENDER_MODE = ${quote(opts.render)};`, "");
 
   return `${sections.join("\n")}\n`;
 }

--- a/packages/cli/src/commands/inspect.ts
+++ b/packages/cli/src/commands/inspect.ts
@@ -1,4 +1,4 @@
-import { readFileSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import { resolve } from "node:path";
 
 import { defineCommand } from "citty";
@@ -85,9 +85,7 @@ async function runInspect(root: string, { target = "all" } = {}): Promise<Inspec
 
   if (project.mode === "manifest") {
     const manifestPath = resolveProjectPath(project.root, project.appFile);
-    try {
-      readFileSync(manifestPath, "utf-8");
-    } catch {
+    if (!existsSync(manifestPath)) {
       throw new Error(`App manifest is missing at ${project.appFile}.`);
     }
   }

--- a/packages/cli/src/constants.ts
+++ b/packages/cli/src/constants.ts
@@ -1,10 +1,6 @@
-export const DEFAULT_SECURITY_HEADERS: Record<string, string> = {
-  "permissions-policy":
-    "accelerometer=(), camera=(), geolocation=(), gyroscope=(), magnetometer=(), microphone=(), payment=(), usb=()",
-  "referrer-policy": "strict-origin-when-cross-origin",
-  "x-content-type-options": "nosniff",
-  "x-frame-options": "SAMEORIGIN",
-};
+import type { HttpMethod } from "@pracht/core";
+
+export type { HttpMethod };
 
 export const VERSION = "0.0.0";
 
@@ -18,8 +14,6 @@ export const PROJECT_DEFAULTS = {
   serverDir: "/src/server",
   shellsDir: "/src/shells",
 };
-
-export type HttpMethod = "GET" | "POST" | "PUT" | "PATCH" | "DELETE" | "HEAD" | "OPTIONS";
 
 export const HTTP_METHODS = new Set<HttpMethod>([
   "GET",

--- a/packages/cli/src/project.ts
+++ b/packages/cli/src/project.ts
@@ -56,7 +56,7 @@ export function resolveRouteModulePath(
   routePath: string,
   extension: string,
 ): { absolutePath: string; relativePath: string } {
-  const segments = segmentsFromRoutePath(routePath);
+  const segments = segmentsFromPath(routePath);
   const relativePath =
     segments.length === 0 ? `index${extension}` : `${segments.join("/")}${extension}`;
   const absolutePath = resolve(resolveProjectPath(project.root, project.routesDir), relativePath);
@@ -68,7 +68,7 @@ export function resolvePagesRouteModulePath(
   routePath: string,
   extension: string,
 ): { absolutePath: string; relativePath: string } {
-  const segments = segmentsFromRoutePath(routePath);
+  const segments = segmentsFromPath(routePath);
   const relativePath =
     segments.length === 0 ? `index${extension}` : `${segments.join("/")}${extension}`;
   const absolutePath = resolve(resolveProjectPath(project.root, project.pagesDir), relativePath);
@@ -79,7 +79,7 @@ export function resolveApiModulePath(
   project: ProjectConfig,
   endpointPath: string,
 ): { absolutePath: string; relativePath: string } {
-  const segments = segmentsFromApiPath(endpointPath);
+  const segments = segmentsFromPath(endpointPath);
   const relativePath = segments.length === 0 ? "index.ts" : `${segments.join("/")}.ts`;
   const absolutePath = resolve(resolveProjectPath(project.root, project.apiDir), relativePath);
   return { absolutePath, relativePath };
@@ -148,19 +148,8 @@ function normalizeConfigPath(value: string): string {
   return value.startsWith("/") ? value : `/${value}`;
 }
 
-function segmentsFromRoutePath(routePath: string): string[] {
-  return routePath
-    .split("/")
-    .filter(Boolean)
-    .map((segment) => {
-      if (segment.startsWith(":")) return `[${segment.slice(1)}]`;
-      if (segment === "*") return "[...slug]";
-      return segment;
-    });
-}
-
-function segmentsFromApiPath(endpointPath: string): string[] {
-  return endpointPath
+function segmentsFromPath(path: string): string[] {
+  return path
     .split("/")
     .filter(Boolean)
     .map((segment) => {

--- a/packages/framework/README.md
+++ b/packages/framework/README.md
@@ -37,7 +37,7 @@ metadata for the failure phase and matched framework files when available.
 - `startApp()` — client-side hydration and runtime
 - `useLocation()` — access the current pathname and search string separately
 - `useRouteData()` — access loader data inside a route component
-- `useRevalidateRoute()` — trigger a revalidation of the current route's data
+- `useRevalidate()` — trigger a revalidation of the current route's data
 - `<Form>` — progressive enhancement form component
 
 ### Types

--- a/packages/framework/src/app.ts
+++ b/packages/framework/src/app.ts
@@ -300,10 +300,6 @@ export function buildPathFromSegments(segments: RouteSegment[], params: RoutePar
   return normalizeRoutePath("/" + parts.join("/"));
 }
 
-// ---------------------------------------------------------------------------
-// API Routes — file-based auto-discovery
-// ---------------------------------------------------------------------------
-
 /**
  * Convert a list of file paths from `import.meta.glob` into resolved API routes.
  *

--- a/packages/framework/src/index.ts
+++ b/packages/framework/src/index.ts
@@ -22,7 +22,6 @@ export {
   useLocation,
   useParams,
   useRevalidate,
-  useRevalidateRoute,
   useRouteData,
   PrachtRuntimeProvider,
 } from "./runtime.ts";

--- a/packages/framework/src/router.ts
+++ b/packages/framework/src/router.ts
@@ -1,19 +1,19 @@
 import { createContext, h } from "preact";
 import { hydrate, render } from "preact";
 import { useContext, useMemo, useState } from "preact/hooks";
-import type { FunctionComponent, VNode } from "preact";
+import type { FunctionComponent } from "preact";
 
 import { matchAppRoute } from "./app.ts";
 import { markHydrating } from "./hydration.ts";
 import { getCachedRouteState, setupPrefetching } from "./prefetch.ts";
 import type { ModuleWarmFn } from "./prefetch.ts";
-import type { ResolvedPrachtApp, RouteMatch, RouteParams } from "./types.ts";
-import { fetchPrachtRouteState, PrachtRuntimeProvider } from "./runtime.ts";
+import type { ResolvedPrachtApp, RouteMatch, RouteModule, RouteParams, ShellModule } from "./types.ts";
+import { deserializeRouteError, fetchPrachtRouteState, PrachtRuntimeProvider } from "./runtime.ts";
 import type { SerializedRouteError, PrachtHydrationState } from "./runtime.ts";
 
 interface RouteRenderState {
   Shell: FunctionComponent | null;
-  Component: FunctionComponent<any>;
+  Component: FunctionComponent;
   componentProps: Record<string, unknown>;
   data: unknown;
   params: RouteParams;
@@ -29,7 +29,7 @@ declare global {
   }
 }
 
-type ModuleMap = Record<string, () => Promise<any>>;
+type ModuleMap = Record<string, () => Promise<unknown>>;
 
 export type NavigateFn = (to: string, options?: { replace?: boolean }) => Promise<void>;
 
@@ -57,13 +57,9 @@ export interface InitClientRouterOptions {
 export async function initClientRouter(options: InitClientRouterOptions): Promise<void> {
   const { app, routeModules, shellModules, root, findModuleKey } = options;
 
-  // ------------------------------------------------------------------
-  // Module cache — avoids re-importing the same shell/route chunk
-  // ------------------------------------------------------------------
+  const moduleCache = new Map<string, Promise<unknown>>();
 
-  const moduleCache = new Map<string, Promise<any>>();
-
-  function loadModule(modules: ModuleMap, key: string): Promise<any> {
+  function loadModule(modules: ModuleMap, key: string): Promise<unknown> {
     let cached = moduleCache.get(key);
     if (!cached) {
       cached = modules[key]();
@@ -72,22 +68,18 @@ export async function initClientRouter(options: InitClientRouterOptions): Promis
     return cached;
   }
 
-  function startRouteImport(match: RouteMatch): Promise<any> | null {
+  function startRouteImport(match: RouteMatch): Promise<unknown> | null {
     const routeKey = findModuleKey(routeModules, match.route.file);
     if (!routeKey) return null;
     return loadModule(routeModules, routeKey);
   }
 
-  function startShellImport(match: RouteMatch): Promise<any> | null {
+  function startShellImport(match: RouteMatch): Promise<unknown> | null {
     if (!match.route.shellFile) return null;
     const shellKey = findModuleKey(shellModules, match.route.shellFile);
     if (!shellKey) return null;
     return loadModule(shellModules, shellKey);
   }
-
-  // ------------------------------------------------------------------
-  // Resolve route state (data object, not VNodes)
-  // ------------------------------------------------------------------
 
   let updateRouteState: ((state: RouteRenderState) => void) | null = null;
   let routeStateVersion = 0;
@@ -99,14 +91,14 @@ export async function initClientRouter(options: InitClientRouterOptions): Promis
 
     const { Shell, Component, componentProps, data, params, routeId, url, version } = routeState;
     const componentTree = Shell
-      ? h(Shell as any, null, h(Component as any, componentProps))
-      : h(Component as any, componentProps);
+      ? h(Shell as FunctionComponent<Record<string, unknown>>, null, h(Component as FunctionComponent<Record<string, unknown>>, componentProps))
+      : h(Component as FunctionComponent<Record<string, unknown>>, componentProps);
 
     return h(
-      NavigateContext.Provider as any,
+      NavigateContext.Provider as FunctionComponent<Record<string, unknown>>,
       { value: navigateValue },
       h(
-        PrachtRuntimeProvider as any,
+        PrachtRuntimeProvider as FunctionComponent<Record<string, unknown>>,
         { data, params, routeId, stateVersion: version, url },
         componentTree,
       ),
@@ -218,10 +210,6 @@ export async function initClientRouter(options: InitClientRouterOptions): Promis
     };
   }
 
-  // ------------------------------------------------------------------
-  // Navigate to a new pathname
-  // ------------------------------------------------------------------
-
   async function navigate(
     to: string,
     opts?: { replace?: boolean; _popstate?: boolean },
@@ -298,7 +286,6 @@ export async function initClientRouter(options: InitClientRouterOptions): Promis
       return;
     }
 
-    // Update browser history
     if (!opts?._popstate) {
       if (opts?.replace) {
         history.replaceState(null, "", target.browserUrl);
@@ -307,7 +294,7 @@ export async function initClientRouter(options: InitClientRouterOptions): Promis
       }
     }
 
-    // Update route state — module imports started above are already in-flight
+    // Module imports started above are already in-flight
     const routeState = await resolveRouteState(
       match,
       state,
@@ -322,26 +309,6 @@ export async function initClientRouter(options: InitClientRouterOptions): Promis
       window.location.href = target.browserUrl;
     }
   }
-
-  // ------------------------------------------------------------------
-  // Dev-mode hydration mismatch monitor (Preact options.__m hook)
-  // ------------------------------------------------------------------
-
-  if ((import.meta as any).env?.DEV) {
-    const prev = (options as any).__m;
-    (options as any).__m = (vnode: VNode, s: string) => {
-      const component =
-        typeof vnode.type === "function" ? vnode.type.displayName || vnode.type.name : vnode.type;
-      const message = `Hydration mismatch in <${component || "Unknown"}>: ${s}`;
-      console.warn(`[pracht] ${message}`);
-      appendHydrationWarning(message);
-      if (prev) prev(vnode, s);
-    };
-  }
-
-  // ------------------------------------------------------------------
-  // Initial hydration — includes NavigateContext so useNavigate works
-  // ------------------------------------------------------------------
 
   const initialTarget = resolveBrowserRouteTarget(options.initialState.url);
   const initialRequestUrl = initialTarget?.requestUrl ?? options.initialState.url;
@@ -422,10 +389,6 @@ export async function initClientRouter(options: InitClientRouterOptions): Promis
     }
   }
 
-  // ------------------------------------------------------------------
-  // Global click interception for <a> elements
-  // ------------------------------------------------------------------
-
   document.addEventListener("click", (e: MouseEvent) => {
     const anchor = (e.target as Element).closest?.("a");
     if (!anchor) return;
@@ -460,10 +423,6 @@ export async function initClientRouter(options: InitClientRouterOptions): Promis
     navigate(url.pathname + url.search + url.hash);
   });
 
-  // ------------------------------------------------------------------
-  // Back / forward navigation
-  // ------------------------------------------------------------------
-
   window.addEventListener("popstate", () => {
     navigate(window.location.pathname + window.location.search + window.location.hash, {
       _popstate: true,
@@ -473,82 +432,11 @@ export async function initClientRouter(options: InitClientRouterOptions): Promis
   window.__PRACHT_NAVIGATE__ = navigate;
   window.__PRACHT_ROUTER_READY__ = true;
 
-  // Start prefetching after hydration is complete
   const warmModules: ModuleWarmFn = (match) => {
     startRouteImport(match);
     startShellImport(match);
   };
   setupPrefetching(app, warmModules);
-}
-
-// ---------------------------------------------------------------------------
-// Dev-only: in-page hydration mismatch warning banner
-// ---------------------------------------------------------------------------
-
-const HYDRATION_BANNER_ID = "__pracht_hydration_warnings__";
-
-function appendHydrationWarning(message: string): void {
-  let container = document.getElementById(HYDRATION_BANNER_ID);
-  if (!container) {
-    container = document.createElement("div");
-    container.id = HYDRATION_BANNER_ID;
-    Object.assign(container.style, {
-      position: "fixed",
-      bottom: "0",
-      left: "0",
-      right: "0",
-      maxHeight: "30vh",
-      overflow: "auto",
-      background: "#2d1b00",
-      borderTop: "2px solid #f0ad4e",
-      color: "#ffc107",
-      fontFamily: "ui-monospace, Consolas, monospace",
-      fontSize: "13px",
-      padding: "12px 16px",
-      zIndex: "2147483647",
-    });
-
-    const header = document.createElement("div");
-    Object.assign(header.style, {
-      display: "flex",
-      justifyContent: "space-between",
-      alignItems: "center",
-      marginBottom: "8px",
-    });
-    header.innerHTML = '<strong style="color:#f0ad4e">⚠ Hydration Mismatches</strong>';
-
-    const close = document.createElement("button");
-    close.textContent = "×";
-    Object.assign(close.style, {
-      background: "none",
-      border: "none",
-      color: "#f0ad4e",
-      fontSize: "18px",
-      cursor: "pointer",
-    });
-    close.onclick = () => container!.remove();
-    header.appendChild(close);
-
-    container.appendChild(header);
-    document.body.appendChild(container);
-  }
-
-  const entry = document.createElement("div");
-  entry.textContent = message;
-  Object.assign(entry.style, { padding: "2px 0" });
-  container.appendChild(entry);
-}
-
-function deserializeRouteError(error: SerializedRouteError): Error {
-  const result = new Error(error.message);
-  result.name = error.name;
-  (
-    result as Error & { diagnostics?: SerializedRouteError["diagnostics"]; status?: number }
-  ).status = error.status;
-  (
-    result as Error & { diagnostics?: SerializedRouteError["diagnostics"]; status?: number }
-  ).diagnostics = error.diagnostics;
-  return result;
 }
 
 function resolveBrowserRouteTarget(to: string): BrowserRouteTarget | null {

--- a/packages/framework/src/router.ts
+++ b/packages/framework/src/router.ts
@@ -7,7 +7,13 @@ import { matchAppRoute } from "./app.ts";
 import { markHydrating } from "./hydration.ts";
 import { getCachedRouteState, setupPrefetching } from "./prefetch.ts";
 import type { ModuleWarmFn } from "./prefetch.ts";
-import type { ResolvedPrachtApp, RouteMatch, RouteModule, RouteParams, ShellModule } from "./types.ts";
+import type {
+  ResolvedPrachtApp,
+  RouteMatch,
+  RouteModule,
+  RouteParams,
+  ShellModule,
+} from "./types.ts";
 import { deserializeRouteError, fetchPrachtRouteState, PrachtRuntimeProvider } from "./runtime.ts";
 import type { SerializedRouteError, PrachtHydrationState } from "./runtime.ts";
 
@@ -91,7 +97,11 @@ export async function initClientRouter(options: InitClientRouterOptions): Promis
 
     const { Shell, Component, componentProps, data, params, routeId, url, version } = routeState;
     const componentTree = Shell
-      ? h(Shell as FunctionComponent<Record<string, unknown>>, null, h(Component as FunctionComponent<Record<string, unknown>>, componentProps))
+      ? h(
+          Shell as FunctionComponent<Record<string, unknown>>,
+          null,
+          h(Component as FunctionComponent<Record<string, unknown>>, componentProps),
+        )
       : h(Component as FunctionComponent<Record<string, unknown>>, componentProps);
 
     return h(

--- a/packages/framework/src/router.ts
+++ b/packages/framework/src/router.ts
@@ -7,13 +7,7 @@ import { matchAppRoute } from "./app.ts";
 import { markHydrating } from "./hydration.ts";
 import { getCachedRouteState, setupPrefetching } from "./prefetch.ts";
 import type { ModuleWarmFn } from "./prefetch.ts";
-import type {
-  ResolvedPrachtApp,
-  RouteMatch,
-  RouteModule,
-  RouteParams,
-  ShellModule,
-} from "./types.ts";
+import type { ResolvedPrachtApp, RouteMatch, RouteParams } from "./types.ts";
 import { deserializeRouteError, fetchPrachtRouteState, PrachtRuntimeProvider } from "./runtime.ts";
 import type { SerializedRouteError, PrachtHydrationState } from "./runtime.ts";
 

--- a/packages/framework/src/runtime.ts
+++ b/packages/framework/src/runtime.ts
@@ -635,9 +635,7 @@ export async function handlePrachtRequest<TContext>(
     const Comp = Component as FunctionComponent<Record<string, unknown>>;
     const componentProps = { data, params: match.params };
 
-    const componentTree = Shell
-      ? h(Shell, null, h(Comp, componentProps))
-      : h(Comp, componentProps);
+    const componentTree = Shell ? h(Shell, null, h(Comp, componentProps)) : h(Comp, componentProps);
 
     const tree = h(
       PrachtRuntimeProvider as FunctionComponent<Record<string, unknown>>,
@@ -1081,13 +1079,26 @@ async function renderRouteErrorResponse<TContext>(options: {
   );
   const renderToString = await getRenderToStringAsync();
 
-  const ErrorBoundary = options.routeModule.ErrorBoundary as unknown as FunctionComponent<{ error: Error }>;
-  const Shell = shellModule?.Shell as unknown as FunctionComponent<{ children?: ComponentChildren }> | undefined;
+  const ErrorBoundary = options.routeModule.ErrorBoundary as unknown as FunctionComponent<{
+    error: Error;
+  }>;
+  const Shell = shellModule?.Shell as unknown as
+    | FunctionComponent<{ children?: ComponentChildren }>
+    | undefined;
   const errorValue = deserializeRouteError(routeErrorWithDiagnostics);
   const componentTree = Shell
     ? h(Shell, null, h(ErrorBoundary, { error: errorValue }))
     : h(ErrorBoundary, { error: errorValue });
-  const tree = h(PrachtRuntimeProvider as unknown as FunctionComponent<{ data: null; routeId: string; url: string; children?: ComponentChildren }>, { data: null, routeId: options.routeId, url: options.requestPath }, componentTree);
+  const tree = h(
+    PrachtRuntimeProvider as unknown as FunctionComponent<{
+      data: null;
+      routeId: string;
+      url: string;
+      children?: ComponentChildren;
+    }>,
+    { data: null, routeId: options.routeId, url: options.requestPath },
+    componentTree,
+  );
   const body = await renderToString(tree);
 
   return htmlResponse(

--- a/packages/framework/src/runtime.ts
+++ b/packages/framework/src/runtime.ts
@@ -1,8 +1,8 @@
 import { createContext, h } from "preact";
-import type { ComponentChildren, JSX } from "preact";
+import type { ComponentChildren, FunctionComponent, JSX } from "preact";
 import { useContext, useEffect, useMemo, useState } from "preact/hooks";
 
-import { matchApiRoute, matchAppRoute } from "./app.ts";
+import { buildPathFromSegments, matchApiRoute, matchAppRoute, resolveApp } from "./app.ts";
 import type {
   ApiRouteArgs,
   ApiRouteModule,
@@ -68,10 +68,8 @@ export interface HandlePrachtRequestOptions<TContext = unknown> {
   /** Expose raw server error details in rendered HTML and route-state JSON. */
   debugErrors?: boolean;
   clientEntryUrl?: string;
-  /** Per-source-file CSS map produced by the vite plugin (preferred over cssUrls). */
+  /** Per-source-file CSS map produced by the vite plugin. */
   cssManifest?: Record<string, string[]>;
-  /** @deprecated Pass cssManifest instead for per-page CSS resolution. */
-  cssUrls?: string[];
   /** Per-source-file JS chunk map produced by the vite plugin for modulepreload hints. */
   jsManifest?: Record<string, string[]>;
   apiRoutes?: ResolvedApiRoute[];
@@ -132,8 +130,6 @@ export function PrachtRuntimeProvider<TData>({
   stateVersion?: number;
   url: string;
 }) {
-  // TODO: make signal with getter to reduce
-  // re-renders caused by the framework itself.
   const [routeDataState, setRouteDataState] = useState({
     data,
     stateVersion,
@@ -199,13 +195,9 @@ export function readHydrationState<TData = unknown>(): PrachtHydrationState<TDat
     return undefined;
   }
 
-  try {
-    const state = JSON.parse(raw) as PrachtHydrationState<TData>;
-    window.__PRACHT_STATE__ = state as PrachtHydrationState;
-    return state;
-  } catch {
-    return undefined;
-  }
+  const state = JSON.parse(raw) as PrachtHydrationState<TData>;
+  window.__PRACHT_STATE__ = state as PrachtHydrationState;
+  return state;
 }
 
 export function useRouteData<TData = unknown>(): TData {
@@ -252,9 +244,6 @@ export function useRevalidate() {
     return result.data;
   };
 }
-
-/** @deprecated Use useRevalidate instead. */
-export const useRevalidateRoute = useRevalidate;
 
 export function Form(props: FormProps) {
   const { onSubmit, method, ...rest } = props;
@@ -370,7 +359,6 @@ export async function handlePrachtRequest<TContext>(
     options.request.headers.get(ROUTE_STATE_REQUEST_HEADER) === "1" || hasDataParam;
   const exposeDiagnostics = shouldExposeServerErrors(options);
 
-  // --- API route dispatch (before page routes) ---
   if (options.apiRoutes?.length) {
     const apiMatch = matchApiRoute(options.apiRoutes, url.pathname);
     if (apiMatch) {
@@ -422,7 +410,7 @@ export async function handlePrachtRequest<TContext>(
           context: middlewareResult.context,
           signal: AbortSignal.timeout(30_000),
           url,
-          route: apiMatch.route as any,
+          route: apiMatch.route,
         };
 
         return withDefaultSecurityHeaders(await handler(apiRouteArgs));
@@ -559,19 +547,16 @@ export async function handlePrachtRequest<TContext>(
       context: middlewareResult.context,
     };
 
-    // --- Load route module ---
     currentPhase = "render";
     routeModule = await routeModulePromise;
     if (!routeModule) {
       throw new Error("Route module not found");
     }
 
-    // --- Resolve loader from separate data module or route module ---
     currentPhase = "loader";
     const { loader, loaderFile: resolvedLoaderFile } = await dataFunctionsPromise;
     loaderFile = resolvedLoaderFile;
 
-    // --- Execute loader ---
     const loaderResult = loader ? await loader(routeArgs) : undefined;
 
     // Allow loaders to return a Response directly (e.g. for redirects)
@@ -581,18 +566,15 @@ export async function handlePrachtRequest<TContext>(
 
     const data = loaderResult;
 
-    // --- Route state request (client navigation): return JSON ---
     if (isRouteStateRequest) {
       return withRouteResponseHeaders(Response.json({ data }), { isRouteStateRequest: true });
     }
 
-    // --- Load shell module ---
     // Shell import was kicked off up front; this await is usually already
     // resolved by the time we get here (it runs in parallel with the loader).
     currentPhase = "render";
     shellModule = await shellModulePromise;
 
-    // --- Merge document metadata ---
     // head and document headers are independent; run them concurrently.
     const [head, documentHeaders] = await Promise.all([
       mergeHeadMetadata(shellModule, routeModule, routeArgs, data),
@@ -602,13 +584,12 @@ export async function handlePrachtRequest<TContext>(
     const cssUrls = resolvePageCssUrls(options, match.route.shellFile, match.route.file);
     const modulePreloadUrls = resolvePageJsUrls(options, match.route.shellFile, match.route.file);
 
-    // --- SPA mode: render shell chrome / loading state, but keep route component client-only ---
     if (match.route.render === "spa") {
       let body = "";
 
       if (shellModule?.Shell || shellModule?.Loading) {
-        const Shell = shellModule?.Shell as any;
-        const Loading = shellModule?.Loading as any;
+        const Shell = shellModule?.Shell as FunctionComponent | undefined;
+        const Loading = shellModule?.Loading as FunctionComponent | undefined;
         const loadingTree =
           Shell != null
             ? h(Shell, null, Loading ? h(Loading, null) : null)
@@ -643,23 +624,23 @@ export async function handlePrachtRequest<TContext>(
       );
     }
 
-    // --- SSR / SSG / ISG: render Preact tree to string ---
     const DefaultComponent =
       typeof routeModule.default === "function" ? routeModule.default : undefined;
-    const Component = (routeModule.Component ?? DefaultComponent) as any;
+    const Component = (routeModule.Component ?? DefaultComponent) as FunctionComponent | undefined;
     if (!Component) {
       throw new Error("Route has no Component or default export");
     }
 
-    const Shell = shellModule?.Shell;
+    const Shell = shellModule?.Shell as FunctionComponent<Record<string, unknown>> | undefined;
+    const Comp = Component as FunctionComponent<Record<string, unknown>>;
     const componentProps = { data, params: match.params };
 
     const componentTree = Shell
-      ? h(Shell, null, h(Component, componentProps))
-      : h(Component, componentProps);
+      ? h(Shell, null, h(Comp, componentProps))
+      : h(Comp, componentProps);
 
     const tree = h(
-      PrachtRuntimeProvider as any,
+      PrachtRuntimeProvider as FunctionComponent<Record<string, unknown>>,
       {
         data,
         params: match.params,
@@ -706,27 +687,16 @@ export async function handlePrachtRequest<TContext>(
 }
 
 function parseLocation(value: string): Location {
-  try {
-    const url = new URL(value, "http://pracht.local");
-    return {
-      pathname: url.pathname,
-      search: url.search,
-    };
-  } catch {
-    return {
-      pathname: value || "/",
-      search: "",
-    };
-  }
+  const url = new URL(value, "http://pracht.local");
+  return {
+    pathname: url.pathname,
+    search: url.search,
+  };
 }
 
 function getRequestPath(url: URL): string {
   return `${url.pathname}${url.search}`;
 }
-
-// ---------------------------------------------------------------------------
-// Internal helpers
-// ---------------------------------------------------------------------------
 
 /** Strip leading `./` and `/` so all module paths share one canonical form. */
 function normalizeModulePath(path: string): string {
@@ -774,25 +744,30 @@ function resolveManifestEntries(
   return undefined;
 }
 
+function resolvePageUrlsFromManifest(
+  manifest: Record<string, string[]>,
+  shellFile: string | undefined,
+  routeFile: string,
+): string[] {
+  const urls = new Set<string>();
+  const add = (file: string): void => {
+    const entries = resolveManifestEntries(manifest, file);
+    if (entries) {
+      for (const url of entries) urls.add(url);
+    }
+  };
+  if (shellFile) add(shellFile);
+  add(routeFile);
+  return [...urls];
+}
+
 function resolvePageCssUrls(
   options: HandlePrachtRequestOptions<unknown>,
   shellFile: string | undefined,
   routeFile: string,
 ): string[] {
-  if (!options.cssManifest) return options.cssUrls ?? [];
-
-  const css = new Set<string>();
-
-  function addFromManifest(file: string): void {
-    const entries = resolveManifestEntries(options.cssManifest!, file);
-    if (entries) {
-      for (const c of entries) css.add(c);
-    }
-  }
-
-  if (shellFile) addFromManifest(shellFile);
-  addFromManifest(routeFile);
-  return [...css];
+  if (!options.cssManifest) return [];
+  return resolvePageUrlsFromManifest(options.cssManifest, shellFile, routeFile);
 }
 
 function resolvePageJsUrls(
@@ -801,19 +776,7 @@ function resolvePageJsUrls(
   routeFile: string,
 ): string[] {
   if (!options.jsManifest) return [];
-
-  const js = new Set<string>();
-
-  function addFromManifest(file: string): void {
-    const entries = resolveManifestEntries(options.jsManifest!, file);
-    if (entries) {
-      for (const j of entries) js.add(j);
-    }
-  }
-
-  if (shellFile) addFromManifest(shellFile);
-  addFromManifest(routeFile);
-  return [...js];
+  return resolvePageUrlsFromManifest(options.jsManifest, shellFile, routeFile);
 }
 
 async function navigateToClientLocation(
@@ -946,7 +909,7 @@ function normalizeRouteError(
   };
 }
 
-function deserializeRouteError(error: SerializedRouteError): Error {
+export function deserializeRouteError(error: SerializedRouteError): Error {
   const result = new Error(error.message);
   result.name = error.name;
   (result as Error & { diagnostics?: PrachtRuntimeDiagnostics; status?: number }).status =
@@ -1118,21 +1081,13 @@ async function renderRouteErrorResponse<TContext>(options: {
   );
   const renderToString = await getRenderToStringAsync();
 
-  const ErrorBoundary = options.routeModule.ErrorBoundary as any;
-  const Shell = shellModule?.Shell;
+  const ErrorBoundary = options.routeModule.ErrorBoundary as unknown as FunctionComponent<{ error: Error }>;
+  const Shell = shellModule?.Shell as unknown as FunctionComponent<{ children?: ComponentChildren }> | undefined;
   const errorValue = deserializeRouteError(routeErrorWithDiagnostics);
   const componentTree = Shell
     ? h(Shell, null, h(ErrorBoundary, { error: errorValue }))
     : h(ErrorBoundary, { error: errorValue });
-  const tree = h(
-    PrachtRuntimeProvider as any,
-    {
-      data: null,
-      routeId: options.routeId,
-      url: options.requestPath,
-    },
-    componentTree,
-  );
+  const tree = h(PrachtRuntimeProvider as unknown as FunctionComponent<{ data: null; routeId: string; url: string; children?: ComponentChildren }>, { data: null, routeId: options.routeId, url: options.requestPath }, componentTree);
   const body = await renderToString(tree);
 
   return htmlResponse(
@@ -1492,10 +1447,6 @@ function serializeJsonForHtml(value: unknown): string {
     .replace(/\u2029/g, "\\u2029");
 }
 
-// ---------------------------------------------------------------------------
-// SSG Prerendering
-// ---------------------------------------------------------------------------
-
 export interface PrerenderResult {
   path: string;
   html: string;
@@ -1515,12 +1466,10 @@ export interface PrerenderAppOptions {
   app: PrachtApp;
   registry?: ModuleRegistry;
   clientEntryUrl?: string;
-  /** Per-source-file CSS map produced by the vite plugin (preferred over cssUrls). */
+  /** Per-source-file CSS map produced by the vite plugin. */
   cssManifest?: Record<string, string[]>;
   /** Per-source-file JS map produced by the vite plugin for modulepreload hints. */
   jsManifest?: Record<string, string[]>;
-  /** @deprecated Pass cssManifest instead for per-page CSS resolution. */
-  cssUrls?: string[];
 }
 
 export async function prerenderApp(options: PrerenderAppOptions): Promise<PrerenderResult[]>;
@@ -1530,7 +1479,6 @@ export async function prerenderApp(
 export async function prerenderApp(
   options: PrerenderAppOptions & { withISGManifest?: boolean },
 ): Promise<PrerenderResult[] | PrerenderAppResult> {
-  const { resolveApp } = await import("./app.ts");
   const resolved = resolveApp(options.app);
   const results: PrerenderResult[] = [];
   const isgManifest: Record<string, ISGManifestEntry> = {};
@@ -1620,7 +1568,6 @@ async function collectSSGPaths(
     return [];
   }
 
-  const { buildPathFromSegments } = await import("./app.ts");
   const paramSets = await routeModule.getStaticPaths();
   return paramSets.map((params) => buildPathFromSegments(route.segments, params));
 }

--- a/packages/framework/src/types.ts
+++ b/packages/framework/src/types.ts
@@ -39,7 +39,9 @@ export type RouteRevalidate = TimeRevalidatePolicy;
 
 export type HttpMethod = "GET" | "POST" | "PUT" | "PATCH" | "DELETE" | "HEAD" | "OPTIONS";
 
-export type ApiRouteArgs<TContext = RegisteredContext> = BaseRouteArgs<TContext>;
+export type ApiRouteArgs<TContext = RegisteredContext> = Omit<BaseRouteArgs<TContext>, "route"> & {
+  route: ResolvedApiRoute;
+};
 
 export type ApiRouteHandler<TContext = RegisteredContext> = (
   args: ApiRouteArgs<TContext>,

--- a/packages/framework/test/hydration.test.ts
+++ b/packages/framework/test/hydration.test.ts
@@ -5,10 +5,6 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import { markHydrating, useIsHydrated, _resetForTesting } from "../src/hydration.ts";
 
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
 let scratch: HTMLDivElement;
 
 function setupScratch() {
@@ -25,10 +21,6 @@ async function flush(): Promise<void> {
   await new Promise<void>((r) => requestAnimationFrame(() => r()));
   await new Promise<void>((r) => setTimeout(r, 0));
 }
-
-// ---------------------------------------------------------------------------
-// Tests
-// ---------------------------------------------------------------------------
 
 describe("useIsHydrated", () => {
   beforeEach(() => {

--- a/packages/vite-plugin/src/index.ts
+++ b/packages/vite-plugin/src/index.ts
@@ -10,7 +10,10 @@ import {
   stripServerOnlyExportsForClient,
 } from "./client-module-transform.ts";
 
+import type { RenderMode } from "@pracht/core";
 import { generatePagesManifestSource, scanPagesDirectory } from "./pages-router.ts";
+
+export type { RenderMode };
 
 export const PRACHT_CLIENT_MODULE_ID = "virtual:pracht/client";
 export const PRACHT_SERVER_MODULE_ID = "virtual:pracht/server";
@@ -111,8 +114,6 @@ function createDefaultNodeAdapter(): PrachtAdapter {
     },
   };
 }
-
-export type RenderMode = "spa" | "ssr" | "ssg" | "isg";
 
 export interface PrachtPluginOptions {
   appFile?: string;
@@ -290,10 +291,6 @@ export async function pracht(options: PrachtPluginOptions = {}): Promise<Plugin[
   return plugins;
 }
 
-// ---------------------------------------------------------------------------
-// Virtual module source generators
-// ---------------------------------------------------------------------------
-
 export function createPrachtClientModuleSource(
   options: PrachtPluginOptions = {},
   buildOptions: { root?: string } = {},
@@ -431,10 +428,6 @@ export function createPrachtRegistryModuleSource(options: PrachtPluginOptions = 
   ].join("\n");
 }
 
-// ---------------------------------------------------------------------------
-// Pages mode: inline app source generation
-// ---------------------------------------------------------------------------
-
 function generatePagesAppInlineSource(
   options: ResolvedPrachtPluginOptions,
   root = process.cwd(),
@@ -448,10 +441,6 @@ function generatePagesAppInlineSource(
   });
   return source;
 }
-
-// ---------------------------------------------------------------------------
-// Dev SSR middleware
-// ---------------------------------------------------------------------------
 
 function createDevSSRMiddleware(
   server: ViteDevServer,

--- a/packages/vite-plugin/src/pages-router.ts
+++ b/packages/vite-plugin/src/pages-router.ts
@@ -1,10 +1,6 @@
 import { readdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
 import { basename, extname, join, relative } from "node:path";
 
-// ---------------------------------------------------------------------------
-// Types
-// ---------------------------------------------------------------------------
-
 export interface ScannedPage {
   absolutePath: string;
   relativePath: string;
@@ -19,10 +15,6 @@ export interface PagesRouterOptions {
   pagesDir: string;
   pagesDefaultRender?: string;
 }
-
-// ---------------------------------------------------------------------------
-// Scanner
-// ---------------------------------------------------------------------------
 
 const PAGE_EXTENSIONS = new Set([".tsx", ".ts", ".jsx", ".js", ".md", ".mdx"]);
 const SHELL_EXTENSIONS = new Set([".tsx", ".ts", ".jsx", ".js"]);
@@ -75,15 +67,8 @@ function scan(dir: string, root: string, pages: ScannedPage[]): void {
   }
 }
 
-// ---------------------------------------------------------------------------
-// File path → route path
-// ---------------------------------------------------------------------------
-
 export function filePathToRoutePath(relativePath: string): string {
-  // Strip extension
   let route = relativePath.replace(/\.(tsx?|jsx?|mdx?)$/, "");
-
-  // Normalize separators
   route = route.replace(/\\/g, "/");
 
   // _app is not a route
@@ -102,10 +87,6 @@ export function filePathToRoutePath(relativePath: string): string {
   return `/${route}`;
 }
 
-// ---------------------------------------------------------------------------
-// Sorting — static first, dynamic, catch-all last
-// ---------------------------------------------------------------------------
-
 export function sortRoutes(pages: ScannedPage[]): ScannedPage[] {
   return [...pages]
     .filter((p) => p.routePath !== "__shell__")
@@ -123,10 +104,6 @@ export function sortRoutes(pages: ScannedPage[]): ScannedPage[] {
     });
 }
 
-// ---------------------------------------------------------------------------
-// Render mode extraction (lightweight static analysis)
-// ---------------------------------------------------------------------------
-
 const RENDER_MODE_RE = /export\s+const\s+RENDER_MODE\s*=\s*["'](\w+)["']/;
 
 function extractRenderMode(source: string): string | undefined {
@@ -134,9 +111,6 @@ function extractRenderMode(source: string): string | undefined {
   return match ? match[1] : undefined;
 }
 
-// ---------------------------------------------------------------------------
-// Manifest generation
-// ---------------------------------------------------------------------------
 
 export function generatePagesManifestSource(
   pages: ScannedPage[],
@@ -151,7 +125,6 @@ export function generatePagesManifestSource(
   // Only used for ejected files; virtual modules must use plain strings.
   const useImport = options.useImportSyntax ?? false;
 
-  // Check if _app exists by scanning for it
   const allFiles = scanAllFiles(pagesDir);
   const appFile = allFiles.find(
     (f) => basename(f, extname(f)) === "_app" && SHELL_EXTENSIONS.has(extname(f)),
@@ -223,10 +196,6 @@ function scanAllFiles(dir: string): string[] {
   }
   return results;
 }
-
-// ---------------------------------------------------------------------------
-// Physical routes file generation (CLI eject)
-// ---------------------------------------------------------------------------
 
 export function generateRoutesFile(
   pagesDir: string,

--- a/packages/vite-plugin/src/pages-router.ts
+++ b/packages/vite-plugin/src/pages-router.ts
@@ -111,7 +111,6 @@ function extractRenderMode(source: string): string | undefined {
   return match ? match[1] : undefined;
 }
 
-
 export function generatePagesManifestSource(
   pages: ScannedPage[],
   options: PagesRouterOptions & { pagesDirPrefix?: string; useImportSyntax?: boolean },


### PR DESCRIPTION
## Summary

8-agent parallel code quality sweep across all packages. Each commit is one concern:

**Deduplication (DRY)**
- `segmentsFromRoutePath` / `segmentsFromApiPath` were byte-for-byte identical → merged into `segmentsFromPath`
- `resolvePageCssUrls` / `resolvePageJsUrls` shared identical manifest-resolution logic → extracted `resolvePageUrlsFromManifest`
- `deserializeRouteError` existed as a private duplicate in both `runtime.ts` and `router.ts` → single export from `runtime.ts`
- Two scaffold builders in `generate.ts` shared ~75% of their body → `buildRouteModuleSections`

**Type consolidation**
- `HttpMethod` and `RenderMode` were re-defined locally in CLI and vite-plugin — now imported from `@pracht/core`

**Dead code**
- `setDefaultSecurityHeaders` / `DEFAULT_SECURITY_HEADERS` — zero callers anywhere in the repo
- Dead DEV-mode hydration mismatch block in `router.ts` — was attaching to the wrong `options` object (the function parameter, not Preact's global `options`), so the hook never fired. Tracked for correct re-implementation in #114

**Deprecated API removal**
- `cssUrls` option removed from `HandlePrachtRequestOptions`, `PrerenderAppOptions`, and `NodeAdapterOptions` — superseded by `cssManifest`, fallback was unreachable
- `useRevalidateRoute` alias removed — use `useRevalidate`

**Try/catch cleanup**
- `readHydrationState`: dropped catch around `JSON.parse` of framework-generated data — failure should surface as a bug, not silently produce `undefined`
- `parseLocation`: removed dead try/catch around `new URL` — input is always derived from an already-valid `URL` object
- `inspect.ts`: replaced `readFileSync` try/catch with `existsSync` so real I/O errors propagate instead of being swallowed

**Weak types**
- Replaced `FunctionComponent<any>` / `FunctionComponent` with properly typed props at all `h()` call sites in `runtime.ts` and `router.ts`
- `ModuleMap` values and `loadModule` returns typed as `Promise<unknown>` instead of `Promise<any>`
- Circular-dep dynamic imports in `runtime.ts` converted to static (the cycle they were defending against never existed)

**Comments**
- Removed `//---` section banners throughout `runtime.ts`, `router.ts`, `app.ts`, `vite-plugin`, `pages-router.ts`, `adapter-node`, and test files — they restated what the adjacent code obviously does

## Testing

- [ ] `pnpm e2e`
- [ ] `pnpm format`
- [ ] `pnpm lint`
- [ ] `pnpm test`

## Checklist

- [x] Docs updated if needed (ARCHITECTURE.md, ADAPTERS.md, framework/README.md, VISION_MVP.md)
- [ ] Skills updated if needed
- [x] Changeset added if published packages changed (`.changeset/remove-deprecated-css-urls-and-revalidate-route.md`)
