### PR TITLE
Fix dotted route handling in dev

### DIFF
--- a/.changeset/spicy-donuts-shave.md
+++ b/.changeset/spicy-donuts-shave.md
@@ -1,0 +1,5 @@
+---
+"@pracht/vite-plugin": patch
+---
+
+Fix dev-mode route handling so resolved app routes stay framework-owned even when the path includes dotted segments, asset-like filenames, or `@`-prefixed static handles. Route-state `_data=1` requests now also avoid the static-asset bypass.

--- a/docs/ROUTING.md
+++ b/docs/ROUTING.md
@@ -380,6 +380,11 @@ Routes are sorted: static routes first, then dynamic (`:param`), then catch-all
 - **File add/remove** in pages dir: dev server restarts (new routes need
   new globs)
 
+During `pracht dev`, resolved routes take precedence over filename heuristics.
+That means URLs such as `/blog/release-1.2.3`, `/blog/openapi.json`, and
+`/@alice` still render through the framework when they exist as routes. Only
+Vite's reserved dev-internal paths are bypassed directly.
+
 ### Ejecting to Explicit Manifest
 
 To stop using auto-discovery and customize the manifest directly, use the

--- a/e2e/pages-router.test.ts
+++ b/e2e/pages-router.test.ts
@@ -27,6 +27,14 @@ test("about page renders as static page", async ({ page }) => {
   await expect(page.locator("section p").first()).toContainText("static page rendered with SSG");
 });
 
+test("@-prefixed static routes render in dev", async ({ page }) => {
+  const response = await page.goto("/@alice");
+
+  expect(response?.status()).toBe(200);
+  await expect(page.locator(".pages-shell")).toBeVisible();
+  await expect(page.locator("h1")).toContainText("@alice");
+});
+
 // ---------------------------------------------------------------------------
 // _app.tsx shell wraps all pages
 // ---------------------------------------------------------------------------
@@ -56,6 +64,22 @@ test("dynamic route works with different slugs", async ({ page }) => {
 
   await expect(page.locator("h1")).toContainText("Blog: my first post");
   await expect(page.locator("code")).toContainText("my-first-post");
+});
+
+test("dotted dynamic routes render in dev", async ({ page }) => {
+  const response = await page.goto("/blog/release-1.2.3");
+
+  expect(response?.status()).toBe(200);
+  await expect(page.locator("h1")).toContainText("Blog: release 1.2.3");
+  await expect(page.locator("code")).toContainText("release-1.2.3");
+});
+
+test("asset-looking dynamic routes still render as pages in dev", async ({ page }) => {
+  const response = await page.goto("/blog/openapi.json");
+
+  expect(response?.status()).toBe(200);
+  await expect(page.locator("h1")).toContainText("Blog: openapi.json");
+  await expect(page.locator("code")).toContainText("openapi.json");
 });
 
 // ---------------------------------------------------------------------------
@@ -184,6 +208,19 @@ test("route state request returns JSON for pages", async ({ request }) => {
   expect(response.headers()["x-pracht-router"]).toBeUndefined();
   const json = await response.json();
   expect(json.data.message).toContain("file-system routing");
+});
+
+test("route state _data requests work for dotted slugs in dev", async ({ request }) => {
+  const response = await request.get("/blog/openapi.json?_data=1");
+
+  expect(response.status()).toBe(200);
+  expect(response.headers()["content-type"]).toContain("application/json");
+
+  const json = await response.json();
+  expect(json.data).toMatchObject({
+    slug: "openapi.json",
+    title: "Blog: openapi.json",
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/examples/pages-router/src/pages/@alice.tsx
+++ b/examples/pages-router/src/pages/@alice.tsx
@@ -1,0 +1,10 @@
+export const RENDER_MODE = "ssg";
+
+export default function AliceProfile() {
+  return (
+    <section>
+      <h1>@alice</h1>
+      <p>Static handles that start with @ should stay routable in dev.</p>
+    </section>
+  );
+}

--- a/packages/vite-plugin/src/plugin-dev-ssr.ts
+++ b/packages/vite-plugin/src/plugin-dev-ssr.ts
@@ -1,5 +1,6 @@
 import type { IncomingMessage, ServerResponse } from "node:http";
 import type { Connect, ViteDevServer } from "vite";
+import type { ResolvedApiRoute, ResolvedPrachtApp } from "@pracht/core";
 import { CLIENT_BROWSER_PATH, PRACHT_SERVER_MODULE_ID } from "./plugin-assets.ts";
 
 const BODYLESS_METHODS = new Set(["GET", "HEAD"]);
@@ -12,19 +13,24 @@ export function createDevSSRMiddleware(
   const maxBodySize = options.maxBodySize ?? DEFAULT_MAX_BODY_SIZE;
   return async (req: IncomingMessage, res: ServerResponse, next: Connect.NextFunction) => {
     const url = req.url ?? "/";
-    const pathname = new URL(url, "http://localhost").pathname;
-
-    // Let Vite handle assets by pathname. Query params may contain dotted
-    // domains or tokens, but they should not opt the route out of SSR.
-    if (pathname.includes(".") || pathname.startsWith("/node_modules/")) {
-      return next();
-    }
+    const requestUrl = new URL(url, "http://localhost");
 
     try {
       const [framework, serverMod] = await Promise.all([
         server.ssrLoadModule("@pracht/core"),
         server.ssrLoadModule(PRACHT_SERVER_MODULE_ID),
       ]);
+
+      if (
+        shouldBypassDevSSR(requestUrl, req, {
+          app: serverMod.resolvedApp,
+          apiRoutes: serverMod.apiRoutes,
+          matchApiRoute: framework.matchApiRoute,
+          matchAppRoute: framework.matchAppRoute,
+        })
+      ) {
+        return next();
+      }
 
       let webRequest: Request;
       try {
@@ -110,6 +116,161 @@ async function handleDevError(
     next(error);
   }
 }
+
+export function shouldBypassDevSSR(
+  requestUrl: URL | string,
+  req: Pick<IncomingMessage, "headers" | "method">,
+  options: {
+    app?: ResolvedPrachtApp;
+    apiRoutes?: ResolvedApiRoute[];
+    matchApiRoute?: (routes: ResolvedApiRoute[], pathname: string) => unknown;
+    matchAppRoute?: (app: ResolvedPrachtApp, pathname: string) => unknown;
+  } = {},
+): boolean {
+  const url =
+    typeof requestUrl === "string" ? new URL(requestUrl, "http://localhost") : requestUrl;
+  const pathname = url.pathname;
+
+  if (isReservedDevPath(pathname)) {
+    return true;
+  }
+
+  if (isRouteStateRequest(url, req)) {
+    return false;
+  }
+
+  const isApiRequest = pathname === "/api" || pathname.startsWith("/api/");
+  if (isApiRequest) {
+    return false;
+  }
+
+  const method = (req.method ?? "GET").toUpperCase();
+  if (method !== "GET" && method !== "HEAD") {
+    return false;
+  }
+
+  const fetchDest = readRequestHeader(req.headers["sec-fetch-dest"]).toLowerCase();
+  const hasRouteMatch = matchesResolvedRoute(pathname, options);
+
+  if (hasRouteMatch && !NON_DOCUMENT_FETCH_DESTINATIONS.has(fetchDest)) {
+    return false;
+  }
+
+  if (NON_DOCUMENT_FETCH_DESTINATIONS.has(fetchDest)) {
+    return true;
+  }
+
+  const accept = readRequestHeader(req.headers.accept).toLowerCase();
+  if (accept.includes("text/html") || accept.includes("application/xhtml+xml")) {
+    return false;
+  }
+
+  return hasKnownAssetExtension(pathname);
+}
+
+function matchesResolvedRoute(
+  pathname: string,
+  options: {
+    app?: ResolvedPrachtApp;
+    apiRoutes?: ResolvedApiRoute[];
+    matchApiRoute?: (routes: ResolvedApiRoute[], pathname: string) => unknown;
+    matchAppRoute?: (app: ResolvedPrachtApp, pathname: string) => unknown;
+  },
+): boolean {
+  if (options.app && options.matchAppRoute && options.matchAppRoute(options.app, pathname)) {
+    return true;
+  }
+
+  if (
+    options.apiRoutes?.length &&
+    options.matchApiRoute &&
+    options.matchApiRoute(options.apiRoutes, pathname)
+  ) {
+    return true;
+  }
+
+  return false;
+}
+
+function isRouteStateRequest(url: URL, req: Pick<IncomingMessage, "headers" | "method">): boolean {
+  return (
+    req.headers["x-pracht-route-state-request"] === "1" || url.searchParams.get("_data") === "1"
+  );
+}
+
+function readRequestHeader(value: string | string[] | undefined): string {
+  if (Array.isArray(value)) {
+    return value.join(", ");
+  }
+
+  return value ?? "";
+}
+
+function hasKnownAssetExtension(pathname: string): boolean {
+  const fileName = pathname.split("/").pop() ?? "";
+  const extensionIndex = fileName.lastIndexOf(".");
+  if (extensionIndex <= 0) {
+    return false;
+  }
+
+  const extension = fileName.slice(extensionIndex).toLowerCase();
+  return DEV_ASSET_EXTENSIONS.has(extension);
+}
+
+function isReservedDevPath(pathname: string): boolean {
+  return (
+    pathname === CLIENT_BROWSER_PATH ||
+    pathname === "/@vite/client" ||
+    pathname === "/@react-refresh" ||
+    pathname.startsWith("/@vite/") ||
+    pathname.startsWith("/@id/") ||
+    pathname.startsWith("/@fs/") ||
+    pathname.startsWith("/__vite_")
+  );
+}
+
+const NON_DOCUMENT_FETCH_DESTINATIONS = new Set([
+  "audio",
+  "embed",
+  "font",
+  "image",
+  "manifest",
+  "object",
+  "paintworklet",
+  "report",
+  "script",
+  "serviceworker",
+  "sharedworker",
+  "style",
+  "track",
+  "video",
+  "worker",
+]);
+
+const DEV_ASSET_EXTENSIONS = new Set([
+  ".avif",
+  ".bmp",
+  ".cjs",
+  ".css",
+  ".gif",
+  ".ico",
+  ".jpeg",
+  ".jpg",
+  ".js",
+  ".json",
+  ".map",
+  ".mjs",
+  ".pdf",
+  ".png",
+  ".svg",
+  ".txt",
+  ".wasm",
+  ".webmanifest",
+  ".webp",
+  ".woff",
+  ".woff2",
+  ".xml",
+]);
 
 async function nodeToWebRequest(req: IncomingMessage, maxBodySize: number): Promise<Request> {
   // Dev server is always a direct connection — never trust forwarded headers.

--- a/packages/vite-plugin/src/plugin-dev-ssr.ts
+++ b/packages/vite-plugin/src/plugin-dev-ssr.ts
@@ -127,8 +127,7 @@ export function shouldBypassDevSSR(
     matchAppRoute?: (app: ResolvedPrachtApp, pathname: string) => unknown;
   } = {},
 ): boolean {
-  const url =
-    typeof requestUrl === "string" ? new URL(requestUrl, "http://localhost") : requestUrl;
+  const url = typeof requestUrl === "string" ? new URL(requestUrl, "http://localhost") : requestUrl;
   const pathname = url.pathname;
 
   if (isReservedDevPath(pathname)) {

--- a/packages/vite-plugin/test/dev-middleware.test.ts
+++ b/packages/vite-plugin/test/dev-middleware.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it } from "vitest";
+
+import { shouldBypassDevSSR } from "../src/plugin-dev-ssr.ts";
+
+const routeMatchers = {
+  app: {} as any,
+  apiRoutes: [] as any[],
+  matchApiRoute: () => undefined,
+  matchAppRoute: (_app: unknown, pathname: string) =>
+    new Set(["/blog/release-1.2.3", "/blog/openapi.json", "/@alice"]).has(pathname)
+      ? ({ pathname } as const)
+      : undefined,
+};
+
+describe("shouldBypassDevSSR", () => {
+  it("keeps dotted document routes inside framework handling", () => {
+    expect(
+      shouldBypassDevSSR(
+        "/blog/release-1.2.3",
+        {
+          headers: { accept: "text/html,application/xhtml+xml" },
+          method: "GET",
+        },
+        routeMatchers,
+      ),
+    ).toBe(false);
+
+    expect(
+      shouldBypassDevSSR(
+        "/blog/openapi.json",
+        {
+          headers: { accept: "text/html,application/xhtml+xml" },
+          method: "GET",
+        },
+        routeMatchers,
+      ),
+    ).toBe(false);
+
+    expect(
+      shouldBypassDevSSR(
+        "/@alice",
+        {
+          headers: { accept: "text/html,application/xhtml+xml" },
+          method: "GET",
+        },
+        routeMatchers,
+      ),
+    ).toBe(false);
+  });
+
+  it("keeps route-state requests inside framework handling even for dotted slugs", () => {
+    expect(
+      shouldBypassDevSSR("/api/health", {
+        headers: { accept: "application/json" },
+        method: "GET",
+      }),
+    ).toBe(false);
+
+    expect(
+      shouldBypassDevSSR(
+        "/blog/openapi.json?_data=1",
+        {
+          headers: { accept: "*/*" },
+          method: "GET",
+        },
+        routeMatchers,
+      ),
+    ).toBe(false);
+
+    expect(
+      shouldBypassDevSSR(
+        "/blog/release-1.2.3",
+        {
+          headers: {
+            accept: "application/json",
+            "x-pracht-route-state-request": "1",
+          },
+          method: "GET",
+        },
+        routeMatchers,
+      ),
+    ).toBe(false);
+  });
+
+  it("bypasses reserved vite internals and explicit asset fetches", () => {
+    expect(
+      shouldBypassDevSSR("/@vite/client", {
+        headers: { accept: "*/*" },
+        method: "GET",
+      }),
+    ).toBe(true);
+
+    expect(
+      shouldBypassDevSSR("/@id/preact", {
+        headers: { accept: "*/*" },
+        method: "GET",
+      }),
+    ).toBe(true);
+
+    expect(
+      shouldBypassDevSSR("/assets/app.js", {
+        headers: { accept: "*/*", "sec-fetch-dest": "script" },
+        method: "GET",
+      }),
+    ).toBe(true);
+
+    expect(
+      shouldBypassDevSSR("/logo.svg", {
+        headers: { accept: "image/avif,image/webp,*/*", "sec-fetch-dest": "image" },
+        method: "GET",
+      }),
+    ).toBe(true);
+  });
+
+  it("still treats unmatched HTML navigations as document requests", () => {
+    expect(
+      shouldBypassDevSSR("/unknown/file.json", {
+        headers: { accept: "text/html,application/xhtml+xml" },
+        method: "GET",
+      }),
+    ).toBe(false);
+
+    expect(
+      shouldBypassDevSSR("/", {
+        headers: { accept: "*/*" },
+        method: "GET",
+      }),
+    ).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

- Fix dev SSR bypass logic so resolved page and API routes, including dotted slugs, asset-like names, and `@`-prefixed pages, stay framework-owned.
- Add coverage for dotted pages-router routes and route-state `_data=1` requests, plus document the dev routing behavior.

## Testing

- [x] `pnpm run e2e`
- [x] `pnpm run format`
- [x] `pnpm run lint`
- [x] `pnpm run test`

## Checklist

- [x] Docs updated if needed
- [x] Skills updated if needed (N/A, no skill changes needed)
- [x] Changeset added if published packages changed
