### PR TITLE
Copy public/ folder to dist/client/ during build

### DIFF
--- a/.changeset/public-folder-assets.md
+++ b/.changeset/public-folder-assets.md
@@ -1,0 +1,5 @@
+---
+"@pracht/cli": patch
+---
+
+Copy public/ folder contents to dist/client/ during build so that static assets like favicons and robots.txt are available for deployment platforms

--- a/e2e/node-build.test.ts
+++ b/e2e/node-build.test.ts
@@ -1,5 +1,13 @@
 import { execFileSync, spawn } from "node:child_process";
-import { cpSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import {
+  cpSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import { resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -112,6 +120,31 @@ test("pracht build emits a deployable Node server entry", async () => {
     await waitForExit(server);
     rmSync(tempDir, { force: true, recursive: true });
   }
+});
+
+test("public/ folder assets are copied to dist/client/", async () => {
+  test.setTimeout(120_000);
+
+  const { exampleDir, tempDir } = createTempExampleDir("pracht-public-dir-");
+  const distDir = resolve(exampleDir, "dist");
+
+  rmSync(distDir, { force: true, recursive: true });
+
+  const publicDir = resolve(exampleDir, "public");
+  mkdirSync(publicDir, { recursive: true });
+  writeFileSync(resolve(publicDir, "robots.txt"), "User-agent: *\nAllow: /\n", "utf-8");
+  mkdirSync(resolve(publicDir, "icons"), { recursive: true });
+  writeFileSync(resolve(publicDir, "icons/favicon.ico"), "fake-ico", "utf-8");
+
+  buildExample(exampleDir, { PRACHT_ADAPTER: "node" });
+
+  expect(existsSync(resolve(exampleDir, "dist/client/robots.txt"))).toBe(true);
+  expect(readFileSync(resolve(exampleDir, "dist/client/robots.txt"), "utf-8")).toContain(
+    "User-agent",
+  );
+  expect(existsSync(resolve(exampleDir, "dist/client/icons/favicon.ico"))).toBe(true);
+
+  rmSync(tempDir, { force: true, recursive: true });
 });
 
 function createTempExampleDir(prefix: string): { exampleDir: string; tempDir: string } {

--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -53,6 +53,11 @@ export default defineCommand({
       }
     }
 
+    const publicDir = resolve(root, "public");
+    if (existsSync(publicDir)) {
+      cpSync(publicDir, clientDir, { recursive: true });
+    }
+
     if (existsSync(serverEntry)) {
       const serverMod = await import(serverEntry);
       const { prerenderApp } = serverMod;


### PR DESCRIPTION
## Summary

- Explicitly copy `public/` folder contents to `dist/client/` during `pracht build` so favicons and other static assets are reliably included in the deployment output for Vercel, Cloudflare, and Node adapters.
- Adds an E2E test that creates a `public/` folder with nested files and verifies they land in `dist/client/` after the build.
- Ships a patch changeset for `@pracht/cli`.

## Testing

- [x] `pnpm e2e`
- [x] `pnpm format`
- [x] `pnpm lint`
- [x] `pnpm test`

## Checklist

- [x] Docs updated if needed (N/A)
- [x] Skills updated if needed (N/A)
- [x] Changeset added if published packages changed