### PR TITLE
Guard prerendered security headers

### DIFF
--- a/.changeset/prerender-header-guard.md
+++ b/.changeset/prerender-header-guard.md
@@ -1,0 +1,7 @@
+---
+"@pracht/core": patch
+"@pracht/adapter-node": patch
+"create-pracht": patch
+---
+
+Reject dangerous document headers during SSG/ISG prerendering, warn when Node deployments do not configure `canonicalOrigin`, and make create-pracht starters ignore local env files.

--- a/docs/ADAPTERS.md
+++ b/docs/ADAPTERS.md
@@ -100,7 +100,10 @@ createNodeRequestHandler({
 Without `canonicalOrigin`, the Node adapter derives the request URL from the
 socket: protocol is inferred from TLS state, and host from the `Host` header.
 Forwarded headers (`Forwarded`, `X-Forwarded-Proto`, `X-Forwarded-Host`) are
-**ignored** unless `trustProxy: true` is enabled.
+**ignored** unless `trustProxy: true` is enabled. Built Node apps warn when no
+`canonicalOrigin` is configured, because app code that reads `request.url` can
+otherwise inherit attacker-controlled `Host` values in misconfigured
+deployments.
 
 Set `trustProxy: true` when the Node server sits behind a trusted reverse proxy
 (nginx, Cloudflare, a load balancer, etc.) that sets forwarded headers:
@@ -131,7 +134,10 @@ When enabled, header precedence is:
 max-age=31536000, immutable`; HTML and other files get `public, max-age=0,
 must-revalidate`. Clean URLs (e.g. `/about`) resolve to `about/index.html`.
 Prerendered HTML receives route and shell document headers from
-`dist/server/headers-manifest.json`.
+`dist/server/headers-manifest.json`. SSG/ISG prerendering rejects dangerous
+document headers such as `Set-Cookie`, `Authorization`, `Proxy-Authenticate`,
+`WWW-Authenticate`, and secret-shaped custom `x-*` headers before they can enter
+that manifest.
 - **ISG revalidation**: checks `pracht-isg-manifest.json` for time revalidation
   metadata. Compares file mtime against revalidation window. Regenerates stale
   pages and writes updated HTML to disk. Route-state requests (`x-pracht-route-state-request`
@@ -352,6 +358,9 @@ export default {
   section that applies the same baseline security headers to all responses,
   including static assets served by Vercel's CDN. Static prerendered routes also
   get route and shell document headers from the prerender header manifest.
+  SSG/ISG prerendering rejects dangerous document headers such as `Set-Cookie`,
+  `Authorization`, `Proxy-Authenticate`, `WWW-Authenticate`, and secret-shaped
+  custom `x-*` headers before they can enter that manifest.
 
 ### Generated entry options
 

--- a/docs/CSP.md
+++ b/docs/CSP.md
@@ -1,0 +1,91 @@
+# Content Security Policy Recipe
+
+Pracht does not set a Content Security Policy by default because a correct CSP
+depends on each app's script, style, image, font, analytics, and API origins.
+Use route or shell `headers()` exports to add one deliberately.
+
+## Starter Policy
+
+For an app that only loads first-party assets and calls first-party APIs, start
+with:
+
+```ts
+// src/shells/public.tsx
+import type { HeadersArgs } from "@pracht/core";
+
+export function headers(_args: HeadersArgs) {
+  return {
+    "content-security-policy": [
+      "default-src 'self'",
+      "base-uri 'self'",
+      "object-src 'none'",
+      "frame-ancestors 'self'",
+      "form-action 'self'",
+      "script-src 'self'",
+      "style-src 'self'",
+      "img-src 'self' data:",
+      "font-src 'self'",
+      "connect-src 'self'",
+    ].join("; "),
+  };
+}
+```
+
+This allows Pracht's generated module script and same-origin assets while
+blocking plugin/object embeds and cross-origin scripts by default.
+
+## Add Only The Origins You Use
+
+If your app calls an API on another origin or loads assets from a CDN, add those
+origins to the matching directive:
+
+```ts
+export function headers() {
+  return {
+    "content-security-policy": [
+      "default-src 'self'",
+      "script-src 'self'",
+      "style-src 'self'",
+      "img-src 'self' data: https://images.example.com",
+      "font-src 'self' https://fonts.example.com",
+      "connect-src 'self' https://api.example.com",
+      "object-src 'none'",
+      "base-uri 'self'",
+      "frame-ancestors 'self'",
+      "form-action 'self'",
+    ].join("; "),
+  };
+}
+```
+
+Avoid `'unsafe-eval'`. Avoid `'unsafe-inline'` unless an audited dependency or
+legacy integration needs it and the exception is documented.
+
+## Inline Script Entries
+
+Normal Pracht page rendering and hydration do not require executable inline
+scripts from application code. If your route `head()` returns `script` entries
+for JSON-LD or another inline format, test the route with your CSP enabled and
+prefer hashes or a route-specific policy for the exact inline content.
+
+For third-party analytics, prefer loading the script from an explicit origin and
+keep the vendor's collection endpoint in `connect-src`.
+
+## SSG/ISG Header Safety
+
+Document headers for SSG and ISG pages are copied into the prerender header
+manifest so adapters can apply them to static HTML. That manifest is public
+static output for some adapters, so it must only contain public, replay-safe
+headers.
+
+Pracht fails SSG/ISG prerendering when a document response includes dangerous
+headers such as `Set-Cookie`, `Authorization`, `Proxy-Authenticate`,
+`WWW-Authenticate`, or secret-shaped custom `x-*` headers. Set cookies from API
+routes, middleware `Response`s, or SSR-only routes instead.
+
+## Deployment Checklist
+
+- Verify the final CSP in a browser, including client navigation.
+- Check both dynamic HTML and prerendered SSG/ISG HTML.
+- Keep `script-src` and `connect-src` as small as possible.
+- Do not add HSTS preload directives until the domain is permanently HTTPS-only.

--- a/docs/DATA_LOADING.md
+++ b/docs/DATA_LOADING.md
@@ -280,6 +280,16 @@ shell headers with the same name. They apply to HTML document responses,
 including prerendered SSG/ISG HTML, but not API routes or route-state JSON
 fetches.
 
+SSG/ISG document headers are written into the prerender header manifest so
+adapters can replay them for static HTML. Pracht rejects dangerous headers such
+as `Set-Cookie`, `Authorization`, `Proxy-Authenticate`, `WWW-Authenticate`, and
+secret-shaped custom `x-*` headers during SSG/ISG prerendering because those
+values would become public static output or be replayed across visitors. Use API
+routes, middleware `Response`s, or SSR-only routes for cookies and
+authentication headers.
+
+See [docs/CSP.md](CSP.md) for a Content Security Policy recipe.
+
 ---
 
 ## Client Hooks

--- a/examples/docs/src/routes.ts
+++ b/examples/docs/src/routes.ts
@@ -83,6 +83,10 @@ export const app = defineApp({
         id: "recipes-auth",
         render: "ssg",
       }),
+      route("/docs/recipes/csp", () => import("./routes/docs/recipes-csp.md"), {
+        id: "recipes-csp",
+        render: "ssg",
+      }),
       route("/docs/recipes/forms", () => import("./routes/docs/recipes-forms.md"), {
         id: "recipes-forms",
         render: "ssg",

--- a/examples/docs/src/routes/docs/recipes-auth.md
+++ b/examples/docs/src/routes/docs/recipes-auth.md
@@ -6,8 +6,8 @@ prev:
   href: /docs/recipes/i18n
   title: i18n
 next:
-  href: /docs/recipes/forms
-  title: Forms
+  href: /docs/recipes/csp
+  title: Content Security Policy
 ---
 
 ## Architecture

--- a/examples/docs/src/routes/docs/recipes-csp.md
+++ b/examples/docs/src/routes/docs/recipes-csp.md
@@ -1,0 +1,89 @@
+---
+title: Content Security Policy
+lead: Add a focused Content Security Policy with route or shell headers, then verify it against dynamic and prerendered pages.
+breadcrumb: CSP
+prev:
+  href: /docs/recipes/auth
+  title: Authentication
+next:
+  href: /docs/recipes/forms
+  title: Forms
+---
+
+## Starter Policy
+
+For an app that only uses same-origin scripts, styles, images, fonts, and API
+calls, put the policy on the shell that wraps those pages:
+
+```ts [src/shells/public.tsx]
+export function headers() {
+  return {
+    "content-security-policy": [
+      "default-src 'self'",
+      "base-uri 'self'",
+      "object-src 'none'",
+      "frame-ancestors 'self'",
+      "form-action 'self'",
+      "script-src 'self'",
+      "style-src 'self'",
+      "img-src 'self' data:",
+      "font-src 'self'",
+      "connect-src 'self'",
+    ].join("; "),
+  };
+}
+```
+
+This allows Pracht's generated module script and same-origin assets while
+blocking cross-origin script execution and plugin embeds by default.
+
+## Add Origins Deliberately
+
+Only add the external origins your app actually uses:
+
+```ts [src/shells/public.tsx]
+export function headers() {
+  return {
+    "content-security-policy": [
+      "default-src 'self'",
+      "script-src 'self'",
+      "style-src 'self'",
+      "img-src 'self' data: https://images.example.com",
+      "font-src 'self' https://fonts.example.com",
+      "connect-src 'self' https://api.example.com",
+      "object-src 'none'",
+      "base-uri 'self'",
+      "frame-ancestors 'self'",
+      "form-action 'self'",
+    ].join("; "),
+  };
+}
+```
+
+Avoid `'unsafe-eval'`. Avoid `'unsafe-inline'` unless an audited integration
+requires it and the exception is documented.
+
+## Inline Script Entries
+
+Pracht does not require app-authored executable inline scripts for normal page
+rendering. If a route `head()` returns inline `script` entries, such as JSON-LD,
+test that route with the CSP enabled and prefer route-specific hashes for exact
+inline content.
+
+## SSG/ISG Header Safety
+
+Headers for SSG and ISG pages are copied into the prerender header manifest so
+adapters can apply them to static HTML. That manifest is public static output
+for some adapters, so it must only contain public, replay-safe headers.
+
+Pracht fails SSG/ISG prerendering when document headers include dangerous names
+such as `Set-Cookie`, `Authorization`, `Proxy-Authenticate`,
+`WWW-Authenticate`, or secret-shaped custom `x-*` headers. Set cookies from API
+routes, middleware `Response`s, or SSR-only routes instead.
+
+## Verify
+
+- Load an SSR page and an SSG/ISG page in a browser.
+- Navigate client-side between routes.
+- Check the console for CSP violations.
+- Keep `script-src` and `connect-src` as small as possible.

--- a/examples/docs/src/routes/docs/recipes-forms.md
+++ b/examples/docs/src/routes/docs/recipes-forms.md
@@ -3,8 +3,8 @@ title: Forms & Validation
 lead: Handle form submissions with progressive enhancement using pracht's <code>&lt;Form&gt;</code> component and API routes. Forms work without JavaScript and upgrade to fetch-based submissions when JS is available.
 breadcrumb: Forms
 prev:
-  href: /docs/recipes/auth
-  title: Authentication
+  href: /docs/recipes/csp
+  title: Content Security Policy
 next:
   href: /docs/recipes/testing
   title: Testing

--- a/examples/docs/src/shells/docs.tsx
+++ b/examples/docs/src/shells/docs.tsx
@@ -66,6 +66,7 @@ const NAV = [
     links: [
       { href: "/docs/recipes/i18n", Icon: IconWorld, title: "i18n" },
       { href: "/docs/recipes/auth", Icon: IconLock, title: "Authentication" },
+      { href: "/docs/recipes/csp", Icon: IconShield, title: "CSP" },
       { href: "/docs/recipes/forms", Icon: IconForms, title: "Forms" },
       { href: "/docs/recipes/testing", Icon: IconTestPipe, title: "Testing" },
       {

--- a/packages/adapter-node/src/node-handler.ts
+++ b/packages/adapter-node/src/node-handler.ts
@@ -84,18 +84,14 @@ export function createNodeRequestHandler<TContext = unknown>(
     throw new Error("nodeAdapter({ maxBodySize }) expects a positive integer number of bytes.");
   }
 
-  if (
-    !canonicalOrigin &&
-    process.env.NODE_ENV === "production" &&
-    !warnedAboutMissingCanonicalOrigin
-  ) {
-    warnedAboutMissingCanonicalOrigin = true;
-    console.warn(
-      "[pracht] @pracht/adapter-node is deriving request.url from Host headers. Set nodeAdapter({ canonicalOrigin }) in production to avoid host-header poisoning.",
-    );
-  }
-
   return async (req: IncomingMessage, res: ServerResponse): Promise<void> => {
+    if (!canonicalOrigin && shouldWarnAboutMissingCanonicalOrigin(staticDir)) {
+      warnedAboutMissingCanonicalOrigin = true;
+      console.warn(
+        "[pracht] @pracht/adapter-node is deriving request.url from Host headers. Set nodeAdapter({ canonicalOrigin }) for deployed Node apps to avoid host-header poisoning.",
+      );
+    }
+
     let request: Request;
     try {
       request = await createWebRequest(req, { canonicalOrigin, trustProxy, maxBodySize });
@@ -178,6 +174,12 @@ export function createNodeRequestHandler<TContext = unknown>(
 
     await writeWebResponse(res, response);
   };
+}
+
+function shouldWarnAboutMissingCanonicalOrigin(staticDir: string | undefined): boolean {
+  if (warnedAboutMissingCanonicalOrigin) return false;
+  if (process.env.NODE_ENV === "production") return true;
+  return typeof staticDir === "string" && staticDir.length > 0;
 }
 
 async function serveStaticFile(

--- a/packages/adapter-node/test/index.test.ts
+++ b/packages/adapter-node/test/index.test.ts
@@ -9,7 +9,7 @@ import {
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { once } from "node:events";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { defineApp, resolveApiRoutes, route, timeRevalidate } from "@pracht/core";
 
@@ -48,6 +48,8 @@ async function waitFor(predicate: () => boolean, timeoutMs = 2_000): Promise<voi
 }
 
 afterEach(async () => {
+  vi.restoreAllMocks();
+
   for (const server of servers) {
     server.close();
     await once(server, "close");
@@ -78,6 +80,33 @@ describe("createNodeServerEntryModule", () => {
 });
 
 describe("createNodeRequestHandler", () => {
+  it("warns for deployed Node handlers without a canonical origin", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const staticDir = makeTempDir();
+
+    const handler = createNodeRequestHandler({
+      app: defineApp({ routes: [] }),
+      staticDir,
+    });
+
+    const server = createServer((req: IncomingMessage, res: ServerResponse) => {
+      void handler(req, res);
+    });
+    servers.add(server);
+
+    server.listen(0, "127.0.0.1");
+    await once(server, "listening");
+    const address = server.address();
+    if (!address || typeof address === "string") {
+      throw new Error("Expected TCP server address");
+    }
+
+    await fetch(`http://127.0.0.1:${address.port}/missing`);
+
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining("canonicalOrigin"));
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining("host-header poisoning"));
+  });
+
   it("rejects request bodies above the configured limit", async () => {
     const app = defineApp({
       routes: [route("/upload", "./routes/upload.tsx", { render: "ssr" })],

--- a/packages/framework/src/prerender.ts
+++ b/packages/framework/src/prerender.ts
@@ -36,6 +36,16 @@ export interface PrerenderAppOptions {
   concurrency?: number;
 }
 
+const DANGEROUS_PRERENDER_HEADER_NAMES = new Set([
+  "authorization",
+  "proxy-authenticate",
+  "proxy-authorization",
+  "set-cookie",
+  "www-authenticate",
+]);
+const SECRET_SHAPED_PRERENDER_HEADER_RE =
+  /^x-.*(?:api[-_]?key|client[-_]?secret|credential|jwt[-_]?secret|password|private[-_]?key|refresh[-_]?token|secret|session[-_]?secret|token|webhook[-_]?secret)(?:$|[-_])/i;
+
 export async function prerenderApp(options: PrerenderAppOptions): Promise<PrerenderResult[]>;
 export async function prerenderApp(
   options: PrerenderAppOptions & { withISGManifest: true },
@@ -89,6 +99,8 @@ export async function prerenderApp(
           return null;
         }
 
+        assertSafePrerenderHeaders(response.headers, item);
+
         const html = await response.text();
         return { headers: Object.fromEntries(response.headers), html, item };
       }),
@@ -112,6 +124,29 @@ export async function prerenderApp(
   }
 
   return results;
+}
+
+function assertSafePrerenderHeaders(
+  headers: Headers,
+  item: { pathname: string; render: string },
+): void {
+  const dangerous = [...headers.keys()].filter(isDangerousPrerenderHeader);
+  if (dangerous.length === 0) return;
+
+  const names = dangerous.map((name) => `"${name}"`).join(", ");
+  throw new Error(
+    `Refusing to prerender ${item.render.toUpperCase()} route "${item.pathname}" because its document headers include ${names}. ` +
+      "SSG/ISG document headers are serialized into public static output and replayed for every visitor. " +
+      "Move cookies/authentication headers to API routes, loaders, middleware responses, or SSR-only routes.",
+  );
+}
+
+function isDangerousPrerenderHeader(name: string): boolean {
+  const normalized = name.toLowerCase();
+  return (
+    DANGEROUS_PRERENDER_HEADER_NAMES.has(normalized) ||
+    SECRET_SHAPED_PRERENDER_HEADER_RE.test(normalized)
+  );
 }
 
 async function collectSSGPaths(route: ResolvedRoute, registry?: ModuleRegistry): Promise<string[]> {

--- a/packages/framework/test/runtime.test.ts
+++ b/packages/framework/test/runtime.test.ts
@@ -9,6 +9,7 @@ import {
   prerenderApp,
   resolveApiRoutes,
   route,
+  timeRevalidate,
   useLocation,
   useParams,
 } from "../src/index.ts";
@@ -757,6 +758,70 @@ describe("prerenderApp", () => {
       "content-security-policy": "default-src 'self'",
       "x-plan": "MVP",
     });
+  });
+
+  it.each([
+    ["authorization", "Bearer secret"],
+    ["proxy-authenticate", 'Basic realm="proxy"'],
+    ["set-cookie", "session=abc; Path=/; HttpOnly"],
+    ["www-authenticate", 'Basic realm="admin"'],
+    ["x-api-key", "secret"],
+  ])("rejects %s document headers on SSG pages", async (name, value) => {
+    const app = defineApp({
+      routes: [route("/pricing", "./routes/pricing.tsx", { render: "ssg" })],
+    });
+
+    await expect(
+      prerenderApp({
+        app,
+        registry: {
+          routeModules: {
+            "/src/routes/pricing.tsx": async () => ({
+              Component: () => h("main", null, "Pricing"),
+              headers: () => ({ [name]: value }),
+            }),
+          },
+        },
+      }),
+    ).rejects.toThrow(
+      `Refusing to prerender SSG route "/pricing" because its document headers include "${name}"`,
+    );
+  });
+
+  it("rejects dangerous shell document headers on ISG pages", async () => {
+    const app = defineApp({
+      routes: [
+        route("/pricing", "./routes/pricing.tsx", {
+          render: "isg",
+          revalidate: timeRevalidate(60),
+          shell: "public",
+        }),
+      ],
+      shells: {
+        public: "./shells/public.tsx",
+      },
+    });
+
+    await expect(
+      prerenderApp({
+        app,
+        registry: {
+          routeModules: {
+            "/src/routes/pricing.tsx": async () => ({
+              Component: () => h("main", null, "Pricing"),
+            }),
+          },
+          shellModules: {
+            "/src/shells/public.tsx": async () => ({
+              headers: () => ({ "set-cookie": "shared=1; Path=/" }),
+              Shell: ({ children }) => h("section", null, children),
+            }),
+          },
+        },
+      }),
+    ).rejects.toThrow(
+      'Refusing to prerender ISG route "/pricing" because its document headers include "set-cookie"',
+    );
   });
 
   it("renders multiple static paths concurrently", async () => {

--- a/packages/start/src/index.js
+++ b/packages/start/src/index.js
@@ -420,7 +420,7 @@ async function buildProjectFiles({
   const versions = await resolveVersions(packagesToResolve, { remote: resolveRemoteVersions });
 
   const files = {
-    ".gitignore": "dist\nnode_modules\n.wrangler\n.vercel\n",
+    ".gitignore": "dist\nnode_modules\n.wrangler\n.vercel\n.env*\n!.env.example\n.dev.vars\n",
     "README.md": createReadme({ adapter, packageManager, projectName, router }),
     "package.json": createPackageJson({ adapter, projectName, versions }),
     "src/api/health.ts": createHealthRoute(adapter),

--- a/packages/start/test/index.test.js
+++ b/packages/start/test/index.test.js
@@ -32,12 +32,16 @@ describe("create-pracht", () => {
     });
 
     const packageJson = await readFile(join(targetDir, "package.json"), "utf-8");
+    const gitignore = await readFile(join(targetDir, ".gitignore"), "utf-8");
     const routes = await readFile(join(targetDir, "src/routes.ts"), "utf-8");
 
     expect(packageJson).toMatch(/"@pracht\/cli": "\^\d+\.\d+\.\d+"/);
     expect(packageJson).toMatch(/"@pracht\/adapter-node": "\^\d+\.\d+\.\d+"/);
     expect(packageJson).toContain('"start": "node dist/server/server.js"');
     expect(packageJson).not.toContain("wrangler");
+    expect(gitignore).toContain(".env*");
+    expect(gitignore).toContain("!.env.example");
+    expect(gitignore).toContain(".dev.vars");
     expect(routes).toContain('route("/", "./routes/home.tsx"');
     expect(existsSync(join(targetDir, "wrangler.jsonc"))).toBe(false);
 

--- a/skills/audit-headers/SKILL.md
+++ b/skills/audit-headers/SKILL.md
@@ -77,15 +77,35 @@ Generate a starter CSP from observed origins:
 2. Group by directive: `default-src`, `script-src`, `style-src`, `img-src`,
    `font-src`, `connect-src`, `frame-src`.
 3. Always include `'self'` per directive.
-4. For inline styles/scripts pracht emits (hydration state script), recommend
-   nonce-based CSP — pracht injects `__PRACHT_STATE__` inline, so
-   `'unsafe-inline'` for `script-src` is the easy path; nonces require
-   wiring through render.
+4. Account for framework-emitted scripts: pracht injects hydration state in
+   `<script id="pracht-state" type="application/json">` and injects a module
+   client entry. Prefer a CSP that keeps executable scripts tight; do not jump
+   to `'unsafe-inline'` unless the app truly emits executable inline scripts and
+   the tradeoff is documented.
 
 Output a draft CSP and explain what each origin is for. Do not hand the user
 a CSP that breaks their site — present as draft.
 
-## Step 5: Cross-origin isolation (optional)
+## Step 5: Prerendered header manifest safety
+
+For SSG/ISG output, inspect `dist/client/_pracht/headers.json` after build and
+the route/shell `headers()` exports that feed it. This file is part of the
+public client output, so every value in it must be safe to publish and replay on
+static responses.
+
+Flag as `error` if prerendered headers include:
+
+- `set-cookie`
+- `authorization`
+- `proxy-authorization`
+- `www-authenticate`
+- `proxy-authenticate`
+- custom secret-shaped names such as `x-*-token`, `x-*-secret`, or `x-*-key`
+
+Flag as `warn` when a route-specific header is user-specific but could be
+replayed across users from static output.
+
+## Step 6: Cross-origin isolation (optional)
 
 If the user mentions `SharedArrayBuffer`, WASM threading, or high-precision
 timers, recommend:
@@ -96,7 +116,7 @@ timers, recommend:
 
 Otherwise leave these unset — they break embedded third-party content.
 
-## Step 6: Report
+## Step 7: Report
 
 Two outputs:
 
@@ -104,6 +124,7 @@ Two outputs:
 2. **Recommendations**, in priority order:
    - `error`: Routes with no security headers at all.
    - `warn`: Missing HSTS in production-grade apps.
+   - `warn`: User-specific headers in prerendered static output.
    - `info`: CSP draft, COOP/COEP suggestions.
 
 Show the exact code change required (e.g., where to insert
@@ -119,6 +140,7 @@ Show the exact code change required (e.g., where to insert
 4. For SSG/ISG output, default headers must be applied at the adapter layer
    (Cloudflare/Vercel headers config, or a Node middleware) — flag if the
    adapter does not do this for static responses.
-5. Do not auto-edit. Headers are policy; surface gaps, propose patches.
+5. Treat prerender header manifests as public artifacts.
+6. Do not auto-edit. Headers are policy; surface gaps, propose patches.
 
 $ARGUMENTS

--- a/skills/audit-secrets/SKILL.md
+++ b/skills/audit-secrets/SKILL.md
@@ -16,10 +16,10 @@ allowed-tools:
 
 # Pracht Audit Secrets
 
-Pracht serializes loader return values into `window.__PRACHT_STATE__` and
-hydrates the client from them. Anything a loader returns ends up readable in
-the browser. The Vite plugin also strips server-only exports from route files,
-but it cannot save you from a value that flows into the return.
+Pracht serializes loader return values into the `pracht-state` JSON script and
+hydrates the client from them. Anything a loader returns ends up readable in the
+browser. The Vite plugin also strips server-only exports from route files, but
+it cannot save you from a value that flows into the return.
 
 ## Step 1: Identify "secret-shaped" identifiers
 
@@ -67,9 +67,9 @@ client bundle. Flag those imports.
 Check for accidental exposure outside loaders:
 
 - `head()` returns: rare, but a `meta` value containing a token leaks into HTML.
-- `headers()` returns: less risky (response headers stay on the server side
-  of the request), but flag values that look like secrets — they may be
-  echoed to the browser as cache keys or correlation IDs.
+- `headers()` returns: flag values that look like secrets. For SSG/ISG pages,
+  document headers can be copied into `dist/client/_pracht/headers.json`, which
+  is public client output and may be replayed on static responses.
 - `<Form>` `action` URLs containing tokens in the query string.
 - `prefetchRouteState(url)` calls with sensitive query params.
 - Inline `<script>` content emitted from custom shells.
@@ -77,6 +77,7 @@ Check for accidental exposure outside loaders:
 ## Step 5: `.env` discipline
 
 - Confirm `.env*` is in `.gitignore`.
+- Confirm generated starters preserve `!.env.example` if they ignore `.env*`.
 - Grep tracked files for likely committed secrets (long random strings near
   identifier names from step 1).
 - Confirm any client-side env access uses `import.meta.env.VITE_*` — anything


### PR DESCRIPTION
## Summary

- Reject dangerous document headers during SSG/ISG prerendering before public header manifests can expose or replay them.
- Add a Node adapter `canonicalOrigin` warning, update create-pracht env ignores, and document CSP guidance in docs and audit skills.
- Issue: N/A

## Testing

- [x] `pnpm e2e`
- [x] `pnpm format`
- [x] `pnpm lint`
- [x] `pnpm test`

## Checklist

- [x] Docs updated if needed
- [x] Skills updated if needed
- [x] Changeset added if published packages changed
