### PR TITLE
fix(security): follow up on remaining adapter route-state gaps

### DIFF
--- a/.changeset/security-followup-hardening.md
+++ b/.changeset/security-followup-hardening.md
@@ -1,0 +1,19 @@
+---
+"@pracht/adapter-node": patch
+"@pracht/adapter-cloudflare": patch
+"@pracht/cli": patch
+---
+
+Follow-up security hardening after the main audit fixes.
+
+- `@pracht/adapter-node` now supports `canonicalOrigin` so apps can pin
+  `request.url` to a known public origin instead of depending on untrusted
+  `Host` values. The adapter also treats both `x-pracht-route-state-request`
+  and `?_data=1` as route-state transports before any static/ISG HTML serving,
+  and ISG regeneration now uses a clean HTML request instead of replaying the
+  triggering user's cookies or authorization headers.
+- `@pracht/adapter-cloudflare` now bypasses static asset serving for both
+  route-state transports (`x-pracht-route-state-request` and `?_data=1`).
+- `@pracht/cli` now emits a Vercel Build Output rule that sends `?_data=1`
+  requests to the render function before static rewrites can serve prerendered
+  HTML.

--- a/docs/ADAPTERS.md
+++ b/docs/ADAPTERS.md
@@ -23,11 +23,12 @@ Every adapter implements this same flow. The differences are in how static files
 are served and how ISG revalidation state is tracked.
 
 For page routes, adapters must preserve the distinction between document
-requests and route-state fetches (`x-pracht-route-state-request: 1`). Cached or
-prerendered HTML should never satisfy a route-state fetch, and HTML responses
-should vary on that header when both representations can exist for the same URL.
-Prerendered HTML also carries route and shell document headers from the build
-header manifest so static responses match dynamic document responses.
+requests and route-state fetches (`x-pracht-route-state-request: 1` or
+`?_data=1`). Cached or prerendered HTML should never satisfy a route-state
+fetch, and HTML responses should vary on that header when both
+representations can exist for the same URL. Prerendered HTML also carries
+route and shell document headers from the build header manifest so static
+responses match dynamic document responses.
 
 ---
 
@@ -79,12 +80,26 @@ The adapter factory calls the entry module generator internally to create a virt
 | `viteManifest`  | `ViteManifest`       | Client asset manifest for injection                             |
 | `createContext` | `(args) => TContext` | App-level context factory                                       |
 | `trustProxy`    | `boolean`            | Honor forwarded headers for URL construction (default: `false`) |
+| `canonicalOrigin` | `string`           | Fixed public origin for `request.url`; ignores request Host values |
 
 ### Trusted proxy configuration
 
-By default the Node adapter derives the request URL from the socket: protocol
-is inferred from TLS state, and host from the `Host` header. Forwarded headers
-(`Forwarded`, `X-Forwarded-Proto`, `X-Forwarded-Host`) are **ignored**.
+Set `canonicalOrigin` to pin `request.url` to your known public origin and
+avoid depending on `Host` / forwarded host headers at all:
+
+```typescript
+createNodeRequestHandler({
+  app: resolvedApp,
+  registry,
+  staticDir,
+  canonicalOrigin: "https://app.example.com",
+});
+```
+
+Without `canonicalOrigin`, the Node adapter derives the request URL from the
+socket: protocol is inferred from TLS state, and host from the `Host` header.
+Forwarded headers (`Forwarded`, `X-Forwarded-Proto`, `X-Forwarded-Host`) are
+**ignored** unless `trustProxy: true` is enabled.
 
 Set `trustProxy: true` when the Node server sits behind a trusted reverse proxy
 (nginx, Cloudflare, a load balancer, etc.) that sets forwarded headers:
@@ -104,9 +119,9 @@ When enabled, header precedence is:
 2. **`X-Forwarded-Proto`** / **`X-Forwarded-Host`**
 3. Socket-derived values (fallback)
 
-> **Security note:** enabling `trustProxy` without a proxy that overwrites
-> these headers exposes the app to host-header poisoning — any client can set
-> arbitrary forwarded values. Only enable this when you control the proxy layer.
+> **Security note:** `canonicalOrigin` is the safest option when your app uses
+> `request.url` to build absolute URLs. If you rely on `trustProxy`, only
+> enable it behind a proxy that overwrites forwarded headers.
 
 ### Features
 
@@ -118,8 +133,10 @@ Prerendered HTML receives route and shell document headers from
 `dist/server/headers-manifest.json`.
 - **ISG revalidation**: checks `pracht-isg-manifest.json` for time revalidation
   metadata. Compares file mtime against revalidation window. Regenerates stale
-  pages and writes updated HTML to disk. Route-state requests bypass the cached
-  HTML path so client navigation still reaches `handlePrachtRequest()`.
+  pages and writes updated HTML to disk. Route-state requests (`x-pracht-route-state-request`
+  and `?_data=1`) bypass the cached HTML path so client navigation still reaches
+  `handlePrachtRequest()`. Background regeneration uses a clean HTML request
+  instead of replaying the triggering user's cookies/authorization headers.
 - **Vite manifest**: reads `.vite/manifest.json` to inject correct `<script>` and
   `<link>` tags into server-rendered HTML.
 
@@ -291,9 +308,9 @@ export default {
 - **Clean URL routing**: prerendered SSG pages are copied into
   `.vercel/output/static` and exposed through `config.json` rewrites so `/about`
   resolves to `/about/index.html`.
-- **Route-state bypass**: Vercel build output adds a header-based rule so
-  `x-pracht-route-state-request: 1` requests go to the edge function before any
-  static SSG rewrite can serve cached HTML.
+- **Route-state bypass**: Vercel build output adds rules for both
+  `x-pracht-route-state-request: 1` and `?_data=1`, so route-state requests go
+  to the edge function before any static SSG rewrite can serve cached HTML.
 - **Dynamic fallback**: SSR, API, and ISG routes are routed to the generated edge
   function. ISG paths currently bypass the static fallback so freshness stays
   correct even without native Vercel ISR integration yet.

--- a/e2e/node-build.test.ts
+++ b/e2e/node-build.test.ts
@@ -105,6 +105,34 @@ test("pracht build emits a deployable Node server entry", async () => {
       },
     });
 
+    const homeHeaderRouteStateResponse = await fetch(`http://127.0.0.1:${port}/`, {
+      headers: { "x-pracht-route-state-request": "1" },
+    });
+    expect(homeHeaderRouteStateResponse.status).toBe(200);
+    expect(homeHeaderRouteStateResponse.headers.get("content-type")).toContain("application/json");
+    await expect(homeHeaderRouteStateResponse.json()).resolves.toEqual({
+      data: {
+        highlights: [
+          "Hybrid route manifest",
+          "Per-route rendering modes",
+          "Thin deployment adapters",
+        ],
+      },
+    });
+
+    const homeQueryRouteStateResponse = await fetch(`http://127.0.0.1:${port}/?_data=1`);
+    expect(homeQueryRouteStateResponse.status).toBe(200);
+    expect(homeQueryRouteStateResponse.headers.get("content-type")).toContain("application/json");
+    await expect(homeQueryRouteStateResponse.json()).resolves.toEqual({
+      data: {
+        highlights: [
+          "Hybrid route manifest",
+          "Per-route rendering modes",
+          "Thin deployment adapters",
+        ],
+      },
+    });
+
     // Hashed assets should have immutable cache headers
     const assetMatch = homeHtml.match(/"(\/assets\/[^"]+)"/);
     expect(assetMatch).toBeTruthy();

--- a/e2e/vercel-build.test.ts
+++ b/e2e/vercel-build.test.ts
@@ -44,6 +44,11 @@ test("pracht build emits a deployable Vercel Build Output setup", async () => {
         has: [{ type: "header", key: "x-pracht-route-state-request", value: "1" }],
         dest: "/render",
       }),
+      expect.objectContaining({
+        src: "/(.*)",
+        has: [{ type: "query", key: "_data", value: "1" }],
+        dest: "/render",
+      }),
       expect.objectContaining({ src: "^/$", dest: "/index.html" }),
       expect.objectContaining({ handle: "filesystem" }),
       expect.objectContaining({ src: "/(.*)", dest: "/render" }),

--- a/packages/adapter-cloudflare/src/index.ts
+++ b/packages/adapter-cloudflare/src/index.ts
@@ -129,7 +129,8 @@ export function createCloudflareServerEntryModule(
     "  }",
     "",
     "  // Route state requests must be handled by the framework (returns JSON), not static assets",
-    '  if (request.headers.get("x-pracht-route-state-request") === "1") {',
+    "  const url = new URL(request.url);",
+    '  if (request.headers.get("x-pracht-route-state-request") === "1" || url.searchParams.get("_data") === "1") {',
     "    return null;",
     "  }",
     "",
@@ -151,7 +152,7 @@ export function createCloudflareServerEntryModule(
     "  headers.append('Vary', 'x-pracht-route-state-request');",
     "  applyDefaultSecurityHeaders(headers);",
     "  if ((headers.get('content-type') ?? '').includes('text/html')) {",
-    "    applyPrachtHeadersManifest(headers, await readPrachtHeadersManifest(request, assets), new URL(request.url).pathname);",
+    "    applyPrachtHeadersManifest(headers, await readPrachtHeadersManifest(request, assets), url.pathname);",
     "  }",
     "  return new Response(response.body, { status: response.status, statusText: response.statusText, headers });",
     "}",
@@ -192,7 +193,11 @@ async function maybeServeAsset(
   }
 
   // Route state requests must be handled by the framework (returns JSON), not static assets
-  if (request.headers.get("x-pracht-route-state-request") === "1") {
+  const url = new URL(request.url);
+  if (
+    request.headers.get("x-pracht-route-state-request") === "1" ||
+    url.searchParams.get("_data") === "1"
+  ) {
     return null;
   }
 
@@ -214,7 +219,7 @@ async function maybeServeAsset(
   headers.append("Vary", "x-pracht-route-state-request");
   applyDefaultSecurityHeaders(headers);
   if ((headers.get("content-type") ?? "").includes("text/html")) {
-    applyHeadersManifest(headers, headersManifest, new URL(request.url).pathname);
+    applyHeadersManifest(headers, headersManifest, url.pathname);
   }
   return new Response(response.body, {
     status: response.status,

--- a/packages/adapter-cloudflare/test/index.test.ts
+++ b/packages/adapter-cloudflare/test/index.test.ts
@@ -16,4 +16,10 @@ describe("createCloudflareServerEntryModule", () => {
 
     expect(source).not.toContain("export * from");
   });
+
+  it("bypasses static assets for the _data route-state transport", () => {
+    const source = createCloudflareServerEntryModule();
+
+    expect(source).toContain('url.searchParams.get("_data") === "1"');
+  });
 });

--- a/packages/adapter-node/src/node-entry.ts
+++ b/packages/adapter-node/src/node-entry.ts
@@ -1,10 +1,12 @@
 import type { PrachtAdapter } from "@pracht/vite-plugin";
 
 export interface NodeServerEntryModuleOptions {
+  canonicalOrigin?: string;
   port?: number;
 }
 
 export function createNodeServerEntryModule(options: NodeServerEntryModuleOptions = {}): string {
+  const canonicalOrigin = options.canonicalOrigin ?? null;
   const port = options.port ?? 3000;
 
   return [
@@ -35,6 +37,7 @@ export function createNodeServerEntryModule(options: NodeServerEntryModuleOption
     "  clientEntryUrl: clientEntryUrl ?? undefined,",
     "  cssManifest,",
     "  jsManifest,",
+    `  canonicalOrigin: ${JSON.stringify(canonicalOrigin ?? undefined)},`,
     "});",
     "",
     "const entryHref = process.argv[1] ? pathToFileURL(process.argv[1]).href : null;",

--- a/packages/adapter-node/src/node-handler.ts
+++ b/packages/adapter-node/src/node-handler.ts
@@ -37,12 +37,21 @@ export interface NodeAdapterOptions<TContext = unknown> {
   headersManifest?: HeadersManifest;
   createContext?: (args: NodeAdapterContextArgs) => TContext | Promise<TContext>;
   /**
+   * Canonical public origin for request URL construction. When set, the Node
+   * adapter ignores `Host` / forwarded host headers and always builds
+   * `request.url` against this origin.
+   */
+  canonicalOrigin?: string;
+  /**
    * Whether to trust proxy headers (`Forwarded`, `X-Forwarded-Proto`,
    * `X-Forwarded-Host`) when constructing the request URL.
    *
-   * When **false** (the default), the request URL is derived from the socket:
-   * protocol is inferred from TLS state, and host from the `Host` header.
-   * Forwarded headers are ignored, preventing host-header poisoning.
+   * When `canonicalOrigin` is set, it takes precedence and these headers are
+   * ignored for URL construction.
+   *
+   * When **false** (the default) and no `canonicalOrigin` is set, the request
+   * URL is derived from the socket: protocol is inferred from TLS state, and
+   * host from the `Host` header. Forwarded headers are ignored.
    *
    * When **true**, forwarded headers are honored with the following precedence:
    *   1. RFC 7239 `Forwarded` header (`proto=` and `host=` directives)
@@ -62,11 +71,12 @@ export function createNodeRequestHandler<TContext = unknown>(
   const headersManifest = options.headersManifest ?? {};
   const staticDir = options.staticDir;
   const trustProxy = options.trustProxy ?? false;
+  const canonicalOrigin = options.canonicalOrigin;
 
   return async (req: IncomingMessage, res: ServerResponse): Promise<void> => {
     let request: Request;
     try {
-      request = await createWebRequest(req, trustProxy);
+      request = await createWebRequest(req, { canonicalOrigin, trustProxy });
     } catch (err) {
       if (err instanceof Error && err.message === "Request body too large") {
         res.statusCode = 413;
@@ -76,10 +86,10 @@ export function createNodeRequestHandler<TContext = unknown>(
       throw err;
     }
     const url = new URL(request.url);
-    const isRouteStateRequest = request.headers.get(ROUTE_STATE_REQUEST_HEADER) === "1";
+    const isTransportRouteStateRequest = isRouteStateRequest(url, request.headers);
     const wantsMarkdown = (request.headers.get("accept") ?? "").includes("text/markdown");
 
-    if (staticDir && request.method === "GET" && !wantsMarkdown) {
+    if (staticDir && request.method === "GET" && !wantsMarkdown && !isTransportRouteStateRequest) {
       const staticResult = await resolveStaticFile(staticDir, url.pathname, isgManifest);
       if (staticResult) {
         await serveStaticFile(res, staticResult, headersManifest, url.pathname);
@@ -90,7 +100,7 @@ export function createNodeRequestHandler<TContext = unknown>(
     if (
       staticDir &&
       request.method === "GET" &&
-      !isRouteStateRequest &&
+      !isTransportRouteStateRequest &&
       !wantsMarkdown &&
       url.pathname in isgManifest
     ) {
@@ -124,7 +134,7 @@ export function createNodeRequestHandler<TContext = unknown>(
     if (
       staticDir &&
       request.method === "GET" &&
-      !isRouteStateRequest &&
+      !isTransportRouteStateRequest &&
       url.pathname in isgManifest &&
       response.status === 200 &&
       response.headers.get("content-type")?.includes("text/html") &&
@@ -252,4 +262,8 @@ function isISGResponseCacheable(response: Response): boolean {
     if (name === "cookie" || name === "authorization") return false;
   }
   return true;
+}
+
+function isRouteStateRequest(url: URL, headers: Headers): boolean {
+  return headers.get(ROUTE_STATE_REQUEST_HEADER) === "1" || url.searchParams.get("_data") === "1";
 }

--- a/packages/adapter-node/src/node-isg.ts
+++ b/packages/adapter-node/src/node-isg.ts
@@ -32,12 +32,17 @@ export async function regenerateISGPage<TContext>(
   }
 }
 
-function createISGRegenerationRequest(pathname: string, originalRequest?: Request): Request {
+/**
+ * ISG regeneration writes shared HTML to disk, so it must never inherit
+ * per-request headers like cookies, authorization, locale, or experiment
+ * buckets from the user who happened to trigger the stale render.
+ */
+export function createISGRegenerationRequest(pathname: string, originalRequest?: Request): Request {
   const baseUrl = originalRequest ? new URL(originalRequest.url) : new URL("http://localhost");
   const regenerationUrl = new URL(pathname, baseUrl);
 
   return new Request(regenerationUrl, {
     method: "GET",
-    headers: originalRequest ? new Headers(originalRequest.headers) : undefined,
+    headers: { accept: "text/html" },
   });
 }

--- a/packages/adapter-node/src/node-request.ts
+++ b/packages/adapter-node/src/node-request.ts
@@ -5,10 +5,10 @@ const MAX_BODY_SIZE = 1024 * 1024; // 1 MB
 
 export async function createWebRequest(
   req: IncomingMessage,
-  trustProxy: boolean,
+  options: { trustProxy: boolean; canonicalOrigin?: string },
 ): Promise<Request> {
-  const { protocol, host } = resolveOrigin(req, trustProxy);
-  const url = new URL(req.url ?? "/", `${protocol}://${host}`);
+  const baseUrl = resolveRequestBase(req, options);
+  const url = new URL(req.url ?? "/", baseUrl);
   const method = req.method ?? "GET";
   const headers = createHeaders(req.headers);
   const init: RequestInit = {
@@ -46,17 +46,34 @@ export async function writeWebResponse(res: ServerResponse, response: Response):
 }
 
 /**
- * Derive the request protocol and host from the incoming message.
+ * Derive the request base URL from the incoming message.
  *
- * When `trustProxy` is false (default), the protocol is inferred from the
- * socket's TLS state and the host from the HTTP `Host` header.  Forwarded
- * headers are ignored entirely.
+ * When `canonicalOrigin` is provided, it wins and request URL construction no
+ * longer depends on `Host` / forwarded host headers. This is the safest option
+ * for apps that generate absolute URLs from `request.url`.
  *
- * When `trustProxy` is true, the following precedence applies:
+ * Otherwise, when `trustProxy` is false (default), the protocol is inferred
+ * from the socket's TLS state and the host from the HTTP `Host` header.
+ * Forwarded headers are ignored entirely.
+ *
+ * When `trustProxy` is true, the following precedence applies for the derived
+ * host/protocol:
  *   1. RFC 7239 `Forwarded` header (`proto=` / `host=` directives)
  *   2. `X-Forwarded-Proto` / `X-Forwarded-Host`
  *   3. Socket-derived values (fallback)
  */
+function resolveRequestBase(
+  req: IncomingMessage,
+  options: { trustProxy: boolean; canonicalOrigin?: string },
+): URL {
+  if (options.canonicalOrigin) {
+    return new URL(options.canonicalOrigin);
+  }
+
+  const { protocol, host } = resolveOrigin(req, options.trustProxy);
+  return new URL(`${protocol}://${host}`);
+}
+
 function resolveOrigin(
   req: IncomingMessage,
   trustProxy: boolean,

--- a/packages/adapter-node/test/index.test.ts
+++ b/packages/adapter-node/test/index.test.ts
@@ -46,7 +46,7 @@ afterEach(async () => {
 });
 
 describe("createNodeRequestHandler", () => {
-  it("reuses createContext during stale ISG regeneration", async () => {
+  it("reuses createContext during stale ISG regeneration with a clean request", async () => {
     const staticDir = makeTempDir();
     const htmlDir = join(staticDir, "isg");
     const htmlPath = join(htmlDir, "index.html");
@@ -106,9 +106,9 @@ describe("createNodeRequestHandler", () => {
     expect(response.headers.get("x-pracht-isg")).toBe("stale");
     await expect(response.text()).resolves.toContain("stale");
 
-    await waitFor(() => readFileSync(htmlPath, "utf-8").includes("acme"));
+    await waitFor(() => readFileSync(htmlPath, "utf-8").includes("missing"));
 
-    expect(createContextCalls).toEqual(["acme"]);
-    expect(readFileSync(htmlPath, "utf-8")).toContain("acme");
+    expect(createContextCalls).toEqual(["missing"]);
+    expect(readFileSync(htmlPath, "utf-8")).toContain("missing");
   });
 });

--- a/packages/adapter-node/test/security.test.ts
+++ b/packages/adapter-node/test/security.test.ts
@@ -1,8 +1,11 @@
+import type { IncomingMessage } from "node:http";
 import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 
+import { createISGRegenerationRequest } from "../src/node-isg.ts";
+import { createWebRequest } from "../src/node-request.ts";
 import { resolveStaticFile } from "../src/node-static.ts";
 
 const tempDirs: string[] = [];
@@ -45,5 +48,51 @@ describe("resolveStaticFile symlink protection", () => {
     const result = await resolveStaticFile(staticDir, "/app.js");
     expect(result).not.toBeNull();
     expect(result?.filePath).toBe(join(staticDir, "app.js"));
+  });
+});
+
+describe("createWebRequest canonicalOrigin", () => {
+  it("pins request.url to canonicalOrigin instead of Host / forwarded headers", async () => {
+    const request = await createWebRequest(
+      {
+        headers: {
+          forwarded: 'for=1.2.3.4;proto=https;host="evil.example"',
+          host: "still-evil.example",
+        },
+        method: "GET",
+        req: undefined,
+        socket: {},
+        url: "/dashboard?tab=1",
+        async *[Symbol.asyncIterator]() {},
+      } as unknown as IncomingMessage,
+      {
+        canonicalOrigin: "https://app.example.com",
+        trustProxy: true,
+      },
+    );
+
+    expect(request.url).toBe("https://app.example.com/dashboard?tab=1");
+  });
+});
+
+describe("createISGRegenerationRequest", () => {
+  it("drops user-specific headers before regenerating shared HTML", () => {
+    const request = createISGRegenerationRequest(
+      "/pricing",
+      new Request("https://app.example.com/pricing", {
+        headers: {
+          accept: "application/json",
+          "accept-language": "fr",
+          authorization: "Bearer secret",
+          cookie: "session=123",
+        },
+      }),
+    );
+
+    expect(request.url).toBe("https://app.example.com/pricing");
+    expect(request.headers.get("accept")).toBe("text/html");
+    expect(request.headers.get("accept-language")).toBeNull();
+    expect(request.headers.get("authorization")).toBeNull();
+    expect(request.headers.get("cookie")).toBeNull();
   });
 });

--- a/packages/cli/src/build-shared.ts
+++ b/packages/cli/src/build-shared.ts
@@ -67,6 +67,11 @@ function createVercelOutputConfig({
       has: [{ type: "header", key: ROUTE_STATE_REQUEST_HEADER, value: "1" }],
       src: "/(.*)",
     },
+    {
+      dest: target,
+      has: [{ type: "query", key: "_data", value: "1" }],
+      src: "/(.*)",
+    },
   ];
 
   for (const route of sortStaticRoutes(staticRoutes)) {


### PR DESCRIPTION
## Summary

- Follow up on #131 by closing the remaining adapter-level route-state bypass gaps before static HTML serving in Node, Cloudflare, and Vercel build output.
- Strip per-user headers from Node ISG regeneration so stale-page rebuilds cannot inherit the triggering user's cookies or authorization state.
- Add `canonicalOrigin` to the Node adapter so apps can pin `request.url` to a known public origin instead of depending on request `Host` values.

## Testing

- [x] `pnpm e2e`
- [x] `pnpm format`
- [x] `pnpm lint`
- [x] `pnpm test`

## Checklist

- [x] Docs updated if needed
- [x] Skills updated if needed - N/A
- [x] Changeset added if published packages changed