### PR TITLE
fix(vite-plugin): strip server-only exports from route files without the pracht-client query

### DIFF
--- a/.changeset/strip-route-files-client-env.md
+++ b/.changeset/strip-route-files-client-env.md
@@ -1,0 +1,14 @@
+---
+"@pracht/vite-plugin": patch
+---
+
+Strip server-only exports from route and shell files in the client environment
+even when they are imported without the `?pracht-client` query.
+
+Previously, the transform ran only for ids that carried the query added by the
+`import.meta.glob` registry. A client module that imported a route file
+directly (e.g. `import Foo from "../routes/foo.tsx"`) bypassed the registry
+and exposed `loader`, `head`, `headers`, and `getStaticPaths` in the browser
+bundle. The transform now also triggers for any `.ts/.tsx/.js/.jsx/.md/.mdx`
+file inside the configured `routesDir`, `shellsDir`, or `pagesDir` whenever
+Vite is processing the file for a non-SSR environment.

--- a/packages/vite-plugin/src/index.ts
+++ b/packages/vite-plugin/src/index.ts
@@ -38,6 +38,7 @@ export async function pracht(options: PrachtPluginOptions = {}): Promise<Plugin[
   const resolved = resolveOptions(options);
   const isPagesMode = !!resolved.pagesDir;
   let root = process.cwd();
+  let routeFileDirs: string[] = [];
 
   if (isPagesMode && options.appFile) {
     console.warn(
@@ -84,6 +85,7 @@ export async function pracht(options: PrachtPluginOptions = {}): Promise<Plugin[
     configResolved(config) {
       root = config.root;
       isBuild = config.command === "build";
+      routeFileDirs = computeRouteFileDirs(root, resolved);
     },
 
     resolveId(id) {
@@ -157,8 +159,11 @@ export async function pracht(options: PrachtPluginOptions = {}): Promise<Plugin[
     name: "pracht:client-module-transform",
     enforce: "post",
 
-    transform(code, id) {
-      if (!isPrachtClientModuleId(id)) return null;
+    transform(code, id, transformOptions) {
+      const shouldStrip =
+        isPrachtClientModuleId(id) ||
+        (!transformOptions?.ssr && isRouteOrShellFile(id, routeFileDirs));
+      if (!shouldStrip) return null;
 
       const transformed = stripServerOnlyExportsForClient(code, id);
       if (transformed === code) return null;
@@ -195,4 +200,33 @@ function invalidateVirtualModules(server: import("vite").ViteDevServer): void {
   const serverMod = server.moduleGraph.getModuleById(PRACHT_SERVER_MODULE_ID);
   if (clientMod) server.moduleGraph.invalidateModule(clientMod);
   if (serverMod) server.moduleGraph.invalidateModule(serverMod);
+}
+
+const ROUTE_FILE_EXTENSIONS = new Set([".ts", ".tsx", ".js", ".jsx", ".md", ".mdx"]);
+
+function computeRouteFileDirs(root: string, resolved: ResolvedPrachtPluginOptions): string[] {
+  const dirs = resolved.pagesDir ? [resolved.pagesDir] : [resolved.routesDir, resolved.shellsDir];
+  return dirs.map((dir) => toPosixPath(resolve(root, dir.replace(/^\//, "")))).map(withTrailingSep);
+}
+
+function isRouteOrShellFile(id: string, dirs: string[]): boolean {
+  if (dirs.length === 0) return false;
+  const queryStart = id.indexOf("?");
+  const path = queryStart === -1 ? id : id.slice(0, queryStart);
+  // Skip virtual modules and non-file ids.
+  if (path.startsWith("\0") || path.startsWith("virtual:")) return false;
+  const extIndex = path.lastIndexOf(".");
+  if (extIndex === -1) return false;
+  const ext = path.slice(extIndex);
+  if (!ROUTE_FILE_EXTENSIONS.has(ext)) return false;
+  const normalized = toPosixPath(path);
+  return dirs.some((dir) => normalized.startsWith(dir));
+}
+
+function toPosixPath(p: string): string {
+  return p.replace(/\\/g, "/");
+}
+
+function withTrailingSep(p: string): string {
+  return p.endsWith("/") ? p : `${p}/`;
 }

--- a/packages/vite-plugin/test/client-module-transform.test.ts
+++ b/packages/vite-plugin/test/client-module-transform.test.ts
@@ -454,4 +454,94 @@ export default function Home() {
 
     expect(output).not.toContain("SERVER_ONLY_META_MARKER");
   });
+
+  it("strips server-only exports from route files in the client environment even without the pracht-client query", async () => {
+    // Regression: before the fix, stripping ran only when the module id
+    // carried the `?pracht-client` query added by the import.meta.glob
+    // registry. A client component that imported a route module directly
+    // (no query) slipped past the transform and exposed the loader.
+    const plugins = await pracht({ pagesDir: "/src/pages" });
+    const transformPlugin = plugins.find((p) => p.name === "pracht:client-module-transform");
+    if (!transformPlugin || typeof transformPlugin.transform !== "function") {
+      throw new Error("pracht:client-module-transform plugin is missing a transform hook");
+    }
+    // Bring the plugin out of its "not yet configured" state so it knows
+    // where the pages dir is on disk.
+    const configResolved = findPrachtConfigResolved(plugins);
+    configResolved({ root: "/project", command: "build" } as never);
+
+    const routeFileId = "/project/src/pages/index.tsx";
+    const source = [
+      "export function loader() {",
+      '  return "SERVER_ONLY_LOADER_MARKER";',
+      "}",
+      "export function head() {",
+      '  return { title: "x" };',
+      "}",
+      "export default function Home() {",
+      '  return "ok";',
+      "}",
+      "",
+    ].join("\n");
+
+    // Client transform — no ?pracht-client query. Must strip.
+    const clientResult = await callTransform(transformPlugin.transform, source, routeFileId, {
+      ssr: false,
+    });
+    expect(clientResult).not.toBeNull();
+    expect(clientResult).not.toContain("SERVER_ONLY_LOADER_MARKER");
+    expect(clientResult).not.toContain("function loader");
+    expect(clientResult).not.toContain("function head");
+    expect(clientResult).toContain("function Home");
+
+    // SSR transform — must NOT strip (server needs the loader).
+    const ssrResult = await callTransform(transformPlugin.transform, source, routeFileId, {
+      ssr: true,
+    });
+    expect(ssrResult).toBeNull();
+
+    // Non-route file in the client environment — must NOT be touched.
+    const componentResult = await callTransform(
+      transformPlugin.transform,
+      source,
+      "/project/src/components/sidebar.tsx",
+      { ssr: false },
+    );
+    expect(componentResult).toBeNull();
+  });
 });
+
+type TransformHook = Parameters<typeof Object.getPrototypeOf>[0];
+
+function findPrachtConfigResolved(plugins: readonly unknown[]): (config: unknown) => void {
+  for (const plugin of plugins) {
+    if (
+      plugin &&
+      typeof plugin === "object" &&
+      (plugin as { name?: string }).name === "pracht" &&
+      typeof (plugin as { configResolved?: unknown }).configResolved === "function"
+    ) {
+      return (plugin as { configResolved: (config: unknown) => void }).configResolved;
+    }
+  }
+  throw new Error("pracht plugin not found");
+}
+
+async function callTransform(
+  transform: unknown,
+  code: string,
+  id: string,
+  options: { ssr: boolean },
+): Promise<string | null> {
+  const handler =
+    typeof transform === "function" ? transform : (transform as { handler: TransformHook }).handler;
+  const result = await (handler as (c: string, i: string, o: { ssr: boolean }) => unknown).call(
+    {} as never,
+    code,
+    id,
+    options,
+  );
+  if (result === null || result === undefined) return null;
+  if (typeof result === "string") return result;
+  return (result as { code: string }).code;
+}


### PR DESCRIPTION
## Summary

- The client-module transform previously gated on the `?pracht-client` query added by the `import.meta.glob` registry. A client component that imported a route module directly (e.g. `import Foo from "../routes/foo.tsx"`) bypassed the registry and carried the route's `loader`/`head`/`headers`/`getStaticPaths` into the browser bundle.
- The transform now also fires for any `.ts/.tsx/.js/.jsx/.md/.mdx` file inside the configured `routesDir`/`shellsDir`/`pagesDir` whenever Vite is processing it for a non-SSR environment.
- Added a regression test that calls the plugin's `transform` hook directly and asserts stripping runs on an unqueried route file in the client environment, does NOT run in SSR, and does NOT run on non-route files.
- Addresses the stripping-query-coupling issue surfaced in the recent security review. Companion PRs: #121 (originCheck) and #122 (safe navigation).

## Testing

- [x] `pnpm e2e`
- [x] `pnpm format`
- [x] `pnpm lint`
- [x] `pnpm test`

## Checklist

- [ ] Docs updated if needed
- [ ] Skills updated if needed
- [x] Changeset added if published packages changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)