### PR TITLE
feat(vite-plugin): let adapters declare edge runtime via `edge` flag

### DIFF
--- a/.changeset/adapter-edge-flag.md
+++ b/.changeset/adapter-edge-flag.md
@@ -1,0 +1,7 @@
+---
+"@pracht/vite-plugin": minor
+"@pracht/adapter-cloudflare": patch
+"@pracht/adapter-vercel": patch
+---
+
+Add an `edge` flag to `PrachtAdapter`. Adapters that target edge runtimes (where `node_modules` cannot be resolved at runtime) set `edge: true`, and the Vite plugin reads it to enable `ssr.noExternal` for SSR builds. The built-in Cloudflare and Vercel adapters opt in; custom edge adapters can do the same instead of the plugin hard-coding adapter ids.

--- a/docs/ADAPTERS.md
+++ b/docs/ADAPTERS.md
@@ -334,6 +334,10 @@ export default async function handle(request) {
     // Optional: set to true when the adapter's Vite plugin runs the dev server
     // itself (pracht will skip installing its own SSR middleware).
     ownsDevServer: true,
+    // Optional: set to true when targeting an edge runtime that cannot resolve
+    // dependencies from node_modules at runtime. Forces Vite to bundle all
+    // dependencies into the SSR output (ssr.noExternal = true).
+    edge: true,
   };
 }
 ```

--- a/packages/adapter-cloudflare/src/index.ts
+++ b/packages/adapter-cloudflare/src/index.ts
@@ -237,6 +237,7 @@ export function cloudflareAdapter(options: CloudflareServerEntryModuleOptions = 
   return {
     id: "cloudflare",
     ownsDevServer: true,
+    edge: true,
     serverImports:
       'import { applyDefaultSecurityHeaders, handlePrachtRequest, resolveApp, resolveApiRoutes } from "@pracht/core";',
     createServerEntryModule() {

--- a/packages/adapter-vercel/src/index.ts
+++ b/packages/adapter-vercel/src/index.ts
@@ -96,6 +96,7 @@ export function createVercelServerEntryModule(
 export function vercelAdapter(options: VercelServerEntryModuleOptions = {}): PrachtAdapter {
   return {
     id: "vercel",
+    edge: true,
     serverImports:
       'import { handlePrachtRequest, resolveApp, resolveApiRoutes } from "@pracht/core";',
     createServerEntryModule() {

--- a/packages/vite-plugin/src/index.ts
+++ b/packages/vite-plugin/src/index.ts
@@ -52,7 +52,7 @@ export async function pracht(options: PrachtPluginOptions = {}): Promise<Plugin[
     enforce: "pre",
 
     config(_config, env) {
-      const isEdge = resolved.adapter.id === "vercel" || resolved.adapter.id === "cloudflare";
+      const isEdge = resolved.adapter.edge === true;
       const isSSRBuild = env.isSsrBuild;
 
       return {

--- a/packages/vite-plugin/src/plugin-adapter.ts
+++ b/packages/vite-plugin/src/plugin-adapter.ts
@@ -32,6 +32,13 @@ export interface PrachtAdapter {
    * (e.g. Cloudflare workerd via `@cloudflare/vite-plugin`).
    */
   ownsDevServer?: boolean;
+  /**
+   * If true, the adapter targets an edge runtime that cannot resolve
+   * dependencies from `node_modules` at runtime. The Vite plugin will set
+   * `ssr.noExternal = true` for SSR builds so all dependencies are bundled
+   * into the server output.
+   */
+  edge?: boolean;
 }
 
 export function createDefaultNodeAdapter(): PrachtAdapter {


### PR DESCRIPTION
## Summary

- Replace the hardcoded `adapter.id === "vercel" || "cloudflare"` check in `@pracht/vite-plugin` with a generic `edge?: boolean` field on `PrachtAdapter`; the plugin now reads that flag to enable `ssr.noExternal` for SSR builds.
- Opt the built-in Cloudflare and Vercel adapters in (`edge: true`), document the field in the custom-adapter example, and add a changeset (`minor` for `@pracht/vite-plugin`, `patch` for the two adapters).

## Testing

- [x] `pnpm e2e`
- [x] `pnpm format`
- [x] `pnpm lint`
- [x] `pnpm test`

## Checklist

- [x] Docs updated if needed
- [x] Skills updated if needed (N/A)
- [x] Changeset added if published packages changed