### PR TITLE
feat(framework,cli): support catch-all segments in API routes

### DIFF
--- a/.changeset/api-route-catchall.md
+++ b/.changeset/api-route-catchall.md
@@ -1,0 +1,6 @@
+---
+"@pracht/core": minor
+"@pracht/cli": minor
+---
+
+API routes now support catch-all segments (e.g. `src/api/files/[...path].ts` → `/api/files/*`), matching the existing page-routing convention. The matched rest-path is exposed on the route params as `"*"`. Previously `[...param]` was silently turned into a `:...param` dynamic segment with a broken name.

--- a/docs/DATA_LOADING.md
+++ b/docs/DATA_LOADING.md
@@ -383,6 +383,9 @@ export default async function handler({ params, request, context }: ApiRouteArgs
 API routes:
 
 - Live in `src/api/` with file-based path mapping
+- Support dynamic params (`src/api/users/[id].ts` → `/api/users/:id`) and
+  catch-alls (`src/api/files/[...path].ts` → `/api/files/*`, accessible via
+  `params["*"]`)
 - Export named HTTP method handlers (`GET`, `POST`, `PUT`, `PATCH`, `DELETE`)
   or one default handler that branches on `args.request.method`
 - Return `Response` objects directly

--- a/docs/WORKSPACE.md
+++ b/docs/WORKSPACE.md
@@ -23,7 +23,9 @@ described in `VISION_MVP.md`.
   matching.
 - **API routes** — File-based auto-discovery from `src/api/`. Files are globbed
   by the Vite plugin and resolved to URL paths (e.g. `src/api/health.ts` →
-  `/api/health`, `src/api/users/[id].ts` → `/api/users/:id`). Modules export
+  `/api/health`, `src/api/users/[id].ts` → `/api/users/:id`,
+  `src/api/files/[...path].ts` → `/api/files/*`, exposed on `params` as `"*"`).
+  Modules export
   named HTTP method handlers (`GET`, `POST`, etc.) or one default handler that
   branches on `request.method` and returns `Response` objects directly. API
   routes are dispatched before page routes in `handlePrachtRequest()`. Missing

--- a/packages/cli/src/verification-helpers.ts
+++ b/packages/cli/src/verification-helpers.ts
@@ -58,6 +58,7 @@ export function resolveApiRoutePath(apiDir: string, file: string): string {
     relativePath = relativePath.replace(/\/index$/, "");
   }
 
+  relativePath = relativePath.replace(/\[\.\.\.[^\]]+\]/g, "*");
   relativePath = relativePath.replace(/\[([^\]]+)\]/g, ":$1");
 
   return normalizeRoutePath(relativePath ? `/api/${relativePath}` : "/api");

--- a/packages/framework/src/app.ts
+++ b/packages/framework/src/app.ts
@@ -326,6 +326,7 @@ function encodeCatchAllSegment(part: string): string {
  *
  * Example: `"/src/api/health.ts"` → path `/api/health`
  *          `"/src/api/users/[id].ts"` → path `/api/users/:id`
+ *          `"/src/api/files/[...path].ts"` → path `/api/files/*`
  *          `"/src/api/index.ts"` → path `/api`
  */
 export function resolveApiRoutes(files: string[], apiDir: string = "/src/api"): ResolvedApiRoute[] {
@@ -345,7 +346,7 @@ export function resolveApiRoutes(files: string[], apiDir: string = "/src/api"): 
         relative = relative.slice(0, -"/index".length) || "/";
       }
 
-      // Convert [param] to :param for consistency with page routes
+      relative = relative.replace(/\[\.\.\.[^\]]+\]/g, "*");
       relative = relative.replace(/\[([^\]]+)\]/g, ":$1");
 
       const path = normalizeRoutePath(`/api${relative}`);

--- a/packages/framework/test/router.test.ts
+++ b/packages/framework/test/router.test.ts
@@ -150,4 +150,28 @@ describe("API route matching", () => {
     expect(dynamicMatch?.route.file).toBe("/src/api/users/[id].ts");
     expect(dynamicMatch?.params).toEqual({ id: "42" });
   });
+
+  it("resolves catch-all api routes to a wildcard path", () => {
+    const [route] = resolveApiRoutes(["/src/api/files/[...path].ts"]);
+
+    expect(route?.path).toBe("/api/files/*");
+  });
+
+  it("matches catch-all api routes and exposes the rest as a param", () => {
+    const routes = resolveApiRoutes([
+      "/src/api/files/[...path].ts",
+      "/src/api/files/readme.ts",
+      "/src/api/files/[id].ts",
+    ]);
+
+    const staticMatch = matchApiRoute(routes, "/api/files/readme");
+    const dynamicMatch = matchApiRoute(routes, "/api/files/42");
+    const catchAllMatch = matchApiRoute(routes, "/api/files/docs/getting-started");
+
+    expect(staticMatch?.route.file).toBe("/src/api/files/readme.ts");
+    expect(dynamicMatch?.route.file).toBe("/src/api/files/[id].ts");
+    expect(dynamicMatch?.params).toEqual({ id: "42" });
+    expect(catchAllMatch?.route.file).toBe("/src/api/files/[...path].ts");
+    expect(catchAllMatch?.params).toEqual({ "*": "docs/getting-started" });
+  });
 });


### PR DESCRIPTION
## Summary

- File-based API routes now recognize `[...param]` as a catch-all and resolve it to a `*` route segment, matching the pages-router convention. The rest-path is exposed on the route params as `"*"`.
- Previously the regex silently rewrote `[...param]` into the nonsense dynamic segment `:...param`, which then only matched a single segment.
- Applies to both the runtime resolver (`resolveApiRoutes` in `@pracht/core`) and the CLI verification helper (`resolveApiRoutePath` in `@pracht/cli`) so that route-listing output matches runtime matching.

## Testing

- [x] `pnpm e2e`
- [x] `pnpm format`
- [x] `pnpm lint`
- [x] `pnpm test`

## Checklist

- [x] Docs updated if needed
- [x] Skills updated if needed — N/A
- [x] Changeset added if published packages changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)