### PR TITLE
feat(framework): surface hydration mismatch banner in dev

### DIFF
--- a/.changeset/hydration-mismatch-warning.md
+++ b/.changeset/hydration-mismatch-warning.md
@@ -1,0 +1,5 @@
+---
+"@pracht/core": minor
+---
+
+Surface a visible in-page banner when Preact reports a hydration mismatch in dev mode. The banner is wired up by `initClientRouter` via Preact's `options.__m` hook, includes the offending component name, chains to any pre-existing hook, and is fully removed in production builds via `import.meta.env.DEV`.

--- a/packages/framework/src/env.d.ts
+++ b/packages/framework/src/env.d.ts
@@ -1,0 +1,9 @@
+interface ImportMetaEnv {
+  readonly DEV?: boolean;
+  readonly PROD?: boolean;
+  readonly MODE?: string;
+}
+
+interface ImportMeta {
+  readonly env?: ImportMetaEnv;
+}

--- a/packages/framework/src/env.d.ts
+++ b/packages/framework/src/env.d.ts
@@ -1,1 +1,0 @@
-/// <reference types="vite/types/importMeta.js" />

--- a/packages/framework/src/env.d.ts
+++ b/packages/framework/src/env.d.ts
@@ -1,9 +1,1 @@
-interface ImportMetaEnv {
-  readonly DEV?: boolean;
-  readonly PROD?: boolean;
-  readonly MODE?: string;
-}
-
-interface ImportMeta {
-  readonly env?: ImportMetaEnv;
-}
+/// <reference types="vite/types/importMeta.js" />

--- a/packages/framework/src/hydration-mismatch.ts
+++ b/packages/framework/src/hydration-mismatch.ts
@@ -1,0 +1,83 @@
+import { options as preactOptions } from "preact";
+import type { VNode } from "preact";
+
+const HYDRATION_BANNER_ID = "__pracht_hydration_mismatch__";
+
+let installed = false;
+
+export function installHydrationMismatchWarning(): void {
+  if (installed) return;
+  installed = true;
+
+  const prev = (preactOptions as { __m?: (vnode: VNode) => void }).__m;
+  (preactOptions as { __m?: (vnode: VNode) => void }).__m = function (vnode: VNode) {
+    appendHydrationWarning(vnode);
+    if (prev) prev(vnode);
+  };
+}
+
+function appendHydrationWarning(vnode: VNode): void {
+  if (typeof document === "undefined") return;
+
+  const componentName = getVNodeName(vnode);
+  let banner = document.getElementById(HYDRATION_BANNER_ID);
+  const message = `Hydration mismatch detected on <${componentName}>. The server-rendered HTML did not match the client.`;
+
+  if (banner) {
+    const list = banner.querySelector(`[data-pracht-mismatch-list]`);
+    if (list) {
+      const item = document.createElement("li");
+      item.textContent = message;
+      list.appendChild(item);
+    }
+    return;
+  }
+
+  banner = document.createElement("div");
+  banner.id = HYDRATION_BANNER_ID;
+  banner.setAttribute("role", "alert");
+  banner.style.cssText = [
+    "position:fixed",
+    "top:0",
+    "left:0",
+    "right:0",
+    "z-index:2147483647",
+    "background:#1a1a2e",
+    "color:#ff6b6b",
+    "padding:12px 16px",
+    "font:12px/1.5 ui-monospace,Menlo,Consolas,monospace",
+    "border-bottom:2px solid #e74c3c",
+    "box-shadow:0 2px 8px rgba(0,0,0,0.3)",
+  ].join(";");
+
+  const title = document.createElement("strong");
+  title.textContent = "pracht: hydration mismatch";
+  title.style.cssText = "display:block;margin-bottom:4px;color:#fff";
+  banner.appendChild(title);
+
+  const list = document.createElement("ul");
+  list.setAttribute("data-pracht-mismatch-list", "");
+  list.style.cssText = "margin:0;padding-left:18px";
+  const item = document.createElement("li");
+  item.textContent = message;
+  list.appendChild(item);
+  banner.appendChild(list);
+
+  document.body.appendChild(banner);
+}
+
+function getVNodeName(vnode: VNode | null | undefined): string {
+  if (!vnode) return "Unknown";
+  const type = vnode.type as unknown;
+  if (typeof type === "string") return type;
+  if (typeof type === "function") {
+    const fn = type as { displayName?: string; name?: string };
+    return fn.displayName || fn.name || "Component";
+  }
+  return "Unknown";
+}
+
+export function _resetHydrationMismatchForTesting(): void {
+  installed = false;
+  (preactOptions as { __m?: (vnode: VNode) => void }).__m = undefined;
+}

--- a/packages/framework/src/router.ts
+++ b/packages/framework/src/router.ts
@@ -4,6 +4,7 @@ import { useContext, useMemo, useState } from "preact/hooks";
 import type { FunctionComponent } from "preact";
 
 import { matchAppRoute } from "./app.ts";
+import { installHydrationMismatchWarning } from "./hydration-mismatch.ts";
 import { markHydrating } from "./hydration.ts";
 import { getCachedRouteState, setupPrefetching } from "./prefetch.ts";
 import type { ModuleWarmFn } from "./prefetch.ts";
@@ -61,6 +62,10 @@ export interface InitClientRouterOptions {
 
 export async function initClientRouter(options: InitClientRouterOptions): Promise<void> {
   const { app, routeModules, shellModules, root, findModuleKey } = options;
+
+  if (import.meta.env?.DEV) {
+    installHydrationMismatchWarning();
+  }
 
   const moduleCache = new Map<string, Promise<unknown>>();
 

--- a/packages/framework/test/hydration-mismatch.test.ts
+++ b/packages/framework/test/hydration-mismatch.test.ts
@@ -1,0 +1,103 @@
+// @vitest-environment jsdom
+import { h, hydrate, options as preactOptions, render } from "preact";
+import type { VNode } from "preact";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import {
+  _resetHydrationMismatchForTesting,
+  installHydrationMismatchWarning,
+} from "../src/hydration-mismatch.ts";
+
+const BANNER_ID = "__pracht_hydration_mismatch__";
+
+describe("installHydrationMismatchWarning", () => {
+  let scratch: HTMLDivElement;
+
+  beforeEach(() => {
+    document.body.innerHTML = "";
+    scratch = document.createElement("div");
+    document.body.appendChild(scratch);
+    _resetHydrationMismatchForTesting();
+  });
+
+  afterEach(() => {
+    if (scratch.isConnected) {
+      render(null, scratch);
+      scratch.remove();
+    }
+    _resetHydrationMismatchForTesting();
+  });
+
+  it("appends a visible banner with the component name when Preact reports a hydration mismatch", () => {
+    installHydrationMismatchWarning();
+
+    function Profile() {
+      return h("span", null, "client");
+    }
+
+    const vnode = h(Profile, null) as unknown as VNode;
+    (preactOptions as { __m?: (vnode: VNode) => void }).__m!(vnode);
+
+    const banner = document.getElementById(BANNER_ID);
+    expect(banner).not.toBeNull();
+    expect(banner!.textContent).toContain("Profile");
+    expect(banner!.textContent).toContain("Hydration mismatch");
+    expect(banner!.getAttribute("role")).toBe("alert");
+  });
+
+  it("chains to a previously installed __m hook", () => {
+    const calls: VNode[] = [];
+    (preactOptions as { __m?: (vnode: VNode) => void }).__m = (vnode) => {
+      calls.push(vnode);
+    };
+
+    installHydrationMismatchWarning();
+
+    const vnode = h("div", null) as unknown as VNode;
+    (preactOptions as { __m?: (vnode: VNode) => void }).__m!(vnode);
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toBe(vnode);
+    expect(document.getElementById(BANNER_ID)).not.toBeNull();
+  });
+
+  it("only installs the hook once across repeated calls", () => {
+    installHydrationMismatchWarning();
+    const firstHook = (preactOptions as { __m?: (vnode: VNode) => void }).__m;
+
+    installHydrationMismatchWarning();
+    const secondHook = (preactOptions as { __m?: (vnode: VNode) => void }).__m;
+
+    expect(secondHook).toBe(firstHook);
+  });
+
+  it("appends additional mismatches as list items in the existing banner", () => {
+    installHydrationMismatchWarning();
+
+    const m = (preactOptions as { __m?: (vnode: VNode) => void }).__m!;
+    m(h("div", null) as unknown as VNode);
+    m(h("span", null) as unknown as VNode);
+
+    const banner = document.getElementById(BANNER_ID)!;
+    const items = banner.querySelectorAll("li");
+    expect(items).toHaveLength(2);
+    expect(items[0].textContent).toContain("div");
+    expect(items[1].textContent).toContain("span");
+  });
+
+  it("surfaces the banner on a real hydration mismatch", () => {
+    installHydrationMismatchWarning();
+
+    scratch.innerHTML = "<section>server</section>";
+
+    function App() {
+      return h("article", null, "client");
+    }
+
+    hydrate(h(App, null), scratch);
+
+    const banner = document.getElementById(BANNER_ID);
+    expect(banner).not.toBeNull();
+    expect(banner!.textContent).toContain("Hydration mismatch");
+  });
+});

--- a/skills/debug/SKILL.md
+++ b/skills/debug/SKILL.md
@@ -57,7 +57,7 @@ Work through these in order, stopping when you find the root cause:
 ### 3. Rendering issues
 
 - **Blank page**: Check if the route has `render: "spa"` (no SSR content expected) vs `"ssr"`.
-- **Hydration mismatch**: Compare server-rendered HTML vs client component output. Common causes:
+- **Hydration mismatch**: In dev, pracht surfaces a fixed-position red banner at the top of the page listing each mismatched component (via Preact's `options.__m` hook). Compare server-rendered HTML vs client component output. Common causes:
   - Date/time rendering differences
   - Browser-only APIs used during SSR (`window`, `document`, `localStorage`)
   - Conditional rendering based on client state

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,7 @@
     "lib": ["ES2022", "DOM", "DOM.Iterable"],
     "strict": true,
     "skipLibCheck": true,
-    "types": ["node"],
+    "types": ["node", "vite/client"],
     "jsx": "react-jsx",
     "jsxImportSource": "preact",
     "baseUrl": ".",


### PR DESCRIPTION
## Summary

- Hooks Preact's `options.__m` from `initClientRouter` (gated by `import.meta.env.DEV`) so hydration mismatches surface as a fixed red banner listing each offending component instead of being silent.
- New `packages/framework/src/hydration-mismatch.ts` owns the install + banner; chains to any pre-existing hook and installs only once.
- Adds `env.d.ts` so `import.meta.env?.DEV` type-checks without `as any`, plus a changeset (`@pracht/core` minor) and an updated `skills/debug/SKILL.md` debugging note.
- Closes #114.

## Testing

- [x] `pnpm e2e`
- [x] `pnpm format`
- [x] `pnpm lint`
- [x] `pnpm test`

## Checklist

- [x] Docs updated if needed
- [x] Skills updated if needed
- [x] Changeset added if published packages changed