### PR TITLE
fix(vite-plugin): skip strings when stripping server-only exports

### DIFF
--- a/.changeset/ast-client-module-transform.md
+++ b/.changeset/ast-client-module-transform.md
@@ -1,0 +1,9 @@
+---
+"@pracht/vite-plugin": major
+---
+
+Switch the client-module stripping pass to a Vite 8 Rolldown/Oxc post-transform
+so typed route exports, mixed export declarations, Markdown route modules, and
+local re-export forms are handled without producing invalid client bundles.
+
+This also narrows `@pracht/vite-plugin` to `vite@^8.0.0`.

--- a/.changeset/ast-client-module-transform.md
+++ b/.changeset/ast-client-module-transform.md
@@ -1,9 +1,0 @@
----
-"@pracht/vite-plugin": major
----
-
-Switch the client-module stripping pass to a Vite 8 Rolldown/Oxc post-transform
-so typed route exports, mixed export declarations, Markdown route modules, and
-local re-export forms are handled without producing invalid client bundles.
-
-This also narrows `@pracht/vite-plugin` to `vite@^8.0.0`.

--- a/.changeset/fix-strip-template-literals.md
+++ b/.changeset/fix-strip-template-literals.md
@@ -1,0 +1,5 @@
+---
+"@pracht/vite-plugin": patch
+---
+
+Fix the client-module transform so it no longer matches `export` / `import` patterns inside string or template literals. Previously, source containing code-block strings (e.g. documentation pages embedding `export async function loader` inside a `` `` template) had those fragments stripped, breaking the surrounding string and producing "Unterminated string" build errors.

--- a/.changeset/rolldown-client-strip-safety.md
+++ b/.changeset/rolldown-client-strip-safety.md
@@ -4,4 +4,6 @@
 
 Preserve import/export attributes during partial client-module stripping rewrites
 and correctly prune dead server-only imports when names are shadowed by loop,
-switch, or hoisted `var` bindings.
+switch, catch, parameter, label, or hoisted `var` bindings, or when matching
+identifiers only appear inside meta-property syntax such as `import.meta` and
+`new.target`.

--- a/.changeset/rolldown-client-strip-safety.md
+++ b/.changeset/rolldown-client-strip-safety.md
@@ -1,0 +1,7 @@
+---
+"@pracht/vite-plugin": patch
+---
+
+Preserve import/export attributes during partial client-module stripping rewrites
+and correctly prune dead server-only imports when names are shadowed by loop,
+switch, or hoisted `var` bindings.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,9 @@ jobs:
       - name: Build
         run: pnpm build
 
+      - name: Build examples/docs
+        run: pnpm --filter @pracht/example-docs build
+
       - name: Cache build output
         uses: actions/cache/save@668228422ae6a00e4ad889ee87cd7109ec5666a7
         with:

--- a/docs/DATA_LOADING.md
+++ b/docs/DATA_LOADING.md
@@ -57,7 +57,9 @@ API keys) safe.
 For inline loaders, pracht also loads a client-transformed copy of the route
 module in the browser. Server-only route exports such as `loader`, `head`,
 `headers`, and `getStaticPaths` are omitted from that client module, along with
-imports that were only referenced by those exports.
+imports that were only referenced by those exports. This stripping happens as a
+Vite 8 post-transform pass on Rolldown/Oxc ASTs so it still works after user
+plugins turn Markdown/MDX or TypeScript route files into JavaScript.
 
 Framework-generated route-state responses add `Vary: x-pracht-route-state-request`
 so caches keep HTML and JSON variants separate. Those JSON responses also default

--- a/e2e/client-bundle-strip.test.ts
+++ b/e2e/client-bundle-strip.test.ts
@@ -1,0 +1,131 @@
+import { execFileSync } from "node:child_process";
+import {
+  cpSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { expect, test } from "@playwright/test";
+
+// Regression coverage for https://github.com/JoviDeCroock/pracht/pull/116 —
+// "Strip server-only route exports from client bundles".  Builds a copy of
+// examples/basic with a route whose loader references a distinctive marker
+// string (plus an import only the loader uses) and asserts those markers do
+// NOT survive into the client JS bundle.
+const repoRoot = resolve(fileURLToPath(new URL("..", import.meta.url)));
+const fixtureDir = resolve(repoRoot, "examples/basic");
+const cliEntry = resolve(repoRoot, "packages/cli/bin/pracht.js");
+
+const SERVER_ONLY_MARKER = "SERVER_ONLY_STRIP_MARKER_7f3c";
+const LOADER_BODY_MARKER = "LOADER_BODY_STRIP_MARKER_2a91";
+const COMPONENT_MARKER = "COMPONENT_STRIP_MARKER_b55e";
+
+test("server-only route exports and their imports are stripped from client bundles", async () => {
+  test.setTimeout(120_000);
+
+  const tempRoot = resolve(repoRoot, ".tmp");
+  mkdirSync(tempRoot, { recursive: true });
+  const tempDir = mkdtempSync(resolve(tempRoot, "pracht-client-strip-"));
+  const exampleDir = resolve(tempDir, "project");
+
+  cpSync(fixtureDir, exampleDir, {
+    filter(source) {
+      return ![".vercel", "dist", "test-results"].some((entry) =>
+        source.includes(`/examples/basic/${entry}`),
+      );
+    },
+    recursive: true,
+  });
+
+  try {
+    writeFileSync(
+      resolve(exampleDir, "src/secret.ts"),
+      `export const secretMessage = ${JSON.stringify(SERVER_ONLY_MARKER)};\n`,
+      "utf-8",
+    );
+
+    writeFileSync(
+      resolve(exampleDir, "src/routes/strip-marker.tsx"),
+      [
+        `import type { LoaderArgs, RouteComponentProps } from "@pracht/core";`,
+        `import { secretMessage } from "../secret.ts";`,
+        ``,
+        `export async function loader(_args: LoaderArgs) {`,
+        `  const marker = ${JSON.stringify(LOADER_BODY_MARKER)};`,
+        `  return { marker, secret: secretMessage };`,
+        `}`,
+        ``,
+        `export function Component({ data }: RouteComponentProps<typeof loader>) {`,
+        `  return (`,
+        `    <section>`,
+        `      <h1>${COMPONENT_MARKER}</h1>`,
+        `      <p>{data.marker}</p>`,
+        `    </section>`,
+        `  );`,
+        `}`,
+        ``,
+      ].join("\n"),
+      "utf-8",
+    );
+
+    const routesPath = resolve(exampleDir, "src/routes.ts");
+    const routesSource = readFileSync(routesPath, "utf-8");
+    writeFileSync(
+      routesPath,
+      routesSource.replace(
+        'route("/", () => import("./routes/home.tsx"), { id: "home", render: "ssg" }),',
+        `route("/", () => import("./routes/home.tsx"), { id: "home", render: "ssg" }),\n      route("/strip-marker", () => import("./routes/strip-marker.tsx"), { id: "strip-marker", render: "ssr" }),`,
+      ),
+      "utf-8",
+    );
+
+    execFileSync(process.execPath, [cliEntry, "build"], {
+      cwd: exampleDir,
+      env: {
+        ...process.env,
+        NODE_OPTIONS: "--experimental-strip-types",
+        PRACHT_ADAPTER: "node",
+      },
+      stdio: "pipe",
+    });
+
+    const clientJs = collectJsSource(resolve(exampleDir, "dist/client/assets"));
+    const serverJs = collectJsSource(resolve(exampleDir, "dist/server"));
+
+    // The component body must survive into the client bundle — otherwise the
+    // strip transform has been too aggressive.
+    expect(clientJs).toContain(COMPONENT_MARKER);
+
+    // The loader body and anything imported solely by the loader must not.
+    expect(clientJs).not.toContain(LOADER_BODY_MARKER);
+    expect(clientJs).not.toContain(SERVER_ONLY_MARKER);
+
+    // Sanity: both strings do exist server-side, so the strip isn't just a
+    // silent broken build.
+    expect(serverJs).toContain(LOADER_BODY_MARKER);
+    expect(serverJs).toContain(SERVER_ONLY_MARKER);
+  } finally {
+    rmSync(tempDir, { force: true, recursive: true });
+  }
+});
+
+function collectJsSource(dir: string): string {
+  const entries = readdirSync(dir, { withFileTypes: true, recursive: true });
+  const pieces: string[] = [];
+  for (const entry of entries) {
+    if (!entry.isFile()) continue;
+    if (!entry.name.endsWith(".js") && !entry.name.endsWith(".mjs")) continue;
+    const parent =
+      (entry as unknown as { parentPath?: string; path?: string }).parentPath ??
+      (entry as unknown as { path?: string }).path ??
+      dir;
+    pieces.push(readFileSync(resolve(parent, entry.name), "utf-8"));
+  }
+  return pieces.join("\n");
+}

--- a/examples/docs/vite-plugin-md.ts
+++ b/examples/docs/vite-plugin-md.ts
@@ -286,7 +286,10 @@ export function markdown(): Plugin {
     enforce: "pre",
 
     transform(code, id) {
-      if (!id.endsWith(".md")) return;
+      // Strip query suffix (e.g. `?pracht-client`) before checking extension —
+      // Vite adds queries for glob-imported client variants.
+      const path = id.split("?")[0];
+      if (!path.endsWith(".md")) return;
 
       const { frontmatter, body } = parseFrontmatter(code);
       let contentHtml = marked.parse(body) as string;

--- a/packages/vite-plugin/README.md
+++ b/packages/vite-plugin/README.md
@@ -29,7 +29,7 @@ export default defineConfig({
 
 ## Peer Dependencies
 
-- `vite@^7.0.0 || ^8.0.0`
+- `vite@^8.0.0`
 
 Target-specific Vite plugins (e.g. `@cloudflare/vite-plugin`) are pulled in by
 the adapter package you install (`@pracht/adapter-cloudflare`,

--- a/packages/vite-plugin/package.json
+++ b/packages/vite-plugin/package.json
@@ -39,6 +39,6 @@
     "@prefresh/vite": "^2.0.0"
   },
   "peerDependencies": {
-    "vite": "^7.0.0 || ^8.0.0"
+    "vite": "^8.0.0"
   }
 }

--- a/packages/vite-plugin/src/client-module-transform.ts
+++ b/packages/vite-plugin/src/client-module-transform.ts
@@ -567,8 +567,15 @@ function renderImportDeclaration(code: string, statement: OxcNode, state: Statem
     );
   }
 
-  const importPrefix = statement.importKind === "type" ? "import type " : "import ";
-  return `${importPrefix}${clauseParts.join(", ")} from ${code.slice(statement.source.start, statement.source.end)};`;
+  const importPrefix = ["import"];
+  if (statement.importKind === "type") {
+    importPrefix.push("type");
+  }
+  if (typeof statement.phase === "string" && statement.phase.length > 0) {
+    importPrefix.push(statement.phase);
+  }
+
+  return `${importPrefix.join(" ")} ${clauseParts.join(", ")} from ${code.slice(statement.source.start, statement.end)}`;
 }
 
 function renderExportSpecifiers(code: string, statement: OxcNode, state: StatementState): string {
@@ -577,10 +584,11 @@ function renderExportSpecifiers(code: string, statement: OxcNode, state: Stateme
   );
   if (remaining.length === 0) return "";
 
+  const exportPrefix = statement.exportKind === "type" ? "export type" : "export";
   const sourceSuffix = statement.source
-    ? ` from ${code.slice(statement.source.start, statement.source.end)}`
-    : "";
-  return `export { ${remaining.map((specifier) => code.slice(specifier.start, specifier.end)).join(", ")} }${sourceSuffix};`;
+    ? ` from ${code.slice(statement.source.start, statement.end)}`
+    : ";";
+  return `${exportPrefix} { ${remaining.map((specifier) => code.slice(specifier.start, specifier.end)).join(", ")} }${sourceSuffix}`;
 }
 
 function renderVariableDeclaration(
@@ -742,9 +750,19 @@ function visitNode(
     case "CatchClause":
       visitCatchClause(node, scopeStack, topLevelBindingNames, references, excludedNames);
       return;
+    case "ForStatement":
+      visitForStatement(node, scopeStack, topLevelBindingNames, references, excludedNames);
+      return;
+    case "ForInStatement":
+    case "ForOfStatement":
+      visitForInOrOfStatement(node, scopeStack, topLevelBindingNames, references, excludedNames);
+      return;
     case "ClassDeclaration":
     case "ClassExpression":
       visitClassLike(node, scopeStack, topLevelBindingNames, references, excludedNames);
+      return;
+    case "SwitchStatement":
+      visitSwitchStatement(node, scopeStack, topLevelBindingNames, references, excludedNames);
       return;
     case "JSXElement":
       visitNode(
@@ -903,10 +921,8 @@ function visitFunctionLike(
       scope.add(name);
     }
   }
-  if (node.body?.type === "BlockStatement") {
-    for (const name of collectDirectBindings(node.body.body as OxcNode[])) {
-      scope.add(name);
-    }
+  for (const name of collectFunctionScopedVarBindings(node.body as OxcNode | null)) {
+    scope.add(name);
   }
 
   scopeStack.push(scope);
@@ -924,7 +940,7 @@ function visitBlockStatement(
   references: Set<string>,
   excludedNames: Set<string>,
 ): void {
-  const scope = collectDirectBindings(node.body as OxcNode[]);
+  const scope = collectBlockScopeBindings(node.body as OxcNode[]);
   scopeStack.push(scope);
   for (const statement of node.body as OxcNode[]) {
     visitNode(statement, scopeStack, topLevelBindingNames, references, excludedNames);
@@ -945,7 +961,7 @@ function visitCatchClause(
       scope.add(name);
     }
   }
-  for (const name of collectDirectBindings((node.body as OxcNode).body as OxcNode[])) {
+  for (const name of collectBlockScopeBindings((node.body as OxcNode).body as OxcNode[])) {
     scope.add(name);
   }
 
@@ -960,6 +976,110 @@ function visitCatchClause(
     );
   }
   visitNode(node.body as OxcNode, scopeStack, topLevelBindingNames, references, excludedNames);
+  scopeStack.pop();
+}
+
+function visitForStatement(
+  node: OxcNode,
+  scopeStack: Array<Set<string>>,
+  topLevelBindingNames: Set<string>,
+  references: Set<string>,
+  excludedNames: Set<string>,
+): void {
+  const init = node.init as OxcNode | null;
+  if (init?.type === "VariableDeclaration" && init.kind !== "var") {
+    const scope = new Set(collectBindingNamesFromDeclaration(init));
+    scopeStack.push(scope);
+    visitNode(init, scopeStack, topLevelBindingNames, references, excludedNames);
+    visitNode(
+      node.test as OxcNode | null,
+      scopeStack,
+      topLevelBindingNames,
+      references,
+      excludedNames,
+    );
+    visitNode(
+      node.update as OxcNode | null,
+      scopeStack,
+      topLevelBindingNames,
+      references,
+      excludedNames,
+    );
+    visitNode(node.body as OxcNode, scopeStack, topLevelBindingNames, references, excludedNames);
+    scopeStack.pop();
+    return;
+  }
+
+  visitNode(init, scopeStack, topLevelBindingNames, references, excludedNames);
+  visitNode(
+    node.test as OxcNode | null,
+    scopeStack,
+    topLevelBindingNames,
+    references,
+    excludedNames,
+  );
+  visitNode(
+    node.update as OxcNode | null,
+    scopeStack,
+    topLevelBindingNames,
+    references,
+    excludedNames,
+  );
+  visitNode(node.body as OxcNode, scopeStack, topLevelBindingNames, references, excludedNames);
+}
+
+function visitForInOrOfStatement(
+  node: OxcNode,
+  scopeStack: Array<Set<string>>,
+  topLevelBindingNames: Set<string>,
+  references: Set<string>,
+  excludedNames: Set<string>,
+): void {
+  const left = node.left as OxcNode | null;
+  if (left?.type === "VariableDeclaration" && left.kind !== "var") {
+    const scope = new Set(collectBindingNamesFromDeclaration(left));
+    scopeStack.push(scope);
+    visitNode(left, scopeStack, topLevelBindingNames, references, excludedNames);
+    visitNode(node.right as OxcNode, scopeStack, topLevelBindingNames, references, excludedNames);
+    visitNode(node.body as OxcNode, scopeStack, topLevelBindingNames, references, excludedNames);
+    scopeStack.pop();
+    return;
+  }
+
+  visitNode(left, scopeStack, topLevelBindingNames, references, excludedNames);
+  visitNode(node.right as OxcNode, scopeStack, topLevelBindingNames, references, excludedNames);
+  visitNode(node.body as OxcNode, scopeStack, topLevelBindingNames, references, excludedNames);
+}
+
+function visitSwitchStatement(
+  node: OxcNode,
+  scopeStack: Array<Set<string>>,
+  topLevelBindingNames: Set<string>,
+  references: Set<string>,
+  excludedNames: Set<string>,
+): void {
+  visitNode(
+    node.discriminant as OxcNode,
+    scopeStack,
+    topLevelBindingNames,
+    references,
+    excludedNames,
+  );
+
+  const scope = collectSwitchScopeBindings(node.cases as OxcNode[]);
+  scopeStack.push(scope);
+  for (const switchCase of node.cases as OxcNode[]) {
+    visitNode(
+      switchCase.test as OxcNode | null,
+      scopeStack,
+      topLevelBindingNames,
+      references,
+      excludedNames,
+    );
+    for (const statement of switchCase.consequent as OxcNode[]) {
+      visitNode(statement, scopeStack, topLevelBindingNames, references, excludedNames);
+    }
+  }
   scopeStack.pop();
 }
 
@@ -1059,18 +1179,83 @@ function visitPattern(
   }
 }
 
-function collectDirectBindings(statements: OxcNode[]): Set<string> {
+function collectBlockScopeBindings(statements: OxcNode[]): Set<string> {
   const names = new Set<string>();
 
   for (const statement of statements) {
     const declaration = getStatementDeclaration(statement);
     if (!declaration) continue;
+    if (declaration.type === "VariableDeclaration" && declaration.kind === "var") {
+      continue;
+    }
     for (const name of collectBindingNamesFromDeclaration(declaration)) {
       names.add(name);
     }
   }
 
   return names;
+}
+
+function collectFunctionScopedVarBindings(node: OxcNode | null | undefined): Set<string> {
+  const names = new Set<string>();
+  collectFunctionScopedVarBindingsInto(node, names);
+  return names;
+}
+
+function collectFunctionScopedVarBindingsInto(
+  node: OxcNode | null | undefined,
+  names: Set<string>,
+): void {
+  if (!node) return;
+  if (node.type.startsWith("TS")) return;
+
+  switch (node.type) {
+    case "ArrowFunctionExpression":
+    case "FunctionDeclaration":
+    case "FunctionExpression":
+    case "ClassDeclaration":
+    case "ClassExpression":
+      return;
+    case "VariableDeclaration":
+      if (node.kind === "var") {
+        for (const declarator of node.declarations as OxcNode[]) {
+          for (const name of collectBindingNamesFromPattern(declarator.id as OxcNode)) {
+            names.add(name);
+          }
+        }
+      }
+      return;
+    default:
+      for (const [key, value] of Object.entries(node)) {
+        if (SKIPPED_KEYS.has(key)) continue;
+        if (key === "id" || key === "implements" || key === "superTypeArguments") continue;
+        collectFunctionScopedVarBindingsFromUnknown(value, names);
+      }
+  }
+}
+
+function collectFunctionScopedVarBindingsFromUnknown(value: unknown, names: Set<string>): void {
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      collectFunctionScopedVarBindingsFromUnknown(item, names);
+    }
+    return;
+  }
+
+  if (!isNode(value)) return;
+  collectFunctionScopedVarBindingsInto(value, names);
+}
+
+function collectSwitchScopeBindings(cases: OxcNode[]): Set<string> {
+  const statements: OxcNode[] = [];
+
+  for (const switchCase of cases) {
+    for (const statement of switchCase.consequent as OxcNode[]) {
+      statements.push(statement);
+    }
+  }
+
+  return collectBlockScopeBindings(statements);
 }
 
 function getStatementDeclaration(statement: OxcNode): OxcNode | null {

--- a/packages/vite-plugin/src/client-module-transform.ts
+++ b/packages/vite-plugin/src/client-module-transform.ts
@@ -1,9 +1,51 @@
+import { parseAst } from "vite";
+
 const CLIENT_MODULE_QUERY = "pracht-client";
 const SERVER_ONLY_EXPORTS = new Set(["loader", "head", "headers", "getStaticPaths"]);
+const JSX_COMPONENT_RE = /^[A-Z]/;
+const SKIPPED_KEYS = new Set([
+  "attributes",
+  "decorators",
+  "end",
+  "exportKind",
+  "importKind",
+  "optional",
+  "phase",
+  "raw",
+  "returnType",
+  "start",
+  "superTypeArguments",
+  "type",
+  "typeAnnotation",
+  "typeArguments",
+  "typeParameters",
+  "value",
+]);
 
-type Range = {
-  start: number;
+type RolldownLang = "js" | "jsx" | "ts" | "tsx";
+
+type OxcNode = {
   end: number;
+  start: number;
+  type: string;
+  [key: string]: any;
+};
+
+type StatementState = {
+  node: OxcNode;
+  removed: boolean;
+  removedDeclarators: Set<number>;
+  removedSpecifiers: Set<number>;
+};
+
+type BindingInfo = {
+  declaratorIndex?: number;
+  dependencies: Set<string>;
+  kind: "class" | "function" | "import" | "variable";
+  names: Set<string>;
+  node: OxcNode;
+  specifierIndex?: number;
+  statementIndex: number;
 };
 
 export const PRACHT_CLIENT_MODULE_QUERY = `?${CLIENT_MODULE_QUERY}`;
@@ -31,315 +73,1114 @@ export function stripPrachtClientModuleQuery(id: string): string {
   return query.length > 0 ? `${path}?${query.join("&")}` : path;
 }
 
-export function stripServerOnlyExportsForClient(code: string): string {
-  const masked = maskStringsAndComments(code);
-  const withoutDeclarations = removeRanges(code, collectServerOnlyDeclarationRanges(code, masked));
-  const withoutSpecifiers = removeServerOnlyExportSpecifiers(withoutDeclarations);
-  return removeUnusedImports(withoutSpecifiers);
-}
-
-function collectServerOnlyDeclarationRanges(code: string, masked: string): Range[] {
-  const ranges: Range[] = [];
-
-  const functionRe = /\bexport\s+(?:async\s+)?function\s+([A-Za-z_$][\w$]*)\b/g;
-  for (const match of masked.matchAll(functionRe)) {
-    const name = match[1];
-    if (!SERVER_ONLY_EXPORTS.has(name)) continue;
-    ranges.push({
-      start: match.index ?? 0,
-      end: findFunctionDeclarationEnd(code, match.index ?? 0),
-    });
-  }
-
-  const variableRe = /\bexport\s+(?:const|let|var)\s+([A-Za-z_$][\w$]*)\b/g;
-  for (const match of masked.matchAll(variableRe)) {
-    const name = match[1];
-    if (!SERVER_ONLY_EXPORTS.has(name)) continue;
-    ranges.push({
-      start: match.index ?? 0,
-      end: findStatementEnd(code, match.index ?? 0),
-    });
-  }
-
-  return ranges;
-}
-
-function removeServerOnlyExportSpecifiers(code: string): string {
-  const masked = maskStringsAndComments(code);
-  const pattern = /\bexport\s+(type\s+)?\{([^}]*)\}(\s+from\s+["'][^"']+["'])?\s*;?/g;
-  const edits: Array<{ start: number; end: number; replacement: string }> = [];
-
-  for (const match of masked.matchAll(pattern)) {
-    const start = match.index ?? 0;
-    const end = start + match[0].length;
-    const statement = code.slice(start, end);
-    const typeKeyword = match[1];
-    const specifierList = match[2];
-    const fromClause = match[3] ?? "";
-
-    if (typeKeyword) continue;
-
-    const remaining = specifierList
-      .split(",")
-      .map((specifier) => specifier.trim())
-      .filter(Boolean)
-      .filter((specifier) => {
-        const [localName, exportedName = localName] = specifier.split(/\s+as\s+/);
-        return (
-          !SERVER_ONLY_EXPORTS.has(localName.trim()) &&
-          !SERVER_ONLY_EXPORTS.has(exportedName.trim())
-        );
-      });
-
-    const replacement =
-      remaining.length === 0 ? "" : `export { ${remaining.join(", ")} }${fromClause};`;
-    if (replacement !== statement) {
-      edits.push({ start, end, replacement });
-    }
-  }
-
-  return applyEdits(code, edits);
-}
-
-function removeUnusedImports(code: string): string {
-  const masked = maskStringsAndComments(code);
-  const imports = collectImportRanges(code, masked);
-  if (imports.length === 0) return code;
-
-  const maskedWithoutImports = removeRanges(masked, imports);
-  const removable = imports.filter((range) => {
-    const statement = code.slice(range.start, range.end);
-    if (isSideEffectImport(statement) || isTypeOnlyImport(statement)) return false;
-
-    const localNames = getImportLocalNames(statement);
-    return (
-      localNames.length > 0 &&
-      localNames.every((name) => !isIdentifierUsed(maskedWithoutImports, name))
-    );
-  });
-
-  return removeRanges(code, removable);
-}
-
-function collectImportRanges(code: string, masked: string): Range[] {
-  const ranges: Range[] = [];
-  const importRe = /\bimport\s/g;
-
-  for (const match of masked.matchAll(importRe)) {
-    const start = match.index ?? 0;
-    const end = findStatementEnd(code, start);
-    const statement = code.slice(start, end);
-
-    if (isImportDeclaration(statement)) {
-      ranges.push({ start, end });
-    }
-  }
-
-  return ranges;
-}
-
-function applyEdits(
+export function stripServerOnlyExportsForClient(
   code: string,
-  edits: Array<{ start: number; end: number; replacement: string }>,
+  id = "pracht-client-route.tsx",
 ): string {
-  if (edits.length === 0) return code;
-  return [...edits]
-    .sort((a, b) => b.start - a.start)
-    .reduce(
-      (current, edit) => current.slice(0, edit.start) + edit.replacement + current.slice(edit.end),
-      code,
-    );
+  const program = parseAst(code, { lang: getRolldownLang(id) }) as OxcNode;
+  const states = createStatementStates(program);
+  const initialBindingNames = collectCurrentTopLevelBindingNames(states);
+  const { changed, candidates } = removeServerOnlyExports(states, initialBindingNames);
+
+  if (!changed) return code;
+
+  pruneDeadBindings(states, initialBindingNames, candidates);
+  return renderProgram(code, states);
 }
 
-function maskStringsAndComments(code: string): string {
-  let out = "";
-  let i = 0;
-  while (i < code.length) {
-    const skipped = skipIgnoredJavaScript(code, i);
-    if (skipped !== i) {
-      // Preserve length and newlines so match indices and line numbers stay aligned.
-      for (let j = i; j < skipped; j += 1) {
-        out += code[j] === "\n" ? "\n" : " ";
+function createStatementStates(program: OxcNode): StatementState[] {
+  return (program.body as OxcNode[]).map((node) => ({
+    node,
+    removed: false,
+    removedDeclarators: new Set<number>(),
+    removedSpecifiers: new Set<number>(),
+  }));
+}
+
+function removeServerOnlyExports(
+  states: StatementState[],
+  initialBindingNames: Set<string>,
+): { candidates: Set<string>; changed: boolean } {
+  let changed = false;
+  const candidates = new Set<string>();
+
+  for (const state of states) {
+    const statement = state.node;
+    if (statement.type !== "ExportNamedDeclaration" || statement.exportKind === "type") {
+      continue;
+    }
+
+    const declaration = statement.declaration as OxcNode | null;
+    if (declaration?.type === "FunctionDeclaration") {
+      const name = declaration.id?.name as string | undefined;
+      if (!name || !SERVER_ONLY_EXPORTS.has(name)) continue;
+
+      changed = true;
+      state.removed = true;
+      enqueueDependencies(
+        candidates,
+        collectTopLevelReferences(declaration, initialBindingNames, new Set([name])),
+      );
+      continue;
+    }
+
+    if (declaration?.type === "VariableDeclaration") {
+      const removable = getRemainingDeclaratorIndices(state).filter((index) =>
+        collectBindingNamesFromPattern(declaration.declarations[index].id).some((name) =>
+          SERVER_ONLY_EXPORTS.has(name),
+        ),
+      );
+
+      if (removable.length === 0) continue;
+
+      changed = true;
+      for (const index of removable) {
+        const declarator = declaration.declarations[index] as OxcNode;
+        const declaredNames = new Set(collectBindingNamesFromPattern(declarator.id as OxcNode));
+        enqueueDependencies(
+          candidates,
+          collectVariableDeclaratorDependencies(declarator, initialBindingNames, declaredNames),
+        );
+        state.removedDeclarators.add(index);
       }
-      i = skipped;
-    } else {
-      out += code[i];
-      i += 1;
+
+      if (getRemainingDeclaratorIndices(state).length === 0) {
+        state.removed = true;
+      }
+
+      continue;
+    }
+
+    const removableSpecifiers = getRemainingSpecifierIndices(state).filter((index) => {
+      const specifier = statement.specifiers[index] as OxcNode;
+      if (specifier.type !== "ExportSpecifier" || specifier.exportKind === "type") return false;
+
+      const localName = getIdentifierName(specifier.local as OxcNode | null);
+      const exportedName = getIdentifierName(specifier.exported as OxcNode | null);
+      return (
+        SERVER_ONLY_EXPORTS.has(localName ?? "") || SERVER_ONLY_EXPORTS.has(exportedName ?? "")
+      );
+    });
+
+    if (removableSpecifiers.length === 0) continue;
+
+    changed = true;
+    for (const index of removableSpecifiers) {
+      const specifier = statement.specifiers[index] as OxcNode;
+      if (!statement.source) {
+        const localName = getIdentifierName(specifier.local as OxcNode | null);
+        if (localName) {
+          candidates.add(localName);
+        }
+      }
+      state.removedSpecifiers.add(index);
+    }
+
+    if (getRemainingSpecifierIndices(state).length === 0) {
+      state.removed = true;
     }
   }
-  return out;
+
+  return { changed, candidates };
 }
 
-function isImportDeclaration(statement: string): boolean {
-  return /^import\s+(?:type\s+)?(?:["']|[\s\S]+\s+from\s+["'])/.test(statement.trim());
-}
+function pruneDeadBindings(
+  states: StatementState[],
+  initialBindingNames: Set<string>,
+  candidates: Set<string>,
+): void {
+  let changed = true;
 
-function isSideEffectImport(statement: string): boolean {
-  return /^import\s+["']/.test(statement.trim());
-}
+  while (changed) {
+    changed = false;
 
-function isTypeOnlyImport(statement: string): boolean {
-  return /^import\s+type\s+/.test(statement.trim());
-}
+    const bindings = collectTopLevelBindings(states, initialBindingNames);
+    const topLevelBindingNames = new Set(bindings.keys());
+    const exportedNames = collectExportedBindingNames(states);
+    const referencedNames = collectProgramReferences(states, topLevelBindingNames);
 
-function getImportLocalNames(statement: string): string[] {
-  const trimmed = statement.trim().replace(/;$/, "");
-  const fromMatch = /\sfrom\s+["'][^"']+["']$/.exec(trimmed);
-  if (!fromMatch) return [];
+    const pendingNames = Array.from(candidates);
+    for (const name of pendingNames) {
+      const binding = bindings.get(name);
+      if (!binding) continue;
+      if (exportedNames.has(name) || referencedNames.has(name)) continue;
 
-  const clause = trimmed.slice("import".length, fromMatch.index).trim();
-  const withoutType = clause.startsWith("type ") ? clause.slice("type ".length).trim() : clause;
-  const names: string[] = [];
-
-  const defaultMatch = /^([A-Za-z_$][\w$]*)\s*(?:,|$)/.exec(withoutType);
-  if (defaultMatch) {
-    names.push(defaultMatch[1]);
+      removeBinding(states, binding);
+      enqueueDependencies(candidates, binding.dependencies);
+      changed = true;
+    }
   }
+}
 
-  const namespaceMatch = /\*\s+as\s+([A-Za-z_$][\w$]*)/.exec(withoutType);
-  if (namespaceMatch) {
-    names.push(namespaceMatch[1]);
-  }
+function collectTopLevelBindings(
+  states: StatementState[],
+  dependencyBindingNames: Set<string>,
+): Map<string, BindingInfo> {
+  const bindings = new Map<string, BindingInfo>();
 
-  const namedStart = withoutType.indexOf("{");
-  const namedEnd = withoutType.lastIndexOf("}");
-  if (namedStart !== -1 && namedEnd > namedStart) {
-    const namedSpecifiers = withoutType.slice(namedStart + 1, namedEnd).split(",");
-    for (const rawSpecifier of namedSpecifiers) {
-      const specifier = rawSpecifier.trim();
-      if (!specifier) continue;
+  for (const [statementIndex, state] of states.entries()) {
+    if (state.removed) continue;
 
-      const withoutSpecifierType = specifier.startsWith("type ")
-        ? specifier.slice("type ".length).trim()
-        : specifier;
-      const [, localName = withoutSpecifierType] = withoutSpecifierType.split(/\s+as\s+/);
-      const name = localName.trim();
+    const statement = state.node;
+    if (statement.type === "ImportDeclaration") {
+      if (statement.importKind === "type") continue;
 
-      if (/^[A-Za-z_$][\w$]*$/.test(name)) {
-        names.push(name);
+      for (const index of getRemainingSpecifierIndices(state)) {
+        const specifier = statement.specifiers[index] as OxcNode;
+        if (specifier.type === "ImportSpecifier" && specifier.importKind === "type") continue;
+
+        const local = specifier.local as OxcNode | null;
+        const name = getIdentifierName(local);
+        if (!name) continue;
+
+        const info: BindingInfo = {
+          dependencies: new Set<string>(),
+          kind: "import",
+          names: new Set([name]),
+          node: specifier,
+          specifierIndex: index,
+          statementIndex,
+        };
+        bindings.set(name, info);
       }
+
+      continue;
+    }
+
+    const declaration = getStatementDeclaration(statement);
+    if (!declaration) continue;
+
+    if (declaration.type === "FunctionDeclaration") {
+      const name = getIdentifierName(declaration.id as OxcNode | null);
+      if (!name) continue;
+
+      const info: BindingInfo = {
+        dependencies: collectTopLevelReferences(
+          declaration,
+          dependencyBindingNames,
+          new Set([name]),
+        ),
+        kind: "function",
+        names: new Set([name]),
+        node: declaration,
+        statementIndex,
+      };
+      bindings.set(name, info);
+      continue;
+    }
+
+    if (declaration.type === "ClassDeclaration") {
+      const name = getIdentifierName(declaration.id as OxcNode | null);
+      if (!name) continue;
+
+      const info: BindingInfo = {
+        dependencies: collectTopLevelReferences(
+          declaration,
+          dependencyBindingNames,
+          new Set([name]),
+        ),
+        kind: "class",
+        names: new Set([name]),
+        node: declaration,
+        statementIndex,
+      };
+      bindings.set(name, info);
+      continue;
+    }
+
+    if (declaration.type !== "VariableDeclaration") continue;
+
+    for (const index of getRemainingDeclaratorIndices(state)) {
+      const declarator = declaration.declarations[index] as OxcNode;
+      const names = new Set(collectBindingNamesFromPattern(declarator.id as OxcNode));
+      if (names.size === 0) continue;
+
+      const info: BindingInfo = {
+        declaratorIndex: index,
+        dependencies: collectVariableDeclaratorDependencies(
+          declarator,
+          dependencyBindingNames,
+          names,
+        ),
+        kind: "variable",
+        names,
+        node: declarator,
+        statementIndex,
+      };
+
+      for (const name of names) {
+        bindings.set(name, info);
+      }
+    }
+  }
+
+  return bindings;
+}
+
+function collectCurrentTopLevelBindingNames(states: StatementState[]): Set<string> {
+  const names = new Set<string>();
+
+  for (const state of states) {
+    if (state.removed) continue;
+
+    const statement = state.node;
+    if (statement.type === "ImportDeclaration") {
+      if (statement.importKind === "type") continue;
+
+      for (const index of getRemainingSpecifierIndices(state)) {
+        const specifier = statement.specifiers[index] as OxcNode;
+        if (specifier.type === "ImportSpecifier" && specifier.importKind === "type") continue;
+
+        const localName = getIdentifierName(specifier.local as OxcNode | null);
+        if (localName) {
+          names.add(localName);
+        }
+      }
+
+      continue;
+    }
+
+    const declaration = getStatementDeclaration(statement);
+    if (!declaration) continue;
+
+    if (declaration.type === "VariableDeclaration") {
+      for (const index of getRemainingDeclaratorIndices(state)) {
+        const declarator = declaration.declarations[index] as OxcNode;
+        for (const name of collectBindingNamesFromPattern(declarator.id as OxcNode)) {
+          names.add(name);
+        }
+      }
+      continue;
+    }
+
+    for (const name of collectBindingNamesFromDeclaration(declaration)) {
+      names.add(name);
     }
   }
 
   return names;
 }
 
-function isIdentifierUsed(code: string, name: string): boolean {
-  return new RegExp(`(^|[^A-Za-z0-9_$])${escapeRegExp(name)}(?![A-Za-z0-9_$])`).test(code);
-}
+function collectExportedBindingNames(states: StatementState[]): Set<string> {
+  const names = new Set<string>();
 
-function removeRanges(code: string, ranges: Range[]): string {
-  if (ranges.length === 0) return code;
+  for (const state of states) {
+    if (state.removed) continue;
 
-  return [...ranges]
-    .sort((a, b) => b.start - a.start)
-    .reduce((current, range) => current.slice(0, range.start) + current.slice(range.end), code);
-}
+    const statement = state.node;
+    if (statement.type === "ExportNamedDeclaration") {
+      const declaration = statement.declaration as OxcNode | null;
+      if (declaration) {
+        if (declaration.type === "VariableDeclaration") {
+          for (const index of getRemainingDeclaratorIndices(state)) {
+            const declarator = declaration.declarations[index] as OxcNode;
+            for (const name of collectBindingNamesFromPattern(declarator.id as OxcNode)) {
+              names.add(name);
+            }
+          }
+        } else {
+          for (const name of collectBindingNamesFromDeclaration(declaration)) {
+            names.add(name);
+          }
+        }
+      }
 
-function findFunctionDeclarationEnd(code: string, start: number): number {
-  const paramsStart = code.indexOf("(", start);
-  if (paramsStart === -1) return findStatementEnd(code, start);
+      for (const index of getRemainingSpecifierIndices(state)) {
+        const specifier = statement.specifiers[index] as OxcNode;
+        if (specifier.type !== "ExportSpecifier" || specifier.exportKind === "type") continue;
+        const localName = getIdentifierName(specifier.local as OxcNode | null);
+        if (localName) {
+          names.add(localName);
+        }
+      }
+    }
 
-  const paramsEnd = findMatchingDelimiterEnd(code, paramsStart, "(", ")");
-  const bodyStart = code.indexOf("{", paramsEnd);
-  if (bodyStart === -1) return findStatementEnd(code, start);
+    if (statement.type !== "ExportDefaultDeclaration") continue;
 
-  return findMatchingBraceEnd(code, bodyStart);
-}
-
-function findStatementEnd(code: string, start: number): number {
-  let parenDepth = 0;
-  let bracketDepth = 0;
-  let braceDepth = 0;
-
-  for (let index = start; index < code.length; index += 1) {
-    const skipped = skipIgnoredJavaScript(code, index);
-    if (skipped !== index) {
-      index = skipped - 1;
+    const declaration = statement.declaration as OxcNode;
+    if (declaration.type === "Identifier") {
+      names.add(declaration.name as string);
       continue;
     }
 
-    const char = code[index];
-    if (char === "(") parenDepth += 1;
-    else if (char === ")") parenDepth = Math.max(0, parenDepth - 1);
-    else if (char === "[") bracketDepth += 1;
-    else if (char === "]") bracketDepth = Math.max(0, bracketDepth - 1);
-    else if (char === "{") braceDepth += 1;
-    else if (char === "}") braceDepth = Math.max(0, braceDepth - 1);
-    else if (char === ";" && parenDepth === 0 && bracketDepth === 0 && braceDepth === 0) {
-      return index + 1;
+    if (
+      (declaration.type === "FunctionDeclaration" || declaration.type === "ClassDeclaration") &&
+      declaration.id
+    ) {
+      names.add((declaration.id as OxcNode).name as string);
     }
   }
 
-  return code.length;
+  return names;
 }
 
-function findMatchingBraceEnd(code: string, openBraceIndex: number): number {
-  return findMatchingDelimiterEnd(code, openBraceIndex, "{", "}");
+function collectProgramReferences(
+  states: StatementState[],
+  topLevelBindingNames: Set<string>,
+): Set<string> {
+  const references = new Set<string>();
+  const scopeStack: Array<Set<string>> = [];
+
+  for (const state of states) {
+    if (state.removed) continue;
+
+    const statement = state.node;
+    if (statement.type === "ImportDeclaration") continue;
+
+    if (statement.type === "ExportNamedDeclaration") {
+      visitExportNamedDeclaration(statement, state, scopeStack, topLevelBindingNames, references);
+      continue;
+    }
+
+    if (statement.type === "ExportDefaultDeclaration") {
+      visitExportDefaultDeclaration(statement, scopeStack, topLevelBindingNames, references);
+      continue;
+    }
+
+    visitNode(statement, scopeStack, topLevelBindingNames, references);
+  }
+
+  return references;
 }
 
-function findMatchingDelimiterEnd(
+function visitExportNamedDeclaration(
+  statement: OxcNode,
+  state: StatementState,
+  scopeStack: Array<Set<string>>,
+  topLevelBindingNames: Set<string>,
+  references: Set<string>,
+): void {
+  const declaration = statement.declaration as OxcNode | null;
+  if (!declaration) return;
+
+  if (declaration.type === "VariableDeclaration") {
+    for (const index of getRemainingDeclaratorIndices(state)) {
+      visitVariableDeclarator(
+        declaration.declarations[index] as OxcNode,
+        scopeStack,
+        topLevelBindingNames,
+        references,
+      );
+    }
+    return;
+  }
+
+  visitNode(declaration, scopeStack, topLevelBindingNames, references);
+}
+
+function visitExportDefaultDeclaration(
+  statement: OxcNode,
+  scopeStack: Array<Set<string>>,
+  topLevelBindingNames: Set<string>,
+  references: Set<string>,
+): void {
+  const declaration = statement.declaration as OxcNode;
+  if (declaration.type === "Identifier") return;
+  visitNode(declaration, scopeStack, topLevelBindingNames, references);
+}
+
+function removeBinding(states: StatementState[], binding: BindingInfo): void {
+  const state = states[binding.statementIndex];
+  if (binding.kind === "import" && binding.specifierIndex !== undefined) {
+    state.removedSpecifiers.add(binding.specifierIndex);
+    if (getRemainingSpecifierIndices(state).length === 0) {
+      state.removed = true;
+    }
+    return;
+  }
+
+  if (binding.kind === "variable" && binding.declaratorIndex !== undefined) {
+    state.removedDeclarators.add(binding.declaratorIndex);
+    if (getRemainingDeclaratorIndices(state).length === 0) {
+      state.removed = true;
+    }
+    return;
+  }
+
+  state.removed = true;
+}
+
+function renderProgram(code: string, states: StatementState[]): string {
+  let cursor = 0;
+  let out = "";
+
+  for (const state of states) {
+    const statement = state.node;
+    out += code.slice(cursor, statement.start);
+    out += renderStatement(code, state);
+    cursor = statement.end;
+  }
+
+  out += code.slice(cursor);
+  return out;
+}
+
+function renderStatement(code: string, state: StatementState): string {
+  if (state.removed) return "";
+
+  const statement = state.node;
+  const declaration = getStatementDeclaration(statement);
+
+  if (statement.type === "ImportDeclaration" && state.removedSpecifiers.size > 0) {
+    return renderImportDeclaration(code, statement, state);
+  }
+
+  if (
+    statement.type === "ExportNamedDeclaration" &&
+    !statement.declaration &&
+    state.removedSpecifiers.size > 0
+  ) {
+    return renderExportSpecifiers(code, statement, state);
+  }
+
+  if (declaration?.type === "VariableDeclaration" && state.removedDeclarators.size > 0) {
+    return renderVariableDeclaration(code, statement, declaration, state);
+  }
+
+  return code.slice(statement.start, statement.end);
+}
+
+function renderImportDeclaration(code: string, statement: OxcNode, state: StatementState): string {
+  const remaining = getRemainingSpecifierIndices(state).map(
+    (index) => statement.specifiers[index] as OxcNode,
+  );
+  if (remaining.length === 0) return "";
+
+  const defaultSpecifier = remaining.find(
+    (specifier) => specifier.type === "ImportDefaultSpecifier",
+  );
+  const namespaceSpecifier = remaining.find(
+    (specifier) => specifier.type === "ImportNamespaceSpecifier",
+  );
+  const namedSpecifiers = remaining.filter((specifier) => specifier.type === "ImportSpecifier");
+  const clauseParts: string[] = [];
+
+  if (defaultSpecifier) {
+    clauseParts.push(code.slice(defaultSpecifier.start, defaultSpecifier.end));
+  }
+  if (namespaceSpecifier) {
+    clauseParts.push(code.slice(namespaceSpecifier.start, namespaceSpecifier.end));
+  }
+  if (namedSpecifiers.length > 0) {
+    clauseParts.push(
+      `{ ${namedSpecifiers.map((specifier) => code.slice(specifier.start, specifier.end)).join(", ")} }`,
+    );
+  }
+
+  const importPrefix = statement.importKind === "type" ? "import type " : "import ";
+  return `${importPrefix}${clauseParts.join(", ")} from ${code.slice(statement.source.start, statement.source.end)};`;
+}
+
+function renderExportSpecifiers(code: string, statement: OxcNode, state: StatementState): string {
+  const remaining = getRemainingSpecifierIndices(state).map(
+    (index) => statement.specifiers[index] as OxcNode,
+  );
+  if (remaining.length === 0) return "";
+
+  const sourceSuffix = statement.source
+    ? ` from ${code.slice(statement.source.start, statement.source.end)}`
+    : "";
+  return `export { ${remaining.map((specifier) => code.slice(specifier.start, specifier.end)).join(", ")} }${sourceSuffix};`;
+}
+
+function renderVariableDeclaration(
   code: string,
-  openDelimiterIndex: number,
-  openDelimiter: string,
-  closeDelimiter: string,
-): number {
-  let depth = 1;
+  statement: OxcNode,
+  declaration: OxcNode,
+  state: StatementState,
+): string {
+  const remaining = getRemainingDeclaratorIndices(state).map(
+    (index) => declaration.declarations[index] as OxcNode,
+  );
+  if (remaining.length === 0) return "";
 
-  for (let index = openDelimiterIndex + 1; index < code.length; index += 1) {
-    const skipped = skipIgnoredJavaScript(code, index);
-    if (skipped !== index) {
-      index = skipped - 1;
-      continue;
-    }
-
-    const char = code[index];
-    if (char === openDelimiter) depth += 1;
-    else if (char === closeDelimiter) {
-      depth -= 1;
-      if (depth === 0) return index + 1;
-    }
-  }
-
-  return code.length;
+  const prefix = statement.type === "ExportNamedDeclaration" ? "export " : "";
+  return `${prefix}${declaration.kind as string} ${remaining.map((item) => code.slice(item.start, item.end)).join(", ")};`;
 }
 
-function skipIgnoredJavaScript(code: string, start: number): number {
-  const char = code[start];
-  const next = code[start + 1];
+function getRemainingDeclaratorIndices(state: StatementState): number[] {
+  const declaration = getStatementDeclaration(state.node);
+  if (!declaration || declaration.type !== "VariableDeclaration") return [];
 
-  if (char === "/" && next === "/") {
-    const newline = code.indexOf("\n", start + 2);
-    return newline === -1 ? code.length : newline;
-  }
-
-  if (char === "/" && next === "*") {
-    const commentEnd = code.indexOf("*/", start + 2);
-    return commentEnd === -1 ? code.length : commentEnd + 2;
-  }
-
-  if (char === '"' || char === "'" || char === "`") {
-    return skipQuotedString(code, start, char);
-  }
-
-  return start;
+  return declaration.declarations
+    .map((_item: unknown, index: number) => index)
+    .filter((index: number) => !state.removedDeclarators.has(index));
 }
 
-function skipQuotedString(code: string, start: number, quote: string): number {
-  for (let index = start + 1; index < code.length; index += 1) {
-    const char = code[index];
-    if (char === "\\") {
-      index += 1;
-      continue;
+function getRemainingSpecifierIndices(state: StatementState): number[] {
+  const statement = state.node;
+  if (!("specifiers" in statement) || !Array.isArray(statement.specifiers)) return [];
+
+  return statement.specifiers
+    .map((_item: unknown, index: number) => index)
+    .filter((index: number) => !state.removedSpecifiers.has(index));
+}
+
+function collectVariableDeclaratorDependencies(
+  declarator: OxcNode,
+  topLevelBindingNames: Set<string>,
+  excludedNames: Set<string>,
+): Set<string> {
+  const dependencies = new Set<string>();
+  visitPattern(declarator.id as OxcNode, [], topLevelBindingNames, dependencies);
+  visitNode(
+    declarator.init as OxcNode | null,
+    [],
+    topLevelBindingNames,
+    dependencies,
+    excludedNames,
+  );
+  return dependencies;
+}
+
+function collectTopLevelReferences(
+  node: OxcNode,
+  topLevelBindingNames: Set<string>,
+  excludedNames: Set<string>,
+): Set<string> {
+  const references = new Set<string>();
+  visitNode(node, [], topLevelBindingNames, references, excludedNames);
+  return references;
+}
+
+function visitNode(
+  node: OxcNode | null | undefined,
+  scopeStack: Array<Set<string>>,
+  topLevelBindingNames: Set<string>,
+  references: Set<string>,
+  excludedNames = new Set<string>(),
+): void {
+  if (!node) return;
+  if (node.type.startsWith("TS")) return;
+
+  switch (node.type) {
+    case "Identifier":
+      addReference(
+        node.name as string,
+        scopeStack,
+        topLevelBindingNames,
+        references,
+        excludedNames,
+      );
+      return;
+    case "JSXIdentifier":
+      if (JSX_COMPONENT_RE.test(node.name as string)) {
+        addReference(
+          node.name as string,
+          scopeStack,
+          topLevelBindingNames,
+          references,
+          excludedNames,
+        );
+      }
+      return;
+    case "ArrowFunctionExpression":
+    case "FunctionDeclaration":
+    case "FunctionExpression":
+      visitFunctionLike(node, scopeStack, topLevelBindingNames, references, excludedNames);
+      return;
+    case "VariableDeclaration":
+      for (const declarator of node.declarations as OxcNode[]) {
+        visitVariableDeclarator(
+          declarator,
+          scopeStack,
+          topLevelBindingNames,
+          references,
+          excludedNames,
+        );
+      }
+      return;
+    case "MemberExpression":
+      visitNode(
+        node.object as OxcNode,
+        scopeStack,
+        topLevelBindingNames,
+        references,
+        excludedNames,
+      );
+      if (node.computed) {
+        visitNode(
+          node.property as OxcNode,
+          scopeStack,
+          topLevelBindingNames,
+          references,
+          excludedNames,
+        );
+      }
+      return;
+    case "Property":
+      if (node.computed) {
+        visitNode(node.key as OxcNode, scopeStack, topLevelBindingNames, references, excludedNames);
+      }
+      if (node.shorthand) {
+        visitNode(
+          node.value as OxcNode,
+          scopeStack,
+          topLevelBindingNames,
+          references,
+          excludedNames,
+        );
+      } else {
+        visitNode(
+          node.value as OxcNode,
+          scopeStack,
+          topLevelBindingNames,
+          references,
+          excludedNames,
+        );
+      }
+      return;
+    case "BlockStatement":
+      visitBlockStatement(node, scopeStack, topLevelBindingNames, references, excludedNames);
+      return;
+    case "ObjectPattern":
+    case "ArrayPattern":
+    case "AssignmentPattern":
+    case "RestElement":
+      visitPattern(node, scopeStack, topLevelBindingNames, references, excludedNames);
+      return;
+    case "CatchClause":
+      visitCatchClause(node, scopeStack, topLevelBindingNames, references, excludedNames);
+      return;
+    case "ClassDeclaration":
+    case "ClassExpression":
+      visitClassLike(node, scopeStack, topLevelBindingNames, references, excludedNames);
+      return;
+    case "JSXElement":
+      visitNode(
+        node.openingElement as OxcNode,
+        scopeStack,
+        topLevelBindingNames,
+        references,
+        excludedNames,
+      );
+      for (const child of node.children as OxcNode[]) {
+        visitNode(child, scopeStack, topLevelBindingNames, references, excludedNames);
+      }
+      return;
+    case "JSXFragment":
+      for (const child of node.children as OxcNode[]) {
+        visitNode(child, scopeStack, topLevelBindingNames, references, excludedNames);
+      }
+      return;
+    case "JSXOpeningElement":
+      visitNode(node.name as OxcNode, scopeStack, topLevelBindingNames, references, excludedNames);
+      for (const attribute of node.attributes as OxcNode[]) {
+        visitNode(attribute, scopeStack, topLevelBindingNames, references, excludedNames);
+      }
+      return;
+    case "JSXClosingElement":
+      visitNode(node.name as OxcNode, scopeStack, topLevelBindingNames, references, excludedNames);
+      return;
+    case "JSXAttribute":
+      visitNode(
+        node.value as OxcNode | null,
+        scopeStack,
+        topLevelBindingNames,
+        references,
+        excludedNames,
+      );
+      return;
+    case "JSXExpressionContainer":
+      visitNode(
+        node.expression as OxcNode,
+        scopeStack,
+        topLevelBindingNames,
+        references,
+        excludedNames,
+      );
+      return;
+    case "JSXMemberExpression":
+      visitNode(
+        node.object as OxcNode,
+        scopeStack,
+        topLevelBindingNames,
+        references,
+        excludedNames,
+      );
+      return;
+    case "MethodDefinition":
+    case "PropertyDefinition":
+      if (node.computed) {
+        visitNode(node.key as OxcNode, scopeStack, topLevelBindingNames, references, excludedNames);
+      }
+      visitNode(
+        node.value as OxcNode | null,
+        scopeStack,
+        topLevelBindingNames,
+        references,
+        excludedNames,
+      );
+      return;
+    case "ImportDeclaration":
+      return;
+    case "ExportNamedDeclaration":
+      if (node.declaration) {
+        visitNode(
+          node.declaration as OxcNode,
+          scopeStack,
+          topLevelBindingNames,
+          references,
+          excludedNames,
+        );
+      }
+      return;
+    case "ExportDefaultDeclaration":
+      if ((node.declaration as OxcNode).type !== "Identifier") {
+        visitNode(
+          node.declaration as OxcNode,
+          scopeStack,
+          topLevelBindingNames,
+          references,
+          excludedNames,
+        );
+      }
+      return;
+    default:
+      for (const [key, value] of Object.entries(node)) {
+        if (SKIPPED_KEYS.has(key)) continue;
+        if (key === "id" || key === "implements" || key === "superTypeArguments") continue;
+        visitUnknownValue(value, scopeStack, topLevelBindingNames, references, excludedNames);
+      }
+  }
+}
+
+function visitUnknownValue(
+  value: unknown,
+  scopeStack: Array<Set<string>>,
+  topLevelBindingNames: Set<string>,
+  references: Set<string>,
+  excludedNames: Set<string>,
+): void {
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      visitUnknownValue(item, scopeStack, topLevelBindingNames, references, excludedNames);
     }
-    if (char === quote) {
-      return index + 1;
+    return;
+  }
+
+  if (!isNode(value)) return;
+  visitNode(value, scopeStack, topLevelBindingNames, references, excludedNames);
+}
+
+function visitVariableDeclarator(
+  declarator: OxcNode,
+  scopeStack: Array<Set<string>>,
+  topLevelBindingNames: Set<string>,
+  references: Set<string>,
+  excludedNames = new Set<string>(),
+): void {
+  visitPattern(
+    declarator.id as OxcNode,
+    scopeStack,
+    topLevelBindingNames,
+    references,
+    excludedNames,
+  );
+  visitNode(
+    declarator.init as OxcNode | null,
+    scopeStack,
+    topLevelBindingNames,
+    references,
+    excludedNames,
+  );
+}
+
+function visitFunctionLike(
+  node: OxcNode,
+  scopeStack: Array<Set<string>>,
+  topLevelBindingNames: Set<string>,
+  references: Set<string>,
+  excludedNames: Set<string>,
+): void {
+  const scope = new Set<string>();
+  const functionName = getIdentifierName(node.id as OxcNode | null);
+  if (functionName) {
+    scope.add(functionName);
+  }
+  for (const param of node.params as OxcNode[]) {
+    for (const name of collectBindingNamesFromPattern(param)) {
+      scope.add(name);
+    }
+  }
+  if (node.body?.type === "BlockStatement") {
+    for (const name of collectDirectBindings(node.body.body as OxcNode[])) {
+      scope.add(name);
     }
   }
 
-  return code.length;
+  scopeStack.push(scope);
+  for (const param of node.params as OxcNode[]) {
+    visitPattern(param, scopeStack, topLevelBindingNames, references, excludedNames);
+  }
+  visitNode(node.body as OxcNode, scopeStack, topLevelBindingNames, references, excludedNames);
+  scopeStack.pop();
 }
 
-function escapeRegExp(value: string): string {
-  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+function visitBlockStatement(
+  node: OxcNode,
+  scopeStack: Array<Set<string>>,
+  topLevelBindingNames: Set<string>,
+  references: Set<string>,
+  excludedNames: Set<string>,
+): void {
+  const scope = collectDirectBindings(node.body as OxcNode[]);
+  scopeStack.push(scope);
+  for (const statement of node.body as OxcNode[]) {
+    visitNode(statement, scopeStack, topLevelBindingNames, references, excludedNames);
+  }
+  scopeStack.pop();
+}
+
+function visitCatchClause(
+  node: OxcNode,
+  scopeStack: Array<Set<string>>,
+  topLevelBindingNames: Set<string>,
+  references: Set<string>,
+  excludedNames: Set<string>,
+): void {
+  const scope = new Set<string>();
+  if (node.param) {
+    for (const name of collectBindingNamesFromPattern(node.param as OxcNode)) {
+      scope.add(name);
+    }
+  }
+  for (const name of collectDirectBindings((node.body as OxcNode).body as OxcNode[])) {
+    scope.add(name);
+  }
+
+  scopeStack.push(scope);
+  if (node.param) {
+    visitPattern(
+      node.param as OxcNode,
+      scopeStack,
+      topLevelBindingNames,
+      references,
+      excludedNames,
+    );
+  }
+  visitNode(node.body as OxcNode, scopeStack, topLevelBindingNames, references, excludedNames);
+  scopeStack.pop();
+}
+
+function visitClassLike(
+  node: OxcNode,
+  scopeStack: Array<Set<string>>,
+  topLevelBindingNames: Set<string>,
+  references: Set<string>,
+  excludedNames: Set<string>,
+): void {
+  visitNode(
+    node.superClass as OxcNode | null,
+    scopeStack,
+    topLevelBindingNames,
+    references,
+    excludedNames,
+  );
+
+  const scope = new Set<string>();
+  const name = getIdentifierName(node.id as OxcNode | null);
+  if (name) {
+    scope.add(name);
+  }
+
+  scopeStack.push(scope);
+  visitNode(node.body as OxcNode, scopeStack, topLevelBindingNames, references, excludedNames);
+  scopeStack.pop();
+}
+
+function visitPattern(
+  node: OxcNode | null | undefined,
+  scopeStack: Array<Set<string>>,
+  topLevelBindingNames: Set<string>,
+  references: Set<string>,
+  excludedNames = new Set<string>(),
+): void {
+  if (!node) return;
+  if (node.type.startsWith("TS")) return;
+
+  switch (node.type) {
+    case "AssignmentPattern":
+      visitNode(node.right as OxcNode, scopeStack, topLevelBindingNames, references, excludedNames);
+      visitPattern(
+        node.left as OxcNode,
+        scopeStack,
+        topLevelBindingNames,
+        references,
+        excludedNames,
+      );
+      return;
+    case "ObjectPattern":
+      for (const property of node.properties as OxcNode[]) {
+        if (property.type === "Property") {
+          if (property.computed) {
+            visitNode(
+              property.key as OxcNode,
+              scopeStack,
+              topLevelBindingNames,
+              references,
+              excludedNames,
+            );
+          }
+          visitPattern(
+            property.value as OxcNode,
+            scopeStack,
+            topLevelBindingNames,
+            references,
+            excludedNames,
+          );
+          continue;
+        }
+        visitPattern(
+          property.argument as OxcNode,
+          scopeStack,
+          topLevelBindingNames,
+          references,
+          excludedNames,
+        );
+      }
+      return;
+    case "ArrayPattern":
+      for (const element of node.elements as Array<OxcNode | null>) {
+        visitPattern(element, scopeStack, topLevelBindingNames, references, excludedNames);
+      }
+      return;
+    case "RestElement":
+      visitPattern(
+        node.argument as OxcNode,
+        scopeStack,
+        topLevelBindingNames,
+        references,
+        excludedNames,
+      );
+      return;
+    default:
+      return;
+  }
+}
+
+function collectDirectBindings(statements: OxcNode[]): Set<string> {
+  const names = new Set<string>();
+
+  for (const statement of statements) {
+    const declaration = getStatementDeclaration(statement);
+    if (!declaration) continue;
+    for (const name of collectBindingNamesFromDeclaration(declaration)) {
+      names.add(name);
+    }
+  }
+
+  return names;
+}
+
+function getStatementDeclaration(statement: OxcNode): OxcNode | null {
+  if (statement.type === "ExportNamedDeclaration") {
+    return (statement.declaration as OxcNode | null) ?? null;
+  }
+
+  if (
+    statement.type === "ExportDefaultDeclaration" &&
+    ((statement.declaration as OxcNode).type === "FunctionDeclaration" ||
+      (statement.declaration as OxcNode).type === "ClassDeclaration")
+  ) {
+    return statement.declaration as OxcNode;
+  }
+
+  if (
+    statement.type === "FunctionDeclaration" ||
+    statement.type === "ClassDeclaration" ||
+    statement.type === "VariableDeclaration"
+  ) {
+    return statement;
+  }
+
+  return null;
+}
+
+function collectBindingNamesFromDeclaration(declaration: OxcNode): string[] {
+  if (declaration.type === "FunctionDeclaration" || declaration.type === "ClassDeclaration") {
+    return declaration.id ? [(declaration.id as OxcNode).name as string] : [];
+  }
+
+  if (declaration.type === "VariableDeclaration") {
+    return (declaration.declarations as OxcNode[]).flatMap((declarator) =>
+      collectBindingNamesFromPattern(declarator.id as OxcNode),
+    );
+  }
+
+  return [];
+}
+
+function collectBindingNamesFromPattern(pattern: OxcNode | null | undefined): string[] {
+  if (!pattern) return [];
+
+  switch (pattern.type) {
+    case "Identifier":
+      return [pattern.name as string];
+    case "AssignmentPattern":
+      return collectBindingNamesFromPattern(pattern.left as OxcNode);
+    case "RestElement":
+      return collectBindingNamesFromPattern(pattern.argument as OxcNode);
+    case "ObjectPattern":
+      return (pattern.properties as OxcNode[]).flatMap((property) => {
+        if (property.type === "Property") {
+          return collectBindingNamesFromPattern(property.value as OxcNode);
+        }
+        return collectBindingNamesFromPattern(property.argument as OxcNode);
+      });
+    case "ArrayPattern":
+      return (pattern.elements as Array<OxcNode | null>).flatMap((element) =>
+        collectBindingNamesFromPattern(element),
+      );
+    default:
+      return [];
+  }
+}
+
+function addReference(
+  name: string,
+  scopeStack: Array<Set<string>>,
+  topLevelBindingNames: Set<string>,
+  references: Set<string>,
+  excludedNames: Set<string>,
+): void {
+  if (excludedNames.has(name)) return;
+  if (!topLevelBindingNames.has(name)) return;
+  if (isShadowed(name, scopeStack)) return;
+  references.add(name);
+}
+
+function isShadowed(name: string, scopeStack: Array<Set<string>>): boolean {
+  return scopeStack.some((scope) => scope.has(name));
+}
+
+function enqueueDependencies(target: Set<string>, dependencies: Iterable<string>): void {
+  for (const name of dependencies) {
+    target.add(name);
+  }
+}
+
+function getIdentifierName(node: OxcNode | null | undefined): string | null {
+  if (!node) return null;
+  if (node.type === "Identifier" || node.type === "JSXIdentifier") {
+    return node.name as string;
+  }
+  if (node.type === "Literal" && typeof node.value === "string") {
+    return node.value as string;
+  }
+  return null;
+}
+
+function getRolldownLang(id: string): RolldownLang {
+  const path = stripPrachtClientModuleQuery(id).split("?")[0];
+  if (/\.(c|m)?tsx$/i.test(path)) return "tsx";
+  if (/\.(c|m)?ts$/i.test(path)) return "ts";
+  if (/\.(c|m)?jsx$/i.test(path)) return "jsx";
+  if (/\.mdx?$/i.test(path)) return "jsx";
+  if (/\.(c|m)?js$/i.test(path)) return "js";
+  return "tsx";
+}
+
+function isNode(value: unknown): value is OxcNode {
+  return !!value && typeof value === "object" && "type" in value;
 }

--- a/packages/vite-plugin/src/client-module-transform.ts
+++ b/packages/vite-plugin/src/client-module-transform.ts
@@ -32,16 +32,17 @@ export function stripPrachtClientModuleQuery(id: string): string {
 }
 
 export function stripServerOnlyExportsForClient(code: string): string {
-  const withoutDeclarations = removeRanges(code, collectServerOnlyDeclarationRanges(code));
+  const masked = maskStringsAndComments(code);
+  const withoutDeclarations = removeRanges(code, collectServerOnlyDeclarationRanges(code, masked));
   const withoutSpecifiers = removeServerOnlyExportSpecifiers(withoutDeclarations);
   return removeUnusedImports(withoutSpecifiers);
 }
 
-function collectServerOnlyDeclarationRanges(code: string): Range[] {
+function collectServerOnlyDeclarationRanges(code: string, masked: string): Range[] {
   const ranges: Range[] = [];
 
   const functionRe = /\bexport\s+(?:async\s+)?function\s+([A-Za-z_$][\w$]*)\b/g;
-  for (const match of code.matchAll(functionRe)) {
+  for (const match of masked.matchAll(functionRe)) {
     const name = match[1];
     if (!SERVER_ONLY_EXPORTS.has(name)) continue;
     ranges.push({
@@ -51,7 +52,7 @@ function collectServerOnlyDeclarationRanges(code: string): Range[] {
   }
 
   const variableRe = /\bexport\s+(?:const|let|var)\s+([A-Za-z_$][\w$]*)\b/g;
-  for (const match of code.matchAll(variableRe)) {
+  for (const match of masked.matchAll(variableRe)) {
     const name = match[1];
     if (!SERVER_ONLY_EXPORTS.has(name)) continue;
     ranges.push({
@@ -64,35 +65,48 @@ function collectServerOnlyDeclarationRanges(code: string): Range[] {
 }
 
 function removeServerOnlyExportSpecifiers(code: string): string {
-  return code.replace(
-    /\bexport\s+(type\s+)?\{([^}]*)\}(\s+from\s+["'][^"']+["'])?\s*;?/g,
-    (statement, typeKeyword: string | undefined, specifierList: string, fromClause = "") => {
-      if (typeKeyword) return statement;
+  const masked = maskStringsAndComments(code);
+  const pattern = /\bexport\s+(type\s+)?\{([^}]*)\}(\s+from\s+["'][^"']+["'])?\s*;?/g;
+  const edits: Array<{ start: number; end: number; replacement: string }> = [];
 
-      const remaining = specifierList
-        .split(",")
-        .map((specifier) => specifier.trim())
-        .filter(Boolean)
-        .filter((specifier) => {
-          const [localName, exportedName = localName] = specifier.split(/\s+as\s+/);
-          return (
-            !SERVER_ONLY_EXPORTS.has(localName.trim()) &&
-            !SERVER_ONLY_EXPORTS.has(exportedName.trim())
-          );
-        });
+  for (const match of masked.matchAll(pattern)) {
+    const start = match.index ?? 0;
+    const end = start + match[0].length;
+    const statement = code.slice(start, end);
+    const typeKeyword = match[1];
+    const specifierList = match[2];
+    const fromClause = match[3] ?? "";
 
-      if (remaining.length === 0) return "";
+    if (typeKeyword) continue;
 
-      return `export { ${remaining.join(", ")} }${fromClause};`;
-    },
-  );
+    const remaining = specifierList
+      .split(",")
+      .map((specifier) => specifier.trim())
+      .filter(Boolean)
+      .filter((specifier) => {
+        const [localName, exportedName = localName] = specifier.split(/\s+as\s+/);
+        return (
+          !SERVER_ONLY_EXPORTS.has(localName.trim()) &&
+          !SERVER_ONLY_EXPORTS.has(exportedName.trim())
+        );
+      });
+
+    const replacement =
+      remaining.length === 0 ? "" : `export { ${remaining.join(", ")} }${fromClause};`;
+    if (replacement !== statement) {
+      edits.push({ start, end, replacement });
+    }
+  }
+
+  return applyEdits(code, edits);
 }
 
 function removeUnusedImports(code: string): string {
-  const imports = collectImportRanges(code);
+  const masked = maskStringsAndComments(code);
+  const imports = collectImportRanges(code, masked);
   if (imports.length === 0) return code;
 
-  const codeWithoutImports = removeRanges(code, imports);
+  const maskedWithoutImports = removeRanges(masked, imports);
   const removable = imports.filter((range) => {
     const statement = code.slice(range.start, range.end);
     if (isSideEffectImport(statement) || isTypeOnlyImport(statement)) return false;
@@ -100,18 +114,18 @@ function removeUnusedImports(code: string): string {
     const localNames = getImportLocalNames(statement);
     return (
       localNames.length > 0 &&
-      localNames.every((name) => !isIdentifierUsed(codeWithoutImports, name))
+      localNames.every((name) => !isIdentifierUsed(maskedWithoutImports, name))
     );
   });
 
   return removeRanges(code, removable);
 }
 
-function collectImportRanges(code: string): Range[] {
+function collectImportRanges(code: string, masked: string): Range[] {
   const ranges: Range[] = [];
   const importRe = /\bimport\s/g;
 
-  for (const match of code.matchAll(importRe)) {
+  for (const match of masked.matchAll(importRe)) {
     const start = match.index ?? 0;
     const end = findStatementEnd(code, start);
     const statement = code.slice(start, end);
@@ -122,6 +136,38 @@ function collectImportRanges(code: string): Range[] {
   }
 
   return ranges;
+}
+
+function applyEdits(
+  code: string,
+  edits: Array<{ start: number; end: number; replacement: string }>,
+): string {
+  if (edits.length === 0) return code;
+  return [...edits]
+    .sort((a, b) => b.start - a.start)
+    .reduce(
+      (current, edit) => current.slice(0, edit.start) + edit.replacement + current.slice(edit.end),
+      code,
+    );
+}
+
+function maskStringsAndComments(code: string): string {
+  let out = "";
+  let i = 0;
+  while (i < code.length) {
+    const skipped = skipIgnoredJavaScript(code, i);
+    if (skipped !== i) {
+      // Preserve length and newlines so match indices and line numbers stay aligned.
+      for (let j = i; j < skipped; j += 1) {
+        out += code[j] === "\n" ? "\n" : " ";
+      }
+      i = skipped;
+    } else {
+      out += code[i];
+      i += 1;
+    }
+  }
+  return out;
 }
 
 function isImportDeclaration(statement: string): boolean {

--- a/packages/vite-plugin/src/client-module-transform.ts
+++ b/packages/vite-plugin/src/client-module-transform.ts
@@ -716,6 +716,14 @@ function visitNode(
         );
       }
       return;
+    case "MetaProperty":
+      return;
+    case "LabeledStatement":
+      visitNode(node.body as OxcNode, scopeStack, topLevelBindingNames, references, excludedNames);
+      return;
+    case "BreakStatement":
+    case "ContinueStatement":
+      return;
     case "Property":
       if (node.computed) {
         visitNode(node.key as OxcNode, scopeStack, topLevelBindingNames, references, excludedNames);

--- a/packages/vite-plugin/src/index.ts
+++ b/packages/vite-plugin/src/index.ts
@@ -211,10 +211,6 @@ export async function pracht(options: PrachtPluginOptions = {}): Promise<Plugin[
     },
 
     transform(code, id) {
-      if (isPrachtClientModuleId(id)) {
-        return { code: stripServerOnlyExportsForClient(code), map: null };
-      }
-
       // Transform () => import("./path") to "./path" in the app manifest file.
       // This lets users write import() for IDE click-to-navigate while keeping
       // the framework's string-based file resolution intact.
@@ -280,7 +276,20 @@ export async function pracht(options: PrachtPluginOptions = {}): Promise<Plugin[
     },
   };
 
-  const plugins: Plugin[] = [...preact(), prachtPlugin];
+  const clientModuleTransformPlugin: Plugin = {
+    name: "pracht:client-module-transform",
+    enforce: "post",
+
+    transform(code, id) {
+      if (!isPrachtClientModuleId(id)) return null;
+
+      const transformed = stripServerOnlyExportsForClient(code, id);
+      if (transformed === code) return null;
+      return { code: transformed, map: null };
+    },
+  };
+
+  const plugins: Plugin[] = [...preact(), prachtPlugin, clientModuleTransformPlugin];
 
   const adapterPlugins = await resolved.adapter.vitePlugins?.();
   if (adapterPlugins?.length) {

--- a/packages/vite-plugin/test/client-module-transform.test.ts
+++ b/packages/vite-plugin/test/client-module-transform.test.ts
@@ -159,6 +159,42 @@ export default function Page() {
     expectValidModuleSource(transformed);
   });
 
+  it("preserves import attributes when pruning unused import specifiers", () => {
+    const source = `
+import { loaderDep, shared } from "./data.json" with { type: "json" };
+
+export function loader() {
+  return loaderDep;
+}
+
+export default function Page() {
+  return <div>{shared}</div>;
+}
+`;
+
+    const transformed = stripServerOnlyExportsForClient(source);
+
+    expect(transformed).toContain('import { shared } from "./data.json" with { type: "json" };');
+    expect(transformed).not.toContain("loaderDep");
+    expectValidModuleSource(transformed);
+  });
+
+  it("preserves re-export attributes when pruning server-only specifiers", () => {
+    const source = `
+export { loader, shared } from "./data.json" with { type: "json" };
+
+export default function Page() {
+  return <div>ok</div>;
+}
+`;
+
+    const transformed = stripServerOnlyExportsForClient(source);
+
+    expect(transformed).toContain('export { shared } from "./data.json" with { type: "json" };');
+    expect(transformed).not.toContain("export { loader");
+    expectValidModuleSource(transformed);
+  });
+
   it("removes local server-only re-exports and their dead imports", () => {
     const source = `
 import serverOnly from "../server-only";
@@ -177,6 +213,78 @@ export default function Page() {
     expect(transformed).not.toContain("../server-only");
     expect(transformed).not.toContain("export { loader");
     expect(transformed).not.toContain("const loader");
+    expectValidModuleSource(transformed);
+  });
+
+  it("drops dead imports when loop header bindings shadow the server-only name", () => {
+    const source = `
+import serverOnly from "../server-only";
+
+export function loader() {
+  return serverOnly();
+}
+
+export default function Page() {
+  for (const serverOnly of [1]) {
+    console.log(serverOnly);
+  }
+  return <div />;
+}
+`;
+
+    const transformed = stripServerOnlyExportsForClient(source);
+
+    expect(transformed).not.toContain("../server-only");
+    expect(transformed).toContain("for (const serverOnly of [1])");
+    expectValidModuleSource(transformed);
+  });
+
+  it("drops dead imports when hoisted var bindings shadow the server-only name", () => {
+    const source = `
+import serverOnly from "../server-only";
+
+export function loader() {
+  return serverOnly();
+}
+
+export default function Page() {
+  if (true) {
+    var serverOnly = 1;
+  }
+  return <div>{serverOnly}</div>;
+}
+`;
+
+    const transformed = stripServerOnlyExportsForClient(source);
+
+    expect(transformed).not.toContain("../server-only");
+    expect(transformed).toContain("var serverOnly = 1");
+    expectValidModuleSource(transformed);
+  });
+
+  it("drops dead imports when switch cases introduce lexical shadowing", () => {
+    const source = `
+import serverOnly from "../server-only";
+
+export function loader() {
+  return serverOnly();
+}
+
+export default function Page() {
+  switch (1) {
+    case 1:
+      const serverOnly = 1;
+      return <div>{serverOnly}</div>;
+    default:
+      return <div />;
+  }
+}
+`;
+
+    const transformed = stripServerOnlyExportsForClient(source);
+
+    expect(transformed).not.toContain("../server-only");
+    expect(transformed).toContain("const serverOnly = 1");
     expectValidModuleSource(transformed);
   });
 

--- a/packages/vite-plugin/test/client-module-transform.test.ts
+++ b/packages/vite-plugin/test/client-module-transform.test.ts
@@ -3,6 +3,7 @@ import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { build } from "vite";
+import { parseAst } from "vite";
 import { afterEach, describe, expect, it } from "vitest";
 
 import { pracht } from "../src/index.ts";
@@ -23,6 +24,10 @@ function readBuiltJs(root: string): string {
     .filter((file) => file.endsWith(".js"))
     .map((file) => readFileSync(join(assetsDir, file), "utf-8"))
     .join("\n");
+}
+
+function expectValidModuleSource(code: string): void {
+  expect(() => parseAst(code, { lang: "tsx" })).not.toThrow();
 }
 
 afterEach(() => {
@@ -113,10 +118,94 @@ export default function Home() {
 
     expect(transformed).toContain("export { loader } from './foo';");
   });
+
+  it("handles typed server-only function signatures without corrupting the module", () => {
+    const source = `
+import serverOnly from "../server-only";
+
+export function loader(): { ok: boolean } {
+  return { ok: !!serverOnly };
+}
+
+export default function Page() {
+  return <main>ok</main>;
+}
+`;
+
+    const transformed = stripServerOnlyExportsForClient(source);
+
+    expect(transformed).not.toContain("../server-only");
+    expect(transformed).not.toContain("function loader");
+    expect(transformed).toContain("function Page");
+    expectValidModuleSource(transformed);
+  });
+
+  it("keeps client exports when server-only declarators share the same export statement", () => {
+    const source = `
+import serverOnly from "../server-only";
+
+export const loader = () => serverOnly(), shared = 1;
+
+export default function Page() {
+  return <main>{shared}</main>;
+}
+`;
+
+    const transformed = stripServerOnlyExportsForClient(source);
+
+    expect(transformed).not.toContain("../server-only");
+    expect(transformed).toMatch(/export\s+const\s+shared\s*=\s*1/);
+    expect(transformed).toContain("shared");
+    expectValidModuleSource(transformed);
+  });
+
+  it("removes local server-only re-exports and their dead imports", () => {
+    const source = `
+import serverOnly from "../server-only";
+
+const loader = () => serverOnly();
+
+export { loader };
+
+export default function Page() {
+  return <main>ok</main>;
+}
+`;
+
+    const transformed = stripServerOnlyExportsForClient(source);
+
+    expect(transformed).not.toContain("../server-only");
+    expect(transformed).not.toContain("export { loader");
+    expect(transformed).not.toContain("const loader");
+    expectValidModuleSource(transformed);
+  });
+
+  it("parses transformed markdown route modules through the post-transform client path", () => {
+    const source = `
+import { h } from "preact";
+
+export function head() {
+  return { title: "docs" };
+}
+
+export function Component() {
+  return h("div", null, "docs");
+}
+`;
+
+    const transformed = stripServerOnlyExportsForClient(
+      source,
+      "/src/routes/docs/page.md?pracht-client",
+    );
+
+    expect(transformed).not.toContain("function head");
+    expect(transformed).toContain("function Component");
+    expectValidModuleSource(transformed);
+  });
 });
 
 describe("client route module build", () => {
-  it("excludes imports used only by inline loaders from browser bundles", async () => {
+  it("excludes imports used only by typed inline loaders from browser bundles", async () => {
     const root = makeTempProject();
     mkdirSync(join(root, "src", "pages"), { recursive: true });
 
@@ -126,8 +215,8 @@ describe("client route module build", () => {
 import serverOnly from "../server-only";
 import { shared } from "../shared";
 
-export async function loader() {
-  return serverOnly();
+export function loader(): { ok: string } {
+  return { ok: serverOnly() };
 }
 
 export default function Home() {

--- a/packages/vite-plugin/test/client-module-transform.test.ts
+++ b/packages/vite-plugin/test/client-module-transform.test.ts
@@ -195,6 +195,28 @@ export default function Page() {
     expectValidModuleSource(transformed);
   });
 
+  it("preserves mixed default and named import clauses when pruning loader-only specifiers", () => {
+    const source = `
+import data, { loaderDep, shared as label } from "./data.json" with { type: "json" };
+
+export function loader() {
+  return loaderDep;
+}
+
+export default function Page() {
+  return <div>{data.title}{label}</div>;
+}
+`;
+
+    const transformed = stripServerOnlyExportsForClient(source);
+
+    expect(transformed).toContain(
+      'import data, { shared as label } from "./data.json" with { type: "json" };',
+    );
+    expect(transformed).not.toContain("loaderDep");
+    expectValidModuleSource(transformed);
+  });
+
   it("removes local server-only re-exports and their dead imports", () => {
     const source = `
 import serverOnly from "../server-only";
@@ -213,6 +235,29 @@ export default function Page() {
     expect(transformed).not.toContain("../server-only");
     expect(transformed).not.toContain("export { loader");
     expect(transformed).not.toContain("const loader");
+    expectValidModuleSource(transformed);
+  });
+
+  it("removes aliased local server-only re-exports while preserving client aliases", () => {
+    const source = `
+import serverOnly from "../server-only";
+
+const loadRoute = () => serverOnly();
+const shared = 1;
+
+export { loadRoute as loader, shared as pageData };
+
+export default function Page() {
+  return <main>{shared}</main>;
+}
+`;
+
+    const transformed = stripServerOnlyExportsForClient(source);
+
+    expect(transformed).not.toContain("../server-only");
+    expect(transformed).not.toContain("loadRoute as loader");
+    expect(transformed).toContain("export { shared as pageData };");
+    expect(transformed).not.toContain("const loadRoute");
     expectValidModuleSource(transformed);
   });
 
@@ -236,6 +281,29 @@ export default function Page() {
 
     expect(transformed).not.toContain("../server-only");
     expect(transformed).toContain("for (const serverOnly of [1])");
+    expectValidModuleSource(transformed);
+  });
+
+  it("drops dead imports when classic for-loop headers shadow the server-only name", () => {
+    const source = `
+import serverOnly from "../server-only";
+
+export function loader() {
+  return serverOnly();
+}
+
+export default function Page() {
+  for (let serverOnly = 0; serverOnly < 1; serverOnly++) {
+    console.log(serverOnly);
+  }
+  return <div />;
+}
+`;
+
+    const transformed = stripServerOnlyExportsForClient(source);
+
+    expect(transformed).not.toContain("../server-only");
+    expect(transformed).toContain("for (let serverOnly = 0; serverOnly < 1; serverOnly++)");
     expectValidModuleSource(transformed);
   });
 
@@ -285,6 +353,138 @@ export default function Page() {
 
     expect(transformed).not.toContain("../server-only");
     expect(transformed).toContain("const serverOnly = 1");
+    expectValidModuleSource(transformed);
+  });
+
+  it("drops dead imports when function parameters shadow the server-only name", () => {
+    const source = `
+import serverOnly from "../server-only";
+
+export function loader() {
+  return serverOnly();
+}
+
+export default function Page() {
+  return [1].map((serverOnly) => <div>{serverOnly}</div>);
+}
+`;
+
+    const transformed = stripServerOnlyExportsForClient(source);
+
+    expect(transformed).not.toContain("../server-only");
+    expect(transformed).toContain(".map((serverOnly) => <div>{serverOnly}</div>)");
+    expectValidModuleSource(transformed);
+  });
+
+  it("drops dead imports when catch parameters shadow the server-only name", () => {
+    const source = `
+import serverOnly from "../server-only";
+
+export function loader() {
+  return serverOnly();
+}
+
+export default function Page() {
+  try {
+    throw new Error("boom");
+  } catch (serverOnly) {
+    return <div>{String(serverOnly)}</div>;
+  }
+
+  return <div />;
+}
+`;
+
+    const transformed = stripServerOnlyExportsForClient(source);
+
+    expect(transformed).not.toContain("../server-only");
+    expect(transformed).toContain("catch (serverOnly)");
+    expectValidModuleSource(transformed);
+  });
+
+  it("keeps default-exported identifiers while pruning loader-only imports", () => {
+    const source = `
+import serverOnly from "../server-only";
+
+export function loader() {
+  return serverOnly();
+}
+
+const Page = () => <div>ok</div>;
+
+export default Page;
+`;
+
+    const transformed = stripServerOnlyExportsForClient(source);
+
+    expect(transformed).not.toContain("../server-only");
+    expect(transformed).toContain("const Page = () => <div>ok</div>;");
+    expect(transformed).toContain("export default Page;");
+    expectValidModuleSource(transformed);
+  });
+
+  it("drops dead imports when the remaining matching identifiers are statement labels", () => {
+    const source = `
+import serverOnly from "../server-only";
+
+export function loader() {
+  return serverOnly();
+}
+
+export default function Page() {
+  serverOnly: for (;;) {
+    break serverOnly;
+  }
+
+  return <div />;
+}
+`;
+
+    const transformed = stripServerOnlyExportsForClient(source);
+
+    expect(transformed).not.toContain("../server-only");
+    expect(transformed).toContain("serverOnly: for (;;)");
+    expect(transformed).toContain("break serverOnly;");
+    expectValidModuleSource(transformed);
+  });
+
+  it("drops dead imports when the remaining matching identifier appears in import.meta", () => {
+    const source = `
+import meta from "../server-only";
+
+export function loader() {
+  return meta();
+}
+
+export default function Page() {
+  return <div>{import.meta.env.MODE}</div>;
+}
+`;
+
+    const transformed = stripServerOnlyExportsForClient(source);
+
+    expect(transformed).not.toContain("../server-only");
+    expect(transformed).toContain("import.meta.env.MODE");
+    expectValidModuleSource(transformed);
+  });
+
+  it("drops dead imports when the remaining matching identifier appears in new.target", () => {
+    const source = `
+import target from "../server-only";
+
+export function loader() {
+  return target();
+}
+
+export default function Page() {
+  return (() => new.target)();
+}
+`;
+
+    const transformed = stripServerOnlyExportsForClient(source);
+
+    expect(transformed).not.toContain("../server-only");
+    expect(transformed).toContain("new.target");
     expectValidModuleSource(transformed);
   });
 

--- a/packages/vite-plugin/test/client-module-transform.test.ts
+++ b/packages/vite-plugin/test/client-module-transform.test.ts
@@ -64,6 +64,55 @@ export default function Home() {
     expect(transformed).toContain("../shared");
     expect(transformed).toContain("function Home");
   });
+
+  it("does not strip export declarations that appear inside string/template literals", () => {
+    const source = [
+      "import { CodeBlock } from '../components';",
+      "",
+      "export default function Home() {",
+      "  return (",
+      "    <CodeBlock",
+      "      code={`",
+      "export async function loader() {",
+      "  return {};",
+      "}",
+      "",
+      "export function head() {",
+      "  return { title: 'x' };",
+      "}",
+      "`}",
+      "    />",
+      "  );",
+      "}",
+      "",
+    ].join("\n");
+
+    const transformed = stripServerOnlyExportsForClient(source);
+
+    // The template literal must still be terminated — i.e. the closing backtick
+    // is still present.  Previously the regex matched `export ... function` inside
+    // the template and stripped through the first `}` it found, removing the
+    // closing backtick and producing an unterminated string.
+    expect(transformed).toContain("`}");
+    expect(transformed).toContain("export async function loader");
+    expect(transformed).toContain("export function head");
+    expect(transformed).toContain("function Home");
+  });
+
+  it("does not strip export specifiers that appear inside string/template literals", () => {
+    const source = [
+      "const docs = `export { loader } from './foo';`;",
+      "",
+      "export default function Home() {",
+      "  return docs;",
+      "}",
+      "",
+    ].join("\n");
+
+    const transformed = stripServerOnlyExportsForClient(source);
+
+    expect(transformed).toContain("export { loader } from './foo';");
+  });
 });
 
 describe("client route module build", () => {

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -9,7 +9,7 @@ export default defineConfig({
     {
       name: "basic",
       testMatch:
-        /basic\.test\.ts|node-build\.test\.ts|cloudflare-build\.test\.ts|vercel-build\.test\.ts/,
+        /basic\.test\.ts|node-build\.test\.ts|cloudflare-build\.test\.ts|vercel-build\.test\.ts|client-bundle-strip\.test\.ts/,
       use: {
         baseURL: "http://localhost:3100",
       },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -256,7 +256,7 @@ importers:
         specifier: ^2.0.0
         version: 2.4.12(preact@10.29.1)(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@22.19.17)(esbuild@0.27.3))
       vite:
-        specifier: ^7.0.0 || ^8.0.0
+        specifier: ^8.0.0
         version: 8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@22.19.17)(esbuild@0.27.3)
 
 packages:


### PR DESCRIPTION
## Summary

- Follow-up to #116. The client strip transform matched `export` / `import` patterns via regex on the raw source, so any source that embedded those keywords inside a string or template literal (e.g. documentation pages with code samples in `` `` ``) had those fragments stripped out mid-string — producing `Unterminated string` build errors. The matcher now runs against a string/comment-masked copy of the source while edits apply to the original.
- Fix the `examples/docs` markdown plugin to treat `*.md?pracht-client` ids as markdown — Vite appends the query for glob-imported client variants, which made the plugin's `id.endsWith(".md")` check silently skip every docs page.
- Add an e2e regression test that exercises the full CLI build and asserts loader bodies + loader-only imports are absent from client JS (the contract introduced in #116).
- Add `examples/docs` build to CI so markdown / template-literal regressions surface in PR checks rather than on release.

## Testing

- [x] `pnpm e2e`
- [x] `pnpm format`
- [x] `pnpm lint`
- [x] `pnpm test`

## Checklist

- [x] Docs updated if needed — N/A
- [x] Skills updated if needed — N/A
- [x] Changeset added if published packages changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)