### PR TITLE
feat: agent-readiness for examples/docs and Markdown-for-Agents in core

### DIFF
--- a/.changeset/markdown-for-agents.md
+++ b/.changeset/markdown-for-agents.md
@@ -1,0 +1,17 @@
+---
+"@pracht/core": minor
+"@pracht/adapter-cloudflare": patch
+"@pracht/adapter-node": patch
+---
+
+Add Markdown-for-Agents content negotiation.
+
+Route modules can now export a `markdown: string` alongside their `Component`.
+When a request arrives with `Accept: text/markdown` (or markdown ranked above
+`text/html` via q-values), the runtime returns the raw markdown source with
+`Content-Type: text/markdown; charset=utf-8` and `Vary: Accept`, bypassing
+the component render pipeline.
+
+The Cloudflare and Node adapters skip static-asset serving for these
+requests so SSG routes fall through to the framework, where the markdown
+source is read from the route module instead of the prerendered HTML.

--- a/docs/ADAPTERS.md
+++ b/docs/ADAPTERS.md
@@ -382,7 +382,9 @@ At the runtime level, an adapter also typically needs to:
 
 1. **Accept a platform request** and convert it to a Web `Request` object
 2. **Check for static assets** -- serve files from `dist/client/` with appropriate
-   headers (content-type, cache-control with immutable for hashed assets)
+   headers (content-type, cache-control with immutable for hashed assets). Skip
+   asset serving when the request has `Accept: text/markdown` so routes that
+   export a `markdown` source can respond from the framework.
 3. **Check for prerendered pages** -- SSG and ISG routes have HTML files on disk.
    For ISG, implement staleness checking.
 4. **Delegate dynamic requests** to `handlePrachtRequest()` from `pracht`

--- a/docs/DATA_LOADING.md
+++ b/docs/DATA_LOADING.md
@@ -27,8 +27,13 @@ export default function Dashboard({ data }: RouteComponentProps<typeof loader>) 
 ```
 
 The route component can be a function default export or a named `Component`
-export. Named route exports such as `loader`, `head`, `headers`,
+export. Named route exports such as `loader`, `head`, `headers`, `markdown`,
 `ErrorBoundary`, and `getStaticPaths` remain separate special exports.
+
+A `markdown` string export opts the route into Markdown-for-Agents content
+negotiation: when a request arrives with `Accept: text/markdown`, the runtime
+returns the raw markdown source with `Content-Type: text/markdown` instead of
+rendering the component.
 
 ### LoaderArgs
 

--- a/examples/docs/public/robots.txt
+++ b/examples/docs/public/robots.txt
@@ -1,0 +1,39 @@
+# pracht docs — robots.txt
+# https://www.rfc-editor.org/rfc/rfc9309
+
+User-agent: *
+Allow: /
+Disallow: /_pracht/
+
+# Content Signals (https://contentsignals.org/)
+Content-Signal: search=yes, ai-input=yes, ai-train=yes
+
+# AI crawlers — explicit policy per agent
+User-agent: GPTBot
+Allow: /
+
+User-agent: OAI-SearchBot
+Allow: /
+
+User-agent: ChatGPT-User
+Allow: /
+
+User-agent: Claude-Web
+Allow: /
+
+User-agent: ClaudeBot
+Allow: /
+
+User-agent: Claude-SearchBot
+Allow: /
+
+User-agent: Google-Extended
+Allow: /
+
+User-agent: PerplexityBot
+Allow: /
+
+User-agent: CCBot
+Allow: /
+
+Sitemap: https://pracht.dev/sitemap.xml

--- a/examples/docs/src/routes/home.tsx
+++ b/examples/docs/src/routes/home.tsx
@@ -21,6 +21,17 @@ export function head() {
   return { title: "pracht — Preact-first. Vite-native. Explicit routing." };
 }
 
+export function headers() {
+  // RFC 8288 Link headers for agent discovery.
+  return {
+    link: [
+      '</.well-known/agent-skills/index.json>; rel="agent-skills"',
+      '</sitemap.xml>; rel="sitemap"; type="application/xml"',
+      '</docs/getting-started>; rel="service-doc"',
+    ].join(", "),
+  };
+}
+
 const FEATURES: { Icon: Icon; title: string; desc: string }[] = [
   {
     Icon: IconSitemap,

--- a/examples/docs/vite-plugin-agent-skills.ts
+++ b/examples/docs/vite-plugin-agent-skills.ts
@@ -1,0 +1,154 @@
+/**
+ * Vite plugin that publishes an Agent Skills Discovery index
+ * (https://github.com/cloudflare/agent-skills-discovery-rfc).
+ *
+ * Reads SKILL.md files from a directory, computes SHA-256 digests, and
+ * exposes two things:
+ *   - /skills/<name>/SKILL.md — the skill source, served as a public asset
+ *   - /.well-known/agent-skills/index.json — the discovery manifest that
+ *     points at each /skills/<name>/SKILL.md URL
+ *
+ * In dev, the same paths are served from the dev middleware.
+ */
+
+import { createHash } from "node:crypto";
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { join } from "node:path";
+
+import type { Plugin } from "vite";
+
+export interface AgentSkillsPluginOptions {
+  // Directory containing one folder per skill (each with a SKILL.md).
+  skillsDir: string;
+  // Site origin without trailing slash, e.g. https://pracht.dev
+  origin: string;
+  // Public URL prefix where the SKILL.md files are exposed. Defaults to `/skills`.
+  publicPrefix?: string;
+  // Schema URL referenced by the manifest.
+  schemaUrl?: string;
+}
+
+interface SkillEntry {
+  name: string;
+  description: string;
+  source: string;
+}
+
+const DEFAULT_SCHEMA = "https://agentskills.io/schema/v0.2.0/index.json";
+const INDEX_PATH = ".well-known/agent-skills/index.json";
+
+function readSkills(dir: string): SkillEntry[] {
+  const entries: SkillEntry[] = [];
+  let names: string[];
+  try {
+    names = readdirSync(dir);
+  } catch {
+    return entries;
+  }
+  for (const name of names) {
+    const skillFile = join(dir, name, "SKILL.md");
+    let stat;
+    try {
+      stat = statSync(skillFile);
+    } catch {
+      continue;
+    }
+    if (!stat.isFile()) continue;
+    const source = readFileSync(skillFile, "utf-8");
+    const description = parseDescription(source) ?? `Pracht ${name} skill`;
+    entries.push({ name, description, source });
+  }
+  return entries.sort((a, b) => a.name.localeCompare(b.name));
+}
+
+function parseDescription(source: string): string | undefined {
+  const fmMatch = source.match(/^---\r?\n([\s\S]*?)\r?\n---/);
+  if (!fmMatch) return undefined;
+  const lines = fmMatch[1].split(/\r?\n/);
+  let inDesc = false;
+  const collected: string[] = [];
+  for (const line of lines) {
+    if (!inDesc) {
+      const start = line.match(/^description:\s*(.*)$/);
+      if (!start) continue;
+      const rest = start[1].trim();
+      if (rest === "|" || rest === ">" || rest === "") {
+        inDesc = true;
+        continue;
+      }
+      return rest.replace(/^["']|["']$/g, "");
+    }
+    if (/^\S/.test(line)) break;
+    collected.push(line.trim());
+  }
+  return collected.join(" ").trim() || undefined;
+}
+
+function buildFiles(
+  origin: string,
+  schemaUrl: string,
+  publicPrefix: string,
+  skills: SkillEntry[],
+): { fileName: string; source: string }[] {
+  const files: { fileName: string; source: string }[] = [];
+  const items = skills.map((skill) => {
+    const fileName = `${publicPrefix}/${skill.name}/SKILL.md`;
+    const sha256 = createHash("sha256").update(skill.source).digest("hex");
+    files.push({ fileName, source: skill.source });
+    return {
+      name: skill.name,
+      type: "claude-skill",
+      description: skill.description,
+      url: `${origin}/${fileName}`,
+      sha256,
+    };
+  });
+
+  const json = JSON.stringify({ $schema: schemaUrl, skills: items }, null, 2) + "\n";
+  files.push({ fileName: INDEX_PATH, source: json });
+  return files;
+}
+
+function normalizePrefix(value: string | undefined): string {
+  const raw = (value ?? "/skills").replace(/^\/+|\/+$/g, "");
+  return raw || "skills";
+}
+
+export function agentSkills(options: AgentSkillsPluginOptions): Plugin {
+  const origin = options.origin.replace(/\/$/, "");
+  const schemaUrl = options.schemaUrl ?? DEFAULT_SCHEMA;
+  const publicPrefix = normalizePrefix(options.publicPrefix);
+  const generate = () => buildFiles(origin, schemaUrl, publicPrefix, readSkills(options.skillsDir));
+
+  return {
+    name: "pracht-agent-skills",
+    apply(_config, env) {
+      return env.command === "serve" || (env.command === "build" && !env.isSsrBuild);
+    },
+    configureServer(server) {
+      server.middlewares.use((req, res, next) => {
+        const url = req.url ?? "/";
+        if (url === `/${INDEX_PATH}`) {
+          const { source } = generate().find((f) => f.fileName === INDEX_PATH)!;
+          res.setHeader("content-type", "application/json; charset=utf-8");
+          res.end(source);
+          return;
+        }
+        const skillMatch = url.match(new RegExp(`^/${publicPrefix}/([^/]+)/SKILL\\.md$`));
+        if (skillMatch) {
+          const file = generate().find((f) => f.fileName.endsWith(`/${skillMatch[1]}/SKILL.md`));
+          if (!file) return next();
+          res.setHeader("content-type", "text/markdown; charset=utf-8");
+          res.end(file.source);
+          return;
+        }
+        next();
+      });
+    },
+    generateBundle() {
+      for (const file of generate()) {
+        this.emitFile({ type: "asset", fileName: file.fileName, source: file.source });
+      }
+    },
+  };
+}

--- a/examples/docs/vite-plugin-llms-txt.ts
+++ b/examples/docs/vite-plugin-llms-txt.ts
@@ -1,0 +1,177 @@
+/**
+ * Vite plugin that emits `/llms.txt` and `/llms-full.txt`
+ * (https://llmstxt.org). Both files give LLM agents a curated view of the
+ * site: `llms.txt` is a summary plus link list, `llms-full.txt` inlines the
+ * full markdown source of every listed page.
+ *
+ * Reads route → file mappings by scanning the manifest as text (same
+ * rationale as vite-plugin-sitemap.ts) and pulls title/lead from each .md
+ * file's frontmatter.
+ */
+
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import type { Plugin } from "vite";
+
+export interface LlmsTxtSection {
+  // Section heading, rendered as `## <heading>` in llms.txt.
+  heading: string;
+  // Path prefix that routes must match to be included (e.g. `/docs`).
+  match: string;
+  // Mark this section as `## Optional` per the llmstxt.org convention.
+  optional?: boolean;
+}
+
+export interface LlmsTxtPluginOptions {
+  origin: string;
+  routesFile: string;
+  title: string;
+  description: string;
+  // Optional paragraphs shown between the blockquote and the first section.
+  details?: string[];
+  sections: LlmsTxtSection[];
+}
+
+interface RouteEntry {
+  path: string;
+  file: string;
+}
+
+interface DocEntry extends RouteEntry {
+  title: string;
+  lead?: string;
+  body: string;
+}
+
+function extractRoutes(source: string): RouteEntry[] {
+  // `route("/path", () => import("./file"), …)` or `route("/path", "./file", …)`.
+  const pattern =
+    /\broute\s*\(\s*(["'])([^"']+)\1\s*,\s*(?:\(\s*\)\s*=>\s*import\s*\(\s*(["'])([^"']+)\3\s*\)|(["'])([^"']+)\5)/g;
+  const out: RouteEntry[] = [];
+  let match: RegExpExecArray | null;
+  while ((match = pattern.exec(source))) {
+    const path = match[2];
+    const file = match[4] ?? match[6];
+    if (!path.startsWith("/") || !file) continue;
+    if (path.includes(":") || path.includes("*")) continue;
+    out.push({ path, file });
+  }
+  return out;
+}
+
+interface Frontmatter {
+  title?: string;
+  lead?: string;
+}
+
+function parseMd(source: string): { fm: Frontmatter; body: string } {
+  const match = source.match(/^---\r?\n([\s\S]*?)\r?\n---\r?\n([\s\S]*)$/);
+  if (!match) return { fm: {}, body: source };
+
+  const fm: Frontmatter = {};
+  for (const line of match[1].split(/\r?\n/)) {
+    const kv = line.match(/^(\w+):\s*(.*)$/);
+    if (!kv) continue;
+    const key = kv[1];
+    const value = kv[2].replace(/^["']|["']$/g, "").trim();
+    if (key === "title" || key === "lead") fm[key] = value;
+  }
+  return { fm, body: match[2] };
+}
+
+function loadDocs(routesFile: string): DocEntry[] {
+  const source = readFileSync(routesFile, "utf-8");
+  const baseDir = dirname(routesFile);
+  const docs: DocEntry[] = [];
+  for (const route of extractRoutes(source)) {
+    if (!route.file.endsWith(".md")) continue;
+    const absolute = resolve(baseDir, route.file);
+    let raw: string;
+    try {
+      raw = readFileSync(absolute, "utf-8");
+    } catch {
+      continue;
+    }
+    const { fm, body } = parseMd(raw);
+    docs.push({
+      ...route,
+      title: fm.title ?? route.path,
+      lead: fm.lead,
+      body: body.trim(),
+    });
+  }
+  return docs;
+}
+
+function buildLlmsTxt(options: LlmsTxtPluginOptions, docs: DocEntry[]): string {
+  const origin = options.origin.replace(/\/$/, "");
+  const parts: string[] = [];
+  parts.push(`# ${options.title}`, "", `> ${options.description}`);
+  if (options.details?.length) {
+    parts.push("");
+    for (const p of options.details) parts.push(p);
+  }
+
+  for (const section of options.sections) {
+    const prefix = section.match.replace(/\/$/, "");
+    const matched = docs.filter((doc) => doc.path === prefix || doc.path.startsWith(`${prefix}/`));
+    if (!matched.length) continue;
+    matched.sort((a, b) => a.path.localeCompare(b.path));
+    parts.push("", section.optional ? `## Optional` : `## ${section.heading}`, "");
+    for (const doc of matched) {
+      const url = `${origin}${doc.path}`;
+      const lead = doc.lead ? `: ${doc.lead}` : "";
+      parts.push(`- [${doc.title}](${url})${lead}`);
+    }
+  }
+
+  return parts.join("\n") + "\n";
+}
+
+function buildLlmsFull(options: LlmsTxtPluginOptions, docs: DocEntry[]): string {
+  const parts: string[] = [];
+  parts.push(`# ${options.title}`, "", `> ${options.description}`, "");
+
+  for (const section of options.sections) {
+    const prefix = section.match.replace(/\/$/, "");
+    const matched = docs.filter((doc) => doc.path === prefix || doc.path.startsWith(`${prefix}/`));
+    matched.sort((a, b) => a.path.localeCompare(b.path));
+    for (const doc of matched) {
+      parts.push(`---`, ``, `# ${doc.title}`, ``);
+      if (doc.lead) parts.push(`> ${doc.lead}`, ``);
+      parts.push(doc.body, ``);
+    }
+  }
+
+  return parts.join("\n") + "\n";
+}
+
+export function llmsTxt(options: LlmsTxtPluginOptions): Plugin {
+  const generate = () => {
+    const docs = loadDocs(options.routesFile);
+    return {
+      summary: buildLlmsTxt(options, docs),
+      full: buildLlmsFull(options, docs),
+    };
+  };
+
+  return {
+    name: "pracht-llms-txt",
+    apply(_config, env) {
+      return env.command === "serve" || (env.command === "build" && !env.isSsrBuild);
+    },
+    configureServer(server) {
+      server.middlewares.use((req, res, next) => {
+        if (req.url !== "/llms.txt" && req.url !== "/llms-full.txt") return next();
+        const { summary, full } = generate();
+        res.setHeader("content-type", "text/markdown; charset=utf-8");
+        res.end(req.url === "/llms.txt" ? summary : full);
+      });
+    },
+    generateBundle() {
+      const { summary, full } = generate();
+      this.emitFile({ type: "asset", fileName: "llms.txt", source: summary });
+      this.emitFile({ type: "asset", fileName: "llms-full.txt", source: full });
+    },
+  };
+}

--- a/examples/docs/vite-plugin-md.ts
+++ b/examples/docs/vite-plugin-md.ts
@@ -307,6 +307,8 @@ export function markdown(): Plugin {
       const output = [
         `import { h } from "preact";`,
         ``,
+        `export const markdown = ${JSON.stringify(code)};`,
+        ``,
         `export function head() {`,
         `  return { title: ${JSON.stringify(headTitle)} };`,
         `}`,

--- a/examples/docs/vite-plugin-sitemap.ts
+++ b/examples/docs/vite-plugin-sitemap.ts
@@ -1,0 +1,101 @@
+/**
+ * Vite plugin that emits sitemap.xml from a pracht route manifest.
+ *
+ * The plugin reads the route manifest file as text and extracts `route("…")`
+ * paths by regex, rather than importing it — importing routes.ts from the
+ * vite config would pull lazy `() => import("*.md")` calls through esbuild
+ * while bundling the config, and those transforms don't run there.
+ *
+ * - Dev: serves /sitemap.xml from the dev middleware.
+ * - Build: emits dist/client/sitemap.xml as a build asset.
+ */
+
+import { readFileSync } from "node:fs";
+import type { Plugin } from "vite";
+
+export interface SitemapPluginOptions {
+  /** Site origin without trailing slash, e.g. https://pracht.dev */
+  origin: string;
+  /** Absolute path to the route manifest file (typically src/routes.ts). */
+  routesFile: string;
+  /** Optional last-modified ISO date applied to every entry. */
+  lastmod?: string;
+  /** Extra paths to include (e.g. manually-managed sections). */
+  extraPaths?: string[];
+}
+
+function extractRoutePaths(source: string): string[] {
+  // Match route("/path", …) / route('/path', …). Skips dynamic segments.
+  const pattern = /\broute\s*\(\s*(["'])([^"']+)\1/g;
+  const paths: string[] = [];
+  let match: RegExpExecArray | null;
+  while ((match = pattern.exec(source))) {
+    const path = match[2];
+    if (!path.startsWith("/")) continue;
+    if (path.includes(":") || path.includes("*")) continue;
+    paths.push(path);
+  }
+  return paths;
+}
+
+function buildSitemap(origin: string, paths: string[], lastmod?: string): string {
+  const seen = new Set<string>();
+  const entries = paths
+    .filter((p) => {
+      if (seen.has(p)) return false;
+      seen.add(p);
+      return true;
+    })
+    .sort()
+    .map((path) => {
+      const loc = `${origin}${path === "/" ? "" : path}`;
+      const lm = lastmod ? `\n    <lastmod>${lastmod}</lastmod>` : "";
+      return `  <url>\n    <loc>${escapeXml(loc)}</loc>${lm}\n  </url>`;
+    });
+
+  return [
+    `<?xml version="1.0" encoding="UTF-8"?>`,
+    `<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">`,
+    ...entries,
+    `</urlset>`,
+    ``,
+  ].join("\n");
+}
+
+function escapeXml(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&apos;");
+}
+
+export function sitemap(options: SitemapPluginOptions): Plugin {
+  const origin = options.origin.replace(/\/$/, "");
+  const generate = () => {
+    const source = readFileSync(options.routesFile, "utf-8");
+    const paths = [...extractRoutePaths(source), ...(options.extraPaths ?? [])];
+    return buildSitemap(origin, paths, options.lastmod);
+  };
+
+  return {
+    name: "pracht-sitemap",
+    apply(_config, env) {
+      return env.command === "serve" || (env.command === "build" && !env.isSsrBuild);
+    },
+    configureServer(server) {
+      server.middlewares.use("/sitemap.xml", (_req, res) => {
+        res.setHeader("content-type", "application/xml; charset=utf-8");
+        res.end(generate());
+      });
+    },
+    generateBundle() {
+      this.emitFile({
+        type: "asset",
+        fileName: "sitemap.xml",
+        source: generate(),
+      });
+    },
+  };
+}

--- a/examples/docs/vite.config.ts
+++ b/examples/docs/vite.config.ts
@@ -1,8 +1,29 @@
+import { fileURLToPath } from "node:url";
 import { defineConfig } from "vite";
 import { pracht } from "@pracht/vite-plugin";
 import { cloudflareAdapter } from "@pracht/adapter-cloudflare";
 import { markdown } from "./vite-plugin-md";
+import { sitemap } from "./vite-plugin-sitemap";
+import { agentSkills } from "./vite-plugin-agent-skills";
+import { llmsTxt } from "./vite-plugin-llms-txt";
+
+const SITE_ORIGIN = "https://pracht.dev";
+const routesFile = fileURLToPath(new URL("./src/routes.ts", import.meta.url));
+const skillsDir = fileURLToPath(new URL("../../skills", import.meta.url));
 
 export default defineConfig({
-  plugins: [markdown(), pracht({ adapter: cloudflareAdapter() })],
+  plugins: [
+    markdown(),
+    sitemap({ origin: SITE_ORIGIN, routesFile }),
+    agentSkills({ origin: SITE_ORIGIN, skillsDir }),
+    llmsTxt({
+      origin: SITE_ORIGIN,
+      routesFile,
+      title: "pracht",
+      description:
+        "A full-stack Preact framework built on Vite with hybrid rendering (SSG, SSR, ISG, SPA) and a unified data-loading model.",
+      sections: [{ heading: "Docs", match: "/docs" }],
+    }),
+    pracht({ adapter: cloudflareAdapter() }),
+  ],
 });

--- a/packages/adapter-cloudflare/src/index.ts
+++ b/packages/adapter-cloudflare/src/index.ts
@@ -133,6 +133,12 @@ export function createCloudflareServerEntryModule(
     "    return null;",
     "  }",
     "",
+    "  // Markdown negotiation: let the framework serve markdown source for",
+    "  // routes that export it instead of the prerendered HTML.",
+    '  if ((request.headers.get("accept") ?? "").includes("text/markdown")) {',
+    "    return null;",
+    "  }",
+    "",
     `  const assets = env?.[${JSON.stringify(assetsBinding)}];`,
     '  if (!assets || typeof assets.fetch !== "function") {',
     "    return null;",
@@ -187,6 +193,12 @@ async function maybeServeAsset(
 
   // Route state requests must be handled by the framework (returns JSON), not static assets
   if (request.headers.get("x-pracht-route-state-request") === "1") {
+    return null;
+  }
+
+  // Markdown negotiation: let the framework serve raw markdown for routes
+  // that export it, instead of the prerendered HTML asset.
+  if ((request.headers.get("accept") ?? "").includes("text/markdown")) {
     return null;
   }
 

--- a/packages/adapter-node/src/node-handler.ts
+++ b/packages/adapter-node/src/node-handler.ts
@@ -77,8 +77,9 @@ export function createNodeRequestHandler<TContext = unknown>(
     }
     const url = new URL(request.url);
     const isRouteStateRequest = request.headers.get(ROUTE_STATE_REQUEST_HEADER) === "1";
+    const wantsMarkdown = (request.headers.get("accept") ?? "").includes("text/markdown");
 
-    if (staticDir && request.method === "GET") {
+    if (staticDir && request.method === "GET" && !wantsMarkdown) {
       const staticResult = await resolveStaticFile(staticDir, url.pathname, isgManifest);
       if (staticResult) {
         await serveStaticFile(res, staticResult, headersManifest, url.pathname);
@@ -90,6 +91,7 @@ export function createNodeRequestHandler<TContext = unknown>(
       staticDir &&
       request.method === "GET" &&
       !isRouteStateRequest &&
+      !wantsMarkdown &&
       url.pathname in isgManifest
     ) {
       const served = await serveISGEntry(

--- a/packages/framework/src/runtime-negotiation.ts
+++ b/packages/framework/src/runtime-negotiation.ts
@@ -1,0 +1,51 @@
+import { applyDefaultSecurityHeaders, appendVaryHeader } from "./runtime-headers.ts";
+
+export const MARKDOWN_MEDIA_TYPE = "text/markdown";
+
+interface AcceptEntry {
+  type: string;
+  quality: number;
+}
+
+function parseAccept(header: string | null): AcceptEntry[] {
+  if (!header) return [];
+  const entries: AcceptEntry[] = [];
+  for (const raw of header.split(",")) {
+    const parts = raw.trim().split(";");
+    const type = parts.shift()?.trim().toLowerCase();
+    if (!type) continue;
+    let quality = 1;
+    for (const param of parts) {
+      const [key, value] = param.split("=").map((p) => p.trim());
+      if (key === "q" && value != null) {
+        const parsed = Number.parseFloat(value);
+        if (!Number.isNaN(parsed)) quality = parsed;
+      }
+    }
+    entries.push({ type, quality });
+  }
+  return entries;
+}
+
+// Return true when the client explicitly prefers text/markdown over the
+// default text/html. We deliberately ignore wildcard entries (text/*, */*)
+// so browsers that send `Accept: */*` keep getting HTML.
+export function prefersMarkdown(accept: string | null): boolean {
+  const entries = parseAccept(accept);
+  if (!entries.length) return false;
+  const md = entries.find((e) => e.type === MARKDOWN_MEDIA_TYPE);
+  if (!md || md.quality === 0) return false;
+  const html = entries.find((e) => e.type === "text/html");
+  if (!html) return true;
+  return md.quality >= html.quality;
+}
+
+export function markdownResponse(source: string): Response {
+  const headers = new Headers({
+    "content-type": "text/markdown; charset=utf-8",
+    "cache-control": "public, max-age=0, must-revalidate",
+  });
+  appendVaryHeader(headers, "Accept");
+  applyDefaultSecurityHeaders(headers);
+  return new Response(source, { status: 200, headers });
+}

--- a/packages/framework/src/runtime.ts
+++ b/packages/framework/src/runtime.ts
@@ -32,6 +32,7 @@ import {
   renderRouteErrorResponse,
 } from "./runtime-response.ts";
 import { withRouteResponseHeaders } from "./runtime-headers.ts";
+import { markdownResponse, prefersMarkdown } from "./runtime-negotiation.ts";
 import type {
   ApiRouteArgs,
   ApiRouteModule,
@@ -265,6 +266,16 @@ export async function handlePrachtRequest<TContext>(
     routeModule = await routeModulePromise;
     if (!routeModule) {
       throw new Error("Route module not found");
+    }
+
+    // Markdown-for-Agents negotiation: if the route exposes raw markdown and
+    // the client prefers `text/markdown`, skip render and return the source.
+    if (
+      !isRouteStateRequest &&
+      typeof routeModule.markdown === "string" &&
+      prefersMarkdown(options.request.headers.get("accept"))
+    ) {
+      return markdownResponse(routeModule.markdown);
     }
 
     currentPhase = "loader";

--- a/packages/framework/src/types.ts
+++ b/packages/framework/src/types.ts
@@ -234,6 +234,10 @@ export interface RouteModule<TContext = any, TLoader extends LoaderLike = undefi
   default?: FunctionComponent<RouteComponentProps<TLoader>>;
   ErrorBoundary?: FunctionComponent<ErrorBoundaryProps>;
   getStaticPaths?: () => MaybePromise<RouteParams[]>;
+  // Raw markdown served when a client requests `Accept: text/markdown`
+  // (Markdown-for-Agents). The runtime returns this string with
+  // `Content-Type: text/markdown` instead of rendering the component.
+  markdown?: string;
 }
 
 export interface ShellModule<TContext = any> {

--- a/packages/framework/test/runtime-negotiation.test.ts
+++ b/packages/framework/test/runtime-negotiation.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from "vitest";
+
+import { defineApp, handlePrachtRequest, route } from "../src/index.ts";
+import { markdownResponse, prefersMarkdown } from "../src/runtime-negotiation.ts";
+
+describe("prefersMarkdown", () => {
+  it("returns false when the header is absent or empty", () => {
+    expect(prefersMarkdown(null)).toBe(false);
+    expect(prefersMarkdown("")).toBe(false);
+  });
+
+  it("returns false for browsers sending */*", () => {
+    expect(prefersMarkdown("*/*")).toBe(false);
+    expect(prefersMarkdown("text/html,*/*")).toBe(false);
+  });
+
+  it("returns true for explicit text/markdown", () => {
+    expect(prefersMarkdown("text/markdown")).toBe(true);
+  });
+
+  it("respects q-values", () => {
+    expect(prefersMarkdown("text/html;q=0.9, text/markdown;q=1.0")).toBe(true);
+    expect(prefersMarkdown("text/markdown;q=0.5, text/html;q=0.9")).toBe(false);
+    expect(prefersMarkdown("text/markdown;q=0")).toBe(false);
+  });
+});
+
+describe("markdownResponse", () => {
+  it("returns markdown with Accept in Vary", () => {
+    const response = markdownResponse("# hello");
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toBe("text/markdown; charset=utf-8");
+    expect(response.headers.get("vary")?.toLowerCase()).toContain("accept");
+  });
+});
+
+describe("handlePrachtRequest markdown negotiation", () => {
+  const app = defineApp({
+    routes: [route("/", "./routes/home.md")],
+  });
+
+  it("returns markdown source when the client prefers it", async () => {
+    const response = await handlePrachtRequest({
+      app,
+      registry: {
+        routeModules: {
+          "./routes/home.md": async () => ({
+            markdown: "# Home\n",
+            Component: () => null,
+          }),
+        },
+      },
+      request: new Request("http://localhost/", {
+        headers: { accept: "text/markdown" },
+      }),
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toBe("text/markdown; charset=utf-8");
+    expect(await response.text()).toBe("# Home\n");
+  });
+
+  it("still renders HTML when the client only sends */*", async () => {
+    const response = await handlePrachtRequest({
+      app,
+      registry: {
+        routeModules: {
+          "./routes/home.md": async () => ({
+            markdown: "# Home\n",
+            Component: () => null,
+          }),
+        },
+      },
+      request: new Request("http://localhost/", {
+        headers: { accept: "text/html,*/*" },
+      }),
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")?.includes("text/html")).toBe(true);
+  });
+
+  it("falls through to HTML when the route has no markdown export", async () => {
+    const response = await handlePrachtRequest({
+      app,
+      registry: {
+        routeModules: {
+          "./routes/home.md": async () => ({
+            Component: () => null,
+          }),
+        },
+      },
+      request: new Request("http://localhost/", {
+        headers: { accept: "text/markdown" },
+      }),
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")?.includes("text/html")).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Improves agent-readiness of the `examples/docs` site and lands Markdown-for-Agents content negotiation in the framework.

**Docs site (`examples/docs`)**
- `public/robots.txt` with RFC 9309 rules, AI-crawler allowlist, Content-Signal header, and sitemap pointer
- `vite-plugin-sitemap.ts` — extracts static routes from `routes.ts` and emits `/sitemap.xml`
- `vite-plugin-agent-skills.ts` — exposes repo `skills/<name>/SKILL.md` files at `/skills/<name>/SKILL.md` and emits an Agent Skills Discovery index at `/.well-known/agent-skills/index.json` with sha256 digests
- `vite-plugin-llms-txt.ts` — synthesizes `/llms.txt` (curated link list) and `/llms-full.txt` (inlined markdown bodies) per llmstxt.org
- Home route exports `headers()` returning RFC 8288 `Link` header pointing at the discovery surfaces
- `vite-plugin-md.ts` now exports the raw markdown source from generated route modules so the framework can serve it

**Framework (`@pracht/core`)**
- New `markdown?: string` route export — when present and the client prefers `Accept: text/markdown` (q-value aware), the runtime returns the raw source with `Content-Type: text/markdown; charset=utf-8` and `Vary: Accept`, bypassing render
- `runtime-negotiation.ts` parses Accept headers ignoring `*/*` wildcards so browsers still get HTML

**Adapters**
- `@pracht/adapter-cloudflare` and `@pracht/adapter-node` skip static-asset serving when `Accept: text/markdown` so SSG routes fall through to the framework

## Testing

- [x] `pnpm e2e` (47 passed)
- [x] `pnpm format`
- [x] `pnpm lint`
- [x] `pnpm test` (142 passed)

## Checklist

- [x] Docs updated if needed (`docs/DATA_LOADING.md`, `docs/ADAPTERS.md`)
- [x] Skills updated if needed — N/A
- [x] Changeset added if published packages changed (`.changeset/markdown-for-agents.md` — `@pracht/core` minor, `@pracht/adapter-cloudflare` and `@pracht/adapter-node` patch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)