### PR TITLE
fix(vite-plugin): skip strings when stripping server-only exports

### DIFF
--- a/.changeset/client-module-scope-analyzer.md
+++ b/.changeset/client-module-scope-analyzer.md
@@ -1,0 +1,5 @@
+---
+"@pracht/vite-plugin": patch
+---
+
+Refine client-module stripping with a dedicated scope analyzer so dead server-only imports drop correctly across additional syntax patterns such as loop scopes, catch bindings, labels, `import.meta`, and JSX/component references.

--- a/.changeset/ts-wrapper-client-strip-fix.md
+++ b/.changeset/ts-wrapper-client-strip-fix.md
@@ -1,0 +1,7 @@
+---
+"@pracht/vite-plugin": patch
+---
+
+Fix client-module stripping so imports referenced through TypeScript expression
+wrappers such as `as`, non-null (`!`), and `satisfies` are preserved in the
+browser bundle instead of being pruned as dead code.

--- a/packages/vite-plugin/src/client-module-scope-analysis.ts
+++ b/packages/vite-plugin/src/client-module-scope-analysis.ts
@@ -1,0 +1,1051 @@
+const JSX_COMPONENT_RE = /^[A-Z]/;
+const SKIPPED_KEYS = new Set([
+  "attributes",
+  "decorators",
+  "end",
+  "exportKind",
+  "importKind",
+  "optional",
+  "phase",
+  "raw",
+  "returnType",
+  "start",
+  "superTypeArguments",
+  "type",
+  "typeAnnotation",
+  "typeArguments",
+  "typeParameters",
+  "value",
+]);
+
+type BindingKind =
+  | "catch"
+  | "class"
+  | "const"
+  | "function"
+  | "import"
+  | "let"
+  | "param"
+  | "placeholder"
+  | "var";
+
+type ScopeType = "block" | "catch" | "class" | "for" | "function" | "program" | "switch";
+
+export type OxcNode = {
+  end: number;
+  start: number;
+  type: string;
+  [key: string]: any;
+};
+
+export type Scope = {
+  bindings: Map<string, Binding>;
+  node: OxcNode | null;
+  parent: Scope | null;
+  type: ScopeType;
+};
+
+export type Binding = {
+  kind: BindingKind;
+  name: string;
+  node: OxcNode | null;
+  scope: Scope;
+};
+
+export type Reference = {
+  name: string;
+  node: OxcNode;
+  resolvedBinding: Binding | null;
+};
+
+export type RetainedStatement = {
+  node: OxcNode;
+};
+
+export type ScopeAnalysisResult = {
+  programScope: Scope;
+  referencedTopLevelNames: Set<string>;
+  references: Reference[];
+};
+
+type AnalyzeScopeOptions = {
+  excludedNames?: Iterable<string>;
+  knownTopLevelNames?: Iterable<string>;
+};
+
+export function analyzeRetainedStatements(
+  statements: RetainedStatement[],
+  options: AnalyzeScopeOptions = {},
+): ScopeAnalysisResult {
+  const programScope = createScope("program", null, null);
+
+  for (const name of options.knownTopLevelNames ?? []) {
+    declareBinding(programScope, name, "placeholder", null);
+  }
+
+  const scopesByNode = new WeakMap<OxcNode, Scope>();
+  declareProgramScopes(statements, programScope, scopesByNode);
+
+  const result: ScopeAnalysisResult = {
+    programScope,
+    referencedTopLevelNames: new Set<string>(),
+    references: [],
+  };
+  const excludedNames = new Set(options.excludedNames);
+
+  for (const statement of statements) {
+    collectStatementReferences(statement.node, programScope, scopesByNode, result, excludedNames);
+  }
+
+  return result;
+}
+
+function createScope(type: ScopeType, parent: Scope | null, node: OxcNode | null): Scope {
+  return {
+    bindings: new Map<string, Binding>(),
+    node,
+    parent,
+    type,
+  };
+}
+
+function declareProgramScopes(
+  statements: RetainedStatement[],
+  programScope: Scope,
+  scopesByNode: WeakMap<OxcNode, Scope>,
+): void {
+  for (const statement of statements) {
+    declareTopLevelStatement(statement.node, programScope);
+  }
+
+  for (const statement of statements) {
+    declareNodeScopes(statement.node, programScope, scopesByNode);
+  }
+}
+
+function declareTopLevelStatement(statement: OxcNode, programScope: Scope): void {
+  if (statement.type === "ImportDeclaration") {
+    if (statement.importKind === "type") return;
+
+    for (const specifier of statement.specifiers as OxcNode[]) {
+      if (specifier.type === "ImportSpecifier" && specifier.importKind === "type") continue;
+
+      const localName = getIdentifierName(specifier.local as OxcNode | null);
+      if (localName) {
+        declareBinding(programScope, localName, "import", specifier);
+      }
+    }
+
+    return;
+  }
+
+  const declaration = getStatementDeclaration(statement);
+  if (!declaration) return;
+  declareDeclarationBindings(programScope, declaration);
+}
+
+function declareNodeScopes(
+  node: OxcNode | null | undefined,
+  currentScope: Scope,
+  scopesByNode: WeakMap<OxcNode, Scope>,
+): void {
+  if (!node) return;
+  if (node.type.startsWith("TS")) {
+    declareTsRuntimeChildren(node, currentScope, scopesByNode);
+    return;
+  }
+
+  switch (node.type) {
+    case "ImportDeclaration":
+      return;
+    case "ArrowFunctionExpression":
+    case "FunctionDeclaration":
+    case "FunctionExpression": {
+      const functionScope = createScope("function", currentScope, node);
+      scopesByNode.set(node, functionScope);
+      declareFunctionBindings(node, functionScope);
+
+      for (const param of node.params as OxcNode[]) {
+        declareNodeScopes(param, functionScope, scopesByNode);
+      }
+      declareNodeScopes(node.body as OxcNode, functionScope, scopesByNode);
+      return;
+    }
+    case "BlockStatement": {
+      const blockScope = createScope("block", currentScope, node);
+      scopesByNode.set(node, blockScope);
+      declareBlockBindings(node.body as OxcNode[], blockScope);
+
+      for (const statement of node.body as OxcNode[]) {
+        declareNodeScopes(statement, blockScope, scopesByNode);
+      }
+      return;
+    }
+    case "CatchClause": {
+      const catchScope = createScope("catch", currentScope, node);
+      scopesByNode.set(node, catchScope);
+      declareCatchBindings(node, catchScope);
+
+      if (node.param) {
+        declareNodeScopes(node.param as OxcNode, catchScope, scopesByNode);
+      }
+      declareNodeScopes(node.body as OxcNode, catchScope, scopesByNode);
+      return;
+    }
+    case "ForStatement": {
+      const init = node.init as OxcNode | null;
+      if (init?.type === "VariableDeclaration" && init.kind !== "var") {
+        const loopScope = createScope("for", currentScope, node);
+        scopesByNode.set(node, loopScope);
+        declareDeclarationBindings(loopScope, init);
+
+        declareNodeScopes(init, loopScope, scopesByNode);
+        declareNodeScopes(node.test as OxcNode | null, loopScope, scopesByNode);
+        declareNodeScopes(node.update as OxcNode | null, loopScope, scopesByNode);
+        declareNodeScopes(node.body as OxcNode, loopScope, scopesByNode);
+        return;
+      }
+
+      declareNodeScopes(init, currentScope, scopesByNode);
+      declareNodeScopes(node.test as OxcNode | null, currentScope, scopesByNode);
+      declareNodeScopes(node.update as OxcNode | null, currentScope, scopesByNode);
+      declareNodeScopes(node.body as OxcNode, currentScope, scopesByNode);
+      return;
+    }
+    case "ForInStatement":
+    case "ForOfStatement": {
+      const left = node.left as OxcNode | null;
+      if (left?.type === "VariableDeclaration" && left.kind !== "var") {
+        const loopScope = createScope("for", currentScope, node);
+        scopesByNode.set(node, loopScope);
+        declareDeclarationBindings(loopScope, left);
+
+        declareNodeScopes(left, loopScope, scopesByNode);
+        declareNodeScopes(node.right as OxcNode, loopScope, scopesByNode);
+        declareNodeScopes(node.body as OxcNode, loopScope, scopesByNode);
+        return;
+      }
+
+      declareNodeScopes(left, currentScope, scopesByNode);
+      declareNodeScopes(node.right as OxcNode, currentScope, scopesByNode);
+      declareNodeScopes(node.body as OxcNode, currentScope, scopesByNode);
+      return;
+    }
+    case "SwitchStatement": {
+      declareNodeScopes(node.discriminant as OxcNode, currentScope, scopesByNode);
+
+      const switchScope = createScope("switch", currentScope, node);
+      scopesByNode.set(node, switchScope);
+      declareSwitchBindings(node.cases as OxcNode[], switchScope);
+
+      for (const switchCase of node.cases as OxcNode[]) {
+        declareNodeScopes(switchCase, switchScope, scopesByNode);
+      }
+      return;
+    }
+    case "ClassDeclaration":
+    case "ClassExpression": {
+      declareNodeScopes(node.superClass as OxcNode | null, currentScope, scopesByNode);
+
+      const classScope = createScope("class", currentScope, node);
+      scopesByNode.set(node, classScope);
+
+      const name = getIdentifierName(node.id as OxcNode | null);
+      if (name) {
+        declareBinding(classScope, name, "class", node);
+      }
+
+      declareNodeScopes(node.body as OxcNode, classScope, scopesByNode);
+      return;
+    }
+    case "ExportNamedDeclaration":
+      if (node.declaration) {
+        declareNodeScopes(node.declaration as OxcNode, currentScope, scopesByNode);
+      }
+      return;
+    case "ExportDefaultDeclaration":
+      if ((node.declaration as OxcNode).type !== "Identifier") {
+        declareNodeScopes(node.declaration as OxcNode, currentScope, scopesByNode);
+      }
+      return;
+    default:
+      for (const [key, value] of Object.entries(node)) {
+        if (SKIPPED_KEYS.has(key)) continue;
+        if (key === "id" || key === "implements" || key === "superTypeArguments") continue;
+        declareUnknownValue(value, currentScope, scopesByNode);
+      }
+  }
+}
+
+function declareUnknownValue(
+  value: unknown,
+  currentScope: Scope,
+  scopesByNode: WeakMap<OxcNode, Scope>,
+): void {
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      declareUnknownValue(item, currentScope, scopesByNode);
+    }
+    return;
+  }
+
+  if (!isNode(value)) return;
+  declareNodeScopes(value, currentScope, scopesByNode);
+}
+
+function declareFunctionBindings(node: OxcNode, scope: Scope): void {
+  const functionName = getIdentifierName(node.id as OxcNode | null);
+  if (functionName) {
+    declareBinding(scope, functionName, "function", node);
+  }
+
+  for (const param of node.params as OxcNode[]) {
+    for (const name of collectBindingNamesFromPattern(param)) {
+      declareBinding(scope, name, "param", param);
+    }
+  }
+
+  for (const name of collectFunctionScopedVarBindings(node.body as OxcNode | null)) {
+    declareBinding(scope, name, "var", node.body as OxcNode | null);
+  }
+}
+
+function declareBlockBindings(statements: OxcNode[], scope: Scope): void {
+  for (const statement of statements) {
+    const declaration = getStatementDeclaration(statement);
+    if (!declaration) continue;
+
+    if (declaration.type === "VariableDeclaration" && declaration.kind === "var") {
+      continue;
+    }
+
+    declareDeclarationBindings(scope, declaration);
+  }
+}
+
+function declareCatchBindings(node: OxcNode, scope: Scope): void {
+  if (!node.param) return;
+
+  for (const name of collectBindingNamesFromPattern(node.param as OxcNode)) {
+    declareBinding(scope, name, "catch", node.param as OxcNode);
+  }
+}
+
+function declareSwitchBindings(cases: OxcNode[], scope: Scope): void {
+  const statements: OxcNode[] = [];
+
+  for (const switchCase of cases) {
+    for (const statement of switchCase.consequent as OxcNode[]) {
+      statements.push(statement);
+    }
+  }
+
+  declareBlockBindings(statements, scope);
+}
+
+function declareDeclarationBindings(scope: Scope, declaration: OxcNode): void {
+  if (declaration.type === "FunctionDeclaration") {
+    const name = getIdentifierName(declaration.id as OxcNode | null);
+    if (name) {
+      declareBinding(scope, name, "function", declaration);
+    }
+    return;
+  }
+
+  if (declaration.type === "ClassDeclaration") {
+    const name = getIdentifierName(declaration.id as OxcNode | null);
+    if (name) {
+      declareBinding(scope, name, "class", declaration);
+    }
+    return;
+  }
+
+  if (declaration.type !== "VariableDeclaration") return;
+
+  for (const declarator of declaration.declarations as OxcNode[]) {
+    for (const name of collectBindingNamesFromPattern(declarator.id as OxcNode)) {
+      declareBinding(scope, name, declaration.kind as BindingKind, declarator);
+    }
+  }
+}
+
+function declareBinding(
+  scope: Scope,
+  name: string,
+  kind: BindingKind,
+  node: OxcNode | null,
+): Binding {
+  const binding: Binding = {
+    kind,
+    name,
+    node,
+    scope,
+  };
+
+  scope.bindings.set(name, binding);
+  return binding;
+}
+
+function collectStatementReferences(
+  statement: OxcNode,
+  currentScope: Scope,
+  scopesByNode: WeakMap<OxcNode, Scope>,
+  result: ScopeAnalysisResult,
+  excludedNames: Set<string>,
+): void {
+  if (statement.type === "ImportDeclaration") return;
+
+  if (statement.type === "ExportNamedDeclaration") {
+    const declaration = statement.declaration as OxcNode | null;
+    if (declaration) {
+      collectNodeReferences(declaration, currentScope, scopesByNode, result, excludedNames);
+    }
+    return;
+  }
+
+  if (statement.type === "ExportDefaultDeclaration") {
+    const declaration = statement.declaration as OxcNode;
+    if (declaration.type !== "Identifier") {
+      collectNodeReferences(declaration, currentScope, scopesByNode, result, excludedNames);
+    }
+    return;
+  }
+
+  collectNodeReferences(statement, currentScope, scopesByNode, result, excludedNames);
+}
+
+function collectNodeReferences(
+  node: OxcNode | null | undefined,
+  currentScope: Scope,
+  scopesByNode: WeakMap<OxcNode, Scope>,
+  result: ScopeAnalysisResult,
+  excludedNames: Set<string>,
+): void {
+  if (!node) return;
+  if (node.type.startsWith("TS")) {
+    collectTsRuntimeReferences(node, currentScope, scopesByNode, result, excludedNames);
+    return;
+  }
+
+  switch (node.type) {
+    case "Identifier":
+      recordReference(node.name as string, node, currentScope, result, excludedNames);
+      return;
+    case "JSXIdentifier":
+      if (JSX_COMPONENT_RE.test(node.name as string)) {
+        recordReference(node.name as string, node, currentScope, result, excludedNames);
+      }
+      return;
+    case "ArrowFunctionExpression":
+    case "FunctionDeclaration":
+    case "FunctionExpression": {
+      const functionScope = scopesByNode.get(node) ?? currentScope;
+
+      for (const param of node.params as OxcNode[]) {
+        collectPatternReferences(param, functionScope, scopesByNode, result, excludedNames);
+      }
+      collectNodeReferences(
+        node.body as OxcNode,
+        functionScope,
+        scopesByNode,
+        result,
+        excludedNames,
+      );
+      return;
+    }
+    case "BlockStatement": {
+      const blockScope = scopesByNode.get(node) ?? currentScope;
+
+      for (const statement of node.body as OxcNode[]) {
+        collectStatementReferences(statement, blockScope, scopesByNode, result, excludedNames);
+      }
+      return;
+    }
+    case "CatchClause": {
+      const catchScope = scopesByNode.get(node) ?? currentScope;
+
+      if (node.param) {
+        collectPatternReferences(
+          node.param as OxcNode,
+          catchScope,
+          scopesByNode,
+          result,
+          excludedNames,
+        );
+      }
+      collectNodeReferences(node.body as OxcNode, catchScope, scopesByNode, result, excludedNames);
+      return;
+    }
+    case "ForStatement": {
+      const loopScope = scopesByNode.get(node) ?? currentScope;
+
+      collectNodeReferences(
+        node.init as OxcNode | null,
+        loopScope,
+        scopesByNode,
+        result,
+        excludedNames,
+      );
+      collectNodeReferences(
+        node.test as OxcNode | null,
+        loopScope,
+        scopesByNode,
+        result,
+        excludedNames,
+      );
+      collectNodeReferences(
+        node.update as OxcNode | null,
+        loopScope,
+        scopesByNode,
+        result,
+        excludedNames,
+      );
+      collectNodeReferences(node.body as OxcNode, loopScope, scopesByNode, result, excludedNames);
+      return;
+    }
+    case "ForInStatement":
+    case "ForOfStatement": {
+      const loopScope = scopesByNode.get(node) ?? currentScope;
+
+      collectNodeReferences(node.left as OxcNode, loopScope, scopesByNode, result, excludedNames);
+      collectNodeReferences(node.right as OxcNode, loopScope, scopesByNode, result, excludedNames);
+      collectNodeReferences(node.body as OxcNode, loopScope, scopesByNode, result, excludedNames);
+      return;
+    }
+    case "SwitchStatement": {
+      collectNodeReferences(
+        node.discriminant as OxcNode,
+        currentScope,
+        scopesByNode,
+        result,
+        excludedNames,
+      );
+
+      const switchScope = scopesByNode.get(node) ?? currentScope;
+      for (const switchCase of node.cases as OxcNode[]) {
+        collectNodeReferences(
+          switchCase.test as OxcNode | null,
+          switchScope,
+          scopesByNode,
+          result,
+          excludedNames,
+        );
+        for (const statement of switchCase.consequent as OxcNode[]) {
+          collectStatementReferences(statement, switchScope, scopesByNode, result, excludedNames);
+        }
+      }
+      return;
+    }
+    case "ClassDeclaration":
+    case "ClassExpression": {
+      collectNodeReferences(
+        node.superClass as OxcNode | null,
+        currentScope,
+        scopesByNode,
+        result,
+        excludedNames,
+      );
+
+      const classScope = scopesByNode.get(node) ?? currentScope;
+      collectNodeReferences(node.body as OxcNode, classScope, scopesByNode, result, excludedNames);
+      return;
+    }
+    case "VariableDeclaration":
+      for (const declarator of node.declarations as OxcNode[]) {
+        collectVariableDeclaratorReferences(
+          declarator,
+          currentScope,
+          scopesByNode,
+          result,
+          excludedNames,
+        );
+      }
+      return;
+    case "MemberExpression":
+      collectNodeReferences(
+        node.object as OxcNode,
+        currentScope,
+        scopesByNode,
+        result,
+        excludedNames,
+      );
+      if (node.computed) {
+        collectNodeReferences(
+          node.property as OxcNode,
+          currentScope,
+          scopesByNode,
+          result,
+          excludedNames,
+        );
+      }
+      return;
+    case "MetaProperty":
+      return;
+    case "LabeledStatement":
+      collectNodeReferences(
+        node.body as OxcNode,
+        currentScope,
+        scopesByNode,
+        result,
+        excludedNames,
+      );
+      return;
+    case "BreakStatement":
+    case "ContinueStatement":
+      return;
+    case "Property":
+      if (node.computed) {
+        collectNodeReferences(
+          node.key as OxcNode,
+          currentScope,
+          scopesByNode,
+          result,
+          excludedNames,
+        );
+      }
+      collectNodeReferences(
+        node.value as OxcNode,
+        currentScope,
+        scopesByNode,
+        result,
+        excludedNames,
+      );
+      return;
+    case "ObjectPattern":
+    case "ArrayPattern":
+    case "AssignmentPattern":
+    case "RestElement":
+      collectPatternReferences(node, currentScope, scopesByNode, result, excludedNames);
+      return;
+    case "JSXElement":
+      collectNodeReferences(
+        node.openingElement as OxcNode,
+        currentScope,
+        scopesByNode,
+        result,
+        excludedNames,
+      );
+      for (const child of node.children as OxcNode[]) {
+        collectNodeReferences(child, currentScope, scopesByNode, result, excludedNames);
+      }
+      return;
+    case "JSXFragment":
+      for (const child of node.children as OxcNode[]) {
+        collectNodeReferences(child, currentScope, scopesByNode, result, excludedNames);
+      }
+      return;
+    case "JSXOpeningElement":
+      collectNodeReferences(
+        node.name as OxcNode,
+        currentScope,
+        scopesByNode,
+        result,
+        excludedNames,
+      );
+      for (const attribute of node.attributes as OxcNode[]) {
+        collectNodeReferences(attribute, currentScope, scopesByNode, result, excludedNames);
+      }
+      return;
+    case "JSXClosingElement":
+      collectNodeReferences(
+        node.name as OxcNode,
+        currentScope,
+        scopesByNode,
+        result,
+        excludedNames,
+      );
+      return;
+    case "JSXAttribute":
+      collectNodeReferences(
+        node.value as OxcNode | null,
+        currentScope,
+        scopesByNode,
+        result,
+        excludedNames,
+      );
+      return;
+    case "JSXExpressionContainer":
+      collectNodeReferences(
+        node.expression as OxcNode,
+        currentScope,
+        scopesByNode,
+        result,
+        excludedNames,
+      );
+      return;
+    case "JSXMemberExpression":
+      collectNodeReferences(
+        node.object as OxcNode,
+        currentScope,
+        scopesByNode,
+        result,
+        excludedNames,
+      );
+      return;
+    case "MethodDefinition":
+    case "PropertyDefinition":
+      if (node.computed) {
+        collectNodeReferences(
+          node.key as OxcNode,
+          currentScope,
+          scopesByNode,
+          result,
+          excludedNames,
+        );
+      }
+      collectNodeReferences(
+        node.value as OxcNode | null,
+        currentScope,
+        scopesByNode,
+        result,
+        excludedNames,
+      );
+      return;
+    case "ImportDeclaration":
+      return;
+    case "ExportNamedDeclaration":
+      if (node.declaration) {
+        collectNodeReferences(
+          node.declaration as OxcNode,
+          currentScope,
+          scopesByNode,
+          result,
+          excludedNames,
+        );
+      }
+      return;
+    case "ExportDefaultDeclaration":
+      if ((node.declaration as OxcNode).type !== "Identifier") {
+        collectNodeReferences(
+          node.declaration as OxcNode,
+          currentScope,
+          scopesByNode,
+          result,
+          excludedNames,
+        );
+      }
+      return;
+    default:
+      for (const [key, value] of Object.entries(node)) {
+        if (SKIPPED_KEYS.has(key)) continue;
+        if (key === "id" || key === "implements" || key === "superTypeArguments") continue;
+        collectUnknownValueReferences(value, currentScope, scopesByNode, result, excludedNames);
+      }
+  }
+}
+
+function collectUnknownValueReferences(
+  value: unknown,
+  currentScope: Scope,
+  scopesByNode: WeakMap<OxcNode, Scope>,
+  result: ScopeAnalysisResult,
+  excludedNames: Set<string>,
+): void {
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      collectUnknownValueReferences(item, currentScope, scopesByNode, result, excludedNames);
+    }
+    return;
+  }
+
+  if (!isNode(value)) return;
+  collectNodeReferences(value, currentScope, scopesByNode, result, excludedNames);
+}
+
+function collectVariableDeclaratorReferences(
+  declarator: OxcNode,
+  currentScope: Scope,
+  scopesByNode: WeakMap<OxcNode, Scope>,
+  result: ScopeAnalysisResult,
+  excludedNames: Set<string>,
+): void {
+  collectPatternReferences(
+    declarator.id as OxcNode,
+    currentScope,
+    scopesByNode,
+    result,
+    excludedNames,
+  );
+  collectNodeReferences(
+    declarator.init as OxcNode | null,
+    currentScope,
+    scopesByNode,
+    result,
+    excludedNames,
+  );
+}
+
+function collectPatternReferences(
+  node: OxcNode | null | undefined,
+  currentScope: Scope,
+  scopesByNode: WeakMap<OxcNode, Scope>,
+  result: ScopeAnalysisResult,
+  excludedNames: Set<string>,
+): void {
+  if (!node) return;
+  if (node.type.startsWith("TS")) {
+    collectTsRuntimeReferences(node, currentScope, scopesByNode, result, excludedNames);
+    return;
+  }
+
+  switch (node.type) {
+    case "AssignmentPattern":
+      collectNodeReferences(
+        node.right as OxcNode,
+        currentScope,
+        scopesByNode,
+        result,
+        excludedNames,
+      );
+      collectPatternReferences(
+        node.left as OxcNode,
+        currentScope,
+        scopesByNode,
+        result,
+        excludedNames,
+      );
+      return;
+    case "ObjectPattern":
+      for (const property of node.properties as OxcNode[]) {
+        if (property.type === "Property") {
+          if (property.computed) {
+            collectNodeReferences(
+              property.key as OxcNode,
+              currentScope,
+              scopesByNode,
+              result,
+              excludedNames,
+            );
+          }
+          collectPatternReferences(
+            property.value as OxcNode,
+            currentScope,
+            scopesByNode,
+            result,
+            excludedNames,
+          );
+          continue;
+        }
+
+        collectPatternReferences(
+          property.argument as OxcNode,
+          currentScope,
+          scopesByNode,
+          result,
+          excludedNames,
+        );
+      }
+      return;
+    case "ArrayPattern":
+      for (const element of node.elements as Array<OxcNode | null>) {
+        collectPatternReferences(element, currentScope, scopesByNode, result, excludedNames);
+      }
+      return;
+    case "RestElement":
+      collectPatternReferences(
+        node.argument as OxcNode,
+        currentScope,
+        scopesByNode,
+        result,
+        excludedNames,
+      );
+      return;
+    default:
+      return;
+  }
+}
+
+function recordReference(
+  name: string,
+  node: OxcNode,
+  currentScope: Scope,
+  result: ScopeAnalysisResult,
+  excludedNames: Set<string>,
+): void {
+  const resolvedBinding = resolveBinding(name, currentScope);
+  result.references.push({
+    name,
+    node,
+    resolvedBinding,
+  });
+
+  if (!resolvedBinding) return;
+  if (resolvedBinding.scope.type !== "program") return;
+  if (excludedNames.has(name)) return;
+
+  result.referencedTopLevelNames.add(name);
+}
+
+function resolveBinding(name: string, currentScope: Scope): Binding | null {
+  let scope: Scope | null = currentScope;
+
+  while (scope) {
+    const binding = scope.bindings.get(name);
+    if (binding) {
+      return binding;
+    }
+
+    scope = scope.parent;
+  }
+
+  return null;
+}
+
+function getStatementDeclaration(statement: OxcNode): OxcNode | null {
+  if (statement.type === "ExportNamedDeclaration") {
+    return (statement.declaration as OxcNode | null) ?? null;
+  }
+
+  if (
+    statement.type === "ExportDefaultDeclaration" &&
+    ((statement.declaration as OxcNode).type === "FunctionDeclaration" ||
+      (statement.declaration as OxcNode).type === "ClassDeclaration")
+  ) {
+    return statement.declaration as OxcNode;
+  }
+
+  if (
+    statement.type === "FunctionDeclaration" ||
+    statement.type === "ClassDeclaration" ||
+    statement.type === "VariableDeclaration"
+  ) {
+    return statement;
+  }
+
+  return null;
+}
+
+function collectBindingNamesFromPattern(pattern: OxcNode | null | undefined): string[] {
+  if (!pattern) return [];
+
+  switch (pattern.type) {
+    case "Identifier":
+      return [pattern.name as string];
+    case "AssignmentPattern":
+      return collectBindingNamesFromPattern(pattern.left as OxcNode);
+    case "RestElement":
+      return collectBindingNamesFromPattern(pattern.argument as OxcNode);
+    case "ObjectPattern":
+      return (pattern.properties as OxcNode[]).flatMap((property) => {
+        if (property.type === "Property") {
+          return collectBindingNamesFromPattern(property.value as OxcNode);
+        }
+        return collectBindingNamesFromPattern(property.argument as OxcNode);
+      });
+    case "ArrayPattern":
+      return (pattern.elements as Array<OxcNode | null>).flatMap((element) =>
+        collectBindingNamesFromPattern(element),
+      );
+    default:
+      return [];
+  }
+}
+
+function collectFunctionScopedVarBindings(node: OxcNode | null | undefined): Set<string> {
+  const names = new Set<string>();
+  collectFunctionScopedVarBindingsInto(node, names);
+  return names;
+}
+
+function collectFunctionScopedVarBindingsInto(
+  node: OxcNode | null | undefined,
+  names: Set<string>,
+): void {
+  if (!node) return;
+  if (node.type.startsWith("TS")) {
+    collectFunctionScopedVarBindingsFromTsNode(node, names);
+    return;
+  }
+
+  switch (node.type) {
+    case "ArrowFunctionExpression":
+    case "FunctionDeclaration":
+    case "FunctionExpression":
+    case "ClassDeclaration":
+    case "ClassExpression":
+      return;
+    case "VariableDeclaration":
+      if (node.kind === "var") {
+        for (const declarator of node.declarations as OxcNode[]) {
+          for (const name of collectBindingNamesFromPattern(declarator.id as OxcNode)) {
+            names.add(name);
+          }
+        }
+      }
+      return;
+    default:
+      for (const [key, value] of Object.entries(node)) {
+        if (SKIPPED_KEYS.has(key)) continue;
+        if (key === "id" || key === "implements" || key === "superTypeArguments") continue;
+        collectFunctionScopedVarBindingsFromUnknown(value, names);
+      }
+  }
+}
+
+function collectFunctionScopedVarBindingsFromUnknown(value: unknown, names: Set<string>): void {
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      collectFunctionScopedVarBindingsFromUnknown(item, names);
+    }
+    return;
+  }
+
+  if (!isNode(value)) return;
+  collectFunctionScopedVarBindingsInto(value, names);
+}
+
+function declareTsRuntimeChildren(
+  node: OxcNode,
+  currentScope: Scope,
+  scopesByNode: WeakMap<OxcNode, Scope>,
+): void {
+  for (const child of getTsRuntimeChildren(node)) {
+    declareNodeScopes(child, currentScope, scopesByNode);
+  }
+}
+
+function collectTsRuntimeReferences(
+  node: OxcNode,
+  currentScope: Scope,
+  scopesByNode: WeakMap<OxcNode, Scope>,
+  result: ScopeAnalysisResult,
+  excludedNames: Set<string>,
+): void {
+  for (const child of getTsRuntimeChildren(node)) {
+    collectNodeReferences(child, currentScope, scopesByNode, result, excludedNames);
+  }
+}
+
+function collectFunctionScopedVarBindingsFromTsNode(node: OxcNode, names: Set<string>): void {
+  for (const child of getTsRuntimeChildren(node)) {
+    collectFunctionScopedVarBindingsInto(child, names);
+  }
+}
+
+function getTsRuntimeChildren(node: OxcNode): OxcNode[] {
+  switch (node.type) {
+    case "TSAsExpression":
+    case "TSInstantiationExpression":
+    case "TSNonNullExpression":
+    case "TSSatisfiesExpression":
+    case "TSTypeAssertion":
+      return [node.expression as OxcNode];
+    default:
+      return [];
+  }
+}
+
+function getIdentifierName(node: OxcNode | null | undefined): string | null {
+  if (!node) return null;
+  if (node.type === "Identifier" || node.type === "JSXIdentifier") {
+    return node.name as string;
+  }
+  if (node.type === "Literal" && typeof node.value === "string") {
+    return node.value as string;
+  }
+  return null;
+}
+
+function isNode(value: unknown): value is OxcNode {
+  return !!value && typeof value === "object" && "type" in value;
+}

--- a/packages/vite-plugin/src/client-module-transform.ts
+++ b/packages/vite-plugin/src/client-module-transform.ts
@@ -1,35 +1,15 @@
 import { parseAst } from "vite";
 
+import {
+  analyzeRetainedStatements,
+  type OxcNode,
+  type RetainedStatement,
+} from "./client-module-scope-analysis.ts";
+
 const CLIENT_MODULE_QUERY = "pracht-client";
 const SERVER_ONLY_EXPORTS = new Set(["loader", "head", "headers", "getStaticPaths"]);
-const JSX_COMPONENT_RE = /^[A-Z]/;
-const SKIPPED_KEYS = new Set([
-  "attributes",
-  "decorators",
-  "end",
-  "exportKind",
-  "importKind",
-  "optional",
-  "phase",
-  "raw",
-  "returnType",
-  "start",
-  "superTypeArguments",
-  "type",
-  "typeAnnotation",
-  "typeArguments",
-  "typeParameters",
-  "value",
-]);
 
 type RolldownLang = "js" | "jsx" | "ts" | "tsx";
-
-type OxcNode = {
-  end: number;
-  start: number;
-  type: string;
-  [key: string]: any;
-};
 
 type StatementState = {
   node: OxcNode;
@@ -139,7 +119,12 @@ function removeServerOnlyExports(
         const declaredNames = new Set(collectBindingNamesFromPattern(declarator.id as OxcNode));
         enqueueDependencies(
           candidates,
-          collectVariableDeclaratorDependencies(declarator, initialBindingNames, declaredNames),
+          collectVariableDeclaratorDependencies(
+            declarator,
+            declaration.kind as string,
+            initialBindingNames,
+            declaredNames,
+          ),
         );
         state.removedDeclarators.add(index);
       }
@@ -195,9 +180,8 @@ function pruneDeadBindings(
     changed = false;
 
     const bindings = collectTopLevelBindings(states, initialBindingNames);
-    const topLevelBindingNames = new Set(bindings.keys());
     const exportedNames = collectExportedBindingNames(states);
-    const referencedNames = collectProgramReferences(states, topLevelBindingNames);
+    const referencedNames = collectProgramReferences(states);
 
     const pendingNames = Array.from(candidates);
     for (const name of pendingNames) {
@@ -299,6 +283,7 @@ function collectTopLevelBindings(
         declaratorIndex: index,
         dependencies: collectVariableDeclaratorDependencies(
           declarator,
+          declaration.kind as string,
           dependencyBindingNames,
           names,
         ),
@@ -414,69 +399,8 @@ function collectExportedBindingNames(states: StatementState[]): Set<string> {
   return names;
 }
 
-function collectProgramReferences(
-  states: StatementState[],
-  topLevelBindingNames: Set<string>,
-): Set<string> {
-  const references = new Set<string>();
-  const scopeStack: Array<Set<string>> = [];
-
-  for (const state of states) {
-    if (state.removed) continue;
-
-    const statement = state.node;
-    if (statement.type === "ImportDeclaration") continue;
-
-    if (statement.type === "ExportNamedDeclaration") {
-      visitExportNamedDeclaration(statement, state, scopeStack, topLevelBindingNames, references);
-      continue;
-    }
-
-    if (statement.type === "ExportDefaultDeclaration") {
-      visitExportDefaultDeclaration(statement, scopeStack, topLevelBindingNames, references);
-      continue;
-    }
-
-    visitNode(statement, scopeStack, topLevelBindingNames, references);
-  }
-
-  return references;
-}
-
-function visitExportNamedDeclaration(
-  statement: OxcNode,
-  state: StatementState,
-  scopeStack: Array<Set<string>>,
-  topLevelBindingNames: Set<string>,
-  references: Set<string>,
-): void {
-  const declaration = statement.declaration as OxcNode | null;
-  if (!declaration) return;
-
-  if (declaration.type === "VariableDeclaration") {
-    for (const index of getRemainingDeclaratorIndices(state)) {
-      visitVariableDeclarator(
-        declaration.declarations[index] as OxcNode,
-        scopeStack,
-        topLevelBindingNames,
-        references,
-      );
-    }
-    return;
-  }
-
-  visitNode(declaration, scopeStack, topLevelBindingNames, references);
-}
-
-function visitExportDefaultDeclaration(
-  statement: OxcNode,
-  scopeStack: Array<Set<string>>,
-  topLevelBindingNames: Set<string>,
-  references: Set<string>,
-): void {
-  const declaration = statement.declaration as OxcNode;
-  if (declaration.type === "Identifier") return;
-  visitNode(declaration, scopeStack, topLevelBindingNames, references);
+function collectProgramReferences(states: StatementState[]): Set<string> {
+  return analyzeRetainedStatements(normalizeRetainedStatements(states)).referencedTopLevelNames;
 }
 
 function removeBinding(states: StatementState[], binding: BindingInfo): void {
@@ -626,19 +550,19 @@ function getRemainingSpecifierIndices(state: StatementState): number[] {
 
 function collectVariableDeclaratorDependencies(
   declarator: OxcNode,
+  declarationKind: string,
   topLevelBindingNames: Set<string>,
   excludedNames: Set<string>,
 ): Set<string> {
-  const dependencies = new Set<string>();
-  visitPattern(declarator.id as OxcNode, [], topLevelBindingNames, dependencies);
-  visitNode(
-    declarator.init as OxcNode | null,
-    [],
-    topLevelBindingNames,
-    dependencies,
-    excludedNames,
-  );
-  return dependencies;
+  const declaration: OxcNode = {
+    declarations: [declarator],
+    end: declarator.end,
+    kind: declarationKind,
+    start: declarator.start,
+    type: "VariableDeclaration",
+  };
+
+  return collectTopLevelReferences(declaration, topLevelBindingNames, excludedNames);
 }
 
 function collectTopLevelReferences(
@@ -646,624 +570,70 @@ function collectTopLevelReferences(
   topLevelBindingNames: Set<string>,
   excludedNames: Set<string>,
 ): Set<string> {
-  const references = new Set<string>();
-  visitNode(node, [], topLevelBindingNames, references, excludedNames);
-  return references;
-}
-
-function visitNode(
-  node: OxcNode | null | undefined,
-  scopeStack: Array<Set<string>>,
-  topLevelBindingNames: Set<string>,
-  references: Set<string>,
-  excludedNames = new Set<string>(),
-): void {
-  if (!node) return;
-  if (node.type.startsWith("TS")) return;
-
-  switch (node.type) {
-    case "Identifier":
-      addReference(
-        node.name as string,
-        scopeStack,
-        topLevelBindingNames,
-        references,
-        excludedNames,
-      );
-      return;
-    case "JSXIdentifier":
-      if (JSX_COMPONENT_RE.test(node.name as string)) {
-        addReference(
-          node.name as string,
-          scopeStack,
-          topLevelBindingNames,
-          references,
-          excludedNames,
-        );
-      }
-      return;
-    case "ArrowFunctionExpression":
-    case "FunctionDeclaration":
-    case "FunctionExpression":
-      visitFunctionLike(node, scopeStack, topLevelBindingNames, references, excludedNames);
-      return;
-    case "VariableDeclaration":
-      for (const declarator of node.declarations as OxcNode[]) {
-        visitVariableDeclarator(
-          declarator,
-          scopeStack,
-          topLevelBindingNames,
-          references,
-          excludedNames,
-        );
-      }
-      return;
-    case "MemberExpression":
-      visitNode(
-        node.object as OxcNode,
-        scopeStack,
-        topLevelBindingNames,
-        references,
-        excludedNames,
-      );
-      if (node.computed) {
-        visitNode(
-          node.property as OxcNode,
-          scopeStack,
-          topLevelBindingNames,
-          references,
-          excludedNames,
-        );
-      }
-      return;
-    case "MetaProperty":
-      return;
-    case "LabeledStatement":
-      visitNode(node.body as OxcNode, scopeStack, topLevelBindingNames, references, excludedNames);
-      return;
-    case "BreakStatement":
-    case "ContinueStatement":
-      return;
-    case "Property":
-      if (node.computed) {
-        visitNode(node.key as OxcNode, scopeStack, topLevelBindingNames, references, excludedNames);
-      }
-      if (node.shorthand) {
-        visitNode(
-          node.value as OxcNode,
-          scopeStack,
-          topLevelBindingNames,
-          references,
-          excludedNames,
-        );
-      } else {
-        visitNode(
-          node.value as OxcNode,
-          scopeStack,
-          topLevelBindingNames,
-          references,
-          excludedNames,
-        );
-      }
-      return;
-    case "BlockStatement":
-      visitBlockStatement(node, scopeStack, topLevelBindingNames, references, excludedNames);
-      return;
-    case "ObjectPattern":
-    case "ArrayPattern":
-    case "AssignmentPattern":
-    case "RestElement":
-      visitPattern(node, scopeStack, topLevelBindingNames, references, excludedNames);
-      return;
-    case "CatchClause":
-      visitCatchClause(node, scopeStack, topLevelBindingNames, references, excludedNames);
-      return;
-    case "ForStatement":
-      visitForStatement(node, scopeStack, topLevelBindingNames, references, excludedNames);
-      return;
-    case "ForInStatement":
-    case "ForOfStatement":
-      visitForInOrOfStatement(node, scopeStack, topLevelBindingNames, references, excludedNames);
-      return;
-    case "ClassDeclaration":
-    case "ClassExpression":
-      visitClassLike(node, scopeStack, topLevelBindingNames, references, excludedNames);
-      return;
-    case "SwitchStatement":
-      visitSwitchStatement(node, scopeStack, topLevelBindingNames, references, excludedNames);
-      return;
-    case "JSXElement":
-      visitNode(
-        node.openingElement as OxcNode,
-        scopeStack,
-        topLevelBindingNames,
-        references,
-        excludedNames,
-      );
-      for (const child of node.children as OxcNode[]) {
-        visitNode(child, scopeStack, topLevelBindingNames, references, excludedNames);
-      }
-      return;
-    case "JSXFragment":
-      for (const child of node.children as OxcNode[]) {
-        visitNode(child, scopeStack, topLevelBindingNames, references, excludedNames);
-      }
-      return;
-    case "JSXOpeningElement":
-      visitNode(node.name as OxcNode, scopeStack, topLevelBindingNames, references, excludedNames);
-      for (const attribute of node.attributes as OxcNode[]) {
-        visitNode(attribute, scopeStack, topLevelBindingNames, references, excludedNames);
-      }
-      return;
-    case "JSXClosingElement":
-      visitNode(node.name as OxcNode, scopeStack, topLevelBindingNames, references, excludedNames);
-      return;
-    case "JSXAttribute":
-      visitNode(
-        node.value as OxcNode | null,
-        scopeStack,
-        topLevelBindingNames,
-        references,
-        excludedNames,
-      );
-      return;
-    case "JSXExpressionContainer":
-      visitNode(
-        node.expression as OxcNode,
-        scopeStack,
-        topLevelBindingNames,
-        references,
-        excludedNames,
-      );
-      return;
-    case "JSXMemberExpression":
-      visitNode(
-        node.object as OxcNode,
-        scopeStack,
-        topLevelBindingNames,
-        references,
-        excludedNames,
-      );
-      return;
-    case "MethodDefinition":
-    case "PropertyDefinition":
-      if (node.computed) {
-        visitNode(node.key as OxcNode, scopeStack, topLevelBindingNames, references, excludedNames);
-      }
-      visitNode(
-        node.value as OxcNode | null,
-        scopeStack,
-        topLevelBindingNames,
-        references,
-        excludedNames,
-      );
-      return;
-    case "ImportDeclaration":
-      return;
-    case "ExportNamedDeclaration":
-      if (node.declaration) {
-        visitNode(
-          node.declaration as OxcNode,
-          scopeStack,
-          topLevelBindingNames,
-          references,
-          excludedNames,
-        );
-      }
-      return;
-    case "ExportDefaultDeclaration":
-      if ((node.declaration as OxcNode).type !== "Identifier") {
-        visitNode(
-          node.declaration as OxcNode,
-          scopeStack,
-          topLevelBindingNames,
-          references,
-          excludedNames,
-        );
-      }
-      return;
-    default:
-      for (const [key, value] of Object.entries(node)) {
-        if (SKIPPED_KEYS.has(key)) continue;
-        if (key === "id" || key === "implements" || key === "superTypeArguments") continue;
-        visitUnknownValue(value, scopeStack, topLevelBindingNames, references, excludedNames);
-      }
-  }
-}
-
-function visitUnknownValue(
-  value: unknown,
-  scopeStack: Array<Set<string>>,
-  topLevelBindingNames: Set<string>,
-  references: Set<string>,
-  excludedNames: Set<string>,
-): void {
-  if (Array.isArray(value)) {
-    for (const item of value) {
-      visitUnknownValue(item, scopeStack, topLevelBindingNames, references, excludedNames);
-    }
-    return;
-  }
-
-  if (!isNode(value)) return;
-  visitNode(value, scopeStack, topLevelBindingNames, references, excludedNames);
-}
-
-function visitVariableDeclarator(
-  declarator: OxcNode,
-  scopeStack: Array<Set<string>>,
-  topLevelBindingNames: Set<string>,
-  references: Set<string>,
-  excludedNames = new Set<string>(),
-): void {
-  visitPattern(
-    declarator.id as OxcNode,
-    scopeStack,
-    topLevelBindingNames,
-    references,
+  return analyzeRetainedStatements([{ node }], {
     excludedNames,
-  );
-  visitNode(
-    declarator.init as OxcNode | null,
-    scopeStack,
-    topLevelBindingNames,
-    references,
-    excludedNames,
-  );
+    knownTopLevelNames: topLevelBindingNames,
+  }).referencedTopLevelNames;
 }
 
-function visitFunctionLike(
-  node: OxcNode,
-  scopeStack: Array<Set<string>>,
-  topLevelBindingNames: Set<string>,
-  references: Set<string>,
-  excludedNames: Set<string>,
-): void {
-  const scope = new Set<string>();
-  const functionName = getIdentifierName(node.id as OxcNode | null);
-  if (functionName) {
-    scope.add(functionName);
+function normalizeRetainedStatements(states: StatementState[]): RetainedStatement[] {
+  return states
+    .map((state) => normalizeRetainedStatement(state))
+    .filter((state): state is RetainedStatement => state !== null);
+}
+
+function normalizeRetainedStatement(state: StatementState): RetainedStatement | null {
+  if (state.removed) return null;
+
+  const statement = state.node;
+  if (statement.type === "ImportDeclaration" && state.removedSpecifiers.size > 0) {
+    return {
+      node: {
+        ...statement,
+        specifiers: getRemainingSpecifierIndices(state).map(
+          (index) => statement.specifiers[index] as OxcNode,
+        ),
+      },
+    };
   }
-  for (const param of node.params as OxcNode[]) {
-    for (const name of collectBindingNamesFromPattern(param)) {
-      scope.add(name);
+
+  if (
+    statement.type === "ExportNamedDeclaration" &&
+    !statement.declaration &&
+    state.removedSpecifiers.size > 0
+  ) {
+    return {
+      node: {
+        ...statement,
+        specifiers: getRemainingSpecifierIndices(state).map(
+          (index) => statement.specifiers[index] as OxcNode,
+        ),
+      },
+    };
+  }
+
+  const declaration = getStatementDeclaration(statement);
+  if (declaration?.type === "VariableDeclaration" && state.removedDeclarators.size > 0) {
+    const retainedDeclaration: OxcNode = {
+      ...declaration,
+      declarations: getRemainingDeclaratorIndices(state).map(
+        (index) => declaration.declarations[index] as OxcNode,
+      ),
+    };
+
+    if (statement.type === "ExportNamedDeclaration") {
+      return {
+        node: {
+          ...statement,
+          declaration: retainedDeclaration,
+        },
+      };
     }
-  }
-  for (const name of collectFunctionScopedVarBindings(node.body as OxcNode | null)) {
-    scope.add(name);
-  }
 
-  scopeStack.push(scope);
-  for (const param of node.params as OxcNode[]) {
-    visitPattern(param, scopeStack, topLevelBindingNames, references, excludedNames);
-  }
-  visitNode(node.body as OxcNode, scopeStack, topLevelBindingNames, references, excludedNames);
-  scopeStack.pop();
-}
-
-function visitBlockStatement(
-  node: OxcNode,
-  scopeStack: Array<Set<string>>,
-  topLevelBindingNames: Set<string>,
-  references: Set<string>,
-  excludedNames: Set<string>,
-): void {
-  const scope = collectBlockScopeBindings(node.body as OxcNode[]);
-  scopeStack.push(scope);
-  for (const statement of node.body as OxcNode[]) {
-    visitNode(statement, scopeStack, topLevelBindingNames, references, excludedNames);
-  }
-  scopeStack.pop();
-}
-
-function visitCatchClause(
-  node: OxcNode,
-  scopeStack: Array<Set<string>>,
-  topLevelBindingNames: Set<string>,
-  references: Set<string>,
-  excludedNames: Set<string>,
-): void {
-  const scope = new Set<string>();
-  if (node.param) {
-    for (const name of collectBindingNamesFromPattern(node.param as OxcNode)) {
-      scope.add(name);
-    }
-  }
-  for (const name of collectBlockScopeBindings((node.body as OxcNode).body as OxcNode[])) {
-    scope.add(name);
+    return { node: retainedDeclaration };
   }
 
-  scopeStack.push(scope);
-  if (node.param) {
-    visitPattern(
-      node.param as OxcNode,
-      scopeStack,
-      topLevelBindingNames,
-      references,
-      excludedNames,
-    );
-  }
-  visitNode(node.body as OxcNode, scopeStack, topLevelBindingNames, references, excludedNames);
-  scopeStack.pop();
-}
-
-function visitForStatement(
-  node: OxcNode,
-  scopeStack: Array<Set<string>>,
-  topLevelBindingNames: Set<string>,
-  references: Set<string>,
-  excludedNames: Set<string>,
-): void {
-  const init = node.init as OxcNode | null;
-  if (init?.type === "VariableDeclaration" && init.kind !== "var") {
-    const scope = new Set(collectBindingNamesFromDeclaration(init));
-    scopeStack.push(scope);
-    visitNode(init, scopeStack, topLevelBindingNames, references, excludedNames);
-    visitNode(
-      node.test as OxcNode | null,
-      scopeStack,
-      topLevelBindingNames,
-      references,
-      excludedNames,
-    );
-    visitNode(
-      node.update as OxcNode | null,
-      scopeStack,
-      topLevelBindingNames,
-      references,
-      excludedNames,
-    );
-    visitNode(node.body as OxcNode, scopeStack, topLevelBindingNames, references, excludedNames);
-    scopeStack.pop();
-    return;
-  }
-
-  visitNode(init, scopeStack, topLevelBindingNames, references, excludedNames);
-  visitNode(
-    node.test as OxcNode | null,
-    scopeStack,
-    topLevelBindingNames,
-    references,
-    excludedNames,
-  );
-  visitNode(
-    node.update as OxcNode | null,
-    scopeStack,
-    topLevelBindingNames,
-    references,
-    excludedNames,
-  );
-  visitNode(node.body as OxcNode, scopeStack, topLevelBindingNames, references, excludedNames);
-}
-
-function visitForInOrOfStatement(
-  node: OxcNode,
-  scopeStack: Array<Set<string>>,
-  topLevelBindingNames: Set<string>,
-  references: Set<string>,
-  excludedNames: Set<string>,
-): void {
-  const left = node.left as OxcNode | null;
-  if (left?.type === "VariableDeclaration" && left.kind !== "var") {
-    const scope = new Set(collectBindingNamesFromDeclaration(left));
-    scopeStack.push(scope);
-    visitNode(left, scopeStack, topLevelBindingNames, references, excludedNames);
-    visitNode(node.right as OxcNode, scopeStack, topLevelBindingNames, references, excludedNames);
-    visitNode(node.body as OxcNode, scopeStack, topLevelBindingNames, references, excludedNames);
-    scopeStack.pop();
-    return;
-  }
-
-  visitNode(left, scopeStack, topLevelBindingNames, references, excludedNames);
-  visitNode(node.right as OxcNode, scopeStack, topLevelBindingNames, references, excludedNames);
-  visitNode(node.body as OxcNode, scopeStack, topLevelBindingNames, references, excludedNames);
-}
-
-function visitSwitchStatement(
-  node: OxcNode,
-  scopeStack: Array<Set<string>>,
-  topLevelBindingNames: Set<string>,
-  references: Set<string>,
-  excludedNames: Set<string>,
-): void {
-  visitNode(
-    node.discriminant as OxcNode,
-    scopeStack,
-    topLevelBindingNames,
-    references,
-    excludedNames,
-  );
-
-  const scope = collectSwitchScopeBindings(node.cases as OxcNode[]);
-  scopeStack.push(scope);
-  for (const switchCase of node.cases as OxcNode[]) {
-    visitNode(
-      switchCase.test as OxcNode | null,
-      scopeStack,
-      topLevelBindingNames,
-      references,
-      excludedNames,
-    );
-    for (const statement of switchCase.consequent as OxcNode[]) {
-      visitNode(statement, scopeStack, topLevelBindingNames, references, excludedNames);
-    }
-  }
-  scopeStack.pop();
-}
-
-function visitClassLike(
-  node: OxcNode,
-  scopeStack: Array<Set<string>>,
-  topLevelBindingNames: Set<string>,
-  references: Set<string>,
-  excludedNames: Set<string>,
-): void {
-  visitNode(
-    node.superClass as OxcNode | null,
-    scopeStack,
-    topLevelBindingNames,
-    references,
-    excludedNames,
-  );
-
-  const scope = new Set<string>();
-  const name = getIdentifierName(node.id as OxcNode | null);
-  if (name) {
-    scope.add(name);
-  }
-
-  scopeStack.push(scope);
-  visitNode(node.body as OxcNode, scopeStack, topLevelBindingNames, references, excludedNames);
-  scopeStack.pop();
-}
-
-function visitPattern(
-  node: OxcNode | null | undefined,
-  scopeStack: Array<Set<string>>,
-  topLevelBindingNames: Set<string>,
-  references: Set<string>,
-  excludedNames = new Set<string>(),
-): void {
-  if (!node) return;
-  if (node.type.startsWith("TS")) return;
-
-  switch (node.type) {
-    case "AssignmentPattern":
-      visitNode(node.right as OxcNode, scopeStack, topLevelBindingNames, references, excludedNames);
-      visitPattern(
-        node.left as OxcNode,
-        scopeStack,
-        topLevelBindingNames,
-        references,
-        excludedNames,
-      );
-      return;
-    case "ObjectPattern":
-      for (const property of node.properties as OxcNode[]) {
-        if (property.type === "Property") {
-          if (property.computed) {
-            visitNode(
-              property.key as OxcNode,
-              scopeStack,
-              topLevelBindingNames,
-              references,
-              excludedNames,
-            );
-          }
-          visitPattern(
-            property.value as OxcNode,
-            scopeStack,
-            topLevelBindingNames,
-            references,
-            excludedNames,
-          );
-          continue;
-        }
-        visitPattern(
-          property.argument as OxcNode,
-          scopeStack,
-          topLevelBindingNames,
-          references,
-          excludedNames,
-        );
-      }
-      return;
-    case "ArrayPattern":
-      for (const element of node.elements as Array<OxcNode | null>) {
-        visitPattern(element, scopeStack, topLevelBindingNames, references, excludedNames);
-      }
-      return;
-    case "RestElement":
-      visitPattern(
-        node.argument as OxcNode,
-        scopeStack,
-        topLevelBindingNames,
-        references,
-        excludedNames,
-      );
-      return;
-    default:
-      return;
-  }
-}
-
-function collectBlockScopeBindings(statements: OxcNode[]): Set<string> {
-  const names = new Set<string>();
-
-  for (const statement of statements) {
-    const declaration = getStatementDeclaration(statement);
-    if (!declaration) continue;
-    if (declaration.type === "VariableDeclaration" && declaration.kind === "var") {
-      continue;
-    }
-    for (const name of collectBindingNamesFromDeclaration(declaration)) {
-      names.add(name);
-    }
-  }
-
-  return names;
-}
-
-function collectFunctionScopedVarBindings(node: OxcNode | null | undefined): Set<string> {
-  const names = new Set<string>();
-  collectFunctionScopedVarBindingsInto(node, names);
-  return names;
-}
-
-function collectFunctionScopedVarBindingsInto(
-  node: OxcNode | null | undefined,
-  names: Set<string>,
-): void {
-  if (!node) return;
-  if (node.type.startsWith("TS")) return;
-
-  switch (node.type) {
-    case "ArrowFunctionExpression":
-    case "FunctionDeclaration":
-    case "FunctionExpression":
-    case "ClassDeclaration":
-    case "ClassExpression":
-      return;
-    case "VariableDeclaration":
-      if (node.kind === "var") {
-        for (const declarator of node.declarations as OxcNode[]) {
-          for (const name of collectBindingNamesFromPattern(declarator.id as OxcNode)) {
-            names.add(name);
-          }
-        }
-      }
-      return;
-    default:
-      for (const [key, value] of Object.entries(node)) {
-        if (SKIPPED_KEYS.has(key)) continue;
-        if (key === "id" || key === "implements" || key === "superTypeArguments") continue;
-        collectFunctionScopedVarBindingsFromUnknown(value, names);
-      }
-  }
-}
-
-function collectFunctionScopedVarBindingsFromUnknown(value: unknown, names: Set<string>): void {
-  if (Array.isArray(value)) {
-    for (const item of value) {
-      collectFunctionScopedVarBindingsFromUnknown(item, names);
-    }
-    return;
-  }
-
-  if (!isNode(value)) return;
-  collectFunctionScopedVarBindingsInto(value, names);
-}
-
-function collectSwitchScopeBindings(cases: OxcNode[]): Set<string> {
-  const statements: OxcNode[] = [];
-
-  for (const switchCase of cases) {
-    for (const statement of switchCase.consequent as OxcNode[]) {
-      statements.push(statement);
-    }
-  }
-
-  return collectBlockScopeBindings(statements);
+  return { node: statement };
 }
 
 function getStatementDeclaration(statement: OxcNode): OxcNode | null {
@@ -1330,23 +700,6 @@ function collectBindingNamesFromPattern(pattern: OxcNode | null | undefined): st
   }
 }
 
-function addReference(
-  name: string,
-  scopeStack: Array<Set<string>>,
-  topLevelBindingNames: Set<string>,
-  references: Set<string>,
-  excludedNames: Set<string>,
-): void {
-  if (excludedNames.has(name)) return;
-  if (!topLevelBindingNames.has(name)) return;
-  if (isShadowed(name, scopeStack)) return;
-  references.add(name);
-}
-
-function isShadowed(name: string, scopeStack: Array<Set<string>>): boolean {
-  return scopeStack.some((scope) => scope.has(name));
-}
-
 function enqueueDependencies(target: Set<string>, dependencies: Iterable<string>): void {
   for (const name of dependencies) {
     target.add(name);
@@ -1372,8 +725,4 @@ function getRolldownLang(id: string): RolldownLang {
   if (/\.mdx?$/i.test(path)) return "jsx";
   if (/\.(c|m)?js$/i.test(path)) return "js";
   return "tsx";
-}
-
-function isNode(value: unknown): value is OxcNode {
-  return !!value && typeof value === "object" && "type" in value;
 }

--- a/packages/vite-plugin/test/client-module-scope-analysis.test.ts
+++ b/packages/vite-plugin/test/client-module-scope-analysis.test.ts
@@ -1,0 +1,269 @@
+import { parseAst } from "vite";
+import { describe, expect, it } from "vitest";
+
+import { analyzeRetainedStatements, type OxcNode } from "../src/client-module-scope-analysis.ts";
+
+function analyzeReferencedTopLevelNames(source: string): string[] {
+  const program = parseAst(source, { lang: "tsx" }) as OxcNode;
+
+  return [
+    ...analyzeRetainedStatements((program.body as OxcNode[]).map((node) => ({ node })))
+      .referencedTopLevelNames,
+  ].sort();
+}
+
+describe("analyzeRetainedStatements", () => {
+  it("does not count function parameter shadowing as a top-level reference", () => {
+    const names = analyzeReferencedTopLevelNames(`
+import serverOnly from "../server-only";
+
+export default function Page(serverOnly) {
+  return <div>{serverOnly}</div>;
+}
+`);
+
+    expect(names).toEqual([]);
+  });
+
+  it("does not count function-hoisted var shadowing as a top-level reference", () => {
+    const names = analyzeReferencedTopLevelNames(`
+import serverOnly from "../server-only";
+
+export default function Page() {
+  if (true) {
+    var serverOnly = 1;
+  }
+
+  return <div>{serverOnly}</div>;
+}
+`);
+
+    expect(names).toEqual([]);
+  });
+
+  it("does not count block-scoped shadowing as a top-level reference", () => {
+    const names = analyzeReferencedTopLevelNames(`
+import serverOnly from "../server-only";
+
+export default function Page() {
+  if (true) {
+    const serverOnly = 1;
+    return <div>{serverOnly}</div>;
+  }
+
+  return <div />;
+}
+`);
+
+    expect(names).toEqual([]);
+  });
+
+  it("does not count destructured catch parameters as top-level references", () => {
+    const names = analyzeReferencedTopLevelNames(`
+import serverOnly from "../server-only";
+
+export default function Page() {
+  try {
+    throw { serverOnly: 1 };
+  } catch ({ serverOnly }) {
+    return <div>{serverOnly}</div>;
+  }
+
+  return <div />;
+}
+`);
+
+    expect(names).toEqual([]);
+  });
+
+  it("handles lexical loop-header shadowing for for/for-in/for-of", () => {
+    const names = analyzeReferencedTopLevelNames(`
+import serverOnly from "../server-only";
+
+export default function Page() {
+  for (let serverOnly = 0; serverOnly < 1; serverOnly++) {
+    console.log(serverOnly);
+  }
+
+  for (const serverOnly of [1]) {
+    console.log(serverOnly);
+  }
+
+  for (const serverOnly in { a: 1 }) {
+    console.log(serverOnly);
+  }
+
+  return <div />;
+}
+`);
+
+    expect(names).toEqual([]);
+  });
+
+  it("does not count switch-case lexical bindings as top-level references", () => {
+    const names = analyzeReferencedTopLevelNames(`
+import serverOnly from "../server-only";
+
+export default function Page() {
+  switch (1) {
+    case 1:
+      const serverOnly = 1;
+      return <div>{serverOnly}</div>;
+    default:
+      return <div />;
+  }
+}
+`);
+
+    expect(names).toEqual([]);
+  });
+
+  it("ignores local and aliased re-export specifiers", () => {
+    const names = analyzeReferencedTopLevelNames(`
+import shared from "../shared";
+
+export { shared, shared as renamed };
+`);
+
+    expect(names).toEqual([]);
+  });
+
+  it("ignores import.meta and new.target meta properties", () => {
+    const names = analyzeReferencedTopLevelNames(`
+import meta from "../server-only";
+import target from "../target";
+
+export default function Page() {
+  return (
+    <div>
+      {import.meta.env.MODE}
+      {(() => new.target)()}
+    </div>
+  );
+}
+`);
+
+    expect(names).toEqual([]);
+  });
+
+  it("ignores statement labels and break labels", () => {
+    const names = analyzeReferencedTopLevelNames(`
+import serverOnly from "../server-only";
+
+export default function Page() {
+  serverOnly: for (;;) {
+    break serverOnly;
+  }
+
+  return <div />;
+}
+`);
+
+    expect(names).toEqual([]);
+  });
+
+  it("counts computed property keys but not non-computed keys", () => {
+    const names = analyzeReferencedTopLevelNames(`
+import computed from "../computed";
+import plain from "../plain";
+
+export default function Page() {
+  return { [computed]: 1, plain: 2 };
+}
+`);
+
+    expect(names).toEqual(["computed"]);
+  });
+
+  it("counts object shorthand values but not plain property keys", () => {
+    const names = analyzeReferencedTopLevelNames(`
+import shorthand from "../shorthand";
+import plain from "../plain";
+
+export default function Page() {
+  return { shorthand, plain: 1 };
+}
+`);
+
+    expect(names).toEqual(["shorthand"]);
+  });
+
+  it("counts pattern default values and class heritage expressions", () => {
+    const names = analyzeReferencedTopLevelNames(`
+import fallback from "../fallback";
+import Base from "../base";
+
+class Derived extends Base {}
+
+export default function Page({ value = fallback }) {
+  return <div>{value}</div>;
+}
+`);
+
+    expect(names).toEqual(["Base", "fallback"]);
+  });
+
+  it("counts uppercase JSX component identifiers but not lowercase tags", () => {
+    const names = analyzeReferencedTopLevelNames(`
+import Component from "../component";
+import element from "../element";
+
+export default function Page() {
+  return (
+    <>
+      <Component />
+      <element />
+    </>
+  );
+}
+`);
+
+    expect(names).toEqual(["Component"]);
+  });
+
+  it("ignores default-exported identifiers when determining live top-level bindings", () => {
+    const names = analyzeReferencedTopLevelNames(`
+const Page = () => <div>ok</div>;
+
+export default Page;
+`);
+
+    expect(names).toEqual([]);
+  });
+
+  it("counts references wrapped in TypeScript `as` assertions", () => {
+    const names = analyzeReferencedTopLevelNames(`
+import shared from "../shared";
+
+export default function Page() {
+  return <div>{shared as string}</div>;
+}
+`);
+
+    expect(names).toEqual(["shared"]);
+  });
+
+  it("counts references wrapped in TypeScript non-null assertions", () => {
+    const names = analyzeReferencedTopLevelNames(`
+import shared from "../shared";
+
+export default function Page() {
+  return <div>{shared!}</div>;
+}
+`);
+
+    expect(names).toEqual(["shared"]);
+  });
+
+  it("counts references wrapped in TypeScript `satisfies` expressions", () => {
+    const names = analyzeReferencedTopLevelNames(`
+import shared from "../shared";
+
+export default function Page() {
+  return <div>{shared satisfies unknown}</div>;
+}
+`);
+
+    expect(names).toEqual(["shared"]);
+  });
+});

--- a/packages/vite-plugin/test/client-module-transform.test.ts
+++ b/packages/vite-plugin/test/client-module-transform.test.ts
@@ -2,8 +2,7 @@ import { mkdtempSync, mkdirSync, readFileSync, readdirSync, rmSync, writeFileSyn
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
-import { build } from "vite";
-import { parseAst } from "vite";
+import { build, parseAst } from "vite";
 import { afterEach, describe, expect, it } from "vitest";
 
 import { pracht } from "../src/index.ts";
@@ -28,6 +27,57 @@ function readBuiltJs(root: string): string {
 
 function expectValidModuleSource(code: string): void {
   expect(() => parseAst(code, { lang: "tsx" })).not.toThrow();
+}
+
+async function buildTempProject(root: string): Promise<void> {
+  await build({
+    root,
+    configFile: false,
+    logLevel: "silent",
+    plugins: await pracht({ pagesDir: "/src/pages" }),
+    resolve: {
+      alias: [
+        {
+          find: "@pracht/core",
+          replacement: resolve(repoRoot, "packages/framework/src/index.ts"),
+        },
+        {
+          find: "preact/jsx-dev-runtime",
+          replacement: resolve(
+            repoRoot,
+            "node_modules/preact/jsx-runtime/dist/jsxRuntime.module.js",
+          ),
+        },
+        {
+          find: "preact/jsx-runtime",
+          replacement: resolve(
+            repoRoot,
+            "node_modules/preact/jsx-runtime/dist/jsxRuntime.module.js",
+          ),
+        },
+        {
+          find: "preact/hooks",
+          replacement: resolve(repoRoot, "node_modules/preact/hooks/dist/hooks.module.js"),
+        },
+        {
+          find: "preact/devtools",
+          replacement: resolve(repoRoot, "node_modules/preact/devtools/dist/devtools.module.js"),
+        },
+        {
+          find: "preact/debug",
+          replacement: resolve(repoRoot, "node_modules/preact/debug/dist/debug.module.js"),
+        },
+        { find: "preact", replacement: resolve(repoRoot, "node_modules/preact/dist/preact.mjs") },
+      ],
+    },
+    build: {
+      outDir: "dist",
+      manifest: true,
+      rollupOptions: {
+        input: "virtual:pracht/client",
+      },
+    },
+  });
 }
 
 afterEach(() => {
@@ -94,10 +144,6 @@ export default function Home() {
 
     const transformed = stripServerOnlyExportsForClient(source);
 
-    // The template literal must still be terminated — i.e. the closing backtick
-    // is still present.  Previously the regex matched `export ... function` inside
-    // the template and stripped through the first `}` it found, removing the
-    // closing backtick and producing an unterminated string.
     expect(transformed).toContain("`}");
     expect(transformed).toContain("export async function loader");
     expect(transformed).toContain("export function head");
@@ -137,6 +183,66 @@ export default function Page() {
     expect(transformed).not.toContain("../server-only");
     expect(transformed).not.toContain("function loader");
     expect(transformed).toContain("function Page");
+    expectValidModuleSource(transformed);
+  });
+
+  it("keeps imports referenced through TypeScript `as` assertions in client code", () => {
+    const source = `
+import shared from "../shared";
+
+export function loader() {
+  return shared();
+}
+
+export default function Page() {
+  return <main>{shared as string}</main>;
+}
+`;
+
+    const transformed = stripServerOnlyExportsForClient(source);
+
+    expect(transformed).toContain("../shared");
+    expect(transformed).toContain("shared as string");
+    expectValidModuleSource(transformed);
+  });
+
+  it("keeps imports referenced through TypeScript non-null assertions in client code", () => {
+    const source = `
+import shared from "../shared";
+
+export function loader() {
+  return shared();
+}
+
+export default function Page() {
+  return <main>{shared!}</main>;
+}
+`;
+
+    const transformed = stripServerOnlyExportsForClient(source);
+
+    expect(transformed).toContain("../shared");
+    expect(transformed).toContain("shared!");
+    expectValidModuleSource(transformed);
+  });
+
+  it("keeps imports referenced through TypeScript `satisfies` expressions in client code", () => {
+    const source = `
+import shared from "../shared";
+
+export function loader() {
+  return shared();
+}
+
+export default function Page() {
+  return <main>{shared satisfies unknown}</main>;
+}
+`;
+
+    const transformed = stripServerOnlyExportsForClient(source);
+
+    expect(transformed).toContain("../shared");
+    expect(transformed).toContain("shared satisfies unknown");
     expectValidModuleSource(transformed);
   });
 
@@ -261,233 +367,6 @@ export default function Page() {
     expectValidModuleSource(transformed);
   });
 
-  it("drops dead imports when loop header bindings shadow the server-only name", () => {
-    const source = `
-import serverOnly from "../server-only";
-
-export function loader() {
-  return serverOnly();
-}
-
-export default function Page() {
-  for (const serverOnly of [1]) {
-    console.log(serverOnly);
-  }
-  return <div />;
-}
-`;
-
-    const transformed = stripServerOnlyExportsForClient(source);
-
-    expect(transformed).not.toContain("../server-only");
-    expect(transformed).toContain("for (const serverOnly of [1])");
-    expectValidModuleSource(transformed);
-  });
-
-  it("drops dead imports when classic for-loop headers shadow the server-only name", () => {
-    const source = `
-import serverOnly from "../server-only";
-
-export function loader() {
-  return serverOnly();
-}
-
-export default function Page() {
-  for (let serverOnly = 0; serverOnly < 1; serverOnly++) {
-    console.log(serverOnly);
-  }
-  return <div />;
-}
-`;
-
-    const transformed = stripServerOnlyExportsForClient(source);
-
-    expect(transformed).not.toContain("../server-only");
-    expect(transformed).toContain("for (let serverOnly = 0; serverOnly < 1; serverOnly++)");
-    expectValidModuleSource(transformed);
-  });
-
-  it("drops dead imports when hoisted var bindings shadow the server-only name", () => {
-    const source = `
-import serverOnly from "../server-only";
-
-export function loader() {
-  return serverOnly();
-}
-
-export default function Page() {
-  if (true) {
-    var serverOnly = 1;
-  }
-  return <div>{serverOnly}</div>;
-}
-`;
-
-    const transformed = stripServerOnlyExportsForClient(source);
-
-    expect(transformed).not.toContain("../server-only");
-    expect(transformed).toContain("var serverOnly = 1");
-    expectValidModuleSource(transformed);
-  });
-
-  it("drops dead imports when switch cases introduce lexical shadowing", () => {
-    const source = `
-import serverOnly from "../server-only";
-
-export function loader() {
-  return serverOnly();
-}
-
-export default function Page() {
-  switch (1) {
-    case 1:
-      const serverOnly = 1;
-      return <div>{serverOnly}</div>;
-    default:
-      return <div />;
-  }
-}
-`;
-
-    const transformed = stripServerOnlyExportsForClient(source);
-
-    expect(transformed).not.toContain("../server-only");
-    expect(transformed).toContain("const serverOnly = 1");
-    expectValidModuleSource(transformed);
-  });
-
-  it("drops dead imports when function parameters shadow the server-only name", () => {
-    const source = `
-import serverOnly from "../server-only";
-
-export function loader() {
-  return serverOnly();
-}
-
-export default function Page() {
-  return [1].map((serverOnly) => <div>{serverOnly}</div>);
-}
-`;
-
-    const transformed = stripServerOnlyExportsForClient(source);
-
-    expect(transformed).not.toContain("../server-only");
-    expect(transformed).toContain(".map((serverOnly) => <div>{serverOnly}</div>)");
-    expectValidModuleSource(transformed);
-  });
-
-  it("drops dead imports when catch parameters shadow the server-only name", () => {
-    const source = `
-import serverOnly from "../server-only";
-
-export function loader() {
-  return serverOnly();
-}
-
-export default function Page() {
-  try {
-    throw new Error("boom");
-  } catch (serverOnly) {
-    return <div>{String(serverOnly)}</div>;
-  }
-
-  return <div />;
-}
-`;
-
-    const transformed = stripServerOnlyExportsForClient(source);
-
-    expect(transformed).not.toContain("../server-only");
-    expect(transformed).toContain("catch (serverOnly)");
-    expectValidModuleSource(transformed);
-  });
-
-  it("keeps default-exported identifiers while pruning loader-only imports", () => {
-    const source = `
-import serverOnly from "../server-only";
-
-export function loader() {
-  return serverOnly();
-}
-
-const Page = () => <div>ok</div>;
-
-export default Page;
-`;
-
-    const transformed = stripServerOnlyExportsForClient(source);
-
-    expect(transformed).not.toContain("../server-only");
-    expect(transformed).toContain("const Page = () => <div>ok</div>;");
-    expect(transformed).toContain("export default Page;");
-    expectValidModuleSource(transformed);
-  });
-
-  it("drops dead imports when the remaining matching identifiers are statement labels", () => {
-    const source = `
-import serverOnly from "../server-only";
-
-export function loader() {
-  return serverOnly();
-}
-
-export default function Page() {
-  serverOnly: for (;;) {
-    break serverOnly;
-  }
-
-  return <div />;
-}
-`;
-
-    const transformed = stripServerOnlyExportsForClient(source);
-
-    expect(transformed).not.toContain("../server-only");
-    expect(transformed).toContain("serverOnly: for (;;)");
-    expect(transformed).toContain("break serverOnly;");
-    expectValidModuleSource(transformed);
-  });
-
-  it("drops dead imports when the remaining matching identifier appears in import.meta", () => {
-    const source = `
-import meta from "../server-only";
-
-export function loader() {
-  return meta();
-}
-
-export default function Page() {
-  return <div>{import.meta.env.MODE}</div>;
-}
-`;
-
-    const transformed = stripServerOnlyExportsForClient(source);
-
-    expect(transformed).not.toContain("../server-only");
-    expect(transformed).toContain("import.meta.env.MODE");
-    expectValidModuleSource(transformed);
-  });
-
-  it("drops dead imports when the remaining matching identifier appears in new.target", () => {
-    const source = `
-import target from "../server-only";
-
-export function loader() {
-  return target();
-}
-
-export default function Page() {
-  return (() => new.target)();
-}
-`;
-
-    const transformed = stripServerOnlyExportsForClient(source);
-
-    expect(transformed).not.toContain("../server-only");
-    expect(transformed).toContain("new.target");
-    expectValidModuleSource(transformed);
-  });
-
   it("parses transformed markdown route modules through the post-transform client path", () => {
     const source = `
 import { h } from "preact";
@@ -538,58 +417,41 @@ export default function Home() {
     );
     writeFileSync(join(root, "src", "shared.ts"), 'export const shared = "CLIENT_SHARED";\n');
 
-    await build({
-      root,
-      configFile: false,
-      logLevel: "silent",
-      plugins: await pracht({ pagesDir: "/src/pages" }),
-      resolve: {
-        alias: [
-          {
-            find: "@pracht/core",
-            replacement: resolve(repoRoot, "packages/framework/src/index.ts"),
-          },
-          {
-            find: "preact/jsx-dev-runtime",
-            replacement: resolve(
-              repoRoot,
-              "node_modules/preact/jsx-runtime/dist/jsxRuntime.module.js",
-            ),
-          },
-          {
-            find: "preact/jsx-runtime",
-            replacement: resolve(
-              repoRoot,
-              "node_modules/preact/jsx-runtime/dist/jsxRuntime.module.js",
-            ),
-          },
-          {
-            find: "preact/hooks",
-            replacement: resolve(repoRoot, "node_modules/preact/hooks/dist/hooks.module.js"),
-          },
-          {
-            find: "preact/devtools",
-            replacement: resolve(repoRoot, "node_modules/preact/devtools/dist/devtools.module.js"),
-          },
-          {
-            find: "preact/debug",
-            replacement: resolve(repoRoot, "node_modules/preact/debug/dist/debug.module.js"),
-          },
-          { find: "preact", replacement: resolve(repoRoot, "node_modules/preact/dist/preact.mjs") },
-        ],
-      },
-      build: {
-        outDir: "dist",
-        manifest: true,
-        rollupOptions: {
-          input: "virtual:pracht/client",
-        },
-      },
-    });
+    await buildTempProject(root);
 
     const output = readBuiltJs(root);
 
     expect(output).toContain("CLIENT_SHARED");
     expect(output).not.toContain("SERVER_ONLY_MARKER");
+  });
+
+  it("excludes dead server-only imports when import.meta is the remaining client syntax", async () => {
+    const root = makeTempProject();
+    mkdirSync(join(root, "src", "pages"), { recursive: true });
+
+    writeFileSync(
+      join(root, "src", "pages", "index.tsx"),
+      `
+import meta from "../server-only";
+
+export function loader() {
+  return meta();
+}
+
+export default function Home() {
+  return <main>{import.meta.env.MODE}</main>;
+}
+`,
+    );
+    writeFileSync(
+      join(root, "src", "server-only.ts"),
+      'export default function serverOnly() { return "SERVER_ONLY_META_MARKER"; }\n',
+    );
+
+    await buildTempProject(root);
+
+    const output = readBuiltJs(root);
+
+    expect(output).not.toContain("SERVER_ONLY_META_MARKER");
   });
 });


### PR DESCRIPTION
## Summary

- Follow-up to #116. The client strip transform matched `export` / `import` patterns via regex on the raw source, so any source that embedded those keywords inside a string or template literal (e.g. documentation pages with code samples in `` `` ``) had those fragments stripped out mid-string — producing `Unterminated string` build errors. The matcher now runs against a string/comment-masked copy of the source while edits apply to the original.
- Fix the `examples/docs` markdown plugin to treat `*.md?pracht-client` ids as markdown — Vite appends the query for glob-imported client variants, which made the plugin's `id.endsWith(".md")` check silently skip every docs page.
- Add an e2e regression test that exercises the full CLI build and asserts loader bodies + loader-only imports are absent from client JS (the contract introduced in #116).
- Add `examples/docs` build to CI so markdown / template-literal regressions surface in PR checks rather than on release.

## Testing

- [x] `pnpm e2e`
- [x] `pnpm format`
- [x] `pnpm lint`
- [x] `pnpm test`

## Checklist

- [x] Docs updated if needed — N/A
- [x] Skills updated if needed — N/A
- [x] Changeset added if published packages changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
