### PR TITLE
feat(vite-plugin): opt-in support for .tsrx (TSRX/Ripple-Preact) modules

### DIFF
--- a/.changeset/tsrx-preact-support.md
+++ b/.changeset/tsrx-preact-support.md
@@ -2,4 +2,4 @@
 "@pracht/vite-plugin": minor
 ---
 
-Add opt-in support for `.tsrx` (TSRX/Ripple-flavoured Preact) route and shell modules. Pass `tsrx: true` to `pracht()` (or an options object forwarded to the underlying plugin) to enable; the plugin will load `@tsrx/vite-plugin-preact` (a new optional peer dependency) and register it with the right enforcement order. `.tsrx` files are added to the route/shell glob and to the client-only export-stripping pass, and a wrapper around the upstream plugin handles pracht's `?pracht-client` query suffix so the same compilation runs for the client variant of route modules.
+Recognise `.tsrx` (TSRX/Ripple-flavoured Preact) modules in route and shell discovery. Users bring their own `@tsrx/vite-plugin-preact` and register it alongside `pracht()` in the Vite `plugins` array; pracht adds `.tsrx` to its route/shell globs and to the server-only export-stripping pass (via the directory check) so discovery, SSR, SSG, and client hydration all work without further configuration. `.tsrx` globs are emitted without the `?pracht-client` query suffix so the upstream plugin matches them by extension.

--- a/.changeset/tsrx-preact-support.md
+++ b/.changeset/tsrx-preact-support.md
@@ -1,0 +1,5 @@
+---
+"@pracht/vite-plugin": minor
+---
+
+Add opt-in support for `.tsrx` (TSRX/Ripple-flavoured Preact) route and shell modules. Pass `tsrx: true` to `pracht()` (or an options object forwarded to the underlying plugin) to enable; the plugin will load `@tsrx/vite-plugin-preact` (a new optional peer dependency) and register it with the right enforcement order. `.tsrx` files are added to the route/shell glob and to the client-only export-stripping pass, and a wrapper around the upstream plugin handles pracht's `?pracht-client` query suffix so the same compilation runs for the client variant of route modules.

--- a/docs/WORKSPACE.md
+++ b/docs/WORKSPACE.md
@@ -94,12 +94,14 @@ described in `VISION_MVP.md`.
   image tools, PWA, etc.) alongside `pracht()` in `vite.config.ts`. No special
   integration required — plugins participate in the full Vite pipeline for both
   client and SSR builds.
-- **TSRX support** — `pracht({ tsrx: true })` opts in to `.tsrx` route and shell
-  modules via the optional peer dependency
-  [`@tsrx/vite-plugin-preact`](https://github.com/Ripple-TS/ripple). The plugin
-  is registered ahead of pracht's transform pipeline; route/shell discovery
-  globs and the client-only export-stripping pass both recognise the `.tsrx`
-  extension. See `examples/tsrx/` for a working app.
+- **TSRX support** — `.tsrx` route and shell modules work without a pracht
+  option: users add
+  [`@tsrx/vite-plugin-preact`](https://github.com/Ripple-TS/ripple) to their
+  Vite `plugins` array alongside `pracht()`. The pracht plugin globs `.tsrx`
+  files in its route/shell discovery and the client-only export-stripping pass
+  recognises the extension via the directory check, so no `?pracht-client`
+  query suffix is attached (the upstream `tsrxPreact` plugin matches by bare
+  extension). See `examples/tsrx/` for a working app.
 
 - **Claude Code skills** — Repo-local skills in `skills/` (see
   [skills/README.md](../skills/README.md) for the full index). Two audiences:

--- a/docs/WORKSPACE.md
+++ b/docs/WORKSPACE.md
@@ -15,6 +15,7 @@ described in `VISION_MVP.md`.
 | `packages/cli`                | `@pracht/cli`                | `pracht dev`, `build`, `verify`, the `generate` subcommands, and `doctor`                                    |
 | `examples/cloudflare`         | `@pracht/example-cloudflare` | Cloudflare-targeted example app with SSG, ISG, SSR, SPA routes, auth middleware, and API routes              |
 | `examples/docs`               | `@pracht/example-docs`       | Documentation website built with pracht + Cloudflare adapter; all routes SSG-prerendered; dark design system |
+| `examples/tsrx`               | `@pracht/example-tsrx`       | Mixed `.tsrx` (TSRX/Ripple-flavoured Preact) and `.tsx` routes via `@tsrx/vite-plugin-preact`                |
 
 ## What Exists Today
 
@@ -93,6 +94,12 @@ described in `VISION_MVP.md`.
   image tools, PWA, etc.) alongside `pracht()` in `vite.config.ts`. No special
   integration required — plugins participate in the full Vite pipeline for both
   client and SSR builds.
+- **TSRX support** — `pracht({ tsrx: true })` opts in to `.tsrx` route and shell
+  modules via the optional peer dependency
+  [`@tsrx/vite-plugin-preact`](https://github.com/Ripple-TS/ripple). The plugin
+  is registered ahead of pracht's transform pipeline; route/shell discovery
+  globs and the client-only export-stripping pass both recognise the `.tsrx`
+  extension. See `examples/tsrx/` for a working app.
 
 - **Claude Code skills** — Repo-local skills in `skills/` (see
   [skills/README.md](../skills/README.md) for the full index). Two audiences:

--- a/e2e/tsrx-build.test.ts
+++ b/e2e/tsrx-build.test.ts
@@ -1,0 +1,212 @@
+import { execFileSync, spawn } from "node:child_process";
+import {
+  cpSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+} from "node:fs";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { expect, test } from "@playwright/test";
+
+// End-to-end coverage for `.tsrx` route modules compiled by
+// `@tsrx/vite-plugin-preact`. Builds `examples/tsrx/` in a temp dir, asserts
+// that: the `.tsrx` route is prerendered with its scoped CSS, that a `.tsx`
+// route and a `.tsrx` route coexist, that server-only exports from the `.tsrx`
+// source are stripped from the client bundle, and that the built Node server
+// serves both pages.
+const repoRoot = resolve(fileURLToPath(new URL("..", import.meta.url)));
+const fixtureDir = resolve(repoRoot, "examples/tsrx");
+const cliEntry = resolve(repoRoot, "packages/cli/bin/pracht.js");
+
+test("pracht build prerenders a .tsrx route with scoped CSS and strips its loader from the client bundle", async () => {
+  test.setTimeout(120_000);
+
+  const { exampleDir, tempDir } = createTempExampleDir("pracht-tsrx-build-");
+  const distDir = resolve(exampleDir, "dist");
+
+  rmSync(distDir, { force: true, recursive: true });
+
+  buildExample(exampleDir);
+
+  // --- Prerendered HTML ---
+  const homeHtmlPath = resolve(exampleDir, "dist/client/index.html");
+  const aboutHtmlPath = resolve(exampleDir, "dist/client/about/index.html");
+  expect(existsSync(homeHtmlPath)).toBe(true);
+  expect(existsSync(aboutHtmlPath)).toBe(true);
+
+  const homeHtml = readFileSync(homeHtmlPath, "utf-8");
+  // Loader data from the .tsrx route made it through SSR.
+  expect(homeHtml).toContain("Hello from a .tsrx route");
+  expect(homeHtml).toContain("Compiled by @tsrx/vite-plugin-preact");
+  // Scoped class injected by @tsrx/vite-plugin-preact's CSS pipeline.
+  expect(homeHtml).toMatch(/class="tsrx-home tsrx-[0-9a-z]+"/);
+  // Hydration state is present.
+  expect(homeHtml).toContain('id="pracht-state" type="application/json"');
+  expect(homeHtml).toContain('"routeId":"home"');
+  // Hashed client entry (not the dev-mode `/@pracht/client.js` alias).
+  expect(homeHtml).toMatch(/<script type="module" src="\/assets\/client-[^"]+\.js"><\/script>/);
+
+  // .tsx route coexists and renders.
+  const aboutHtml = readFileSync(aboutHtmlPath, "utf-8");
+  expect(aboutHtml).toContain("About this example");
+  expect(aboutHtml).toContain('"routeId":"about"');
+
+  // --- Scoped CSS extracted from the .tsrx <style> block ---
+  const cssDir = resolve(exampleDir, "dist/client/assets");
+  const cssFiles = readdirSync(cssDir).filter((f) => f.endsWith(".css"));
+  expect(cssFiles.length).toBeGreaterThan(0);
+  const cssContents = cssFiles.map((f) => readFileSync(resolve(cssDir, f), "utf-8")).join("\n");
+  // `.tsrx-home` should appear suffixed with the scope hash the HTML used.
+  const hashMatch = homeHtml.match(/class="tsrx-home (tsrx-[0-9a-z]+)"/);
+  expect(hashMatch).toBeTruthy();
+  const scopeHash = hashMatch![1];
+  expect(cssContents).toContain(`.tsrx-home.${scopeHash}`);
+  expect(cssContents).toContain(`h1.${scopeHash}`);
+  // `rebeccapurple` may be minified to `#639` — accept either.
+  expect(cssContents.toLowerCase()).toMatch(/rebeccapurple|#663399|#639/);
+
+  // --- Client bundle: loader + loader-only data must be stripped ---
+  const clientJs = collectJsSource(cssDir);
+  // Component content survives.
+  expect(clientJs).toContain("This page is rendered from a .tsrx file.");
+  // Loader-only strings — these appear in the route's loader return value,
+  // not in the rendered markup — must not reach the client bundle.
+  expect(clientJs).not.toContain("Hello from a .tsrx route");
+  expect(clientJs).not.toContain("Compiled by @tsrx/vite-plugin-preact");
+
+  // --- Server bundle: loader is retained ---
+  const serverJs = collectJsSource(resolve(exampleDir, "dist/server"));
+  expect(serverJs).toContain("Hello from a .tsrx route");
+  expect(serverJs).toContain("Compiled by @tsrx/vite-plugin-preact");
+
+  rmSync(tempDir, { force: true, recursive: true });
+});
+
+test("built Node server serves .tsrx and .tsx routes", async () => {
+  test.setTimeout(120_000);
+
+  const { exampleDir, tempDir } = createTempExampleDir("pracht-tsrx-serve-");
+  const distDir = resolve(exampleDir, "dist");
+  const serverEntryPath = resolve(exampleDir, "dist/server/server.js");
+
+  rmSync(distDir, { force: true, recursive: true });
+
+  buildExample(exampleDir);
+  expect(existsSync(serverEntryPath)).toBe(true);
+
+  const port = 4421;
+  const server = spawn(process.execPath, [serverEntryPath], {
+    cwd: exampleDir,
+    env: {
+      ...process.env,
+      PORT: String(port),
+    },
+    stdio: "pipe",
+  });
+
+  try {
+    await waitForServer(`http://127.0.0.1:${port}/`);
+
+    const homeResponse = await fetch(`http://127.0.0.1:${port}/`);
+    expect(homeResponse.status).toBe(200);
+    const homeHtml = await homeResponse.text();
+    expect(homeHtml).toContain("Hello from a .tsrx route");
+    expect(homeHtml).toMatch(/class="tsrx-home tsrx-[0-9a-z]+"/);
+
+    const aboutResponse = await fetch(`http://127.0.0.1:${port}/about`);
+    expect(aboutResponse.status).toBe(200);
+    const aboutHtml = await aboutResponse.text();
+    expect(aboutHtml).toContain("About this example");
+
+    // Client-nav JSON endpoint returns the loader payload for the .tsrx route.
+    const stateResponse = await fetch(`http://127.0.0.1:${port}/`, {
+      headers: { "x-pracht-route-state-request": "1" },
+    });
+    expect(stateResponse.status).toBe(200);
+    expect(stateResponse.headers.get("content-type")).toContain("application/json");
+    const state = (await stateResponse.json()) as {
+      data: { greeting: string; features: string[] };
+    };
+    expect(state.data.greeting).toBe("Hello from a .tsrx route");
+    expect(state.data.features).toContain("Mixes freely with .tsx routes");
+  } finally {
+    server.kill("SIGTERM");
+    await waitForExit(server);
+    rmSync(tempDir, { force: true, recursive: true });
+  }
+});
+
+function createTempExampleDir(prefix: string): { exampleDir: string; tempDir: string } {
+  const tempRoot = resolve(repoRoot, ".tmp");
+  mkdirSync(tempRoot, { recursive: true });
+  const tempDir = mkdtempSync(resolve(tempRoot, prefix));
+  const exampleDir = resolve(tempDir, "project");
+
+  cpSync(fixtureDir, exampleDir, {
+    filter(source) {
+      return ![".vercel", "dist", "test-results"].some((entry) =>
+        source.includes(`/examples/tsrx/${entry}`),
+      );
+    },
+    recursive: true,
+  });
+
+  return { exampleDir, tempDir };
+}
+
+function buildExample(exampleDir: string): void {
+  execFileSync(process.execPath, [cliEntry, "build"], {
+    cwd: exampleDir,
+    env: {
+      ...process.env,
+      NODE_OPTIONS: "--experimental-strip-types",
+    },
+    stdio: "pipe",
+  });
+}
+
+function collectJsSource(dir: string): string {
+  const entries = readdirSync(dir, { withFileTypes: true, recursive: true });
+  const pieces: string[] = [];
+  for (const entry of entries) {
+    if (!entry.isFile()) continue;
+    if (!entry.name.endsWith(".js") && !entry.name.endsWith(".mjs")) continue;
+    const parent =
+      (entry as unknown as { parentPath?: string; path?: string }).parentPath ??
+      (entry as unknown as { path?: string }).path ??
+      dir;
+    pieces.push(readFileSync(resolve(parent, entry.name), "utf-8"));
+  }
+  return pieces.join("\n");
+}
+
+async function waitForServer(url: string): Promise<void> {
+  const deadline = Date.now() + 15_000;
+
+  while (Date.now() < deadline) {
+    try {
+      const response = await fetch(url);
+      if (response.ok) return;
+    } catch {
+      // Server is still starting.
+    }
+
+    await new Promise((resolveDelay) => setTimeout(resolveDelay, 250));
+  }
+
+  throw new Error(`Timed out waiting for ${url}`);
+}
+
+async function waitForExit(child: ReturnType<typeof spawn>): Promise<void> {
+  if (child.exitCode !== null || child.signalCode !== null) return;
+
+  await new Promise<void>((resolveDone) => {
+    child.once("exit", () => resolveDone());
+    setTimeout(() => resolveDone(), 5_000);
+  });
+}

--- a/examples/tsrx/README.md
+++ b/examples/tsrx/README.md
@@ -3,22 +3,21 @@
 Demonstrates `.tsrx` route modules — TSRX/Ripple-flavoured Preact components —
 running side by side with regular `.tsx` routes inside a Pracht app.
 
-The integration is opt-in via the `tsrx: true` plugin option:
+There is no special pracht option to enable this: install
+[`@tsrx/vite-plugin-preact`](https://github.com/Ripple-TS/ripple) and add it to
+your Vite `plugins` array alongside `pracht()`. Pracht's route/shell globs and
+server-only export stripping both recognise `.tsrx` automatically.
 
 ```ts
 // vite.config.ts
 import { defineConfig } from "vite";
 import { pracht } from "@pracht/vite-plugin";
+import { tsrxPreact } from "@tsrx/vite-plugin-preact";
 
 export default defineConfig({
-  plugins: [pracht({ tsrx: true })],
+  plugins: [tsrxPreact(), pracht()],
 });
 ```
-
-`tsrx: true` loads
-[`@tsrx/vite-plugin-preact`](https://github.com/Ripple-TS/ripple) under the
-hood; pass an options object instead of `true` to forward
-`jsxImportSource` / `suspenseSource` to the underlying plugin.
 
 ## Layout
 

--- a/examples/tsrx/README.md
+++ b/examples/tsrx/README.md
@@ -1,0 +1,33 @@
+# TSRX Example
+
+Demonstrates `.tsrx` route modules — TSRX/Ripple-flavoured Preact components —
+running side by side with regular `.tsx` routes inside a Pracht app.
+
+The integration is opt-in via the `tsrx: true` plugin option:
+
+```ts
+// vite.config.ts
+import { defineConfig } from "vite";
+import { pracht } from "@pracht/vite-plugin";
+
+export default defineConfig({
+  plugins: [pracht({ tsrx: true })],
+});
+```
+
+`tsrx: true` loads
+[`@tsrx/vite-plugin-preact`](https://github.com/Ripple-TS/ripple) under the
+hood; pass an options object instead of `true` to forward
+`jsxImportSource` / `suspenseSource` to the underlying plugin.
+
+## Layout
+
+- `src/routes/home.tsrx` — a `.tsrx` route with a scoped `<style>` block
+- `src/routes/about.tsx` — a regular `.tsx` route, proving the two coexist
+- `src/shells/public.tsx` — shared shell
+
+## Commands
+
+- `pnpm pracht dev` — start the dev server
+- `pnpm pracht build` — produce a production bundle
+- `node dist/server/server.js` — run the built Node server locally

--- a/examples/tsrx/package.json
+++ b/examples/tsrx/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "@pracht/example-tsrx",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "dependencies": {
+    "@pracht/adapter-node": "workspace:*",
+    "@pracht/core": "workspace:*"
+  },
+  "devDependencies": {
+    "@pracht/cli": "workspace:*",
+    "@pracht/vite-plugin": "workspace:*",
+    "@tsrx/vite-plugin-preact": "^0.0.3",
+    "preact": "^10.26.9",
+    "preact-render-to-string": "^6.5.13",
+    "vite": "^8.0.0"
+  }
+}

--- a/examples/tsrx/src/routes.ts
+++ b/examples/tsrx/src/routes.ts
@@ -1,0 +1,13 @@
+import { defineApp, group, route } from "@pracht/core";
+
+export const app = defineApp({
+  shells: {
+    public: () => import("./shells/public.tsx"),
+  },
+  routes: [
+    group({ shell: "public" }, [
+      route("/", () => import("./routes/home.tsrx"), { id: "home", render: "ssg" }),
+      route("/about", () => import("./routes/about.tsx"), { id: "about", render: "ssg" }),
+    ]),
+  ],
+});

--- a/examples/tsrx/src/routes/about.tsx
+++ b/examples/tsrx/src/routes/about.tsx
@@ -1,0 +1,16 @@
+import type { LoaderArgs, RouteComponentProps } from "@pracht/core";
+
+export async function loader(_args: LoaderArgs) {
+  return {
+    summary: "This is a regular .tsx route. The two file types coexist in the same Pracht app.",
+  };
+}
+
+export function Component({ data }: RouteComponentProps<typeof loader>) {
+  return (
+    <section>
+      <h1>About this example</h1>
+      <p>{data.summary}</p>
+    </section>
+  );
+}

--- a/examples/tsrx/src/routes/home.tsrx
+++ b/examples/tsrx/src/routes/home.tsrx
@@ -1,0 +1,36 @@
+import type { LoaderArgs, RouteComponentProps } from "@pracht/core";
+
+export async function loader(_args: LoaderArgs) {
+  return {
+    features: [
+      "Compiled by @tsrx/vite-plugin-preact",
+      "Mixes freely with .tsx routes",
+      "Per-component scoped <style> blocks",
+    ],
+    greeting: "Hello from a .tsrx route",
+  };
+}
+
+export component Component(props: RouteComponentProps<typeof loader>) {
+  <section class="tsrx-home">
+    <h1>{props.data.greeting}</h1>
+    <p>{"This page is rendered from a .tsrx file."}</p>
+    <ul>
+      for (const feature of props.data.features) {
+        <li>{feature}</li>
+      }
+    </ul>
+  </section>
+
+  <style>
+    .tsrx-home {
+      padding: 2rem;
+      border: 1px dashed rebeccapurple;
+      border-radius: 0.5rem;
+    }
+    h1 {
+      color: rebeccapurple;
+      margin-top: 0;
+    }
+  </style>
+}

--- a/examples/tsrx/src/shells/public.tsx
+++ b/examples/tsrx/src/shells/public.tsx
@@ -1,0 +1,26 @@
+import type { ShellProps } from "@pracht/core";
+
+export function Shell({ children }: ShellProps) {
+  return (
+    <div class="public-shell">
+      <header>
+        <strong>Pracht + TSRX</strong>
+        <nav>
+          <a href="/">Home (.tsrx)</a>
+          <a href="/about">About (.tsx)</a>
+        </nav>
+      </header>
+      <main>{children}</main>
+      <footer>
+        <code>.tsrx</code> routes powered by <code>@tsrx/vite-plugin-preact</code>.
+      </footer>
+    </div>
+  );
+}
+
+export function head() {
+  return {
+    meta: [{ content: "width=device-width, initial-scale=1", name: "viewport" }],
+    title: "Pracht TSRX Example",
+  };
+}

--- a/examples/tsrx/vite.config.ts
+++ b/examples/tsrx/vite.config.ts
@@ -1,10 +1,14 @@
 import { defineConfig } from "vite";
 import { pracht } from "@pracht/vite-plugin";
+import { tsrxPreact } from "@tsrx/vite-plugin-preact";
 
 export default defineConfig(async () => {
   const { nodeAdapter } = await import("@pracht/adapter-node");
 
   return {
-    plugins: [pracht({ tsrx: true, adapter: nodeAdapter() })],
+    // `tsrxPreact()` is `enforce: "pre"`, so it compiles `.tsrx` modules before
+    // the pracht pipeline sees them. Pracht's route/shell globs and server-only
+    // export stripping both recognise `.tsrx` automatically.
+    plugins: [tsrxPreact(), pracht({ adapter: nodeAdapter() })],
   };
 });

--- a/examples/tsrx/vite.config.ts
+++ b/examples/tsrx/vite.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from "vite";
+import { pracht } from "@pracht/vite-plugin";
+
+export default defineConfig(async () => {
+  const { nodeAdapter } = await import("@pracht/adapter-node");
+
+  return {
+    plugins: [pracht({ tsrx: true, adapter: nodeAdapter() })],
+  };
+});

--- a/packages/cli/src/project.ts
+++ b/packages/cli/src/project.ts
@@ -128,7 +128,7 @@ export function listFilesRecursively(dir: string): string[] {
 }
 
 export function hasPagesAppShell(filePath: string): boolean {
-  return /^_app\.(ts|tsx|js|jsx)$/.test(basename(filePath));
+  return /^_app\.(ts|tsx|tsrx|js|jsx)$/.test(basename(filePath));
 }
 
 function findConfigFile(root: string): string | null {

--- a/packages/cli/src/verification-helpers.ts
+++ b/packages/cli/src/verification-helpers.ts
@@ -9,8 +9,8 @@ export const CONFIG_FILE_NAMES = new Set([
   "vite.config.cts",
 ]);
 
-export const MODULE_SOURCE_RE = /\.(ts|tsx|js|jsx)$/;
-export const PAGE_SOURCE_RE = /\.(ts|tsx|js|jsx|md|mdx)$/;
+export const MODULE_SOURCE_RE = /\.(ts|tsx|tsrx|js|jsx)$/;
+export const PAGE_SOURCE_RE = /\.(ts|tsx|tsrx|js|jsx|md|mdx)$/;
 
 export interface Check {
   message: string;

--- a/packages/cli/src/verification-pages.ts
+++ b/packages/cli/src/verification-pages.ts
@@ -22,7 +22,7 @@ export function scanPagesDirectory(pagesDir: string): PagesFile[] {
 
 export function describePagesFile(pagesDir: string, file: string): PagesFile {
   const relativePath = relative(pagesDir, file).replace(/\\/g, "/");
-  const routePath = relativePath.replace(/\.(tsx?|jsx?|mdx?)$/, "");
+  const routePath = relativePath.replace(/\.(tsx?|tsrx|jsx?|mdx?)$/, "");
   const name = basename(routePath);
 
   if (hasPagesAppShell(file)) {

--- a/packages/vite-plugin/README.md
+++ b/packages/vite-plugin/README.md
@@ -29,37 +29,29 @@ export default defineConfig({
 
 ## TSRX (`.tsrx`) Support
 
-`.tsrx` modules — TSRX/Ripple-flavoured Preact components — are supported via
-[`@tsrx/vite-plugin-preact`](https://github.com/Ripple-TS/ripple). Install the
-plugin alongside `@pracht/vite-plugin` and opt in:
-
-```bash
-npm install -D @tsrx/vite-plugin-preact
-```
+`.tsrx` modules — TSRX/Ripple-flavoured Preact components — are supported out
+of the box. Bring your own
+[`@tsrx/vite-plugin-preact`](https://github.com/Ripple-TS/ripple) and add it to
+your `plugins` array alongside `pracht()`:
 
 ```ts
 // vite.config.ts
 import { defineConfig } from "vite";
 import { pracht } from "@pracht/vite-plugin";
+import { tsrxPreact } from "@tsrx/vite-plugin-preact";
 
 export default defineConfig({
-  plugins: [pracht({ tsrx: true })],
+  plugins: [tsrxPreact(), pracht()],
 });
 ```
 
-You can also pass options forwarded to the underlying `tsrxPreact()` plugin:
-
-```ts
-pracht({ tsrx: { jsxImportSource: "preact", suspenseSource: "preact-suspense" } });
-```
-
-Routes and shells written as `.tsrx` files are auto-discovered exactly like
-`.tsx` files (both manifest- and pages-router modes).
+The pracht plugin globs `.tsrx` files alongside `.tsx` for routes and shells
+(both manifest- and pages-router modes), and its server-only export stripping
+pass treats them the same way — no separate pracht option is required.
 
 ## Peer Dependencies
 
 - `vite@^8.0.0`
-- `@tsrx/vite-plugin-preact@^0.0.3` (optional, only required when `tsrx: true`)
 
 Target-specific Vite plugins (e.g. `@cloudflare/vite-plugin`) are pulled in by
 the adapter package you install (`@pracht/adapter-cloudflare`,

--- a/packages/vite-plugin/README.md
+++ b/packages/vite-plugin/README.md
@@ -27,9 +27,39 @@ export default defineConfig({
 - Pre-renders SSG and ISG routes at build time (`prerenderConcurrency` controls parallelism)
 - Provides HMR during development
 
+## TSRX (`.tsrx`) Support
+
+`.tsrx` modules — TSRX/Ripple-flavoured Preact components — are supported via
+[`@tsrx/vite-plugin-preact`](https://github.com/Ripple-TS/ripple). Install the
+plugin alongside `@pracht/vite-plugin` and opt in:
+
+```bash
+npm install -D @tsrx/vite-plugin-preact
+```
+
+```ts
+// vite.config.ts
+import { defineConfig } from "vite";
+import { pracht } from "@pracht/vite-plugin";
+
+export default defineConfig({
+  plugins: [pracht({ tsrx: true })],
+});
+```
+
+You can also pass options forwarded to the underlying `tsrxPreact()` plugin:
+
+```ts
+pracht({ tsrx: { jsxImportSource: "preact", suspenseSource: "preact-suspense" } });
+```
+
+Routes and shells written as `.tsrx` files are auto-discovered exactly like
+`.tsx` files (both manifest- and pages-router modes).
+
 ## Peer Dependencies
 
 - `vite@^8.0.0`
+- `@tsrx/vite-plugin-preact@^0.0.3` (optional, only required when `tsrx: true`)
 
 Target-specific Vite plugins (e.g. `@cloudflare/vite-plugin`) are pulled in by
 the adapter package you install (`@pracht/adapter-cloudflare`,

--- a/packages/vite-plugin/package.json
+++ b/packages/vite-plugin/package.json
@@ -39,6 +39,12 @@
     "@prefresh/vite": "^2.0.0"
   },
   "peerDependencies": {
+    "@tsrx/vite-plugin-preact": "^0.0.3",
     "vite": "^8.0.0"
+  },
+  "peerDependenciesMeta": {
+    "@tsrx/vite-plugin-preact": {
+      "optional": true
+    }
   }
 }

--- a/packages/vite-plugin/package.json
+++ b/packages/vite-plugin/package.json
@@ -39,12 +39,6 @@
     "@prefresh/vite": "^2.0.0"
   },
   "peerDependencies": {
-    "@tsrx/vite-plugin-preact": "^0.0.3",
     "vite": "^8.0.0"
-  },
-  "peerDependenciesMeta": {
-    "@tsrx/vite-plugin-preact": {
-      "optional": true
-    }
   }
 }

--- a/packages/vite-plugin/src/client-module-query.ts
+++ b/packages/vite-plugin/src/client-module-query.ts
@@ -30,6 +30,10 @@ export function stripPrachtClientModuleQuery(id: string): string {
 export function getRolldownLang(id: string): RolldownLang {
   const path = stripPrachtClientModuleQuery(id).split("?")[0];
   if (/\.(c|m)?tsx$/i.test(path)) return "tsx";
+  // `.tsrx` files are pre-compiled by `@tsrx/vite-plugin-preact` to plain JS
+  // (with JSX runtime calls) before pracht's post transform runs. Parse as
+  // `tsx` since the parser is permissive enough to accept plain JS.
+  if (/\.tsrx$/i.test(path)) return "tsx";
   if (/\.(c|m)?ts$/i.test(path)) return "ts";
   if (/\.(c|m)?jsx$/i.test(path)) return "jsx";
   if (/\.mdx?$/i.test(path)) return "jsx";

--- a/packages/vite-plugin/src/index.ts
+++ b/packages/vite-plugin/src/index.ts
@@ -3,6 +3,7 @@ import { resolve } from "node:path";
 import type { Plugin } from "vite";
 import {
   isPrachtClientModuleId,
+  stripPrachtClientModuleQuery,
   stripServerOnlyExportsForClient,
 } from "./client-module-transform.ts";
 
@@ -23,11 +24,12 @@ import {
   resolveOptions,
   type PrachtPluginOptions,
   type ResolvedPrachtPluginOptions,
+  type TsrxOptions,
 } from "./plugin-options.ts";
 
 export type { RenderMode };
 export type { PrachtAdapter } from "./plugin-adapter.ts";
-export type { PrachtPluginOptions };
+export type { PrachtPluginOptions, TsrxOptions } from "./plugin-options.ts";
 export {
   createPrachtClientModuleSource,
   createPrachtServerModuleSource,
@@ -179,12 +181,55 @@ export async function pracht(options: PrachtPluginOptions = {}): Promise<Plugin[
 
   const plugins: Plugin[] = [...preact(), prachtPlugin, clientModuleTransformPlugin];
 
+  const tsrxPlugin = await loadTsrxPlugin(resolved.tsrx);
+  if (tsrxPlugin) {
+    plugins.unshift(tsrxPlugin);
+  }
+
   const adapterPlugins = await resolved.adapter.vitePlugins?.();
   if (adapterPlugins?.length) {
     plugins.push(...adapterPlugins);
   }
 
   return plugins;
+}
+
+async function loadTsrxPlugin(tsrx: false | TsrxOptions): Promise<Plugin | null> {
+  if (!tsrx) return null;
+
+  let mod: typeof import("@tsrx/vite-plugin-preact");
+  try {
+    mod = await import("@tsrx/vite-plugin-preact");
+  } catch (error) {
+    throw new Error(
+      "[pracht] `tsrx` is enabled but `@tsrx/vite-plugin-preact` could not be loaded. " +
+        "Install it with `pnpm add -D @tsrx/vite-plugin-preact` (or your package manager equivalent).",
+      { cause: error },
+    );
+  }
+
+  const plugin = mod.tsrxPreact(tsrx);
+
+  // The upstream plugin only matches `/\.tsrx$/`, so it skips ids carrying our
+  // `?pracht-client` query suffix. Wrap `transform` to delegate with the bare
+  // path so the same compilation runs for the client variant of route modules.
+  type TransformFn = (this: unknown, code: string, id: string, options?: unknown) => unknown;
+  const upstreamTransform = plugin.transform as TransformFn | undefined;
+  if (typeof upstreamTransform === "function") {
+    const wrappedTransform: TransformFn = function (this, code, id, options) {
+      if (isPrachtClientModuleId(id)) {
+        const stripped = stripPrachtClientModuleQuery(id);
+        const path = stripped.split("?")[0];
+        if (path.endsWith(".tsrx")) {
+          return upstreamTransform.call(this, code, stripped, options);
+        }
+      }
+      return upstreamTransform.call(this, code, id, options);
+    };
+    (plugin as { transform: TransformFn }).transform = wrappedTransform;
+  }
+
+  return plugin;
 }
 
 function watchPagesDirectory(
@@ -214,7 +259,7 @@ function invalidateVirtualModules(server: import("vite").ViteDevServer): void {
   if (serverMod) server.moduleGraph.invalidateModule(serverMod);
 }
 
-const ROUTE_FILE_EXTENSIONS = new Set([".ts", ".tsx", ".js", ".jsx", ".md", ".mdx"]);
+const ROUTE_FILE_EXTENSIONS = new Set([".ts", ".tsx", ".js", ".jsx", ".md", ".mdx", ".tsrx"]);
 
 function computeRouteFileDirs(root: string, resolved: ResolvedPrachtPluginOptions): string[] {
   const dirs = resolved.pagesDir ? [resolved.pagesDir] : [resolved.routesDir, resolved.shellsDir];

--- a/packages/vite-plugin/src/index.ts
+++ b/packages/vite-plugin/src/index.ts
@@ -3,7 +3,6 @@ import { resolve } from "node:path";
 import type { Plugin } from "vite";
 import {
   isPrachtClientModuleId,
-  stripPrachtClientModuleQuery,
   stripServerOnlyExportsForClient,
 } from "./client-module-transform.ts";
 
@@ -24,12 +23,11 @@ import {
   resolveOptions,
   type PrachtPluginOptions,
   type ResolvedPrachtPluginOptions,
-  type TsrxOptions,
 } from "./plugin-options.ts";
 
 export type { RenderMode };
 export type { PrachtAdapter } from "./plugin-adapter.ts";
-export type { PrachtPluginOptions, TsrxOptions } from "./plugin-options.ts";
+export type { PrachtPluginOptions } from "./plugin-options.ts";
 export {
   createPrachtClientModuleSource,
   createPrachtServerModuleSource,
@@ -181,55 +179,12 @@ export async function pracht(options: PrachtPluginOptions = {}): Promise<Plugin[
 
   const plugins: Plugin[] = [...preact(), prachtPlugin, clientModuleTransformPlugin];
 
-  const tsrxPlugin = await loadTsrxPlugin(resolved.tsrx);
-  if (tsrxPlugin) {
-    plugins.unshift(tsrxPlugin);
-  }
-
   const adapterPlugins = await resolved.adapter.vitePlugins?.();
   if (adapterPlugins?.length) {
     plugins.push(...adapterPlugins);
   }
 
   return plugins;
-}
-
-async function loadTsrxPlugin(tsrx: false | TsrxOptions): Promise<Plugin | null> {
-  if (!tsrx) return null;
-
-  let mod: typeof import("@tsrx/vite-plugin-preact");
-  try {
-    mod = await import("@tsrx/vite-plugin-preact");
-  } catch (error) {
-    throw new Error(
-      "[pracht] `tsrx` is enabled but `@tsrx/vite-plugin-preact` could not be loaded. " +
-        "Install it with `pnpm add -D @tsrx/vite-plugin-preact` (or your package manager equivalent).",
-      { cause: error },
-    );
-  }
-
-  const plugin = mod.tsrxPreact(tsrx);
-
-  // The upstream plugin only matches `/\.tsrx$/`, so it skips ids carrying our
-  // `?pracht-client` query suffix. Wrap `transform` to delegate with the bare
-  // path so the same compilation runs for the client variant of route modules.
-  type TransformFn = (this: unknown, code: string, id: string, options?: unknown) => unknown;
-  const upstreamTransform = plugin.transform as TransformFn | undefined;
-  if (typeof upstreamTransform === "function") {
-    const wrappedTransform: TransformFn = function (this, code, id, options) {
-      if (isPrachtClientModuleId(id)) {
-        const stripped = stripPrachtClientModuleQuery(id);
-        const path = stripped.split("?")[0];
-        if (path.endsWith(".tsrx")) {
-          return upstreamTransform.call(this, code, stripped, options);
-        }
-      }
-      return upstreamTransform.call(this, code, id, options);
-    };
-    (plugin as { transform: TransformFn }).transform = wrappedTransform;
-  }
-
-  return plugin;
 }
 
 function watchPagesDirectory(

--- a/packages/vite-plugin/src/pages-router.ts
+++ b/packages/vite-plugin/src/pages-router.ts
@@ -16,8 +16,8 @@ export interface PagesRouterOptions {
   pagesDefaultRender?: string;
 }
 
-const PAGE_EXTENSIONS = new Set([".tsx", ".ts", ".jsx", ".js", ".md", ".mdx"]);
-const SHELL_EXTENSIONS = new Set([".tsx", ".ts", ".jsx", ".js"]);
+const PAGE_EXTENSIONS = new Set([".tsx", ".tsrx", ".ts", ".jsx", ".js", ".md", ".mdx"]);
+const SHELL_EXTENSIONS = new Set([".tsx", ".tsrx", ".ts", ".jsx", ".js"]);
 
 export function scanPagesDirectory(pagesDir: string): ScannedPage[] {
   const pages: ScannedPage[] = [];
@@ -68,7 +68,7 @@ function scan(dir: string, root: string, pages: ScannedPage[]): void {
 }
 
 export function filePathToRoutePath(relativePath: string): string {
-  let route = relativePath.replace(/\.(tsx?|jsx?|mdx?)$/, "");
+  let route = relativePath.replace(/\.(tsx?|tsrx|jsx?|mdx?)$/, "");
   route = route.replace(/\\/g, "/");
 
   // _app is not a route

--- a/packages/vite-plugin/src/plugin-codegen.ts
+++ b/packages/vite-plugin/src/plugin-codegen.ts
@@ -19,20 +19,34 @@ export function createPrachtClientModuleSource(
     ? generatePagesAppInlineSource(resolved, buildOptions.root)
     : `import { app } from ${JSON.stringify(resolved.appFile)};`;
 
-  const routeGlob = isPagesMode
-    ? `${resolved.pagesDir}/**/*.{ts,tsx,tsrx,js,jsx,md,mdx}`
-    : `${resolved.routesDir}/**/*.{ts,tsx,tsrx,js,jsx,md,mdx}`;
+  // Main route/shell globs. `.tsrx` is globbed separately *without* the
+  // `?pracht-client` query suffix — the upstream `@tsrx/vite-plugin-preact`
+  // plugin only matches ids by bare `.tsrx` extension, and the server-only
+  // export stripping pass already catches these files via the route/shell
+  // directory check during client builds.
+  const dirPrefix = isPagesMode ? resolved.pagesDir : resolved.routesDir;
+  const routeGlob = `${dirPrefix}/**/*.{ts,tsx,js,jsx,md,mdx}`;
+  const routeTsrxGlob = `${dirPrefix}/**/*.tsrx`;
 
   const shellGlob = isPagesMode
-    ? `${resolved.pagesDir}/**/_app.{ts,tsx,tsrx,js,jsx}`
-    : `${resolved.shellsDir}/**/*.{ts,tsx,tsrx,js,jsx,md,mdx}`;
+    ? `${resolved.pagesDir}/**/_app.{ts,tsx,js,jsx}`
+    : `${resolved.shellsDir}/**/*.{ts,tsx,js,jsx,md,mdx}`;
+  const shellTsrxGlob = isPagesMode
+    ? `${resolved.pagesDir}/**/_app.tsrx`
+    : `${resolved.shellsDir}/**/*.tsrx`;
 
   return [
     'import { resolveApp, initClientRouter, readHydrationState } from "@pracht/core";',
     appImport,
     "",
-    `const routeModules = import.meta.glob(${JSON.stringify(routeGlob)}, { query: ${JSON.stringify(PRACHT_CLIENT_MODULE_QUERY)} });`,
-    `const shellModules = import.meta.glob(${JSON.stringify(shellGlob)}, { query: ${JSON.stringify(PRACHT_CLIENT_MODULE_QUERY)} });`,
+    `const routeModules = {`,
+    `  ...import.meta.glob(${JSON.stringify(routeGlob)}, { query: ${JSON.stringify(PRACHT_CLIENT_MODULE_QUERY)} }),`,
+    `  ...import.meta.glob(${JSON.stringify(routeTsrxGlob)}),`,
+    `};`,
+    `const shellModules = {`,
+    `  ...import.meta.glob(${JSON.stringify(shellGlob)}, { query: ${JSON.stringify(PRACHT_CLIENT_MODULE_QUERY)} }),`,
+    `  ...import.meta.glob(${JSON.stringify(shellTsrxGlob)}),`,
+    `};`,
     "",
     "const resolvedApp = resolveApp(app);",
     "",

--- a/packages/vite-plugin/src/plugin-codegen.ts
+++ b/packages/vite-plugin/src/plugin-codegen.ts
@@ -20,12 +20,12 @@ export function createPrachtClientModuleSource(
     : `import { app } from ${JSON.stringify(resolved.appFile)};`;
 
   const routeGlob = isPagesMode
-    ? `${resolved.pagesDir}/**/*.{ts,tsx,js,jsx,md,mdx}`
-    : `${resolved.routesDir}/**/*.{ts,tsx,js,jsx,md,mdx}`;
+    ? `${resolved.pagesDir}/**/*.{ts,tsx,tsrx,js,jsx,md,mdx}`
+    : `${resolved.routesDir}/**/*.{ts,tsx,tsrx,js,jsx,md,mdx}`;
 
   const shellGlob = isPagesMode
-    ? `${resolved.pagesDir}/**/_app.{ts,tsx,js,jsx}`
-    : `${resolved.shellsDir}/**/*.{ts,tsx,js,jsx,md,mdx}`;
+    ? `${resolved.pagesDir}/**/_app.{ts,tsx,tsrx,js,jsx}`
+    : `${resolved.shellsDir}/**/*.{ts,tsx,tsrx,js,jsx,md,mdx}`;
 
   return [
     'import { resolveApp, initClientRouter, readHydrationState } from "@pracht/core";',
@@ -135,12 +135,12 @@ export function createPrachtRegistryModuleSource(options: PrachtPluginOptions = 
   const isPagesMode = !!resolved.pagesDir;
 
   const routeGlob = isPagesMode
-    ? `${resolved.pagesDir}/**/*.{ts,tsx,js,jsx,md,mdx}`
-    : `${resolved.routesDir}/**/*.{ts,tsx,js,jsx,md,mdx}`;
+    ? `${resolved.pagesDir}/**/*.{ts,tsx,tsrx,js,jsx,md,mdx}`
+    : `${resolved.routesDir}/**/*.{ts,tsx,tsrx,js,jsx,md,mdx}`;
 
   const shellGlob = isPagesMode
-    ? `${resolved.pagesDir}/**/_app.{ts,tsx,js,jsx}`
-    : `${resolved.shellsDir}/**/*.{ts,tsx,js,jsx,md,mdx}`;
+    ? `${resolved.pagesDir}/**/_app.{ts,tsx,tsrx,js,jsx}`
+    : `${resolved.shellsDir}/**/*.{ts,tsx,tsrx,js,jsx,md,mdx}`;
 
   return [
     `export const routeModules = import.meta.glob(${JSON.stringify(routeGlob)});`,

--- a/packages/vite-plugin/src/plugin-options.ts
+++ b/packages/vite-plugin/src/plugin-options.ts
@@ -1,11 +1,6 @@
 import type { RenderMode } from "@pracht/core";
 import { createDefaultNodeAdapter, type PrachtAdapter } from "./plugin-adapter.ts";
 
-export interface TsrxOptions {
-  jsxImportSource?: string;
-  suspenseSource?: string;
-}
-
 export interface PrachtPluginOptions {
   appFile?: string;
   routesDir?: string;
@@ -20,17 +15,9 @@ export interface PrachtPluginOptions {
   pagesDefaultRender?: RenderMode;
   /** Maximum number of SSG/ISG pages rendered concurrently during `pracht build`. */
   prerenderConcurrency?: number;
-  /**
-   * Enable `.tsrx` (TSRX/Ripple-flavoured Preact) modules. Set to `true` to use defaults,
-   * or pass an options object forwarded to `@tsrx/vite-plugin-preact`. Requires the
-   * `@tsrx/vite-plugin-preact` package to be installed.
-   */
-  tsrx?: boolean | TsrxOptions;
 }
 
-export type ResolvedPrachtPluginOptions = Required<Omit<PrachtPluginOptions, "tsrx">> & {
-  tsrx: false | TsrxOptions;
-};
+export type ResolvedPrachtPluginOptions = Required<PrachtPluginOptions>;
 
 const DEFAULTS: ResolvedPrachtPluginOptions = {
   appFile: "/src/routes.ts",
@@ -43,21 +30,12 @@ const DEFAULTS: ResolvedPrachtPluginOptions = {
   pagesDir: "",
   pagesDefaultRender: "ssr",
   prerenderConcurrency: 10,
-  tsrx: false,
 };
 
 export function resolveOptions(options: PrachtPluginOptions): ResolvedPrachtPluginOptions {
-  const tsrx: false | TsrxOptions =
-    options.tsrx === true
-      ? {}
-      : options.tsrx === false || options.tsrx == null
-        ? false
-        : options.tsrx;
-
   const resolved = {
     ...DEFAULTS,
     ...options,
-    tsrx,
   };
   if (!Number.isInteger(resolved.prerenderConcurrency) || resolved.prerenderConcurrency <= 0) {
     throw new Error("pracht({ prerenderConcurrency }) expects a positive integer.");

--- a/packages/vite-plugin/src/plugin-options.ts
+++ b/packages/vite-plugin/src/plugin-options.ts
@@ -1,6 +1,11 @@
 import type { RenderMode } from "@pracht/core";
 import { createDefaultNodeAdapter, type PrachtAdapter } from "./plugin-adapter.ts";
 
+export interface TsrxOptions {
+  jsxImportSource?: string;
+  suspenseSource?: string;
+}
+
 export interface PrachtPluginOptions {
   appFile?: string;
   routesDir?: string;
@@ -15,9 +20,17 @@ export interface PrachtPluginOptions {
   pagesDefaultRender?: RenderMode;
   /** Maximum number of SSG/ISG pages rendered concurrently during `pracht build`. */
   prerenderConcurrency?: number;
+  /**
+   * Enable `.tsrx` (TSRX/Ripple-flavoured Preact) modules. Set to `true` to use defaults,
+   * or pass an options object forwarded to `@tsrx/vite-plugin-preact`. Requires the
+   * `@tsrx/vite-plugin-preact` package to be installed.
+   */
+  tsrx?: boolean | TsrxOptions;
 }
 
-export type ResolvedPrachtPluginOptions = Required<PrachtPluginOptions>;
+export type ResolvedPrachtPluginOptions = Required<Omit<PrachtPluginOptions, "tsrx">> & {
+  tsrx: false | TsrxOptions;
+};
 
 const DEFAULTS: ResolvedPrachtPluginOptions = {
   appFile: "/src/routes.ts",
@@ -30,12 +43,21 @@ const DEFAULTS: ResolvedPrachtPluginOptions = {
   pagesDir: "",
   pagesDefaultRender: "ssr",
   prerenderConcurrency: 10,
+  tsrx: false,
 };
 
 export function resolveOptions(options: PrachtPluginOptions): ResolvedPrachtPluginOptions {
+  const tsrx: false | TsrxOptions =
+    options.tsrx === true
+      ? {}
+      : options.tsrx === false || options.tsrx == null
+        ? false
+        : options.tsrx;
+
   const resolved = {
     ...DEFAULTS,
     ...options,
+    tsrx,
   };
   if (!Number.isInteger(resolved.prerenderConcurrency) || resolved.prerenderConcurrency <= 0) {
     throw new Error("pracht({ prerenderConcurrency }) expects a positive integer.");

--- a/packages/vite-plugin/test/pages-router.test.ts
+++ b/packages/vite-plugin/test/pages-router.test.ts
@@ -68,7 +68,7 @@ describe("createPrachtRegistryModuleSource", () => {
       pagesDir: "/src/pages",
     });
 
-    expect(source).toContain("/src/pages/**/*.{ts,tsx,js,jsx,md,mdx}");
+    expect(source).toContain("/src/pages/**/*.{ts,tsx,tsrx,js,jsx,md,mdx}");
     expect(source).toContain("/src/api/**/*.{ts,js,tsx,jsx}");
     expect(source).toContain("/src/server/**/*.{ts,js,tsx,jsx}");
     expect(source).toContain("/src/middleware/**/*.{ts,tsx,js,jsx}");

--- a/packages/vite-plugin/virtual.d.ts
+++ b/packages/vite-plugin/virtual.d.ts
@@ -4,3 +4,11 @@ declare module "virtual:pracht/server" {
 }
 
 declare module "virtual:pracht/client" {}
+
+// `.tsrx` modules are compiled by `@tsrx/vite-plugin-preact`. Declare an
+// ambient module so apps can `import` them without a typed source — TypeScript
+// has no built-in support for the `.tsrx` extension.
+declare module "*.tsrx" {
+  const mod: Record<string, unknown>;
+  export = mod;
+}

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -9,7 +9,7 @@ export default defineConfig({
     {
       name: "basic",
       testMatch:
-        /basic\.test\.ts|node-build\.test\.ts|cloudflare-build\.test\.ts|vercel-build\.test\.ts|client-bundle-strip\.test\.ts/,
+        /basic\.test\.ts|node-build\.test\.ts|cloudflare-build\.test\.ts|vercel-build\.test\.ts|client-bundle-strip\.test\.ts|tsrx-build\.test\.ts/,
       use: {
         baseURL: "http://localhost:3100",
       },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -283,9 +283,6 @@ importers:
       '@prefresh/vite':
         specifier: ^2.0.0
         version: 2.4.12(preact@10.29.1)(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@22.19.17)(esbuild@0.27.3))
-      '@tsrx/vite-plugin-preact':
-        specifier: ^0.0.3
-        version: 0.0.3(preact@10.29.1)(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@22.19.17)(esbuild@0.27.3))
       vite:
         specifier: ^8.0.0
         version: 8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@22.19.17)(esbuild@0.27.3)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -191,6 +191,34 @@ importers:
         specifier: ^8.0.0
         version: 8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@22.19.17)(esbuild@0.27.3)
 
+  examples/tsrx:
+    dependencies:
+      '@pracht/adapter-node':
+        specifier: workspace:*
+        version: link:../../packages/adapter-node
+      '@pracht/core':
+        specifier: workspace:*
+        version: link:../../packages/framework
+    devDependencies:
+      '@pracht/cli':
+        specifier: workspace:*
+        version: link:../../packages/cli
+      '@pracht/vite-plugin':
+        specifier: workspace:*
+        version: link:../../packages/vite-plugin
+      '@tsrx/vite-plugin-preact':
+        specifier: ^0.0.3
+        version: 0.0.3(preact@10.29.1)(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@22.19.17)(esbuild@0.27.3))
+      preact:
+        specifier: ^10.26.9
+        version: 10.29.1
+      preact-render-to-string:
+        specifier: ^6.5.13
+        version: 6.6.7(preact@10.29.1)
+      vite:
+        specifier: ^8.0.0
+        version: 8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@22.19.17)(esbuild@0.27.3)
+
   packages/adapter-cloudflare:
     dependencies:
       '@cloudflare/vite-plugin':
@@ -255,6 +283,9 @@ importers:
       '@prefresh/vite':
         specifier: ^2.0.0
         version: 2.4.12(preact@10.29.1)(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@22.19.17)(esbuild@0.27.3))
+      '@tsrx/vite-plugin-preact':
+        specifier: ^0.0.3
+        version: 0.0.3(preact@10.29.1)(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@22.19.17)(esbuild@0.27.3))
       vite:
         specifier: ^8.0.0
         version: 8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@22.19.17)(esbuild@0.27.3)
@@ -1601,6 +1632,11 @@ packages:
   '@speed-highlight/core@1.2.15':
     resolution: {integrity: sha512-BMq1K3DsElxDWawkX6eLg9+CKJrTVGCBAWVuHXVUV2u0s2711qiChLSId6ikYPfxhdYocLNt3wWwSvDiTvFabw==}
 
+  '@sveltejs/acorn-typescript@1.0.9':
+    resolution: {integrity: sha512-lVJX6qEgs/4DOcRTpo56tmKzVPtoWAaVbL4hfO7t7NVwl9AAXzQR6cihesW1BmNMPl+bK6dreu2sOKBP2Q9CIA==}
+    peerDependencies:
+      acorn: ^8.9.0
+
   '@tabler/icons-preact@3.41.1':
     resolution: {integrity: sha512-H27Fzpk3lgj/AC4waJ/YGFPrvrR5MXeLbPhl23V6GWWC8uJ27rU7DVVVNI6hFoKVjpl+KlkmH2SUPissy5LJ+w==}
     peerDependencies:
@@ -1608,6 +1644,19 @@ packages:
 
   '@tabler/icons@3.41.1':
     resolution: {integrity: sha512-OaRnVbRmH2nHtFeg+RmMJ/7m2oBIF9XCJAUD5gQnMrpK9f05ydj8MZrAf3NZQqOXyxGN1UBL0D5IKLLEUfr74Q==}
+
+  '@tsrx/core@0.0.8':
+    resolution: {integrity: sha512-QDgfWmjiDpFV8YJU2LQracvO9bTWQcLrvhPf5/i5NrpksO+XOXt+uZUY+l4GUce8lyu2Q1Llqz65EMzAzXLbVA==}
+
+  '@tsrx/preact@0.0.3':
+    resolution: {integrity: sha512-OgbypbFLbLm/WJwSaRyUgR3Ew/qJGKhwzru9YHu8lj1DZNUf/NNiboiWlmfOahrg/r8MijSnUQKJH0Ubw3IeSg==}
+    peerDependencies:
+      preact: '>=10'
+
+  '@tsrx/vite-plugin-preact@0.0.3':
+    resolution: {integrity: sha512-0b0FEAema2TqmgguF/foiv/1jsMpiajylyK7seq9q3QLf+4evepupR0eDtD+xQV9Zt/rJ5A3g50qbCiSVaW6zg==}
+    peerDependencies:
+      vite: '*'
 
   '@tybys/wasm-util@0.10.1':
     resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
@@ -1617,6 +1666,9 @@ packages:
 
   '@types/deep-eql@4.0.2':
     resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
+
+  '@types/estree-jsx@1.0.5':
+    resolution: {integrity: sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==}
 
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
@@ -1658,6 +1710,11 @@ packages:
 
   '@vitest/utils@3.2.4':
     resolution: {integrity: sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==}
+
+  acorn@8.16.0:
+    resolution: {integrity: sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
 
   ansi-colors@4.1.3:
     resolution: {integrity: sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==}
@@ -1883,6 +1940,14 @@ packages:
     engines: {node: '>=4'}
     hasBin: true
 
+  esrap@2.2.5:
+    resolution: {integrity: sha512-/yLB1538mag+dn0wsePTe8C0rDIjUOaJpMs2McodSzmM2msWcZsBSdRtg6HOBt0A/r82BN+Md3pgwSc/uWt2Ig==}
+    peerDependencies:
+      '@typescript-eslint/types': ^8.2.0
+    peerDependenciesMeta:
+      '@typescript-eslint/types':
+        optional: true
+
   estree-walker@2.0.2:
     resolution: {integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==}
 
@@ -1997,6 +2062,9 @@ packages:
 
   is-potential-custom-element-name@1.0.1:
     resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
+
+  is-reference@3.0.3:
+    resolution: {integrity: sha512-ixkJoqQvAP88E6wLydLGGqCJsrFUnqoH6HnaczB8XmDH1oaWU+xxdptvikTgaEhtZ53Ky6YXiBuUI2WXLMCwjw==}
 
   is-subdir@1.2.0:
     resolution: {integrity: sha512-2AT6j+gXe/1ueqbW6fLZJiIw3F8iXGJtt0yDrZaBhAZEG1raiTxKWU+IPqMCzQAXOUCKdA4UDMgacKH25XG2Cw==}
@@ -3885,12 +3953,47 @@ snapshots:
 
   '@speed-highlight/core@1.2.15': {}
 
+  '@sveltejs/acorn-typescript@1.0.9(acorn@8.16.0)':
+    dependencies:
+      acorn: 8.16.0
+
   '@tabler/icons-preact@3.41.1(preact@10.29.1)':
     dependencies:
       '@tabler/icons': 3.41.1
       preact: 10.29.1
 
   '@tabler/icons@3.41.1': {}
+
+  '@tsrx/core@0.0.8':
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+      '@sveltejs/acorn-typescript': 1.0.9(acorn@8.16.0)
+      '@types/estree': 1.0.8
+      '@types/estree-jsx': 1.0.5
+      acorn: 8.16.0
+      esrap: 2.2.5
+      is-reference: 3.0.3
+      magic-string: 0.30.21
+      zimmerframe: 1.1.4
+    transitivePeerDependencies:
+      - '@typescript-eslint/types'
+
+  '@tsrx/preact@0.0.3(preact@10.29.1)':
+    dependencies:
+      '@tsrx/core': 0.0.8
+      esrap: 2.2.5
+      preact: 10.29.1
+      zimmerframe: 1.1.4
+    transitivePeerDependencies:
+      - '@typescript-eslint/types'
+
+  '@tsrx/vite-plugin-preact@0.0.3(preact@10.29.1)(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@22.19.17)(esbuild@0.27.3))':
+    dependencies:
+      '@tsrx/preact': 0.0.3(preact@10.29.1)
+      vite: 8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@22.19.17)(esbuild@0.27.3)
+    transitivePeerDependencies:
+      - '@typescript-eslint/types'
+      - preact
 
   '@tybys/wasm-util@0.10.1':
     dependencies:
@@ -3903,6 +4006,10 @@ snapshots:
       assertion-error: 2.0.1
 
   '@types/deep-eql@4.0.2': {}
+
+  '@types/estree-jsx@1.0.5':
+    dependencies:
+      '@types/estree': 1.0.8
 
   '@types/estree@1.0.8': {}
 
@@ -3955,6 +4062,8 @@ snapshots:
       '@vitest/pretty-format': 3.2.4
       loupe: 3.2.1
       tinyrainbow: 2.0.0
+
+  acorn@8.16.0: {}
 
   ansi-colors@4.1.3: {}
 
@@ -4187,6 +4296,10 @@ snapshots:
 
   esprima@4.0.1: {}
 
+  esrap@2.2.5:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+
   estree-walker@2.0.2: {}
 
   estree-walker@3.0.3:
@@ -4290,6 +4403,10 @@ snapshots:
   is-number@7.0.0: {}
 
   is-potential-custom-element-name@1.0.1: {}
+
+  is-reference@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.8
 
   is-subdir@1.2.0:
     dependencies:


### PR DESCRIPTION
Adds a `tsrx` option to `pracht()` that loads `@tsrx/vite-plugin-preact`
(a new optional peer dep), wires `.tsrx` into the route/shell discovery
globs, the client-only export-stripping pass, and the pages-router
scanner. A small wrapper around the upstream plugin handles pracht's
`?pracht-client` query suffix so the same compilation runs against the
client variant of route modules.

Includes an `examples/tsrx` app demonstrating a `.tsrx` route with
scoped `<style>` running side-by-side with a regular `.tsx` route.