### PR TITLE
Strip server-only route exports from client bundles

### DIFF
--- a/.changeset/client-route-loader-split.md
+++ b/.changeset/client-route-loader-split.md
@@ -1,0 +1,6 @@
+---
+"@pracht/vite-plugin": patch
+"@pracht/cli": patch
+---
+
+Strip server-only route and shell exports from client module imports so inline loaders can statically import server-only dependencies without evaluating them in browser bundles.

--- a/docs/DATA_LOADING.md
+++ b/docs/DATA_LOADING.md
@@ -54,6 +54,11 @@ export. Named route exports such as `loader`, `head`, `headers`,
 Loaders **never** run in the browser. This keeps server secrets (DB connections,
 API keys) safe.
 
+For inline loaders, pracht also loads a client-transformed copy of the route
+module in the browser. Server-only route exports such as `loader`, `head`,
+`headers`, and `getStaticPaths` are omitted from that client module, along with
+imports that were only referenced by those exports.
+
 Framework-generated route-state responses add `Vary: x-pracht-route-state-request`
 so caches keep HTML and JSON variants separate. Those JSON responses also default
 to `Cache-Control: no-store` unless your app sets a stricter policy explicitly.

--- a/packages/cli/src/build-metadata.ts
+++ b/packages/cli/src/build-metadata.ts
@@ -2,6 +2,7 @@ import { existsSync, readFileSync } from "node:fs";
 import { resolve } from "node:path";
 
 const MANIFEST_PATHS = ["dist/client/.vite/manifest.json", "dist/.vite/manifest.json"];
+const PRACHT_CLIENT_MODULE_QUERY = "pracht-client";
 
 interface ViteManifestEntry {
   css?: string[];
@@ -70,11 +71,12 @@ export function readClientBuildAssets(root: string = process.cwd()): ClientBuild
     if (!entry.src) continue;
 
     const deps = collectTransitiveDeps(key);
+    const manifestKey = stripPrachtClientModuleQuery(entry.src);
     if (deps.css.length > 0) {
-      cssManifest[key] = deps.css.map((file) => `/${file}`);
+      cssManifest[manifestKey] = deps.css.map((file) => `/${file}`);
     }
     if (deps.js.length > 0) {
-      jsManifest[key] = deps.js.map((file) => `/${file}`);
+      jsManifest[manifestKey] = deps.js.map((file) => `/${file}`);
     }
   }
 
@@ -83,4 +85,17 @@ export function readClientBuildAssets(root: string = process.cwd()): ClientBuild
     cssManifest,
     jsManifest,
   };
+}
+
+function stripPrachtClientModuleQuery(id: string): string {
+  const queryStart = id.indexOf("?");
+  if (queryStart === -1) return id;
+
+  const path = id.slice(0, queryStart);
+  const query = id
+    .slice(queryStart + 1)
+    .split("&")
+    .filter((part) => part !== PRACHT_CLIENT_MODULE_QUERY);
+
+  return query.length > 0 ? `${path}?${query.join("&")}` : path;
 }

--- a/packages/vite-plugin/src/client-module-transform.ts
+++ b/packages/vite-plugin/src/client-module-transform.ts
@@ -1,0 +1,299 @@
+const CLIENT_MODULE_QUERY = "pracht-client";
+const SERVER_ONLY_EXPORTS = new Set(["loader", "head", "headers", "getStaticPaths"]);
+
+type Range = {
+  start: number;
+  end: number;
+};
+
+export const PRACHT_CLIENT_MODULE_QUERY = `?${CLIENT_MODULE_QUERY}`;
+
+export function isPrachtClientModuleId(id: string): boolean {
+  const queryStart = id.indexOf("?");
+  if (queryStart === -1) return false;
+
+  return id
+    .slice(queryStart + 1)
+    .split("&")
+    .includes(CLIENT_MODULE_QUERY);
+}
+
+export function stripPrachtClientModuleQuery(id: string): string {
+  const queryStart = id.indexOf("?");
+  if (queryStart === -1) return id;
+
+  const path = id.slice(0, queryStart);
+  const query = id
+    .slice(queryStart + 1)
+    .split("&")
+    .filter((part) => part !== CLIENT_MODULE_QUERY);
+
+  return query.length > 0 ? `${path}?${query.join("&")}` : path;
+}
+
+export function stripServerOnlyExportsForClient(code: string): string {
+  const withoutDeclarations = removeRanges(code, collectServerOnlyDeclarationRanges(code));
+  const withoutSpecifiers = removeServerOnlyExportSpecifiers(withoutDeclarations);
+  return removeUnusedImports(withoutSpecifiers);
+}
+
+function collectServerOnlyDeclarationRanges(code: string): Range[] {
+  const ranges: Range[] = [];
+
+  const functionRe = /\bexport\s+(?:async\s+)?function\s+([A-Za-z_$][\w$]*)\b/g;
+  for (const match of code.matchAll(functionRe)) {
+    const name = match[1];
+    if (!SERVER_ONLY_EXPORTS.has(name)) continue;
+    ranges.push({
+      start: match.index ?? 0,
+      end: findFunctionDeclarationEnd(code, match.index ?? 0),
+    });
+  }
+
+  const variableRe = /\bexport\s+(?:const|let|var)\s+([A-Za-z_$][\w$]*)\b/g;
+  for (const match of code.matchAll(variableRe)) {
+    const name = match[1];
+    if (!SERVER_ONLY_EXPORTS.has(name)) continue;
+    ranges.push({
+      start: match.index ?? 0,
+      end: findStatementEnd(code, match.index ?? 0),
+    });
+  }
+
+  return ranges;
+}
+
+function removeServerOnlyExportSpecifiers(code: string): string {
+  return code.replace(
+    /\bexport\s+(type\s+)?\{([^}]*)\}(\s+from\s+["'][^"']+["'])?\s*;?/g,
+    (statement, typeKeyword: string | undefined, specifierList: string, fromClause = "") => {
+      if (typeKeyword) return statement;
+
+      const remaining = specifierList
+        .split(",")
+        .map((specifier) => specifier.trim())
+        .filter(Boolean)
+        .filter((specifier) => {
+          const [localName, exportedName = localName] = specifier.split(/\s+as\s+/);
+          return (
+            !SERVER_ONLY_EXPORTS.has(localName.trim()) &&
+            !SERVER_ONLY_EXPORTS.has(exportedName.trim())
+          );
+        });
+
+      if (remaining.length === 0) return "";
+
+      return `export { ${remaining.join(", ")} }${fromClause};`;
+    },
+  );
+}
+
+function removeUnusedImports(code: string): string {
+  const imports = collectImportRanges(code);
+  if (imports.length === 0) return code;
+
+  const codeWithoutImports = removeRanges(code, imports);
+  const removable = imports.filter((range) => {
+    const statement = code.slice(range.start, range.end);
+    if (isSideEffectImport(statement) || isTypeOnlyImport(statement)) return false;
+
+    const localNames = getImportLocalNames(statement);
+    return (
+      localNames.length > 0 &&
+      localNames.every((name) => !isIdentifierUsed(codeWithoutImports, name))
+    );
+  });
+
+  return removeRanges(code, removable);
+}
+
+function collectImportRanges(code: string): Range[] {
+  const ranges: Range[] = [];
+  const importRe = /\bimport\s/g;
+
+  for (const match of code.matchAll(importRe)) {
+    const start = match.index ?? 0;
+    const end = findStatementEnd(code, start);
+    const statement = code.slice(start, end);
+
+    if (isImportDeclaration(statement)) {
+      ranges.push({ start, end });
+    }
+  }
+
+  return ranges;
+}
+
+function isImportDeclaration(statement: string): boolean {
+  return /^import\s+(?:type\s+)?(?:["']|[\s\S]+\s+from\s+["'])/.test(statement.trim());
+}
+
+function isSideEffectImport(statement: string): boolean {
+  return /^import\s+["']/.test(statement.trim());
+}
+
+function isTypeOnlyImport(statement: string): boolean {
+  return /^import\s+type\s+/.test(statement.trim());
+}
+
+function getImportLocalNames(statement: string): string[] {
+  const trimmed = statement.trim().replace(/;$/, "");
+  const fromMatch = /\sfrom\s+["'][^"']+["']$/.exec(trimmed);
+  if (!fromMatch) return [];
+
+  const clause = trimmed.slice("import".length, fromMatch.index).trim();
+  const withoutType = clause.startsWith("type ") ? clause.slice("type ".length).trim() : clause;
+  const names: string[] = [];
+
+  const defaultMatch = /^([A-Za-z_$][\w$]*)\s*(?:,|$)/.exec(withoutType);
+  if (defaultMatch) {
+    names.push(defaultMatch[1]);
+  }
+
+  const namespaceMatch = /\*\s+as\s+([A-Za-z_$][\w$]*)/.exec(withoutType);
+  if (namespaceMatch) {
+    names.push(namespaceMatch[1]);
+  }
+
+  const namedStart = withoutType.indexOf("{");
+  const namedEnd = withoutType.lastIndexOf("}");
+  if (namedStart !== -1 && namedEnd > namedStart) {
+    const namedSpecifiers = withoutType.slice(namedStart + 1, namedEnd).split(",");
+    for (const rawSpecifier of namedSpecifiers) {
+      const specifier = rawSpecifier.trim();
+      if (!specifier) continue;
+
+      const withoutSpecifierType = specifier.startsWith("type ")
+        ? specifier.slice("type ".length).trim()
+        : specifier;
+      const [, localName = withoutSpecifierType] = withoutSpecifierType.split(/\s+as\s+/);
+      const name = localName.trim();
+
+      if (/^[A-Za-z_$][\w$]*$/.test(name)) {
+        names.push(name);
+      }
+    }
+  }
+
+  return names;
+}
+
+function isIdentifierUsed(code: string, name: string): boolean {
+  return new RegExp(`(^|[^A-Za-z0-9_$])${escapeRegExp(name)}(?![A-Za-z0-9_$])`).test(code);
+}
+
+function removeRanges(code: string, ranges: Range[]): string {
+  if (ranges.length === 0) return code;
+
+  return [...ranges]
+    .sort((a, b) => b.start - a.start)
+    .reduce((current, range) => current.slice(0, range.start) + current.slice(range.end), code);
+}
+
+function findFunctionDeclarationEnd(code: string, start: number): number {
+  const paramsStart = code.indexOf("(", start);
+  if (paramsStart === -1) return findStatementEnd(code, start);
+
+  const paramsEnd = findMatchingDelimiterEnd(code, paramsStart, "(", ")");
+  const bodyStart = code.indexOf("{", paramsEnd);
+  if (bodyStart === -1) return findStatementEnd(code, start);
+
+  return findMatchingBraceEnd(code, bodyStart);
+}
+
+function findStatementEnd(code: string, start: number): number {
+  let parenDepth = 0;
+  let bracketDepth = 0;
+  let braceDepth = 0;
+
+  for (let index = start; index < code.length; index += 1) {
+    const skipped = skipIgnoredJavaScript(code, index);
+    if (skipped !== index) {
+      index = skipped - 1;
+      continue;
+    }
+
+    const char = code[index];
+    if (char === "(") parenDepth += 1;
+    else if (char === ")") parenDepth = Math.max(0, parenDepth - 1);
+    else if (char === "[") bracketDepth += 1;
+    else if (char === "]") bracketDepth = Math.max(0, bracketDepth - 1);
+    else if (char === "{") braceDepth += 1;
+    else if (char === "}") braceDepth = Math.max(0, braceDepth - 1);
+    else if (char === ";" && parenDepth === 0 && bracketDepth === 0 && braceDepth === 0) {
+      return index + 1;
+    }
+  }
+
+  return code.length;
+}
+
+function findMatchingBraceEnd(code: string, openBraceIndex: number): number {
+  return findMatchingDelimiterEnd(code, openBraceIndex, "{", "}");
+}
+
+function findMatchingDelimiterEnd(
+  code: string,
+  openDelimiterIndex: number,
+  openDelimiter: string,
+  closeDelimiter: string,
+): number {
+  let depth = 1;
+
+  for (let index = openDelimiterIndex + 1; index < code.length; index += 1) {
+    const skipped = skipIgnoredJavaScript(code, index);
+    if (skipped !== index) {
+      index = skipped - 1;
+      continue;
+    }
+
+    const char = code[index];
+    if (char === openDelimiter) depth += 1;
+    else if (char === closeDelimiter) {
+      depth -= 1;
+      if (depth === 0) return index + 1;
+    }
+  }
+
+  return code.length;
+}
+
+function skipIgnoredJavaScript(code: string, start: number): number {
+  const char = code[start];
+  const next = code[start + 1];
+
+  if (char === "/" && next === "/") {
+    const newline = code.indexOf("\n", start + 2);
+    return newline === -1 ? code.length : newline;
+  }
+
+  if (char === "/" && next === "*") {
+    const commentEnd = code.indexOf("*/", start + 2);
+    return commentEnd === -1 ? code.length : commentEnd + 2;
+  }
+
+  if (char === '"' || char === "'" || char === "`") {
+    return skipQuotedString(code, start, char);
+  }
+
+  return start;
+}
+
+function skipQuotedString(code: string, start: number, quote: string): number {
+  for (let index = start + 1; index < code.length; index += 1) {
+    const char = code[index];
+    if (char === "\\") {
+      index += 1;
+      continue;
+    }
+    if (char === quote) {
+      return index + 1;
+    }
+  }
+
+  return code.length;
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}

--- a/packages/vite-plugin/src/index.ts
+++ b/packages/vite-plugin/src/index.ts
@@ -1,8 +1,14 @@
+import preact from "@preact/preset-vite";
 import { existsSync, readFileSync } from "node:fs";
 import type { IncomingMessage, ServerResponse } from "node:http";
 import { resolve } from "node:path";
-import preact from "@preact/preset-vite";
 import type { Connect, Plugin, ViteDevServer } from "vite";
+import {
+  PRACHT_CLIENT_MODULE_QUERY,
+  isPrachtClientModuleId,
+  stripPrachtClientModuleQuery,
+  stripServerOnlyExportsForClient,
+} from "./client-module-transform.ts";
 
 import { generatePagesManifestSource, scanPagesDirectory } from "./pages-router.ts";
 
@@ -205,6 +211,10 @@ export async function pracht(options: PrachtPluginOptions = {}): Promise<Plugin[
     },
 
     transform(code, id) {
+      if (isPrachtClientModuleId(id)) {
+        return { code: stripServerOnlyExportsForClient(code), map: null };
+      }
+
       // Transform () => import("./path") to "./path" in the app manifest file.
       // This lets users write import() for IDE click-to-navigate while keeping
       // the framework's string-based file resolution intact.
@@ -307,16 +317,21 @@ export function createPrachtClientModuleSource(
     'import { resolveApp, initClientRouter, readHydrationState } from "@pracht/core";',
     appImport,
     "",
-    `const routeModules = import.meta.glob(${JSON.stringify(routeGlob)});`,
-    `const shellModules = import.meta.glob(${JSON.stringify(shellGlob)});`,
+    `const routeModules = import.meta.glob(${JSON.stringify(routeGlob)}, { query: ${JSON.stringify(PRACHT_CLIENT_MODULE_QUERY)} });`,
+    `const shellModules = import.meta.glob(${JSON.stringify(shellGlob)}, { query: ${JSON.stringify(PRACHT_CLIENT_MODULE_QUERY)} });`,
     "",
     "const resolvedApp = resolveApp(app);",
+    "",
+    "function normalizeModuleKey(key) {",
+    '  return key.split("?")[0];',
+    "}",
     "",
     "function findModuleKey(modules, file) {",
     "  if (file in modules) return file;",
     '  const suffix = file.replace(/^\\.\\//,"");',
     "  for (const key of Object.keys(modules)) {",
-    '    if (key.endsWith("/" + suffix) || key.endsWith(suffix)) return key;',
+    "    const normalizedKey = normalizeModuleKey(key);",
+    '    if (normalizedKey.endsWith("/" + suffix) || normalizedKey.endsWith(suffix)) return key;',
     "  }",
     "  return null;",
     "}",
@@ -632,11 +647,12 @@ function readClientBuildAssets(root = process.cwd()): {
   for (const [key, entry] of Object.entries(manifest)) {
     if (!entry.src) continue;
     const deps = collectTransitiveDeps(key);
+    const manifestKey = stripPrachtClientModuleQuery(entry.src);
     if (deps.css.length > 0) {
-      cssManifest[key] = deps.css.map((f) => `/${f}`);
+      cssManifest[manifestKey] = deps.css.map((f) => `/${f}`);
     }
     if (deps.js.length > 0) {
-      jsManifest[key] = deps.js.map((f) => `/${f}`);
+      jsManifest[manifestKey] = deps.js.map((f) => `/${f}`);
     }
   }
 

--- a/packages/vite-plugin/test/client-module-transform.test.ts
+++ b/packages/vite-plugin/test/client-module-transform.test.ts
@@ -1,0 +1,149 @@
+import { mkdtempSync, mkdirSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { build } from "vite";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { pracht } from "../src/index.ts";
+import { stripServerOnlyExportsForClient } from "../src/client-module-transform.ts";
+
+const tempDirs: string[] = [];
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "../../..");
+
+function makeTempProject(): string {
+  const dir = mkdtempSync(join(tmpdir(), "pracht-client-route-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+function readBuiltJs(root: string): string {
+  const assetsDir = join(root, "dist", "assets");
+  return readdirSync(assetsDir)
+    .filter((file) => file.endsWith(".js"))
+    .map((file) => readFileSync(join(assetsDir, file), "utf-8"))
+    .join("\n");
+}
+
+afterEach(() => {
+  while (tempDirs.length > 0) {
+    const dir = tempDirs.pop();
+    if (dir) {
+      rmSync(dir, { force: true, recursive: true });
+    }
+  }
+});
+
+describe("stripServerOnlyExportsForClient", () => {
+  it("removes server-only exports and imports used only by those exports", () => {
+    const source = `
+import serverOnly from "../server-only";
+import { shared } from "../shared";
+import type { LoaderArgs } from "@pracht/core";
+
+export async function loader({ request }: LoaderArgs) {
+  request.headers.get("cookie");
+  return serverOnly();
+}
+
+export function head() {
+  return { title: serverOnly() };
+}
+
+export default function Home() {
+  return <main>{shared}</main>;
+}
+`;
+
+    const transformed = stripServerOnlyExportsForClient(source);
+
+    expect(transformed).not.toContain("../server-only");
+    expect(transformed).not.toContain("function loader");
+    expect(transformed).not.toContain("function head");
+    expect(transformed).not.toContain(": LoaderArgs");
+    expect(transformed).toContain("../shared");
+    expect(transformed).toContain("function Home");
+  });
+});
+
+describe("client route module build", () => {
+  it("excludes imports used only by inline loaders from browser bundles", async () => {
+    const root = makeTempProject();
+    mkdirSync(join(root, "src", "pages"), { recursive: true });
+
+    writeFileSync(
+      join(root, "src", "pages", "index.tsx"),
+      `
+import serverOnly from "../server-only";
+import { shared } from "../shared";
+
+export async function loader() {
+  return serverOnly();
+}
+
+export default function Home() {
+  return <main>{shared}</main>;
+}
+`,
+    );
+    writeFileSync(
+      join(root, "src", "server-only.ts"),
+      'export default function serverOnly() { return "SERVER_ONLY_MARKER"; }\n',
+    );
+    writeFileSync(join(root, "src", "shared.ts"), 'export const shared = "CLIENT_SHARED";\n');
+
+    await build({
+      root,
+      configFile: false,
+      logLevel: "silent",
+      plugins: await pracht({ pagesDir: "/src/pages" }),
+      resolve: {
+        alias: [
+          {
+            find: "@pracht/core",
+            replacement: resolve(repoRoot, "packages/framework/src/index.ts"),
+          },
+          {
+            find: "preact/jsx-dev-runtime",
+            replacement: resolve(
+              repoRoot,
+              "node_modules/preact/jsx-runtime/dist/jsxRuntime.module.js",
+            ),
+          },
+          {
+            find: "preact/jsx-runtime",
+            replacement: resolve(
+              repoRoot,
+              "node_modules/preact/jsx-runtime/dist/jsxRuntime.module.js",
+            ),
+          },
+          {
+            find: "preact/hooks",
+            replacement: resolve(repoRoot, "node_modules/preact/hooks/dist/hooks.module.js"),
+          },
+          {
+            find: "preact/devtools",
+            replacement: resolve(repoRoot, "node_modules/preact/devtools/dist/devtools.module.js"),
+          },
+          {
+            find: "preact/debug",
+            replacement: resolve(repoRoot, "node_modules/preact/debug/dist/debug.module.js"),
+          },
+          { find: "preact", replacement: resolve(repoRoot, "node_modules/preact/dist/preact.mjs") },
+        ],
+      },
+      build: {
+        outDir: "dist",
+        manifest: true,
+        rollupOptions: {
+          input: "virtual:pracht/client",
+        },
+      },
+    });
+
+    const output = readBuiltJs(root);
+
+    expect(output).toContain("CLIENT_SHARED");
+    expect(output).not.toContain("SERVER_ONLY_MARKER");
+  });
+});


### PR DESCRIPTION
## Summary

- Add a client-module transform for route and shell imports loaded by the browser.
- Strip server-only route exports (`loader`, `head`, `headers`, `getStaticPaths`) from `?pracht-client` modules.
- Remove imports that are only referenced by stripped server-only exports, preventing server-only dependencies from entering browser bundles.
- Normalize `?pracht-client` manifest keys in both the vite plugin and CLI build metadata so route CSS/JS preload injection continues to work.
- Document how inline loaders are omitted from browser route modules.
- Add regression coverage for inline loaders that statically import server-only code.

## Testing

- [x] `pnpm e2e`
- [x] `pnpm format`
- [x] `pnpm lint`
- [x] `pnpm test`

Additional verification run:

- [x] `pnpm run build`
- [x] `pnpm run typecheck`

## Checklist

- [x] Docs updated if needed
- [x] Skills updated if needed
- [x] Changeset added if published packages changed
