### PR TITLE
fix(framework): reject unsafe URL schemes in client-side navigation

### DIFF
--- a/.changeset/safe-navigation-urls.md
+++ b/.changeset/safe-navigation-urls.md
@@ -1,0 +1,14 @@
+---
+"@pracht/core": patch
+---
+
+Reject unsafe URL schemes in client-side navigation.
+
+`navigateToClientLocation` and the router's redirect handling now refuse to
+navigate when a server-supplied `Location` header, loader redirect, or form
+action response resolves to anything other than `http:` or `https:`.
+`javascript:`, `data:`, `vbscript:`, `blob:`, and `file:` URLs are logged
+and dropped instead of being assigned to `window.location.href`.
+
+Prevents a server-controlled (or developer-mishandled) redirect from turning
+into script execution or a phishing target in the browser.

--- a/packages/framework/src/router.ts
+++ b/packages/framework/src/router.ts
@@ -8,7 +8,12 @@ import { markHydrating } from "./hydration.ts";
 import { getCachedRouteState, setupPrefetching } from "./prefetch.ts";
 import type { ModuleWarmFn } from "./prefetch.ts";
 import type { ResolvedPrachtApp, RouteMatch, RouteParams } from "./types.ts";
-import { deserializeRouteError, fetchPrachtRouteState, PrachtRuntimeProvider } from "./runtime.ts";
+import {
+  deserializeRouteError,
+  fetchPrachtRouteState,
+  parseSafeNavigationUrl,
+  PrachtRuntimeProvider,
+} from "./runtime.ts";
 import type { SerializedRouteError, PrachtHydrationState } from "./runtime.ts";
 
 interface RouteRenderState {
@@ -186,8 +191,12 @@ export async function initClientRouter(options: InitClientRouterOptions): Promis
     externalUrl?: string;
     internalPath?: string;
     isCurrentLocation: boolean;
+    unsafe?: boolean;
   } {
-    const targetUrl = new URL(location, window.location.href);
+    const targetUrl = parseSafeNavigationUrl(location, window.location.href);
+    if (!targetUrl) {
+      return { isCurrentLocation: false, unsafe: true };
+    }
     const fullInternalTarget = targetUrl.pathname + targetUrl.search + targetUrl.hash;
     const internalPath = targetUrl.pathname + targetUrl.search;
     const currentPath = window.location.pathname + window.location.search + window.location.hash;
@@ -247,6 +256,10 @@ export async function initClientRouter(options: InitClientRouterOptions): Promis
       if (result.type === "redirect") {
         if (result.location) {
           const redirect = resolveRedirectTarget(result.location);
+          if (redirect.unsafe) {
+            console.error(`[pracht] refused to navigate to unsafe URL: ${result.location}`);
+            return;
+          }
           if (redirect.externalUrl) {
             window.location.href = redirect.externalUrl;
             return;
@@ -266,7 +279,7 @@ export async function initClientRouter(options: InitClientRouterOptions): Promis
             return;
           }
 
-          window.location.href = result.location;
+          window.location.href = target.browserUrl;
           return;
         }
         window.location.href = target.browserUrl;
@@ -344,7 +357,12 @@ export async function initClientRouter(options: InitClientRouterOptions): Promis
       try {
         const result = await dataPromise;
         if (result.type === "redirect") {
-          window.location.href = result.location;
+          const safeRedirect = parseSafeNavigationUrl(result.location, window.location.href);
+          if (!safeRedirect) {
+            console.error(`[pracht] refused to navigate to unsafe URL: ${result.location}`);
+            return;
+          }
+          window.location.href = safeRedirect.toString();
           return;
         }
 

--- a/packages/framework/src/runtime-client-fetch.ts
+++ b/packages/framework/src/runtime-client-fetch.ts
@@ -6,6 +6,31 @@ export type RouteStateResult =
   | { type: "redirect"; location: string }
   | { type: "error"; error: SerializedRouteError };
 
+const SAFE_NAVIGATION_PROTOCOLS = new Set(["http:", "https:"]);
+
+/**
+ * Parse a possibly-server-supplied redirect target against a base URL and
+ * return it only if it uses a safe navigation scheme (`http:` or `https:`).
+ *
+ * `javascript:`, `data:`, `vbscript:`, `blob:`, `file:` and similar schemes
+ * can execute script or bypass same-origin assumptions when assigned to
+ * `window.location.href` — a server-controlled redirect (from a loader,
+ * middleware, form action response, or API route) must never be able to
+ * trigger them. Returns `null` for unsafe or unparseable inputs.
+ */
+export function parseSafeNavigationUrl(location: string, base: string | URL): URL | null {
+  let targetUrl: URL;
+  try {
+    targetUrl = new URL(location, base);
+  } catch {
+    return null;
+  }
+  if (!SAFE_NAVIGATION_PROTOCOLS.has(targetUrl.protocol)) {
+    return null;
+  }
+  return targetUrl;
+}
+
 export function buildRouteStateUrl(url: string): string {
   const separator = url.includes("?") ? "&" : "?";
   return `${url}${separator}_data=1`;
@@ -68,7 +93,12 @@ export async function navigateToClientLocation(
     return;
   }
 
-  const targetUrl = new URL(location, window.location.href);
+  const targetUrl = parseSafeNavigationUrl(location, window.location.href);
+  if (!targetUrl) {
+    console.error(`[pracht] refused to navigate to unsafe URL: ${location}`);
+    return;
+  }
+
   const target = targetUrl.pathname + targetUrl.search + targetUrl.hash;
   if (targetUrl.origin === window.location.origin && window.__PRACHT_NAVIGATE__) {
     await window.__PRACHT_NAVIGATE__(target, options);

--- a/packages/framework/src/runtime.ts
+++ b/packages/framework/src/runtime.ts
@@ -433,4 +433,8 @@ export {
   type PrachtHydrationState,
   type StartAppOptions,
 } from "./runtime-hooks.ts";
-export { fetchPrachtRouteState, type RouteStateResult } from "./runtime-client-fetch.ts";
+export {
+  fetchPrachtRouteState,
+  parseSafeNavigationUrl,
+  type RouteStateResult,
+} from "./runtime-client-fetch.ts";

--- a/packages/framework/test/navigation-safety.test.ts
+++ b/packages/framework/test/navigation-safety.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+
+import { parseSafeNavigationUrl } from "../src/runtime.ts";
+
+const BASE = "https://example.com/page";
+
+describe("parseSafeNavigationUrl", () => {
+  it("accepts same-origin absolute paths", () => {
+    const url = parseSafeNavigationUrl("/dashboard", BASE);
+    expect(url?.toString()).toBe("https://example.com/dashboard");
+  });
+
+  it("accepts relative paths", () => {
+    const url = parseSafeNavigationUrl("../other", BASE);
+    expect(url?.origin).toBe("https://example.com");
+  });
+
+  it("accepts http and https cross-origin URLs", () => {
+    expect(parseSafeNavigationUrl("https://trusted.example/", BASE)?.protocol).toBe("https:");
+    expect(parseSafeNavigationUrl("http://plain.example/", BASE)?.protocol).toBe("http:");
+  });
+
+  it("rejects javascript: URLs", () => {
+    expect(parseSafeNavigationUrl("javascript:alert(1)", BASE)).toBeNull();
+    expect(parseSafeNavigationUrl("JaVaScRiPt:alert(1)", BASE)).toBeNull();
+  });
+
+  it("rejects data: URLs", () => {
+    expect(parseSafeNavigationUrl("data:text/html,<script>alert(1)</script>", BASE)).toBeNull();
+  });
+
+  it("rejects vbscript: URLs", () => {
+    expect(parseSafeNavigationUrl("vbscript:msgbox(1)", BASE)).toBeNull();
+  });
+
+  it("rejects file: URLs", () => {
+    expect(parseSafeNavigationUrl("file:///etc/passwd", BASE)).toBeNull();
+  });
+
+  it("rejects blob: URLs", () => {
+    expect(parseSafeNavigationUrl("blob:https://example.com/uuid", BASE)).toBeNull();
+  });
+
+  it("returns null for unparseable inputs", () => {
+    expect(parseSafeNavigationUrl("http://[::1", BASE)).toBeNull();
+  });
+
+  it("tolerates leading/trailing whitespace the URL parser would accept", () => {
+    expect(parseSafeNavigationUrl(" /foo ", BASE)?.pathname).toBe("/foo");
+  });
+});


### PR DESCRIPTION
## Summary

- `navigateToClientLocation` and the client router's redirect handling now refuse to navigate when a server-supplied `Location` header, loader redirect, or form action response resolves to anything other than `http:` or `https:`.
- `javascript:`, `data:`, `vbscript:`, `blob:`, and `file:` URLs are logged to the console and dropped instead of being assigned to `window.location.href`.
- Shared internal helper `parseSafeNavigationUrl(location, base)` is used by both `runtime.ts` (form submit, `useRevalidate`) and `router.ts` (initial hydration redirect, navigate path).
- Addresses the navigation-safety issue surfaced in the recent security review. Companion PRs: #121 (originCheck) and the client-env stripping fix.

## Testing

- [x] `pnpm e2e`
- [x] `pnpm format`
- [x] `pnpm lint`
- [x] `pnpm test`

## Checklist

- [ ] Docs updated if needed
- [ ] Skills updated if needed
- [x] Changeset added if published packages changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)