### PR TITLE
feat(skills): add 20 end-user skills covering audits, testing, and app primitives

### DIFF
--- a/docs/WORKSPACE.md
+++ b/docs/WORKSPACE.md
@@ -90,15 +90,17 @@ described in `VISION_MVP.md`.
   integration required — plugins participate in the full Vite pipeline for both
   client and SSR builds.
 
-- **Claude Code skills** — Three repo-local skills in `skills/`:
-  - `/scaffold` — wraps `pracht generate route|shell|middleware|api` and only
-    falls back to manual wiring when the CLI flags are insufficient.
-  - `/debug` — framework-aware debugging plus `pracht verify` for fast changed
-    scope checks and `pracht doctor` for project-wide wiring validation (route
-    matching, loader errors, hydration mismatches, middleware, API routes,
-    build issues).
-  - `/deploy` — guided adapter setup and deployment for Node.js, Cloudflare,
-    and Vercel (build, configure, deploy checklist).
+- **Claude Code skills** — Repo-local skills in `skills/` (see
+  [skills/README.md](../skills/README.md) for the full index). Two audiences:
+  - **Framework-author**: `/scaffold`, `/debug`, `/deploy`, `/migrate-nextjs`.
+  - **End-user audits**: `/audit-loaders`, `/audit-shells`, `/audit-auth`,
+    `/audit-csrf`, `/audit-headers`, `/audit-secrets`, `/audit-redirects`,
+    `/audit-deps`, `/audit-bundles`, `/audit-seo`, `/audit-a11y`,
+    `/tune-render-mode`, `/pre-deploy`.
+  - **End-user testing scaffolds**: `/scaffold-tests`, `/scaffold-e2e`,
+    `/test-api`.
+  - **End-user app primitives**: `/add-auth`, `/add-db`, `/add-i18n`,
+    `/add-observability`.
 
 ## Later (Phase 2 remaining)
 

--- a/skills/README.md
+++ b/skills/README.md
@@ -1,0 +1,67 @@
+# Pracht Skills
+
+Repo-local Claude Code skills. Two audiences:
+
+- **Framework-author skills** help people working on pracht itself.
+- **End-user skills** help people building applications with pracht.
+
+Skills live one directory per skill, each with a `SKILL.md` defining
+frontmatter (`name`, `version`, `description`, `allowed-tools`) and an
+action-oriented body. Invoke a skill in Claude Code with `/<skill-name>`.
+
+## Framework-author skills
+
+| Skill              | Use when                                                     |
+| ------------------ | ------------------------------------------------------------ |
+| `/scaffold`        | Generate routes, shells, middleware, or API handlers.        |
+| `/debug`           | Investigate route matching, loader, rendering, or HMR bugs.  |
+| `/deploy`          | Configure an adapter and deploy to Node, Cloudflare, Vercel. |
+| `/migrate-nextjs`  | Convert a Next.js app (App or Pages Router) to pracht.       |
+
+## End-user skills
+
+### Audit & review
+
+| Skill               | Use when                                                            |
+| ------------------- | ------------------------------------------------------------------- |
+| `/audit-loaders`    | Check loaders for serializability, leaked secrets, browser-only APIs. |
+| `/audit-shells`     | Verify shell composition: `Loading()`, `head()`, no document tags.  |
+| `/audit-auth`       | Find protected routes missing auth middleware.                      |
+| `/audit-csrf`       | Verify CSRF posture on forms and mutation APIs.                     |
+| `/audit-headers`    | Per-route security header coverage; CSP suggestion.                 |
+| `/audit-secrets`    | Detect env vars / secrets reaching the client bundle.               |
+| `/audit-redirects`  | Open-redirect detection in loaders, middleware, navigation.         |
+| `/audit-deps`       | npm/pnpm audit mapped to which routes use the vulnerable package.   |
+| `/audit-bundles`    | Per-route client payload size and code-splitting recommendations.   |
+| `/audit-seo`        | `head()` coverage, OG cards, sitemap, robots.txt.                   |
+| `/audit-a11y`       | Per-route axe-core run with WCAG 2.1 AA defaults.                   |
+| `/tune-render-mode` | Recommend SSG/ISG/SSR/SPA per route based on loader contents.       |
+| `/pre-deploy`       | Adapter-aware pre-deployment checklist.                             |
+
+### Testing scaffolds
+
+| Skill              | Use when                                                                  |
+| ------------------ | ------------------------------------------------------------------------- |
+| `/scaffold-tests`  | Set up Vitest (browser mode or JSDOM) and emit unit tests.                |
+| `/scaffold-e2e`    | Set up Playwright and emit per-route smoke + navigation tests.            |
+| `/test-api`        | Generate request/response tests for every `src/api/**` handler.           |
+
+### App primitives (additive scaffolds)
+
+| Skill                 | Use when                                                          |
+| --------------------- | ----------------------------------------------------------------- |
+| `/add-auth`           | Wire session-based email/password auth.                           |
+| `/add-db`             | Wire Drizzle ORM (D1, PlanetScale, Neon, Postgres, ...).          |
+| `/add-i18n`           | Add locale routing and translation primitives.                    |
+| `/add-observability`  | Wire Sentry / OpenTelemetry plus Web Vitals.                      |
+
+## Conventions
+
+- Use `pracht inspect routes --json`, `pracht inspect api --json`, and
+  `pracht inspect build --json` as the source of truth instead of globbing
+  `src/`. The resolved graph already accounts for groups and inheritance.
+- Audit skills produce a report; they never auto-fix.
+- Add/scaffold skills generate files but never overwrite an existing config
+  without diffing first.
+- All skills end with `$ARGUMENTS` so the user can pass additional
+  context at invocation time.

--- a/skills/add-auth/SKILL.md
+++ b/skills/add-auth/SKILL.md
@@ -1,0 +1,286 @@
+---
+name: add-auth
+version: 1.0.0
+description: |
+  Drop session-based auth into a pracht app following the framework's
+  recommended pattern (middleware checks the session, loaders read user info,
+  API routes mutate it). Generates session utilities, the auth middleware,
+  login/logout/signup API routes, and the matching `<Form>`-driven pages —
+  then wires the manifest with public vs. protected groups.
+  Use when asked to "add auth", "set up login", "wire authentication",
+  "add session middleware", or "I need users".
+allowed-tools:
+  - Bash
+  - Read
+  - Write
+  - Edit
+  - Grep
+  - Glob
+  - AskUserQuestion
+---
+
+# Pracht Add Auth
+
+Implements the auth pattern documented in
+`examples/docs/src/routes/docs/recipes-auth.md`. This skill stamps out the
+files; the user replaces `verifyCredentials()` with a real DB lookup.
+
+## Step 1: Confirm the scope
+
+Use `AskUserQuestion`:
+
+1. **What flavor?** Session cookie + email/password (default) OR magic link
+   OR OAuth (out of scope — recommend a separate skill / library).
+2. **Where do credentials live?** A DB the user already has, or no DB yet?
+   If no DB, recommend running `add-db` first.
+3. **Cookie posture for CSRF**: `SameSite=Lax` (default, recommended) vs.
+   `SameSite=Strict` vs. `SameSite=None` + token. (Cross-link `audit-csrf`.)
+
+This skill defaults to: session cookie + email/password + `SameSite=Lax`.
+
+## Step 2: Session utilities
+
+`src/server/session.ts`:
+
+```ts
+const SECRET = process.env.SESSION_SECRET!;
+if (!SECRET) throw new Error("SESSION_SECRET is required");
+
+export interface Session {
+  userId: string;
+  email: string;
+}
+
+export async function getSession(request: Request): Promise<Session | null> {
+  const cookie = request.headers.get("cookie") ?? "";
+  const match = cookie.match(/session=([^;]+)/);
+  if (!match) return null;
+  try {
+    const [payload, signature] = match[1].split(".");
+    const expected = await sign(payload);
+    if (signature !== expected) return null;
+    return JSON.parse(atob(payload));
+  } catch {
+    return null;
+  }
+}
+
+export async function createSessionCookie(session: Session): Promise<string> {
+  const payload = btoa(JSON.stringify(session));
+  const signature = await sign(payload);
+  return `session=${payload}.${signature}; Path=/; HttpOnly; Secure; SameSite=Lax; Max-Age=604800`;
+}
+
+export function clearSessionCookie(): string {
+  return "session=; Path=/; HttpOnly; Secure; SameSite=Lax; Max-Age=0";
+}
+
+async function sign(data: string): Promise<string> {
+  const key = await crypto.subtle.importKey(
+    "raw",
+    new TextEncoder().encode(SECRET),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"],
+  );
+  const sig = await crypto.subtle.sign("HMAC", key, new TextEncoder().encode(data));
+  return btoa(String.fromCharCode(...new Uint8Array(sig)));
+}
+```
+
+Notes:
+- `crypto.subtle` works in Node 18+, Cloudflare Workers, and Vercel Edge.
+- Drop `Secure` only if the user is on plain HTTP locally (recommend
+  conditionalizing on `NODE_ENV`).
+
+## Step 3: Auth middleware
+
+`src/middleware/auth.ts`:
+
+```ts
+import type { MiddlewareFn } from "@pracht/core";
+import { getSession } from "../server/session";
+
+export const middleware: MiddlewareFn = async ({ request, url }) => {
+  const session = await getSession(request);
+  if (!session) {
+    const next = encodeURIComponent(url.pathname + url.search);
+    return { redirect: `/login?redirect=${next}` };
+  }
+  request.headers.set("x-user-id", session.userId);
+  request.headers.set("x-user-email", session.email);
+};
+```
+
+This is a **Gate** (returns `redirect` on failure). Cross-reference
+`audit-auth` for the distinction between Gate and Augmenter.
+
+## Step 4: Login / logout API routes
+
+`src/api/auth/login.ts`:
+
+```ts
+import type { BaseRouteArgs } from "@pracht/core";
+import { createSessionCookie } from "../../server/session";
+
+export async function POST({ request, url }: BaseRouteArgs) {
+  const form = await request.formData();
+  const email = String(form.get("email") ?? "").trim();
+  const password = String(form.get("password") ?? "");
+  const requested = String(form.get("redirect") ?? "/dashboard");
+
+  // Enforce same-origin redirect (defense against open-redirect via form input).
+  const safeRedirect = requested.startsWith("/") && !requested.startsWith("//")
+    ? requested
+    : "/dashboard";
+
+  const user = await verifyCredentials(email, password);
+  if (!user) {
+    return Response.json({ error: "Invalid email or password" }, { status: 401 });
+  }
+
+  const cookie = await createSessionCookie({ userId: user.id, email: user.email });
+  return new Response(null, {
+    status: 302,
+    headers: { location: safeRedirect, "set-cookie": cookie },
+  });
+}
+
+async function verifyCredentials(_email: string, _password: string) {
+  // TODO: replace with a real DB lookup + password hash check (argon2 / bcrypt).
+  return null as null | { id: string; email: string };
+}
+```
+
+`src/api/auth/logout.ts`:
+
+```ts
+import type { BaseRouteArgs } from "@pracht/core";
+import { clearSessionCookie } from "../../server/session";
+
+export async function POST(_args: BaseRouteArgs) {
+  return new Response(null, {
+    status: 302,
+    headers: { location: "/", "set-cookie": clearSessionCookie() },
+  });
+}
+```
+
+`src/api/auth/signup.ts` (skeleton — user wires hashing + DB insert):
+
+```ts
+import type { BaseRouteArgs } from "@pracht/core";
+import { createSessionCookie } from "../../server/session";
+
+export async function POST({ request }: BaseRouteArgs) {
+  const form = await request.formData();
+  const email = String(form.get("email") ?? "").trim();
+  const password = String(form.get("password") ?? "");
+  if (!email || password.length < 8) {
+    return Response.json({ error: "Invalid input" }, { status: 400 });
+  }
+  // TODO: hash password, insert user, set session.
+  const user = { id: crypto.randomUUID(), email };
+  const cookie = await createSessionCookie({ userId: user.id, email: user.email });
+  return new Response(null, {
+    status: 302,
+    headers: { location: "/dashboard", "set-cookie": cookie },
+  });
+}
+```
+
+## Step 5: Login & signup pages
+
+`src/routes/login.tsx`:
+
+```tsx
+import type { LoaderArgs, RouteComponentProps } from "@pracht/core";
+import { Form } from "@pracht/core";
+
+export async function loader({ url }: LoaderArgs) {
+  return { redirect: url.searchParams.get("redirect") ?? "/dashboard" };
+}
+
+export function head() {
+  return { title: "Log in" };
+}
+
+export function Component({ data }: RouteComponentProps<typeof loader>) {
+  return (
+    <section class="login">
+      <h1>Log in</h1>
+      <Form method="post" action="/api/auth/login">
+        <input type="hidden" name="redirect" value={data.redirect} />
+        <label>Email <input type="email" name="email" required /></label>
+        <label>Password <input type="password" name="password" required /></label>
+        <button type="submit">Log in</button>
+      </Form>
+    </section>
+  );
+}
+```
+
+Generate `signup.tsx` analogously, posting to `/api/auth/signup`.
+
+## Step 6: Wire the manifest
+
+```ts
+import { defineApp, group, route } from "@pracht/core";
+
+export const app = defineApp({
+  shells: {
+    public: "./shells/public.tsx",
+    app: "./shells/app.tsx",
+  },
+  middleware: {
+    auth: "./middleware/auth.ts",
+  },
+  routes: [
+    group({ shell: "public" }, [
+      route("/", "./routes/home.tsx", { render: "ssg" }),
+      route("/login", "./routes/login.tsx", { render: "ssr" }),
+      route("/signup", "./routes/signup.tsx", { render: "ssr" }),
+    ]),
+    group({ shell: "app", middleware: ["auth"] }, [
+      route("/dashboard", "./routes/dashboard.tsx", { render: "ssr" }),
+      // any other protected routes…
+    ]),
+  ],
+});
+```
+
+If the project already has `defineApp({...})`, merge — preserve existing
+shells/middleware/routes.
+
+## Step 7: Env vars
+
+Add to `.env.example`:
+
+```
+SESSION_SECRET=<generate with: openssl rand -base64 32>
+```
+
+Confirm `.env*` is gitignored.
+
+## Step 8: Verify
+
+- `pracht dev`, navigate to `/dashboard` → redirects to
+  `/login?redirect=%2Fdashboard`.
+- After successful login, lands on `/dashboard`.
+- Logout posts to `/api/auth/logout` and clears the cookie.
+- Run `pnpm test` and `pnpm e2e`.
+- Run `audit-csrf` and `audit-auth` after wiring to confirm posture.
+
+## Rules
+
+1. Always set `HttpOnly`, `SameSite=Lax`, `Secure` on the session cookie.
+2. The login form's `redirect` input is user-supplied — gate it server-side
+   (`startsWith('/')` AND `!startsWith('//')`). Otherwise this is an open
+   redirect.
+3. `verifyCredentials` is a placeholder — never ship the skeleton without
+   real password hashing (argon2 or bcrypt).
+4. `SESSION_SECRET` is required at boot — fail loudly if missing.
+5. After wiring, recommend running `audit-auth` to confirm protected routes
+   are gated and `audit-csrf` for CSRF posture.
+
+$ARGUMENTS

--- a/skills/add-db/SKILL.md
+++ b/skills/add-db/SKILL.md
@@ -1,0 +1,203 @@
+---
+name: add-db
+version: 1.0.0
+description: |
+  Wire Drizzle ORM into a pracht app. Asks the user which database to target
+  (Cloudflare D1, PlanetScale, Neon, Supabase, Turso, Postgres, MySQL, SQLite,
+  ...) and generates the matching driver setup, schema scaffold, migration
+  workflow, and a typed client accessible from loaders, middleware, and API
+  routes.
+  Use when asked to "add database", "set up Drizzle", "wire D1",
+  "add Postgres", "set up an ORM", or "I need a DB".
+allowed-tools:
+  - Bash
+  - Read
+  - Write
+  - Edit
+  - Grep
+  - Glob
+  - AskUserQuestion
+---
+
+# Pracht Add Database (Drizzle)
+
+Drizzle works well in pracht because it is small, type-safe, and runs in
+both Node and edge runtimes (Cloudflare Workers, Vercel Edge). This skill
+sets up the driver, schema directory, migration tooling, and a client
+factory wired to the project's adapter.
+
+## Step 1: Pick the target
+
+Use `AskUserQuestion`:
+
+| Provider           | Driver                                   | Adapter notes                |
+| ------------------ | ---------------------------------------- | ---------------------------- |
+| Cloudflare D1      | `drizzle-orm/d1`                         | Workers binding              |
+| Cloudflare Hyperdrive (Postgres) | `drizzle-orm/postgres-js` or `node-postgres` | Workers binding |
+| PlanetScale        | `drizzle-orm/planetscale-serverless`     | Works on Node + edge         |
+| Neon (Postgres)    | `drizzle-orm/neon-serverless` or `neon-http` | Works on Node + edge     |
+| Supabase Postgres  | `drizzle-orm/postgres-js`                | Node + edge (HTTP variant)   |
+| Turso (libSQL)     | `drizzle-orm/libsql`                     | Node + edge                  |
+| Vanilla Postgres   | `drizzle-orm/node-postgres`              | Node only                    |
+| Vanilla MySQL      | `drizzle-orm/mysql2`                     | Node only                    |
+| SQLite (better-sqlite3) | `drizzle-orm/better-sqlite3`        | Node only                    |
+
+Cross-check with the project's pracht adapter (`pracht inspect build --json`):
+flag mismatches (e.g., `node-postgres` on Cloudflare Workers — won't work).
+
+## Step 2: Install
+
+```bash
+pnpm add drizzle-orm <driver>
+pnpm add -D drizzle-kit
+```
+
+Specific drivers:
+
+- D1: no additional package; uses the Workers binding.
+- PlanetScale: `pnpm add @planetscale/database`.
+- Neon: `pnpm add @neondatabase/serverless`.
+- Postgres / Supabase: `pnpm add postgres` (postgres-js).
+- Turso: `pnpm add @libsql/client`.
+- node-postgres: `pnpm add pg && pnpm add -D @types/pg`.
+- mysql2: `pnpm add mysql2`.
+- better-sqlite3: `pnpm add better-sqlite3 && pnpm add -D @types/better-sqlite3`.
+
+## Step 3: Schema directory
+
+`src/db/schema.ts`:
+
+```ts
+// Postgres example — substitute sqliteTable / mysqlTable for other dialects.
+import { pgTable, serial, text, timestamp } from "drizzle-orm/pg-core";
+
+export const users = pgTable("users", {
+  id: serial("id").primaryKey(),
+  email: text("email").notNull().unique(),
+  createdAt: timestamp("created_at").defaultNow().notNull(),
+});
+```
+
+For D1/SQLite, use `sqliteTable` from `drizzle-orm/sqlite-core`. For MySQL,
+use `mysqlTable` from `drizzle-orm/mysql-core`.
+
+## Step 4: Client factory
+
+`src/db/client.ts`:
+
+```ts
+// Example for Postgres on Node:
+import { drizzle } from "drizzle-orm/node-postgres";
+import { Pool } from "pg";
+
+const pool = new Pool({ connectionString: process.env.DATABASE_URL });
+export const db = drizzle(pool, { schema });
+import * as schema from "./schema";
+```
+
+For Cloudflare D1:
+
+```ts
+import { drizzle } from "drizzle-orm/d1";
+import * as schema from "./schema";
+import type { LoaderArgs } from "@pracht/core";
+
+export function getDb({ context }: Pick<LoaderArgs<{ DB: D1Database }>, "context">) {
+  return drizzle(context.env.DB, { schema });
+}
+```
+
+For PlanetScale / Neon / Turso, follow the matching driver pattern. The
+pattern is:
+
+- **Node + persistent process**: module-level singleton.
+- **Edge + per-request context (Cloudflare/Vercel Edge)**: factory called
+  with `context` inside the loader.
+
+## Step 5: `drizzle.config.ts`
+
+```ts
+import { defineConfig } from "drizzle-kit";
+
+export default defineConfig({
+  schema: "./src/db/schema.ts",
+  out: "./drizzle",
+  dialect: "postgresql", // or "sqlite" / "mysql"
+  dbCredentials: {
+    url: process.env.DATABASE_URL!,
+  },
+});
+```
+
+For D1 use `dialect: "sqlite"` and the wrangler D1 driver path; refer to
+Drizzle's D1 docs and surface that link for the user.
+
+## Step 6: Scripts
+
+Add to `package.json`:
+
+```json
+{
+  "scripts": {
+    "db:generate": "drizzle-kit generate",
+    "db:migrate":  "drizzle-kit migrate",
+    "db:push":     "drizzle-kit push",
+    "db:studio":   "drizzle-kit studio"
+  }
+}
+```
+
+## Step 7: Use in a loader
+
+Demonstrate the wired-up usage:
+
+```ts
+import type { LoaderArgs } from "@pracht/core";
+import { db } from "../db/client"; // or getDb(args) on edge runtimes
+import { users } from "../db/schema";
+
+export async function loader(_args: LoaderArgs) {
+  const rows = await db.select().from(users).limit(20);
+  return { users: rows.map(u => ({ id: u.id, email: u.email })) };
+}
+```
+
+Note: explicit projection — never spread DB rows into loader return values
+(see `audit-secrets`).
+
+## Step 8: Bindings & env vars
+
+- For Cloudflare adapters: add the binding to `wrangler.toml`:
+  ```toml
+  [[d1_databases]]
+  binding = "DB"
+  database_name = "my-app"
+  database_id = "<id>"
+  ```
+- For Node/Vercel: document `DATABASE_URL` in `.env.example`. Add `.env*` to
+  `.gitignore` if missing.
+
+## Step 9: Verify
+
+```bash
+pnpm db:generate
+pnpm db:push   # or db:migrate after creating one
+```
+
+Then run the project's existing tests:
+
+```bash
+pnpm test
+```
+
+## Rules
+
+1. Always confirm the adapter ↔ driver compatibility before installing.
+2. Never spread DB rows into loader return values — project explicitly.
+3. For edge runtimes, do not module-cache a connection — use a factory keyed
+   by `context.env`.
+4. Add `.env*` to `.gitignore` if a connection string is involved.
+5. Recommend a migration workflow (`db:migrate`) over `db:push` for
+   anything beyond local dev.
+
+$ARGUMENTS

--- a/skills/add-i18n/SKILL.md
+++ b/skills/add-i18n/SKILL.md
@@ -1,0 +1,204 @@
+---
+name: add-i18n
+version: 1.0.0
+description: |
+  Wire internationalization into a pracht app following the framework's
+  recommended pattern (middleware detects locale, loaders return translations,
+  components consume via route data). Generates locale dictionaries, the
+  detection middleware (URL-prefix, cookie, or `Accept-Language`), and a
+  helper for in-component translation.
+  Use when asked to "add i18n", "set up translations", "make my app
+  multilingual", "add locale routing", or "extract strings".
+allowed-tools:
+  - Bash
+  - Read
+  - Write
+  - Edit
+  - Grep
+  - Glob
+  - AskUserQuestion
+---
+
+# Pracht Add i18n
+
+Pracht ships no i18n library — the framework gives you primitives. The
+recommended recipe lives at
+`examples/docs/src/routes/docs/recipes-i18n.md`.
+
+## Step 1: Pick the locale-detection strategy
+
+Use `AskUserQuestion`:
+
+| Strategy        | URL shape          | Pros                          | Cons                       |
+| --------------- | ------------------ | ----------------------------- | -------------------------- |
+| URL-prefix      | `/fr/about`        | Best for SEO; explicit        | Requires manifest changes  |
+| Cookie          | `/about` + cookie  | URL stays clean               | Hidden state; SEO weaker   |
+| Accept-Language | `/about` (varies)  | No user action                | Caching/SEO get tricky     |
+
+Default to **URL-prefix** unless the user explicitly chooses otherwise.
+
+## Step 2: Pick the supported locales
+
+Ask once. Default suggestion: `en` plus one to two more. Confirm a default
+locale (used as fallback in `t()`).
+
+## Step 3: Translation files
+
+`src/i18n/<locale>.ts` per locale:
+
+```ts
+export default {
+  "home.title": "Welcome",
+  "home.subtitle": "Built with pracht",
+  "nav.home": "Home",
+  "nav.about": "About",
+} as const;
+```
+
+`src/i18n/index.ts`:
+
+```ts
+import en from "./en";
+import fr from "./fr";
+
+export const translations = { en, fr } as const;
+export const defaultLocale = "en" as const;
+export const supportedLocales = Object.keys(translations) as Array<keyof typeof translations>;
+
+export type Locale = keyof typeof translations;
+export type TranslationKey = keyof typeof en;
+
+export function t(locale: string, key: TranslationKey): string {
+  const dict = (translations as Record<string, Record<string, string>>)[locale]
+    ?? translations[defaultLocale];
+  return dict[key] ?? translations[defaultLocale][key] ?? key;
+}
+```
+
+## Step 4: Locale-detection middleware
+
+### URL-prefix variant
+
+```ts
+// src/middleware/i18n.ts
+import type { MiddlewareFn } from "@pracht/core";
+import { defaultLocale, supportedLocales } from "../i18n";
+
+export const middleware: MiddlewareFn = ({ request, url }) => {
+  const segments = url.pathname.split("/").filter(Boolean);
+  const maybe = segments[0] ?? "";
+  const locale = (supportedLocales as readonly string[]).includes(maybe) ? maybe : defaultLocale;
+  request.headers.set("x-locale", locale);
+};
+```
+
+### Cookie variant
+
+```ts
+import type { MiddlewareFn } from "@pracht/core";
+import { defaultLocale, supportedLocales } from "../i18n";
+
+export const middleware: MiddlewareFn = ({ request }) => {
+  const cookie = request.headers.get("cookie") ?? "";
+  const m = cookie.match(/locale=([^;]+)/);
+  const requested = m?.[1] ?? defaultLocale;
+  const locale = (supportedLocales as readonly string[]).includes(requested) ? requested : defaultLocale;
+  request.headers.set("x-locale", locale);
+};
+```
+
+### Accept-Language variant
+
+```ts
+import type { MiddlewareFn } from "@pracht/core";
+import { defaultLocale, supportedLocales } from "../i18n";
+
+export const middleware: MiddlewareFn = ({ request }) => {
+  const header = request.headers.get("accept-language") ?? "";
+  const preferred = header.split(",").map(p => p.split(";")[0]?.trim().toLowerCase().slice(0, 2));
+  const match = preferred.find(p => (supportedLocales as readonly string[]).includes(p));
+  request.headers.set("x-locale", match ?? defaultLocale);
+};
+```
+
+## Step 5: Use in a loader
+
+```ts
+import type { LoaderArgs } from "@pracht/core";
+import { t } from "../i18n";
+
+export async function loader({ request }: LoaderArgs) {
+  const locale = request.headers.get("x-locale") ?? "en";
+  return {
+    locale,
+    title: t(locale, "home.title"),
+    subtitle: t(locale, "home.subtitle"),
+  };
+}
+```
+
+## Step 6: Wire the manifest
+
+For the URL-prefix strategy, the routes need to live under per-locale
+groups. Update `src/routes.ts`:
+
+```ts
+import { defineApp, group, route } from "@pracht/core";
+
+export const app = defineApp({
+  middleware: { i18n: "./middleware/i18n.ts" },
+  routes: [
+    group({ middleware: ["i18n"] }, [
+      route("/", "./routes/home.tsx", { id: "home-default" }),
+      route("/:locale/", "./routes/home.tsx", { id: "home-localized" }),
+      route("/:locale/about", "./routes/about.tsx"),
+    ]),
+  ],
+});
+```
+
+For cookie / Accept-Language strategies, just add the middleware to the root
+group; no path changes.
+
+## Step 7: SEO touch-ups
+
+- Set `lang` in `head()` per route from the resolved locale.
+- For URL-prefix: emit `<link rel="alternate" hreflang="fr" href="...">`
+  pairs in `head()` so search engines learn the locale graph.
+- Update sitemap (cross-reference with `audit-seo`) to include all
+  per-locale URLs.
+
+## Step 8: String extraction (optional)
+
+Add a script that:
+
+1. Greps for `t(locale, "...")` calls.
+2. Builds a key set.
+3. Diffs against each `src/i18n/<locale>.ts`.
+4. Reports missing keys per locale.
+
+```bash
+node scripts/i18n-extract.mjs
+```
+
+The output is a TODO list per locale, not auto-translation.
+
+## Step 9: Verify
+
+- Boot dev: `pracht dev`.
+- Visit `/` and the locale-prefixed variant; confirm content swaps.
+- `pnpm test` and `pnpm e2e` still pass.
+
+## Rules
+
+1. The middleware sets a request header; loaders read it. Do not stash the
+   locale in module-level state — concurrent requests will collide.
+2. Always include the default locale as the fallback in `t()`.
+3. For SSG, only prerender the URL combinations that exist; provide
+   `getStaticPaths` returning the locale × dynamic-param product.
+4. Recommend `Intl.DateTimeFormat` and `Intl.NumberFormat` for formatting —
+   no library needed.
+5. Never bundle every translation into the client. If translations grow
+   large, split per-locale and import lazily in loaders.
+
+$ARGUMENTS

--- a/skills/add-observability/SKILL.md
+++ b/skills/add-observability/SKILL.md
@@ -1,0 +1,194 @@
+---
+name: add-observability
+version: 1.0.0
+description: |
+  Wire error tracking, request tracing, and Web Vitals into a pracht app.
+  Supports Sentry or OpenTelemetry on the server side (loader/middleware
+  boundaries, API routes), and client-side Web Vitals reporting via the
+  `web-vitals` package.
+  Use when asked to "add observability", "wire Sentry", "set up tracing",
+  "add OpenTelemetry", "monitor Web Vitals", or "track errors".
+allowed-tools:
+  - Bash
+  - Read
+  - Write
+  - Edit
+  - Grep
+  - Glob
+  - AskUserQuestion
+---
+
+# Pracht Add Observability
+
+Three layers, each opt-in:
+
+1. **Server error tracking** — capture loader/middleware/API exceptions.
+2. **Request tracing** — span per request with child spans per loader/db call.
+3. **Web Vitals (LCP/CLS/INP/FCP/TTFB)** — client-side, posted to a beacon
+   endpoint.
+
+## Step 1: Pick the stack
+
+Use `AskUserQuestion`:
+
+- **Sentry** — easiest end-to-end (errors + traces + Web Vitals).
+- **OpenTelemetry + your backend** (Honeycomb, Grafana, Datadog, Jaeger).
+- **Custom beacon** — minimal `fetch('/api/telemetry')` setup, no SaaS.
+
+The skill below shows Sentry and OTel patterns. Custom beacon is mentioned
+but trivial.
+
+## Step 2: Server error tracking
+
+### Sentry path
+
+```bash
+pnpm add @sentry/node    # for Node adapter
+# or
+pnpm add @sentry/cloudflare   # for Cloudflare adapter
+# or
+pnpm add @sentry/vercel-edge  # for Vercel edge
+```
+
+Create `src/server/observability.ts`:
+
+```ts
+import * as Sentry from "@sentry/node";
+
+let initialized = false;
+export function initObservability() {
+  if (initialized) return;
+  initialized = true;
+  Sentry.init({
+    dsn: process.env.SENTRY_DSN,
+    tracesSampleRate: Number(process.env.SENTRY_TRACES_SAMPLE_RATE ?? 0.1),
+    environment: process.env.NODE_ENV,
+  });
+}
+```
+
+Add a global middleware that calls `initObservability()` once and wraps the
+downstream call:
+
+```ts
+// src/middleware/observability.ts
+import type { MiddlewareFn } from "@pracht/core";
+import * as Sentry from "@sentry/node";
+import { initObservability } from "../server/observability";
+
+initObservability();
+
+export const middleware: MiddlewareFn = async ({ request, route }) => {
+  return await Sentry.startSpan(
+    { name: `${request.method} ${route?.path ?? new URL(request.url).pathname}`, op: "http.server" },
+    async () => undefined,
+  );
+};
+```
+
+Wire it as the **first** middleware in `defineApp({ middleware })` so it
+covers everything.
+
+### OpenTelemetry path
+
+```bash
+pnpm add @opentelemetry/api @opentelemetry/sdk-trace-node @opentelemetry/auto-instrumentations-node
+```
+
+Create a SDK init module that runs at server entry — for Node, use the
+`--require ./otel.cjs` flag; for Cloudflare/Vercel edge, OTel is more limited
+(use HTTP exporter directly). Surface this trade-off; don't pretend OTel
+edge is plug-and-play.
+
+## Step 3: Loader/API tracing
+
+For each loader and API handler, wrap the body in a span.
+
+```ts
+import * as Sentry from "@sentry/node";
+
+export async function loader({ request }) {
+  return Sentry.startSpan({ name: "loader: dashboard", op: "function" }, async () => {
+    return { /* ... */ };
+  });
+}
+```
+
+Auto-injection is out of scope; provide a snippet, recommend wrapping the 5-10
+slowest loaders (cross-reference with `audit-bundles` perf hotspots).
+
+## Step 4: Web Vitals on the client
+
+```bash
+pnpm add web-vitals
+```
+
+Create `src/client/vitals.ts`:
+
+```ts
+import { onCLS, onINP, onLCP, onFCP, onTTFB, type Metric } from "web-vitals";
+
+function send(metric: Metric) {
+  navigator.sendBeacon?.(
+    "/api/telemetry/vitals",
+    JSON.stringify({ name: metric.name, value: metric.value, id: metric.id, path: location.pathname }),
+  );
+}
+
+onCLS(send);
+onINP(send);
+onLCP(send);
+onFCP(send);
+onTTFB(send);
+```
+
+Import this from a shell that wraps the SPA-router-using routes (or from a
+lazy-loaded chunk via `useEffect`-equivalent in a top-level component).
+
+## Step 5: Beacon endpoint
+
+```ts
+// src/api/telemetry/vitals.ts
+import type { BaseRouteArgs } from "@pracht/core";
+
+export async function POST({ request }: BaseRouteArgs) {
+  const body = await request.text();
+  // Forward to your destination (Sentry, Honeycomb, custom store).
+  // Keep body small; do not block on the upstream.
+  console.log("vitals", body);
+  return new Response(null, { status: 204 });
+}
+```
+
+For Sentry users, Sentry's browser SDK can capture Web Vitals natively —
+prefer that over a custom beacon if you've gone the Sentry route.
+
+## Step 6: Sampling and PII
+
+- Set `SENTRY_TRACES_SAMPLE_RATE` to a small number (0.05–0.10) in
+  production.
+- Scrub auth headers and cookies from breadcrumbs:
+  ```ts
+  Sentry.init({ beforeSend(event) { delete event.request?.headers?.cookie; return event; } });
+  ```
+- Never send loader return values verbatim — they often contain user data.
+
+## Step 7: Verify
+
+- Trigger a deliberate error in dev and confirm it lands in Sentry/OTel.
+- Open a route, check the Web Vitals beacon fires (Network tab).
+- Confirm `pnpm test` and `pnpm e2e` still pass.
+
+## Rules
+
+1. Confirm adapter compatibility before installing the SDK package
+   (Sentry has separate packages per runtime).
+2. Observability middleware must be the FIRST middleware in the chain to
+   wrap everything.
+3. Web Vitals only matter for SSR/SSG/ISG routes that hydrate; SPA-only
+   routes still benefit but the values reflect the post-bootstrap state.
+4. Sample traces (≤ 10%) in production; full sampling in dev.
+5. Never send raw cookies, auth headers, or full loader payloads to a
+   third-party SaaS.
+
+$ARGUMENTS

--- a/skills/audit-a11y/SKILL.md
+++ b/skills/audit-a11y/SKILL.md
@@ -1,0 +1,142 @@
+---
+name: audit-a11y
+version: 1.0.0
+description: |
+  Per-route accessibility audit for a pracht app. Drives a headless browser
+  through every route in the manifest, runs axe-core, and reports issues
+  grouped by severity and route. Catches alt-text gaps, contrast failures,
+  missing landmarks, focus-order bugs, and form-label problems.
+  Use when asked to "audit a11y", "check accessibility", "axe my app",
+  "WCAG compliance", or "screen reader test".
+allowed-tools:
+  - Bash
+  - Read
+  - Write
+  - Edit
+  - Grep
+  - Glob
+  - AskUserQuestion
+---
+
+# Pracht Audit A11y
+
+Static linting cannot prove a route is accessible — many issues only appear
+in the rendered DOM. This skill renders each route in a real browser and
+runs axe-core against the result.
+
+## Step 1: Boot the app
+
+Prefer `pracht preview` (production build) — production HTML is what users
+actually receive. Fall back to `pracht dev` only if the user can't build.
+
+```bash
+pracht build && pracht preview &
+```
+
+Or, if `BASE_URL` is set, target the deployed app.
+
+## Step 2: Install runner
+
+If Playwright is already wired (see `scaffold-e2e`), reuse it:
+
+```bash
+pnpm add -D @axe-core/playwright
+```
+
+If not, scaffold a one-off script using `playwright` directly. Prefer
+Playwright over Puppeteer for consistency with existing project tooling.
+
+## Step 3: Enumerate routes
+
+```bash
+pracht inspect routes --json
+```
+
+For dynamic-segment routes, ask the user once for example params (or skip
+with a note in the report).
+
+## Step 4: Generate the audit script
+
+`scripts/audit-a11y.ts`:
+
+```ts
+import { chromium } from "playwright";
+import AxeBuilder from "@axe-core/playwright";
+
+const BASE = process.env.BASE_URL ?? "http://localhost:3000";
+const ROUTES: string[] = [/* injected from pracht inspect routes */];
+
+const browser = await chromium.launch();
+const context = await browser.newContext();
+const page = await context.newPage();
+
+const results = [];
+for (const path of ROUTES) {
+  await page.goto(`${BASE}${path}`, { waitUntil: "networkidle" });
+  const axe = await new AxeBuilder({ page })
+    .withTags(["wcag2a", "wcag2aa", "wcag21aa", "best-practice"])
+    .analyze();
+  results.push({ path, violations: axe.violations });
+}
+
+await browser.close();
+console.log(JSON.stringify(results, null, 2));
+```
+
+## Step 5: Run and aggregate
+
+```bash
+pnpm exec tsx scripts/audit-a11y.ts > a11y-report.json
+```
+
+Aggregate by:
+
+- **Per-route summary**: violation count, worst severity.
+- **Per-rule summary**: which rule fires most across the app — usually
+  reveals a single component (header, footer, form) that authors every page.
+
+## Step 6: Report
+
+```
+## Per-route summary
+
+| Route       | Critical | Serious | Moderate | Minor |
+| ----------- | -------- | ------- | -------- | ----- |
+| /           | 0        | 1       | 2        | 0     |
+
+## Per-rule summary (top offenders)
+
+- `color-contrast` — 12 violations across 8 routes
+  → Likely source: shared Button component (src/components/Button.tsx)
+- `image-alt` — 5 violations across 3 routes
+  → Likely source: <img> in shells/marketing.tsx
+
+## Detail
+
+[per-route violations with selectors and help URLs]
+```
+
+## Step 7: Targeted fixes
+
+For the top 3 issues, propose concrete patches:
+
+- `color-contrast` → suggest tokenized color pairs from existing CSS vars.
+- `image-alt` → list every `<img>` missing `alt` and propose either a
+  description or `alt=""` (decorative).
+- `landmark-one-main` → confirm shells render exactly one `<main>` element.
+- `label` → list inputs without associated `<label>` and propose
+  `htmlFor`/`for` or wrapping pattern.
+
+## Rules
+
+1. Run against `pracht preview` if at all possible — minified production
+   markup is what real users hit.
+2. axe with WCAG 2.1 AA + best-practice tags is the default; ask before
+   downgrading.
+3. Aggregate by rule before per-route — the same component is usually
+   responsible for most violations.
+4. Do not auto-fix. Suggest, then let the user review per component.
+5. For SPA routes that need interaction before content appears, ask the user
+   for a setup hook (e.g., a script that logs in and lands on the dashboard).
+
+$ARGUMENTS

--- a/skills/audit-auth/SKILL.md
+++ b/skills/audit-auth/SKILL.md
@@ -1,0 +1,115 @@
+---
+name: audit-auth
+version: 1.0.0
+description: |
+  Find pracht routes that look protected but aren't — missing auth middleware,
+  middleware that augments context but never gates, client-side auth checks
+  with no server enforcement, and API mutations exposed without guards.
+  Use when asked to "audit auth", "check route protection", "is my dashboard
+  protected", "find unauthenticated routes", or "review middleware coverage".
+allowed-tools:
+  - Bash
+  - Read
+  - Grep
+  - Glob
+---
+
+# Pracht Audit Auth
+
+The pracht auth pattern (see `examples/docs/src/routes/docs/recipes-auth.md`):
+middleware checks the session, redirects if absent, and forwards user info via
+request headers; loaders downstream read the headers. This skill verifies that
+every route that *should* be protected actually goes through the gate.
+
+## Step 1: Identify the auth middleware(s)
+
+```bash
+pracht inspect routes --json
+```
+
+Read every file under `src/middleware/`. Classify each:
+
+- **Gate** — calls `getSession`/`getUser` and either returns `{ redirect }` /
+  a `Response` on failure, or returns `void` on success.
+- **Augmenter** — calls `getSession`, sets headers/context with user info, but
+  never short-circuits on absence.
+- **Other** — non-auth middleware (rate limit, logging, CORS, etc.).
+
+The "Augmenter" category is the silent killer: it makes loaders *think*
+auth is enforced because `request.headers.get('x-user-id')` returns a value
+when present, but unauthenticated requests just get `null` and the loader has
+to handle it. Flag every loader downstream of an Augmenter that doesn't.
+
+## Step 2: Identify protected routes
+
+A route is "expected protected" if any of:
+
+- It has `auth`/`session`/`requireUser`/similar middleware applied.
+- Its loader reads `x-user-id`/`x-user-email`/`getSession`/equivalent.
+- It lives under conventional protected paths: `/dashboard*`, `/admin*`,
+  `/account*`, `/settings*`, `/app*` (ask the user to confirm the
+  convention if unclear).
+- The user has flagged it explicitly.
+
+Build a list of expected-protected routes.
+
+## Step 3: Check coverage per protected route
+
+For each expected-protected route:
+
+1. From `pracht inspect routes --json`, read the resolved `middleware` array.
+2. Confirm at least one **Gate** middleware is present.
+3. Confirm the gate runs **before** any other middleware that depends on
+   identity (order matters).
+4. If only an Augmenter is present, mark as `unprotected`.
+
+## Step 4: Check the API surface
+
+Mutation endpoints (`POST`, `PUT`, `PATCH`, `DELETE`) are the highest-impact
+target. From `pracht inspect api --json`:
+
+- For each mutation handler, check whether `defineApp({ api: { middleware } })`
+  applies a Gate, OR the handler reads/validates a session itself.
+- Common bug: dashboard route is protected by middleware, but
+  `POST /api/items` is not — attacker bypasses the UI entirely.
+
+## Step 5: Client/server enforcement parity
+
+Grep client components for patterns like `if (!user) return <Login />`. For
+each occurrence, confirm that **the data path is also gated server-side**.
+Client-side gating without a server gate is purely cosmetic and a common
+source of "I see the data flash before redirect" or worse, leaked data via
+SPA route loaders.
+
+## Step 6: Session cookie sanity
+
+Cross-reference with `audit-csrf`: the same cookies that authorize the user
+are the CSRF target. Recommend running `audit-csrf` after this skill.
+
+## Step 7: Report
+
+| Route/API | Expected | Resolved middleware | Gate present? | Verdict |
+| --------- | -------- | ------------------- | ------------- | ------- |
+
+Verdicts:
+- `protected` — gate confirmed.
+- `augmented-only` — middleware reads session but never blocks; loader must
+  handle null user.
+- `unprotected` — no auth middleware on a route the user expects protected.
+- `client-only` — server allows; client hides UI. Risky.
+- `inconsistent` — UI route is gated; sibling API is not.
+
+## Rules
+
+1. The framework's `pracht inspect routes --json` and `pracht inspect api
+   --json` are the source of truth — group inheritance is already resolved.
+2. Recognize Gates by behavior (returns `redirect`/`Response` on failure), not
+   by filename — projects use `auth.ts`, `requireUser.ts`, `session.ts`, etc.
+3. An Augmenter is a valid pattern when paired with a separate Gate or a
+   loader that explicitly handles the unauthenticated case. Flag it; don't
+   condemn it.
+4. Public routes deliberately exposed (login, signup, marketing) should be
+   listed but not flagged.
+5. Do not auto-add middleware. Auth wiring is policy.
+
+$ARGUMENTS

--- a/skills/audit-bundles/SKILL.md
+++ b/skills/audit-bundles/SKILL.md
@@ -1,0 +1,122 @@
+---
+name: audit-bundles
+version: 1.0.0
+description: |
+  Analyze a pracht production build. Report client bundle size per route,
+  flag fat vendor chunks, find route components that ship large dependencies,
+  and suggest dynamic `import()` and prefetch strategies based on observed
+  navigation patterns.
+  Use when asked to "audit bundles", "why is my JS so big", "bundle size per
+  route", "what's in my vendor chunk", or "tune prefetching".
+allowed-tools:
+  - Bash
+  - Read
+  - Grep
+  - Glob
+---
+
+# Pracht Audit Bundles
+
+Pracht performs route-level code splitting via the Vite plugin and emits a
+manifest. This skill reads that manifest, sizes each route's client payload,
+and surfaces the worst offenders.
+
+## Step 1: Build
+
+```bash
+pracht build
+```
+
+A stale `dist/` produces misleading numbers. Confirm the build succeeded.
+
+## Step 2: Pull the build graph
+
+```bash
+pracht inspect build --json
+```
+
+Captures the resolved adapter, client entry URL, and CSS/JS manifest. Cross
+reference with `dist/client/.vite/manifest.json` for chunk metadata
+(file, imports, dynamicImports, css, isEntry).
+
+## Step 3: Compute per-route payload
+
+For each route, the client payload is:
+
+1. The route module's chunk (via the manifest).
+2. Its `imports[]` (transitive synchronous imports — recurse).
+3. Plus the client entry chunk and its imports (shared by every route).
+4. Plus the route's CSS chunks.
+
+Report:
+
+| Route | Route chunk (gz) | Shared (gz) | Total (gz) | CSS (gz) | LCP-class? |
+| ----- | ---------------- | ----------- | ---------- | -------- | ---------- |
+
+`gz` = gzip size. Use Node's `zlib.gzipSync` on the raw file content if a CLI
+tool is not available.
+
+`LCP-class?` is `yes` when total gz exceeds 200 KB — that's the order of
+magnitude where mid-tier mobile starts losing LCP budget.
+
+## Step 4: Vendor chunk health
+
+Identify chunks under `node_modules/`. For each:
+- Size (raw and gz).
+- Number of route chunks that import it (fan-in).
+
+A vendor chunk imported by every route is the framework runtime — expected.
+A vendor chunk imported by ONE route is a code-splitting opportunity (move
+the import inside that route's component or lazy-load it).
+
+A vendor chunk over 100 KB gz that is imported by every route is worth a
+manual review — common offenders: date libraries, validation libraries,
+icon sets, charting libraries.
+
+## Step 5: Heavy dependencies in route components
+
+For each route chunk over 50 KB gz, run `pracht inspect build --json` plus
+`du`-style analysis on the chunk contents:
+
+- Grep the chunk source for known heavy module headers (`moment`, `lodash`,
+  `chart.js`, `three`, `@stripe/stripe-js`, etc.).
+- For each, recommend: (a) tree-shakeable alternative, (b) dynamic import
+  inside an event handler, (c) lazy-load via `lazy()` from `preact-suspense`.
+
+## Step 6: Prefetch strategy
+
+`pracht inspect routes --json` exposes `prefetch` per route. Pracht supports
+`"none"`, `"hover"`, `"intent"`, `"viewport"`. Recommend:
+
+- `"viewport"` for primary-nav links.
+- `"hover"` for content links inside long pages.
+- `"intent"` (default) is fine if you're not sure.
+- `"none"` for routes that are large and rarely visited (admin, settings) so
+  hover doesn't preload them.
+
+A 300 KB route on `prefetch: "viewport"` will start downloading every time it
+appears in the viewport — expensive on a marketing footer.
+
+## Step 7: Report
+
+Three sections:
+
+1. **Top 10 routes by total client payload** — sorted desc.
+2. **Top 10 vendor chunks by size** — with fan-in.
+3. **Suggestions** — ordered by impact (KB saved × routes affected).
+
+Include before/after estimates for each suggestion: "Lazy-load `chart.js`
+inside `Component`: -180 KB gz off `/dashboard/analytics`."
+
+## Rules
+
+1. Always run `pracht build` first. A stale build is a source of bad advice.
+2. Use the Vite manifest as the source of truth — chunk names rotate per
+   build.
+3. Report gzip size, not raw — the wire size is what users pay.
+4. Distinguish "shared" code (entry + framework) from "route-specific" code
+   when reporting; users can only optimize the latter.
+5. Do not auto-edit. Bundle changes have render-blocking implications;
+   surface and let the user choose.
+
+$ARGUMENTS

--- a/skills/audit-csrf/SKILL.md
+++ b/skills/audit-csrf/SKILL.md
@@ -1,0 +1,120 @@
+---
+name: audit-csrf
+version: 1.0.0
+description: |
+  Inventory every form submission and mutation API in the project, then verify
+  the CSRF posture matches pracht's recommended layers (`SameSite` cookie
+  +/- origin-check middleware +/- token). Pracht ships no built-in CSRF; the
+  defense lives in your cookie strategy and threat model.
+  Use when asked to "audit CSRF", "check CSRF protection", "are forms safe",
+  "review session security", or after enabling cross-origin form usage.
+allowed-tools:
+  - Bash
+  - Read
+  - Grep
+  - Glob
+---
+
+# Pracht Audit CSRF
+
+Pracht does not ship CSRF middleware. The defense depends on three layers
+(see `examples/docs/src/routes/docs/recipes-auth.md` § CSRF Protection):
+
+1. **`SameSite=Lax` (or `Strict`) on session cookies** — primary defense.
+2. **Origin-check middleware** — defense in depth.
+3. **Per-request tokens** — only when `SameSite=None` is required.
+
+This skill enumerates every mutation surface and checks which layers protect
+each.
+
+## Step 1: Inventory mutation surfaces
+
+### Forms
+
+```bash
+```
+
+Grep for `<Form ` across `src/`. For each occurrence:
+- Capture `method` (default is `get` — only `post`/`put`/`patch`/`delete` are
+  CSRF-relevant).
+- Capture `action`.
+
+### API mutations
+
+```bash
+pracht inspect api --json
+```
+
+For each handler file, list the exported HTTP methods. Mutation methods:
+`POST`, `PUT`, `PATCH`, `DELETE`. A single `default` handler that branches on
+`request.method` counts as exposing all methods unless gated.
+
+## Step 2: Inspect the session cookie
+
+Locate cookie issuance — typically `src/server/session.ts`, `src/api/auth/*`,
+or anywhere `Set-Cookie` appears in a response. For every cookie set:
+
+| Attribute        | Required posture             | Failure mode                |
+| ---------------- | ---------------------------- | --------------------------- |
+| `HttpOnly`       | Present                      | XSS can steal the session   |
+| `Secure`         | Present in production        | Sniffable on HTTP           |
+| `SameSite`       | `Lax` or `Strict`            | CSRF wide open              |
+| `Path`           | Set (usually `/`)            | Scope confusion             |
+| `Max-Age`/Expires| Set                          | Browser-session-only cookie |
+
+Flag any cookie missing `HttpOnly`, missing `SameSite`, or with
+`SameSite=None` without an accompanying token check.
+
+## Step 3: Look for an origin-check middleware
+
+Grep `src/middleware/` for files that:
+- Read `request.headers.get('origin')`.
+- Compare against `url.origin` and an allowlist.
+- Reject unsafe-method requests on mismatch.
+
+The canonical shape is in `recipes-auth.md` (the `origin-check.ts` example).
+If the project allows `SameSite=None` cookies and has no origin-check
+middleware AND no token check — that is a CSRF hole.
+
+Verify the middleware is wired:
+- `defineApp({ api: { middleware: [...] } })` covers all API routes, OR
+- It is applied per-group on every group containing a mutation API.
+
+Use `pracht inspect api --json` to check that every mutation API is downstream
+of the middleware.
+
+## Step 4: Look for token-based CSRF
+
+Grep for: `csrf`, `csrfToken`, hidden form fields with token values, headers
+like `x-csrf-token`. Verify both sides of the protocol exist (issue + verify).
+A token issuer with no verifier (or vice versa) is a bug.
+
+## Step 5: Score each mutation surface
+
+For each `<Form>` and each mutation API, assign a posture:
+
+- **Strong**: `SameSite=Lax`/`Strict` + origin-check middleware
+- **Adequate**: `SameSite=Lax`/`Strict` only (sufficient for most first-party
+  apps)
+- **Token-only**: token verified, cookie has `SameSite=None`
+- **Weak**: `SameSite=None` (or absent) and no token / no origin-check
+- **Unknown**: cookie source not located — investigate
+
+Produce:
+
+| Surface | File:Line | Method | Cookie posture | Origin-check? | Token? | Verdict |
+| ------- | --------- | ------ | -------------- | ------------- | ------ | ------- |
+
+## Rules
+
+1. The recipe is the spec — point users at
+   `examples/docs/src/routes/docs/recipes-auth.md` for fixes.
+2. Do not flag GET-only forms or read-only API methods.
+3. Remember: pracht's `<Form>` issues a real `POST` (not XHR JSON), so cookies
+   travel; `SameSite` applies normally.
+4. If the project sets `SameSite=None`, require either a token check or an
+   origin-check — explain why in the report.
+5. Do not auto-fix. CSRF strategy is a policy decision; surface the gaps and
+   let the user choose layers.
+
+$ARGUMENTS

--- a/skills/audit-deps/SKILL.md
+++ b/skills/audit-deps/SKILL.md
@@ -1,0 +1,119 @@
+---
+name: audit-deps
+version: 1.0.0
+description: |
+  Run a dependency vulnerability audit and map each finding to the pracht
+  routes, loaders, middleware, or API handlers that import the affected
+  package — so users know which surface area they need to test after upgrading.
+  Use when asked to "audit deps", "scan for CVEs", "which routes use this
+  vulnerable package", "npm audit", or "dependency security review".
+allowed-tools:
+  - Bash
+  - Read
+  - Grep
+  - Glob
+---
+
+# Pracht Audit Deps
+
+`npm audit` (or `pnpm audit`) gives you a list of vulnerable packages. This
+skill goes one step further: for each advisory, it tells you **which routes
+and APIs touch the vulnerable code path** so you can prioritize and write
+targeted regression tests after upgrading.
+
+## Step 1: Run the audit
+
+Detect the package manager from the lockfile in repo root:
+
+| Lockfile             | Command                          |
+| -------------------- | -------------------------------- |
+| `pnpm-lock.yaml`     | `pnpm audit --json`              |
+| `package-lock.json`  | `npm audit --json`               |
+| `yarn.lock`          | `yarn npm audit --json --recursive` |
+| `bun.lockb` / `bun.lock` | `bun audit --json` (if available; otherwise note as gap) |
+
+Capture the JSON. Track each advisory: package, severity, range, fixed-in.
+
+## Step 2: Resolve "which package depends on the vulnerable one"
+
+For transitive vulns, the direct importer matters more than the leaf. Use the
+package manager:
+
+```bash
+pnpm why <package>
+# or
+npm ls <package>
+```
+
+Capture the dependency chain. The first non-pracht-internal direct dependency
+is the one the user owns.
+
+## Step 3: Map to routes/APIs
+
+For each direct dependency identified in step 2:
+
+1. Grep `src/` for `import .* from "<dep>"` and `require("<dep>")`.
+2. For each hit file, classify it:
+   - Route file under `src/routes/` → which routes use it (cross-reference
+     with `pracht inspect routes --json`).
+   - Middleware under `src/middleware/` → which routes/groups apply it.
+   - API handler under `src/api/` → which API path it lives at.
+   - Shell under `src/shells/` → which routes use the shell.
+   - Other shared module under `src/` → trace upward to the importing route
+     or API handler.
+
+This produces a "blast radius" per advisory.
+
+## Step 4: Categorize urgency
+
+For each advisory, score:
+
+| Factor                                  | Weight |
+| --------------------------------------- | ------ |
+| Severity (`critical`/`high`/`moderate`/`low`) | base |
+| Reachable from a request handler        | +1 tier |
+| Reachable from an unauthenticated route | +1 tier |
+| Reachable only from build scripts / dev tools | -1 tier |
+
+Build scripts that never ship to runtime (e.g., a Vite plugin used only at
+build time) are lower priority than a package imported into a production
+loader.
+
+## Step 5: Report
+
+```
+## High-priority
+
+- <pkg> @ <version> — <severity> — <CVE>
+  Direct importer: <dep>
+  Reachable from:
+    - GET  /api/users          (src/api/users.ts)
+    - SSR  /dashboard          (src/routes/dashboard.tsx → src/server/db.ts)
+  Fix: upgrade to <range>
+  Test after upgrade: <list of routes/APIs above>
+```
+
+End with a one-line verdict: `N critical, N high, N moderate, N low — N
+reachable from runtime`.
+
+## Step 6: Suggest the upgrade
+
+For each fix:
+- If the direct dependency has a non-breaking range covering the fix:
+  `pnpm up <dep>` (or equivalent).
+- If a major bump is required: link to the package's CHANGELOG, do not
+  auto-upgrade.
+- After upgrading, suggest running `pnpm test` and the route-targeted tests
+  derived from step 3.
+
+## Rules
+
+1. Always determine the direct importer; transitive-only output is unhelpful.
+2. Distinguish runtime vs. build-time exposure — they have very different
+   urgency.
+3. Do not auto-upgrade major versions.
+4. If the audit tool reports zero advisories, still note the package counts
+   and lockfile age — staleness is a precursor to advisories.
+5. Cross-reference with `pre-deploy` before shipping any post-upgrade build.
+
+$ARGUMENTS

--- a/skills/audit-headers/SKILL.md
+++ b/skills/audit-headers/SKILL.md
@@ -1,0 +1,124 @@
+---
+name: audit-headers
+version: 1.0.0
+description: |
+  Audit per-route security header coverage in a pracht app. Verifies that
+  `applyDefaultSecurityHeaders` (or equivalent custom `headers()` exports)
+  protect every user-facing response, and suggests a Content-Security-Policy
+  derived from the project's actual asset and connect origins.
+  Use when asked to "audit security headers", "check CSP", "harden headers",
+  "set up HSTS", or "review header policy".
+allowed-tools:
+  - Bash
+  - Read
+  - Grep
+  - Glob
+---
+
+# Pracht Audit Headers
+
+Pracht ships `applyDefaultSecurityHeaders(headers: Headers)` from
+`@pracht/core` which sets four headers when missing:
+
+- `permissions-policy` (disables device sensors)
+- `referrer-policy: strict-origin-when-cross-origin`
+- `x-content-type-options: nosniff`
+- `x-frame-options: SAMEORIGIN`
+
+It does NOT set `strict-transport-security`, `content-security-policy`, or
+`cross-origin-*` headers — those need a project decision.
+
+## Step 1: Inventory routes and APIs
+
+```bash
+pracht inspect routes --json
+pracht inspect api --json
+```
+
+For every route and API handler file, look at:
+- `headers()` export — explicit per-route headers.
+- Calls to `applyDefaultSecurityHeaders(...)` inside loaders, middleware, or
+  API handlers.
+- Hand-rolled `Response` constructions where headers are set inline.
+
+## Step 2: Coverage check
+
+Build a matrix:
+
+| Route/API | Default sec headers | HSTS | CSP | COOP/COEP/CORP |
+| --------- | ------------------- | ---- | --- | -------------- |
+
+A route is "covered" by default headers if **any** of the following is true:
+- A global middleware applies `applyDefaultSecurityHeaders` to outbound
+  responses.
+- The route's `headers()` export sets all four manually.
+- The shell or layout owns header injection (rare — flag for reading).
+
+Flag every route that has none of the above.
+
+## Step 3: HSTS
+
+Grep for `strict-transport-security`. If absent everywhere, recommend adding
+it via global middleware:
+
+```ts
+"strict-transport-security": "max-age=63072000; includeSubDomains; preload"
+```
+
+Only recommend `preload` if the user confirms they want to commit to HTTPS
+permanently and submit to the preload list.
+
+## Step 4: Content-Security-Policy
+
+Generate a starter CSP from observed origins:
+
+1. Grep the app for fetch URLs, image URLs, CSS `@import`, `<script src>`,
+   `<link href>`, font URLs, iframe sources.
+2. Group by directive: `default-src`, `script-src`, `style-src`, `img-src`,
+   `font-src`, `connect-src`, `frame-src`.
+3. Always include `'self'` per directive.
+4. For inline styles/scripts pracht emits (hydration state script), recommend
+   nonce-based CSP — pracht injects `__PRACHT_STATE__` inline, so
+   `'unsafe-inline'` for `script-src` is the easy path; nonces require
+   wiring through render.
+
+Output a draft CSP and explain what each origin is for. Do not hand the user
+a CSP that breaks their site — present as draft.
+
+## Step 5: Cross-origin isolation (optional)
+
+If the user mentions `SharedArrayBuffer`, WASM threading, or high-precision
+timers, recommend:
+
+- `cross-origin-opener-policy: same-origin`
+- `cross-origin-embedder-policy: require-corp`
+- `cross-origin-resource-policy: same-origin` on assets
+
+Otherwise leave these unset — they break embedded third-party content.
+
+## Step 6: Report
+
+Two outputs:
+
+1. **Coverage table** (route × header presence).
+2. **Recommendations**, in priority order:
+   - `error`: Routes with no security headers at all.
+   - `warn`: Missing HSTS in production-grade apps.
+   - `info`: CSP draft, COOP/COEP suggestions.
+
+Show the exact code change required (e.g., where to insert
+`applyDefaultSecurityHeaders` in a global middleware).
+
+## Rules
+
+1. Use the framework helper — do not recommend hand-rolling the four default
+   headers.
+2. Never recommend a CSP with `'unsafe-eval'` unless the user has documented
+   why they need it.
+3. Per-route `headers()` overrides everything else; check it first.
+4. For SSG/ISG output, default headers must be applied at the adapter layer
+   (Cloudflare/Vercel headers config, or a Node middleware) — flag if the
+   adapter does not do this for static responses.
+5. Do not auto-edit. Headers are policy; surface gaps, propose patches.
+
+$ARGUMENTS

--- a/skills/audit-loaders/SKILL.md
+++ b/skills/audit-loaders/SKILL.md
@@ -1,0 +1,107 @@
+---
+name: audit-loaders
+version: 1.0.0
+description: |
+  Audit pracht route loaders for serializability, leaked secrets,
+  browser-only API misuse, and missing AbortSignal plumbing.
+  Use when asked to "audit loaders", "check loader data", "find serialization
+  bugs", "are my loaders safe", or "loader security review".
+allowed-tools:
+  - Bash
+  - Read
+  - Grep
+  - Glob
+---
+
+# Pracht Audit Loaders
+
+Static analysis of every loader in the project. The framework serializes loader
+return values to the client via `window.__PRACHT_STATE__`, so anything returned
+ends up in the browser — including secrets you never meant to expose.
+
+## Step 1: Enumerate routes
+
+```bash
+pracht inspect routes --json
+```
+
+For every route entry, read the `file` it resolves to and inspect the `loader`
+export.
+
+## Step 2: Run the four checks
+
+For each `loader` (and `getStaticPaths` when present):
+
+### 2a. Serializability
+
+Flag returns that contain any of:
+
+| Construct                    | Why it breaks                       |
+| ---------------------------- | ----------------------------------- |
+| `Date`, `Map`, `Set`, `URL`  | Not preserved by `JSON.stringify`   |
+| Class instances              | Lose prototype on the client        |
+| `Function` / arrow values    | Stripped silently                   |
+| `Promise`                    | Becomes `{}`                        |
+| Circular refs                | Throws at serialize time            |
+| `Buffer` / typed arrays      | Becomes `{}` or numeric keys        |
+| `bigint`                     | `JSON.stringify` throws             |
+| `undefined` in arrays/object | Drops keys; arrays become `null`    |
+
+Recommend converting to `string` (ISO for dates), plain arrays, or plain objects
+before return.
+
+### 2b. Secret leaks
+
+Grep the loader body and anything it returns for:
+
+- `process.env.*` references that flow into the return value.
+- `context.env.*` (Cloudflare bindings) flowing into the return value.
+- Variables named `*SECRET*`, `*TOKEN*`, `*KEY*`, `*PASSWORD*`, `*PRIVATE*`,
+  `*API_KEY*` reaching the return.
+- Spreads of full DB rows containing `password_hash`, `mfa_secret`, etc.
+
+Loaders run server-side but **the return value crosses the wire**. Always
+project to a smaller shape before returning.
+
+### 2c. Browser-only APIs at module top level or in loader
+
+Flag any of these accessed unconditionally inside `loader` or at the top level
+of a route module that is rendered SSR/SSG/ISG:
+
+- `window`, `document`, `navigator`, `localStorage`, `sessionStorage`,
+  `IntersectionObserver`, `matchMedia`, `requestAnimationFrame`.
+
+These crash on the server. For SPA-only routes (`render: "spa"`) it's fine
+inside the component — but never inside `loader`.
+
+### 2d. AbortSignal plumbing
+
+For loaders that call `fetch` or any I/O:
+
+- The framework passes `signal` in `LoaderArgs`.
+- Verify it is forwarded to outbound `fetch(url, { signal })` calls and to any
+  database client that accepts cancellation.
+- A loader that ignores `signal` keeps work running after the client navigates
+  away.
+
+## Step 3: Report
+
+Produce a markdown table:
+
+| Route | File | Severity | Finding | Suggested fix |
+| ----- | ---- | -------- | ------- | ------------- |
+
+Severities: `error` (secret leak, crash), `warn` (serialization risk, missing
+signal), `info` (style nit).
+
+## Rules
+
+1. Use `pracht inspect routes --json` as the source of truth — do not glob
+   `src/routes/**` and risk missing manifest wiring or catching orphan files.
+2. Read the actual loader source — do not infer from names.
+3. For each finding, point at the file and line.
+4. Do not auto-fix. Hand the user the report; let them choose.
+5. If the loader returns a typed shape from a DB ORM, recommend an explicit
+   `select` or projection step rather than spreading the row.
+
+$ARGUMENTS

--- a/skills/audit-redirects/SKILL.md
+++ b/skills/audit-redirects/SKILL.md
@@ -1,0 +1,102 @@
+---
+name: audit-redirects
+version: 1.0.0
+description: |
+  Find open-redirect vulnerabilities in pracht loaders, middleware, and
+  navigation calls. The framework already rejects unsafe URL schemes
+  (javascript:, data:, vbscript:, blob:, file:) on the client (commit 901ef5b)
+  but a server-issued cross-origin redirect can still phish your users.
+  Use when asked to "audit redirects", "check for open redirects", "is my
+  ?redirect= param safe", or "review login redirect handling".
+allowed-tools:
+  - Bash
+  - Read
+  - Grep
+  - Glob
+---
+
+# Pracht Audit Redirects
+
+The classic open-redirect bug: `/login?redirect=https://evil.example` →
+after login, the app redirects the user to attacker territory carrying a fresh
+session.
+
+Pracht's client router already drops non-`http(s):` schemes at the navigation
+boundary. This skill audits the **server-side** decision to redirect at all.
+
+## Step 1: Inventory redirect sites
+
+Grep for every redirect-issuing site:
+
+- Middleware returning `{ redirect: ... }`.
+- Loaders that throw a redirect or return a `Response` with `302`/`303`/`307`/`308`.
+- API handlers building responses with a `location` header.
+- `useNavigate()(value)` and `<a href={value}>` where `value` is dynamic.
+- `prefetchRouteState(value)` calls with dynamic input.
+
+## Step 2: Trace the input
+
+For each site, identify whether the redirect target is:
+
+- **Static** — string literal. Safe.
+- **Internal-derived** — built from `params`, `route.path`, or a closed
+  allowlist. Safe if the allowlist is verifiable.
+- **Request-derived** — read from `url.searchParams.get(...)`,
+  `request.headers.get('referer')`, request body fields, cookie values, or
+  query parameters. **Suspect.**
+
+Common suspect names: `redirect`, `redirectTo`, `next`, `returnTo`, `continue`,
+`url`, `dest`, `goto`.
+
+## Step 3: Check the gate
+
+For each request-derived target, look for one of:
+
+| Gate                                   | Safe? |
+| -------------------------------------- | ----- |
+| Hardcoded allowlist of paths/origins   | Yes   |
+| `target.startsWith('/')` AND `!target.startsWith('//')` | Yes — same-origin path only |
+| `new URL(target, base).origin === url.origin`           | Yes — origin comparison |
+| `new URL(target).hostname === expected` | Yes if `expected` is trusted |
+| No check                                | **Open redirect** |
+| `target.includes(domain)` (substring)   | **Bypassable** (`evil.com#yourdomain.com`) |
+| Regex without anchors                   | **Likely bypassable** |
+
+`startsWith('/')` alone is **not** sufficient — `//evil.example/path` parses
+as a protocol-relative URL and most browsers treat it as cross-origin. Require
+both `startsWith('/')` AND `!startsWith('//')`, or use `URL` parsing.
+
+## Step 4: Report
+
+| File:Line | Source | Target expression | Gate | Verdict |
+| --------- | ------ | ----------------- | ---- | ------- |
+
+Verdicts:
+- `safe` — static or properly gated.
+- `risky` — uses substring/regex check; suggest URL-parse rewrite.
+- `open` — no check at all; **fix immediately**.
+
+For each `open`/`risky` finding, propose a fix snippet, e.g.:
+
+```ts
+const raw = url.searchParams.get("redirect") ?? "/dashboard";
+const safe = raw.startsWith("/") && !raw.startsWith("//") ? raw : "/dashboard";
+return { redirect: safe };
+```
+
+## Step 5: Cross-check with the client guard
+
+Note in the report that pracht's client router (since #122) drops
+`javascript:`, `data:`, `vbscript:`, `blob:`, and `file:` schemes — so even an
+open redirect cannot become script execution in-browser. But it can still
+phish (redirect to look-alike origin) and leak session/referrer headers.
+
+## Rules
+
+1. Default to suspicion for any request-derived target.
+2. Recommend `URL` parsing over string prefix checks for non-trivial gates.
+3. Do not trust `referer` as a gate; it is forgeable and often stripped.
+4. After-login redirects are the most dangerous — user is authenticated.
+5. Do not auto-fix; surface the gap and propose the patch.
+
+$ARGUMENTS

--- a/skills/audit-secrets/SKILL.md
+++ b/skills/audit-secrets/SKILL.md
@@ -1,0 +1,109 @@
+---
+name: audit-secrets
+version: 1.0.0
+description: |
+  Detect environment variables and secrets that leak from the server into
+  the client bundle via loader return values, hydration state, or accidental
+  imports of server-only modules from client code paths.
+  Use when asked to "audit secrets", "find leaked env vars", "is my API key
+  exposed", "check client bundle for secrets", or "scan for credential leaks".
+allowed-tools:
+  - Bash
+  - Read
+  - Grep
+  - Glob
+---
+
+# Pracht Audit Secrets
+
+Pracht serializes loader return values into `window.__PRACHT_STATE__` and
+hydrates the client from them. Anything a loader returns ends up readable in
+the browser. The Vite plugin also strips server-only exports from route files,
+but it cannot save you from a value that flows into the return.
+
+## Step 1: Identify "secret-shaped" identifiers
+
+Build a regex of variable names treated as sensitive:
+
+```
+SECRET|TOKEN|API[_-]?KEY|PRIVATE[_-]?KEY|PASSWORD|PASSPHRASE|SESSION[_-]?SECRET|JWT[_-]?SECRET|WEBHOOK[_-]?SECRET|DATABASE[_-]?URL|DB[_-]?URL|CONNECTION[_-]?STRING|CLIENT[_-]?SECRET|REFRESH[_-]?TOKEN
+```
+
+Also flag any direct `process.env.X` or `context.env.X` reference where `X`
+matches the above.
+
+## Step 2: Server → client flow analysis
+
+For every route file, trace whether a sensitive value reaches the loader's
+return value. Steps:
+
+1. Run `pracht inspect routes --json` to enumerate routes.
+2. For each route, read the loader.
+3. Build a small dataflow trace from sensitive identifiers (and `process.env.*`
+   / `context.env.*` reads) to the `return` statement(s).
+4. Flag any spread (`...row`, `...user`, `...env`) that originates from a
+   source containing secrets.
+5. Flag direct returns of objects that name sensitive keys.
+
+This is heuristic — favor over-flagging over silent leaks. Note false-positive
+risk in the report.
+
+## Step 3: Module import boundaries
+
+Grep client-rendered files (route components, shells, anything imported from
+them) for imports of:
+- `node:*` builtins
+- `@pracht/adapter-*`
+- Local `src/server/**` modules
+- Modules whose top level reads `process.env.*`
+
+The Vite plugin strips `loader`, `getStaticPaths`, `headers`, `middleware`
+exports from route files when serving the client query — see commit 594407d.
+But a component that imports `../server/db` will still pull `db` into the
+client bundle. Flag those imports.
+
+## Step 4: Hidden surfaces
+
+Check for accidental exposure outside loaders:
+
+- `head()` returns: rare, but a `meta` value containing a token leaks into HTML.
+- `headers()` returns: less risky (response headers stay on the server side
+  of the request), but flag values that look like secrets — they may be
+  echoed to the browser as cache keys or correlation IDs.
+- `<Form>` `action` URLs containing tokens in the query string.
+- `prefetchRouteState(url)` calls with sensitive query params.
+- Inline `<script>` content emitted from custom shells.
+
+## Step 5: `.env` discipline
+
+- Confirm `.env*` is in `.gitignore`.
+- Grep tracked files for likely committed secrets (long random strings near
+  identifier names from step 1).
+- Confirm any client-side env access uses `import.meta.env.VITE_*` — anything
+  prefixed `VITE_` is intentionally public; warn loudly if a `VITE_` variable
+  has a secret-shaped name.
+
+## Step 6: Report
+
+| File:Line | Identifier / source | Sink (loader return / client import / etc.) | Severity |
+| --------- | ------------------- | ------------------------------------------- | -------- |
+
+Severities:
+- `error` — direct flow from `process.env.SECRET_*` to loader return.
+- `error` — `VITE_*_SECRET` style client-public secret-shaped name.
+- `warn` — spread of a row that may contain secret columns.
+- `warn` — client component imports a module that reads `process.env`.
+- `info` — header value that looks like a token.
+
+## Rules
+
+1. Heuristic-first; document false-positive risk per finding.
+2. Recommend an explicit allowlist projection (`{ id, name, email }`) over
+   blocklist filtering.
+3. For Cloudflare apps, secrets live in `context.env` — same risk profile as
+   `process.env`. Treat them identically.
+4. Never print suspected secret values into the report — refer by name only.
+5. If you find a likely committed secret, recommend immediate rotation in
+   addition to removal from history.
+
+$ARGUMENTS

--- a/skills/audit-seo/SKILL.md
+++ b/skills/audit-seo/SKILL.md
@@ -1,0 +1,124 @@
+---
+name: audit-seo
+version: 1.0.0
+description: |
+  Per-route SEO audit for a pracht app: `head()` coverage, title/description
+  presence, Open Graph and Twitter card completeness, canonical URLs, robots
+  rules, and a generated `sitemap.xml` derived from the route manifest.
+  Use when asked to "audit SEO", "check meta tags", "generate a sitemap",
+  "are my OG cards set", or "review robots.txt".
+allowed-tools:
+  - Bash
+  - Read
+  - Write
+  - Grep
+  - Glob
+---
+
+# Pracht Audit SEO
+
+Pracht owns the document. Per-route SEO lives in the `head()` export
+returning `{ title?, lang?, meta?, link? }`. This skill audits coverage and
+generates the static SEO artifacts.
+
+## Step 1: Inventory
+
+```bash
+pracht inspect routes --json
+```
+
+For every route file, read the `head()` export (and the shell's `head()` for
+inherited values).
+
+## Step 2: Per-route checklist
+
+For each route, capture presence and quality:
+
+| Field                                    | Expected                          |
+| ---------------------------------------- | --------------------------------- |
+| `title`                                  | 30-60 chars, unique per route     |
+| `meta` `description`                     | 70-160 chars, unique per route    |
+| `meta` `og:title`                        | Present (often = `title`)         |
+| `meta` `og:description`                  | Present                           |
+| `meta` `og:image`                        | Absolute URL, ≥ 1200×630          |
+| `meta` `og:url`                          | Absolute, canonical               |
+| `meta` `twitter:card`                    | `summary_large_image` for content |
+| `link` `canonical`                       | Absolute URL                      |
+| `lang`                                   | Set on root or via shell          |
+
+Skip SPA-only / non-indexable routes (admin, dashboard) — flag as "noindex
+candidate" if they don't already declare it.
+
+## Step 3: Cross-route checks
+
+- **Duplicate titles** across routes — list collisions.
+- **Duplicate descriptions** — same.
+- **Missing canonical** on any route that has any `?query` variants.
+- **Missing OG image** — most common issue; recommend a default image at
+  shell level so every route inherits one.
+
+## Step 4: `robots.txt`
+
+Look for:
+- `public/robots.txt` (Vite static asset).
+- Any route at `/robots.txt`.
+- Any API handler at `src/api/robots.ts`.
+
+If absent, recommend creating `public/robots.txt`:
+
+```
+User-agent: *
+Allow: /
+Disallow: /api/
+Disallow: /admin/
+Sitemap: https://<domain>/sitemap.xml
+```
+
+If present, validate:
+- A `Sitemap:` line referencing an existing endpoint.
+- No accidental `Disallow: /` (full-site block).
+- Path patterns match real routes (cross-reference with the manifest).
+
+## Step 5: `sitemap.xml`
+
+Generate (or recommend generating) a sitemap from the route manifest:
+
+- Include every route with `render: "ssg"` or `"isg"` and `prefetch !=
+  "none"`.
+- Skip dynamic-segment routes unless `getStaticPaths` resolved them at build
+  time — pull resolved paths from `dist/client/<route>.html` filenames.
+- Skip routes under auth middleware (private).
+- Default `<changefreq>` from the route's revalidate policy: `timeRevalidate`
+  → `weekly` if `> 86400s`, `daily` if `> 3600s`, `hourly` otherwise.
+
+Offer two output forms:
+
+1. Static `public/sitemap.xml` regenerated at build time via a small script.
+2. A pracht API route at `src/api/sitemap.ts` that emits XML on each request
+   from the inspected manifest.
+
+## Step 6: Structured data (optional)
+
+If the user asks, scaffold JSON-LD for common types via `head()` `meta` /
+`link` tags or a custom shell-level script. This is opt-in — do not push it
+on every audit.
+
+## Step 7: Report
+
+| Route | Title | Description | OG image | Canonical | Verdict |
+| ----- | ----- | ----------- | -------- | --------- | ------- |
+
+Verdicts: `complete`, `partial`, `missing`. Group by verdict.
+
+## Rules
+
+1. Use the resolved manifest — shell `head()` inheritance matters.
+2. Never auto-write `sitemap.xml` to the deployed site without user
+   confirmation; offer the file as a draft.
+3. Recommend a default OG image at the shell level — single highest-leverage
+   fix.
+4. Auth-gated routes should NOT appear in sitemaps.
+5. Cross-reference with `tune-render-mode` — SSG routes are the sitemap
+   candidates; SSR routes need decision per case.
+
+$ARGUMENTS

--- a/skills/audit-shells/SKILL.md
+++ b/skills/audit-shells/SKILL.md
@@ -1,0 +1,99 @@
+---
+name: audit-shells
+version: 1.0.0
+description: |
+  Audit pracht shells for composition bugs: missing `Loading()` on SPA-using
+  shells, accidental `<html>`/`<head>`/`<body>` rendering, broken error
+  bubbling, unused shells, and shells that swallow children.
+  Use when asked to "audit shells", "check shell composition", "find unused
+  shells", or "is my layout structured correctly".
+allowed-tools:
+  - Bash
+  - Read
+  - Grep
+  - Glob
+---
+
+# Pracht Audit Shells
+
+Shells in pracht are named layout components composed around routes. The
+framework owns the document — shells must not render `<html>`, `<head>`, or
+`<body>`. They sit between the framework's HTML scaffold and the route
+component.
+
+## Step 1: Enumerate
+
+```bash
+pracht inspect routes --json
+```
+
+For every shell registered in the manifest, read its source file. Also list
+which routes use which shell (the JSON output includes resolved `shell` per
+route).
+
+## Step 2: Per-shell checks
+
+For each shell file:
+
+### 2a. Document-level tag misuse
+
+Grep for `<html`, `<head>`, `<body>`, `<meta`, `<title>`, `<link rel`. Any of
+these inside a shell is a bug — the framework injects them based on `head()`
+exports. Recommend moving meta/title to the shell's `head()` export and
+removing the JSX tags.
+
+### 2b. `Shell` export shape
+
+- Must be a function component named `Shell`.
+- Must accept `{ children }: ShellProps`.
+- Must render `{children}` somewhere — flag shells that never render
+  `children` (hard to spot, blank page everywhere).
+
+### 2c. `Loading()` for SPA routes
+
+If any route assigned to this shell has `render: "spa"`, the shell SHOULD
+export a `Loading()` function that renders a placeholder during the
+client-only data fetch. Without it, users see blank content during navigation.
+
+### 2d. `head()` export
+
+- Optional, but recommended if the shell sets shared meta tags.
+- Verify return shape matches `{ title?, lang?, meta?, link? }`.
+- Flag shells whose `head()` returns `undefined` unconditionally — delete the
+  export.
+
+### 2e. Error boundary chain
+
+Errors bubble route → shell → global handler. Flag shells that:
+- Have an `ErrorBoundary` export but never re-throw or render fallback UI.
+- Catch errors and `return null` (silent failure).
+
+## Step 3: Coverage and waste
+
+- **Unused shells**: any shell registered in `defineApp({ shells })` that no
+  route or group references. Recommend removal.
+- **Single-use shells**: shells used by exactly one route — sometimes a
+  signal the layout should be inlined. Flag as `info`.
+- **Routes without shells**: routes resolved to no shell. Usually intentional
+  for raw HTML responses, but worth listing.
+
+## Step 4: Report
+
+| Shell | File | Used by | Issue | Severity |
+| ----- | ---- | ------- | ----- | -------- |
+
+Severities: `error` (document tags, missing children), `warn` (no Loading on
+SPA routes, broken ErrorBoundary), `info` (unused, single-use).
+
+## Rules
+
+1. Source of truth is `pracht inspect routes --json` — it shows resolved
+   shell-per-route after group inheritance.
+2. Read the shell source — do not infer from names.
+3. Distinguish `Loading()` (SPA-only fallback) from `ErrorBoundary` (error
+   surface). Both are independent shell exports.
+4. Recommend deletions for unused shells; do not delete automatically.
+5. When in doubt about render mode interaction, cross-reference with
+   `tune-render-mode`.
+
+$ARGUMENTS

--- a/skills/pre-deploy/SKILL.md
+++ b/skills/pre-deploy/SKILL.md
@@ -1,0 +1,118 @@
+---
+name: pre-deploy
+version: 1.0.0
+description: |
+  Adapter-aware pre-deployment checklist for pracht apps targeting Node,
+  Cloudflare Workers, or Vercel. Catches the issues that only surface in the
+  production runtime: missing env vars, Node-only APIs in Cloudflare bundles,
+  ISG manifest absence, oversized edge bundles, missing wrangler/vercel config.
+  Use when asked to "pre-deploy check", "ready to ship?", "deployment
+  checklist", "is my build production-safe", or before running `wrangler
+  deploy` / `vercel deploy`.
+allowed-tools:
+  - Bash
+  - Read
+  - Grep
+  - Glob
+---
+
+# Pracht Pre-Deploy
+
+Run this before every production deploy. Each adapter has a different runtime
+contract; this skill enforces the contract that matches your build.
+
+## Step 1: Detect the adapter
+
+Read `vite.config.ts` and look for `nodeAdapter()`, `cloudflareAdapter()`, or
+`vercelAdapter()`. Confirm with:
+
+```bash
+pracht inspect build --json
+```
+
+The `target` field is authoritative. If `pracht build` has not been run
+recently, run it first:
+
+```bash
+pracht build
+```
+
+## Step 2: Run framework-wide checks
+
+```bash
+pracht doctor --json
+pracht verify --json
+```
+
+These catch app-graph wiring problems independent of the adapter. Resolve all
+`status: "error"` entries before continuing.
+
+## Step 3: Adapter-specific checklist
+
+### Node (`@pracht/adapter-node`)
+
+- `dist/server/server.js` exists.
+- `dist/client/.vite/manifest.json` exists.
+- `dist/server/isg-manifest.json` exists if any route has `render: "isg"`.
+- Smoke test: `node dist/server/server.js` boots and `curl localhost:3000` returns 200.
+- Required env vars (grep `process.env.*` across `src/`) are set in the
+  deployment environment. List them for the user.
+- Reverse-proxy / TLS termination configured (out of scope for this skill —
+  flag for confirmation).
+
+### Cloudflare Workers (`@pracht/adapter-cloudflare`)
+
+- `wrangler.toml` (or `wrangler.jsonc`) present at repo root.
+- `main` points to `dist/server/server.js`.
+- `assets.directory` points to `dist/client`.
+- `compatibility_date` is set and recent.
+- Bindings declared in wrangler config for every `context.env.*` access in
+  loaders, middleware, and API routes (grep, then cross-check).
+- **No Node-only APIs in the server bundle.** Grep server files for: `fs`,
+  `path` (Node form), `process.cwd`, `Buffer`, `__dirname`, `__filename`,
+  `crypto.createHash` (use `crypto.subtle` instead), `child_process`,
+  `cluster`, `worker_threads`. Flag each occurrence.
+- ISG: confirm a binding exists for the manifest if used (KV recommended).
+- Bundle size: report the size of `dist/server/server.js`. Workers limit is
+  ~1 MB compressed for free tier, ~10 MB on paid. Warn at 80% of the active
+  limit.
+
+### Vercel (`@pracht/adapter-vercel`)
+
+- `.vercel/output/config.json` exists post-build.
+- `.vercel/output/functions/render.func/server.js` exists.
+- `.vercel/output/static/` populated.
+- Required env vars are configured in the Vercel project (cannot verify from
+  CLI without `vercel env pull` — run that and diff against `process.env.*`
+  references).
+- Edge runtime constraints: same Node-only API check as Cloudflare if the
+  function is configured for the edge runtime. Check `runtime` in the
+  function's `.vc-config.json`.
+- Build Output API v3 sanity: `config.json` has `version: 3`.
+
+## Step 4: Cross-cutting checks
+
+- Run `audit-secrets` to confirm no `process.env.*` or `context.env.*` values
+  flow into loader return values.
+- Run `audit-headers` to confirm `applyDefaultSecurityHeaders` is in use on
+  user-facing responses (or that `headers()` exports cover the same ground).
+- Confirm `git status` is clean (deploying uncommitted work is a footgun).
+
+## Step 5: Report
+
+Produce a checklist with pass/fail per item, grouped by `Framework`,
+`Adapter`, `Cross-cutting`. End with a one-line verdict: `READY` /
+`BLOCKED (N errors)` / `READY WITH WARNINGS (N warnings)`.
+
+## Rules
+
+1. Always run `pracht build` first. Do not lint a stale `dist/`.
+2. Detect the adapter — never assume.
+3. For Cloudflare/Vercel-edge, the Node-only API check is non-negotiable; a
+   single `Buffer` reference will crash the worker on a code path that may
+   never hit in dev.
+4. Do not deploy on the user's behalf. End the skill at the verdict.
+5. If `pracht doctor` reports errors, do not run any other checks until those
+   are resolved — they will produce noisy false positives.
+
+$ARGUMENTS

--- a/skills/scaffold-e2e/SKILL.md
+++ b/skills/scaffold-e2e/SKILL.md
@@ -1,0 +1,167 @@
+---
+name: scaffold-e2e
+version: 1.0.0
+description: |
+  Scaffold Playwright end-to-end tests for a pracht app: install Playwright,
+  generate `playwright.config.ts` that boots `pracht dev` (or `pracht
+  preview`), and emit a smoke test for every route in the manifest that
+  asserts 200, head/title, no console errors, and basic navigation.
+  Use when asked to "scaffold E2E", "set up Playwright", "add browser tests",
+  or "create smoke tests for my routes".
+allowed-tools:
+  - Bash
+  - Read
+  - Write
+  - Edit
+  - Grep
+  - Glob
+  - AskUserQuestion
+---
+
+# Pracht Scaffold E2E
+
+Generate a Playwright suite that exercises the live app. Aligns with
+`recipes-testing.md`.
+
+## Step 1: Decide which build the tests run against
+
+Ask the user (default: `dev`):
+
+1. **`pracht dev`** — fast, HMR, but can mask production-only bugs (different
+   bundling, different SSG/ISG flow).
+2. **`pracht preview`** — preview production build; slower, closer to prod.
+3. **External URL** — user provides `BASE_URL`; tests do not boot the server.
+
+## Step 2: Install
+
+```bash
+pnpm add -D @playwright/test
+pnpm exec playwright install chromium
+```
+
+Add `firefox` and `webkit` only if the user requests them.
+
+## Step 3: Write `playwright.config.ts`
+
+```ts
+import { defineConfig, devices } from "@playwright/test";
+
+const PORT = Number(process.env.PORT ?? 3000);
+
+export default defineConfig({
+  testDir: "./e2e",
+  fullyParallel: true,
+  retries: process.env.CI ? 2 : 0,
+  reporter: process.env.CI ? "github" : "list",
+  use: {
+    baseURL: process.env.BASE_URL ?? `http://localhost:${PORT}`,
+    trace: "on-first-retry",
+    screenshot: "only-on-failure",
+  },
+  webServer: process.env.BASE_URL
+    ? undefined
+    : {
+        command: "pnpm dev", // or "pnpm preview" — choose at scaffold time
+        url: `http://localhost:${PORT}`,
+        reuseExistingServer: !process.env.CI,
+        timeout: 120_000,
+      },
+  projects: [
+    { name: "chromium", use: devices["Desktop Chrome"] },
+  ],
+});
+```
+
+If `playwright.config.ts` already exists, merge — do not clobber.
+
+## Step 4: Generate per-route smoke tests
+
+```bash
+pracht inspect routes --json
+```
+
+For every route entry, generate one spec under `e2e/smoke/`. Skip routes with
+dynamic segments unless the user provides example params (ask via
+`AskUserQuestion`).
+
+Per-route template:
+
+```ts
+import { test, expect } from "@playwright/test";
+
+test.describe("smoke: <path>", () => {
+  test("loads with 200 and a title", async ({ page }) => {
+    const errors: string[] = [];
+    page.on("console", (msg) => {
+      if (msg.type() === "error") errors.push(msg.text());
+    });
+    page.on("pageerror", (err) => errors.push(err.message));
+
+    const response = await page.goto("<path>");
+    expect(response?.status(), "HTTP status").toBeLessThan(400);
+    await expect(page).toHaveTitle(/.+/);
+    expect(errors, "no console errors").toEqual([]);
+  });
+});
+```
+
+## Step 5: Generate a navigation crawl
+
+A single `e2e/navigation.spec.ts` that:
+
+1. Visits the home route.
+2. Collects every same-origin `<a href>`.
+3. Clicks each in turn, asserts no console errors, no 4xx/5xx.
+
+This catches client-router intercept regressions and broken links.
+
+## Step 6: Generate a hydration check (optional)
+
+If any route is `render: "ssr"` or `"ssg"`/`"isg"`:
+
+```ts
+test("server HTML matches client render", async ({ page }) => {
+  const errors: string[] = [];
+  page.on("console", (m) => m.type() === "error" && errors.push(m.text()));
+  await page.goto("<path>");
+  await page.waitForLoadState("networkidle");
+  expect(errors.filter((e) => /Hydration|hydrat/i.test(e))).toEqual([]);
+});
+```
+
+## Step 7: Wire `package.json`
+
+```json
+{
+  "scripts": {
+    "e2e": "playwright test",
+    "e2e:ui": "playwright test --ui"
+  }
+}
+```
+
+The repo already uses `pnpm e2e` — confirm before overwriting.
+
+## Step 8: Run
+
+```bash
+pnpm e2e
+```
+
+If specs fail on first run, report. Common first-run failures:
+- Port collision (already-running dev server).
+- Missing browser binary (`playwright install chromium`).
+- Strict CSP blocking inline test scripts (rare).
+
+## Rules
+
+1. Source of routes is `pracht inspect routes --json`. Do not glob
+   `src/routes/**`.
+2. Skip dynamic-segment routes unless example params are provided.
+3. Never overwrite an existing `playwright.config.ts` without diffing first.
+4. Use `webServer` to boot `pracht dev` / `pracht preview` so CI works
+   out-of-the-box.
+5. Console-error capture is mandatory — silent JS errors are the most common
+   pracht hydration regression.
+
+$ARGUMENTS

--- a/skills/scaffold-tests/SKILL.md
+++ b/skills/scaffold-tests/SKILL.md
@@ -1,0 +1,224 @@
+---
+name: scaffold-tests
+version: 1.0.0
+description: |
+  Scaffold Vitest unit/integration tests for pracht routes, loaders, and
+  middleware. Asks the user once whether to use vitest browser mode with
+  `vitest-browser-preact` (real DOM, real events) or classic JSDOM-based
+  tests with `@testing-library/preact`. Wires `vitest.config.ts`, mocks
+  `LoaderArgs`, and emits ready-to-run files.
+  Use when asked to "scaffold tests", "set up Vitest", "add unit tests",
+  "test this loader", or "test this route".
+allowed-tools:
+  - Bash
+  - Read
+  - Write
+  - Edit
+  - Grep
+  - Glob
+  - AskUserQuestion
+---
+
+# Pracht Scaffold Tests
+
+Generate Vitest tests aligned with pracht's testing recipe
+(`examples/docs/src/routes/docs/recipes-testing.md`). Loaders and API handlers
+are plain async functions — they test directly with no framework bootstrap.
+Component tests need a renderer; the user picks the flavor.
+
+## Step 1: Pick the rendering strategy
+
+Use `AskUserQuestion` to choose between:
+
+1. **Browser mode** — `vitest` with `@vitest/browser` and
+   `vitest-browser-preact`.
+   - Pros: real browser, real events, fewer hydration false positives,
+     screenshots, works for SPA-mode interaction tests.
+   - Cons: slower, heavier setup, requires a browser binary on CI.
+2. **JSDOM** — `vitest` with `@testing-library/preact`.
+   - Pros: fast, lightweight, runs anywhere.
+   - Cons: JSDOM lacks layout, certain DOM APIs; brittle for complex UIs.
+
+If the project already has one configured, default to it and confirm.
+
+## Step 2: Install dependencies
+
+Detect the package manager from the lockfile.
+
+**Browser mode**:
+
+```bash
+pnpm add -D vitest @vitest/browser playwright vitest-browser-preact
+```
+
+**JSDOM mode**:
+
+```bash
+pnpm add -D vitest jsdom @testing-library/preact @testing-library/jest-dom
+```
+
+Both: `pnpm add -D vitest @types/node`.
+
+## Step 3: Wire `vitest.config.ts`
+
+**Browser mode**:
+
+```ts
+import { defineConfig } from "vitest/config";
+import preact from "@preact/preset-vite";
+
+export default defineConfig({
+  plugins: [preact()],
+  test: {
+    browser: {
+      enabled: true,
+      provider: "playwright",
+      instances: [{ browser: "chromium" }],
+    },
+  },
+});
+```
+
+**JSDOM mode**:
+
+```ts
+import { defineConfig } from "vitest/config";
+import preact from "@preact/preset-vite";
+
+export default defineConfig({
+  plugins: [preact()],
+  test: {
+    environment: "jsdom",
+    setupFiles: ["./test/setup.ts"],
+  },
+});
+```
+
+`test/setup.ts` (JSDOM only):
+
+```ts
+import "@testing-library/jest-dom/vitest";
+```
+
+If `vitest.config.ts` already exists, merge — never clobber.
+
+## Step 4: Generate the tests
+
+Use `pracht inspect routes --json` and `pracht inspect api --json` to find
+targets. Ask the user which subset to scaffold, or pass paths via
+`$ARGUMENTS`.
+
+### Loader test template
+
+```ts
+import { describe, it, expect } from "vitest";
+import { loader } from "./<route-file>";
+
+function args(url: string, init?: RequestInit) {
+  const request = new Request(url, init);
+  return {
+    request,
+    params: {} as Record<string, string>,
+    context: {} as never,
+    url: new URL(request.url),
+    signal: AbortSignal.timeout(5000),
+    route: {} as never,
+  };
+}
+
+describe("<route> loader", () => {
+  it("returns the expected shape", async () => {
+    const data = await loader(args("http://localhost/<path>"));
+    expect(data).toBeDefined();
+  });
+});
+```
+
+### Middleware test template
+
+```ts
+import { describe, it, expect } from "vitest";
+import { middleware } from "./<middleware-file>";
+
+describe("<name> middleware", () => {
+  it("redirects unauthenticated requests", async () => {
+    const request = new Request("http://localhost/dashboard");
+    const result = await middleware({
+      request,
+      params: {},
+      context: {} as never,
+      url: new URL(request.url),
+      signal: AbortSignal.timeout(5000),
+      route: {} as never,
+    });
+    expect(result).toEqual({ redirect: expect.stringMatching(/^\/login/) });
+  });
+});
+```
+
+### Component test template (browser mode)
+
+```tsx
+import { describe, it, expect } from "vitest";
+import { render } from "vitest-browser-preact";
+import { Component } from "./<route-file>";
+
+describe("<route> component", () => {
+  it("renders the heading", async () => {
+    const screen = render(<Component data={{ /* mock loader data */ }} params={{}} />);
+    await expect.element(screen.getByRole("heading")).toBeVisible();
+  });
+});
+```
+
+### Component test template (JSDOM)
+
+```tsx
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/preact";
+import { Component } from "./<route-file>";
+
+describe("<route> component", () => {
+  it("renders the heading", () => {
+    render(<Component data={{ /* mock loader data */ }} params={{}} />);
+    expect(screen.getByRole("heading")).toBeInTheDocument();
+  });
+});
+```
+
+## Step 5: Wire `package.json`
+
+Add (or merge) scripts:
+
+```json
+{
+  "scripts": {
+    "test": "vitest run",
+    "test:watch": "vitest"
+  }
+}
+```
+
+If `pnpm test` already exists, do not overwrite.
+
+## Step 6: Verify
+
+```bash
+pnpm test
+```
+
+If anything fails on first run, report the failure and the fix. Do not commit
+broken scaffolding.
+
+## Rules
+
+1. Ask the rendering-strategy question once per project; persist by
+   inspecting `vitest.config.ts` on subsequent runs.
+2. Only test exports that exist — read the route file before generating.
+3. Use the recipe's `args()` helper shape for `BaseRouteArgs`/`LoaderArgs`
+   construction.
+4. For routes with `getStaticPaths`, scaffold a separate test that calls it.
+5. Generated tests should pass on first run with a placeholder assertion;
+   the user fills in real expectations.
+
+$ARGUMENTS

--- a/skills/test-api/SKILL.md
+++ b/skills/test-api/SKILL.md
@@ -1,0 +1,144 @@
+---
+name: test-api
+version: 1.0.0
+description: |
+  Auto-generate Vitest request/response tests for every handler in `src/api/`.
+  Each test instantiates a `Request`, calls the exported HTTP method handler
+  directly, and asserts on the returned `Response` — no server boot required.
+  Use when asked to "test my API routes", "scaffold API tests", "generate
+  tests for src/api", or "add tests for this endpoint".
+allowed-tools:
+  - Bash
+  - Read
+  - Write
+  - Edit
+  - Grep
+  - Glob
+  - AskUserQuestion
+---
+
+# Pracht Test API
+
+Pracht API handlers are plain functions: `(args: BaseRouteArgs) => Response |
+Promise<Response>`. They test cleanly in Vitest without booting the framework.
+
+## Step 1: Confirm Vitest is installed
+
+If the project has no `vitest` dependency, run `scaffold-tests` first (or
+prompt the user to). This skill does not handle Vitest setup.
+
+## Step 2: Enumerate API handlers
+
+```bash
+pracht inspect api --json
+```
+
+For each entry, capture: `path` (URL), `file` (source path), exported
+`methods` (e.g., `["GET", "POST"]` or `["default"]`).
+
+Ask the user which subset to scaffold or accept paths via `$ARGUMENTS`.
+
+## Step 3: Generate one test per handler file
+
+Place tests next to the handler with `.test.ts` suffix
+(`src/api/users/[id].test.ts`). Use a small helper to construct
+`BaseRouteArgs`:
+
+```ts
+import { describe, it, expect } from "vitest";
+import { GET, POST /* import only what the handler exports */ } from "./<file>";
+
+function args(url: string, init?: RequestInit, params: Record<string, string> = {}) {
+  const request = new Request(url, init);
+  return {
+    request,
+    params,
+    context: {} as never,
+    url: new URL(request.url),
+    signal: AbortSignal.timeout(5000),
+    route: {} as never,
+  };
+}
+
+describe("<METHOD> <api-path>", () => {
+  it("returns 200 on a valid request", async () => {
+    const res = await GET(args("http://localhost<api-path>"));
+    expect(res).toBeInstanceOf(Response);
+    expect(res.status).toBe(200);
+  });
+});
+```
+
+## Step 4: Generate method-specific cases
+
+For each exported method, emit the smallest realistic case:
+
+| Method  | Default case                                                    |
+| ------- | --------------------------------------------------------------- |
+| `GET`   | Plain GET → `expect(res.status).toBeLessThan(400)`              |
+| `POST`  | POST with empty `FormData` → assert validation behavior         |
+| `PUT`   | PUT with JSON body → assert 200 or auth-required (401/403)      |
+| `PATCH` | PATCH with partial body → assert 200 or 422                     |
+| `DELETE`| DELETE on a real-shaped path → assert 200/204 or 401            |
+
+For dynamic segments (`[id].ts` → `/api/users/:id`), pick a placeholder param
+(e.g., `id: "test-1"`) and pass it via `params`. Surface in the report that
+the user may need to provide a real fixture.
+
+## Step 5: Detect auth-gated APIs
+
+If `pracht inspect routes --json` shows the API path (or its group) under
+auth middleware, scaffold an extra test:
+
+```ts
+it("rejects unauthenticated requests", async () => {
+  const res = await POST(args("http://localhost<api-path>", { method: "POST" }));
+  expect([401, 403, 302]).toContain(res.status);
+});
+```
+
+Note: middleware does NOT run when calling the handler directly — this test
+verifies the handler's own defense if it has one. If the only defense is
+middleware, mention that in the report and recommend an integration test that
+goes through the framework's request pipeline (out of scope for this skill).
+
+## Step 6: Validate JSON shape
+
+For handlers that return `Response.json(...)`, generate:
+
+```ts
+it("returns JSON with the expected keys", async () => {
+  const res = await GET(args("http://localhost<api-path>"));
+  expect(res.headers.get("content-type")).toMatch(/application\/json/);
+  const body = await res.json();
+  expect(body).toEqual(expect.objectContaining({ /* fill in */ }));
+});
+```
+
+## Step 7: Default-handler dispatchers
+
+If the handler exports `default` (one function dispatching on
+`request.method`), generate a test per HTTP method the handler appears to
+support (grep for `request.method ===` patterns inside the file).
+
+## Step 8: Run
+
+```bash
+pnpm test
+```
+
+Report passes/failures. Mark generated assertions as TODO so the user knows
+to tighten them.
+
+## Rules
+
+1. Use `pracht inspect api --json` as the inventory — do not glob.
+2. Only import methods the handler actually exports; otherwise the test fails
+   to load.
+3. Direct-handler invocation skips middleware. Be explicit in the report.
+4. Test files live next to handlers with `.test.ts` suffix unless the
+   project already uses a `__tests__/` convention (detect and match).
+5. Never overwrite existing test files; emit a `.next.test.ts` and tell the
+   user to merge.
+
+$ARGUMENTS

--- a/skills/tune-render-mode/SKILL.md
+++ b/skills/tune-render-mode/SKILL.md
@@ -1,0 +1,106 @@
+---
+name: tune-render-mode
+version: 1.0.0
+description: |
+  Recommend the right pracht render mode (ssg, isg, ssr, spa) for each route
+  based on what its loader actually does. Most apps pick a mode once and never
+  revisit; this skill surfaces routes that are mis-tuned.
+  Use when asked to "tune render modes", "make my site faster", "should this
+  route be SSG", "audit render modes", or "review SSG/ISG/SSR choices".
+allowed-tools:
+  - Bash
+  - Read
+  - Grep
+  - Glob
+---
+
+# Pracht Tune Render Mode
+
+Walk every route, read its loader, and recommend the cheapest render mode that
+still satisfies the route's data dependencies.
+
+## Decision Tree
+
+For each route:
+
+1. **No `loader`, no `getStaticPaths`, no per-request data** → **`ssg`**
+   - Pure UI. Build once, serve from CDN. Highest performance.
+
+2. **Loader reads only build-time-stable data** (filesystem, static config,
+   typed CMS export, no `request`/`params`/`context.env` use) → **`ssg`** or
+   **`isg`**
+   - Pick `isg` with `timeRevalidate(seconds)` if the source can change between
+     deploys (CMS, pricing pages, public catalog).
+   - Pick `ssg` if the source only changes when you redeploy.
+
+3. **Loader reads `params` to fetch data, but not `request`/cookies** →
+   **`ssg`** with `getStaticPaths`, or **`isg`** if the universe of params is
+   open-ended (millions of slugs).
+
+4. **Loader reads cookies, headers, `context.env` per-request, or anything
+   personalized** → **`ssr`**
+   - Auth dashboards, anything user-specific, anything that varies by
+     `Accept-Language`/geo at request time.
+
+5. **Heavy client interactivity, no SEO need, auth-gated** → **`spa`**
+   - Internal admin tools, post-login dashboards where the first paint can be a
+     skeleton.
+
+## Step 1: Enumerate
+
+```bash
+pracht inspect routes --json
+```
+
+Capture: `path`, `file`, current `render`, `revalidate`, `middleware`.
+
+## Step 2: Read each loader
+
+For each route, open the file and look at the `loader`/`getStaticPaths`
+exports. Tag the loader with one of:
+
+- `none` — no loader at all
+- `static` — only reads imports / pure data
+- `param-static` — reads `params` only
+- `request-static` — reads `request` for cache keys but data is shareable
+  (e.g. `Accept-Language`)
+- `request-personalized` — reads cookies, auth headers, user-specific
+  `context.env` lookups
+
+## Step 3: Recommend
+
+Produce a table:
+
+| Route | Current | Recommended | Reason |
+| ----- | ------- | ----------- | ------ |
+
+Examples of recommendations:
+- `ssr` → `ssg` when loader is empty: "no loader; no per-request data — make it
+  static."
+- `ssr` → `isg(3600)` when loader fetches a public CMS: "shared data, freshness
+  acceptable at 1 hour."
+- `ssg` → `ssr` when loader reads `request.headers.get('cookie')`: "reads
+  request — cannot be prerendered."
+- `spa` → `ssr` when route has SEO-relevant `head()` and unauthenticated
+  visitors should see content.
+
+## Step 4: Show the diffs (optional)
+
+If the user accepts, edit `src/routes.ts` to update the `render` field. For
+ISG, add `revalidate: timeRevalidate(N)` and import `timeRevalidate` from
+`@pracht/core`.
+
+## Rules
+
+1. Never silently change render modes. Always present the recommendation
+   first.
+2. If a route uses `auth` middleware, default to `ssr` — auth implies cookies.
+3. ISG requires the route to be servable from the same machine that runs
+   builds OR a runtime that can persist the manifest (Node + filesystem,
+   Cloudflare with a bound KV). Confirm adapter capability before recommending
+   ISG.
+4. For dynamic SSG/ISG routes, ensure `getStaticPaths` exists. Flag if missing.
+5. Use `pracht inspect routes --json` rather than reading `src/routes.ts`
+   manually — the resolved graph already accounts for groups and inheritance.
+
+$ARGUMENTS


### PR DESCRIPTION
## Summary

- Adds 20 repo-local Claude Code skills aimed at developers building applications with pracht (vs. the existing four aimed at framework authors).
- Buckets: 13 audits (report-only), 3 testing scaffolds, 4 app primitives.
- Skills lean on `pracht inspect routes|api|build --json` as the source of truth so they survive manifest changes; audits never auto-fix and scaffolds never clobber existing config without diffing.

### Skills added

- **Audits**: `audit-loaders`, `audit-shells`, `audit-auth`, `audit-csrf`, `audit-headers`, `audit-secrets`, `audit-redirects`, `audit-deps`, `audit-bundles`, `audit-seo`, `audit-a11y`, `tune-render-mode`, `pre-deploy`.
- **Testing scaffolds**: `scaffold-tests` (asks browser-mode via `vitest-browser-preact` vs. JSDOM via `@testing-library/preact`), `scaffold-e2e` (Playwright + per-route smoke + nav crawl + hydration check), `test-api`.
- **App primitives**: `add-auth` (sessions + login/signup/logout wired into the manifest), `add-db` (Drizzle, asks D1/PlanetScale/Neon/Postgres/Turso/etc. and cross-checks adapter compatibility), `add-i18n` (URL-prefix / cookie / Accept-Language strategies), `add-observability` (Sentry / OpenTelemetry / Web Vitals).

### Docs

- New `skills/README.md` indexing all 24 skills by category.
- `docs/WORKSPACE.md` updated to link to the index (the prior "three skills" note was stale — `/migrate-nextjs` was already missing).

## Testing

- [x] `pnpm e2e`
- [x] `pnpm format`
- [x] `pnpm lint`
- [x] `pnpm test`

## Checklist

- [x] Docs updated if needed
- [x] Skills updated if needed
- [x] Changeset added if published packages changed — N/A (skills are repo-local, no published-package changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)