### PR TITLE
Skip route-state fetch for loaderless routes

### DIFF
--- a/.changeset/skip-empty-loaders.md
+++ b/.changeset/skip-empty-loaders.md
@@ -1,0 +1,6 @@
+---
+"@pracht/core": patch
+"@pracht/vite-plugin": patch
+---
+
+Skip route-state network requests for routes without loaders or middleware

--- a/.changeset/skip-empty-loaders.md
+++ b/.changeset/skip-empty-loaders.md
@@ -3,4 +3,5 @@
 "@pracht/vite-plugin": patch
 ---
 
-Skip route-state network requests for routes without loaders or middleware
+Skip route-state network requests for routes without loaders or middleware,
+including manifest routes with inline loaders detected from route modules.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -284,11 +284,12 @@ Build starts
 ```
 User clicks <a> or calls navigate()
   → Client router matches new route
-  → In parallel:
+  → If the route has a loader or middleware, in parallel:
       ├─ Fetch route state via GET with x-pracht-route-state-request header
       ├─ Import route module chunk
       └─ Import shell module chunk (if applicable)
-  → Server runs loader, returns JSON (no HTML rendering)
+  → Otherwise, import the route/shell modules only and skip the server fetch
+  → Server runs middleware + loader when needed and returns JSON (no HTML rendering)
   → Client updates component tree with new data + loaded modules
   → Update URL via history.pushState
 ```

--- a/docs/REQUEST_FLOWS.md
+++ b/docs/REQUEST_FLOWS.md
@@ -9,16 +9,16 @@ over the wire.
 
 ## Key: What is a route-state request?
 
-All client-side navigation uses a single shared pattern regardless of the
-rendering mode of the target route. The browser sends a normal `GET` request
-with the extra header:
+Most client-side navigations use a shared route-state pattern. When the target
+route has a loader or middleware, the browser sends a normal `GET` request with
+the extra header:
 
 ```
 x-pracht-route-state-request: 1
 ```
 
-The server detects this, skips HTML rendering, runs the loader, and returns a
-small JSON envelope:
+The server detects this, skips HTML rendering, runs middleware plus the loader,
+and returns a small JSON envelope:
 
 ```json
 { "data": { ... } }
@@ -27,6 +27,9 @@ small JSON envelope:
 The `Vary: x-pracht-route-state-request` response header tells caches to keep
 the HTML and JSON variants separate. JSON responses default to
 `Cache-Control: no-store`.
+
+If the target route has neither a loader nor middleware, client navigation can
+skip the route-state request entirely and only load the route/shell modules.
 
 ---
 

--- a/packages/framework/src/app.ts
+++ b/packages/framework/src/app.ts
@@ -64,6 +64,7 @@ export function route(
     path: normalizeRoutePath(path),
     file: resolveModuleRef(component),
     loaderFile: resolveModuleRef(loader),
+    hasLoader: !!loader,
     ...routeMeta,
   };
 }
@@ -181,6 +182,7 @@ function flattenRouteNode(
     path: fullPath,
     file: node.file,
     loaderFile: node.loaderFile,
+    hasLoader: node.loaderFile ? true : node.hasLoader,
     shell,
     shellFile: shell ? app.shells[shell] : undefined,
     render: node.render ?? inherited.render,

--- a/packages/framework/src/prefetch.ts
+++ b/packages/framework/src/prefetch.ts
@@ -1,13 +1,15 @@
 import { matchAppRoute } from "./app.ts";
-import { fetchPrachtRouteState } from "./runtime-client-fetch.ts";
+import { fetchPrachtRouteState, routeNeedsServerFetch } from "./runtime-client-fetch.ts";
 import type { RouteStateResult } from "./runtime-client-fetch.ts";
-import type { ResolvedPrachtApp, PrefetchStrategy, RouteMatch } from "./types.ts";
+import type { ResolvedPrachtApp, ResolvedRoute, PrefetchStrategy, RouteMatch } from "./types.ts";
 
 export type ModuleWarmFn = (match: RouteMatch) => void;
 
 const CACHE_TTL_MS = 30_000;
 const MAX_PREFETCH_CACHE_ENTRIES = 100;
 const MAX_MATCH_CACHE_ENTRIES = 250;
+const EMPTY_ROUTE_STATE: RouteStateResult = { type: "data", data: undefined };
+const EMPTY_ROUTE_STATE_PROMISE: Promise<RouteStateResult> = Promise.resolve(EMPTY_ROUTE_STATE);
 
 interface CacheEntry {
   promise: Promise<RouteStateResult>;
@@ -39,7 +41,9 @@ export function getCachedRouteState(url: string): Promise<RouteStateResult> | nu
   return entry.promise;
 }
 
-export function prefetchRouteState(url: string): Promise<RouteStateResult> {
+export function prefetchRouteState(url: string, route?: ResolvedRoute): Promise<RouteStateResult> {
+  if (route && !routeNeedsServerFetch(route)) return EMPTY_ROUTE_STATE_PROMISE;
+
   const cached = getCachedRouteState(url);
   if (cached) return cached;
 
@@ -96,10 +100,9 @@ export function setupPrefetching(app: ResolvedPrachtApp, warmModules?: ModuleWar
   }
 
   function prefetchHref(href: string): void {
-    prefetchRouteState(href);
-    if (!warmModules) return;
     const match = getMatchEntry(href).match;
-    if (match) warmModules(match);
+    prefetchRouteState(href, match?.route);
+    if (warmModules && match) warmModules(match);
   }
 
   // Hover / focus prefetching (intent-based)

--- a/packages/framework/src/router.ts
+++ b/packages/framework/src/router.ts
@@ -17,12 +17,17 @@ import type {
   RouteTarget,
 } from "./types.ts";
 import {
-  deserializeRouteError,
   fetchPrachtRouteState,
   parseSafeNavigationUrl,
+  routeNeedsServerFetch,
+} from "./runtime-client-fetch.ts";
+import {
+  deserializeRouteError,
   PrachtRuntimeProvider,
+  type SerializedRouteError,
+  type PrachtHydrationState,
 } from "./runtime.ts";
-import type { SerializedRouteError, PrachtHydrationState } from "./runtime.ts";
+import type { RouteStateResult } from "./runtime-client-fetch.ts";
 
 interface RouteRenderState {
   Shell: FunctionComponent | null;
@@ -267,9 +272,14 @@ export async function initClientRouter(options: InitClientRouterOptions): Promis
     }
 
     // Start route-state fetch and module imports in parallel
-    const statePromise =
-      getCachedRouteState(target.requestUrl) ??
-      fetchPrachtRouteState(target.requestUrl, { signal: abortController.signal });
+    let statePromise: Promise<RouteStateResult>;
+    if (routeNeedsServerFetch(match.route)) {
+      statePromise =
+        getCachedRouteState(target.requestUrl) ??
+        fetchPrachtRouteState(target.requestUrl, { signal: abortController.signal });
+    } else {
+      statePromise = Promise.resolve({ type: "data" as const, data: undefined });
+    }
     const routeModPromise = startRouteImport(match);
     const shellModPromise = startShellImport(match);
 

--- a/packages/framework/src/runtime-client-fetch.ts
+++ b/packages/framework/src/runtime-client-fetch.ts
@@ -1,5 +1,6 @@
 import { ROUTE_STATE_REQUEST_HEADER } from "./runtime-constants.ts";
 import type { SerializedRouteError } from "./runtime-errors.ts";
+import type { ResolvedRoute } from "./types.ts";
 
 export type RouteStateResult =
   | { type: "data"; data: unknown }
@@ -29,6 +30,11 @@ export function parseSafeNavigationUrl(location: string, base: string | URL): UR
     return null;
   }
   return targetUrl;
+}
+
+export function routeNeedsServerFetch(route: ResolvedRoute): boolean {
+  if (route.hasLoader === false && route.middlewareFiles.length === 0) return false;
+  return true;
 }
 
 export function buildRouteStateUrl(url: string): string {

--- a/packages/framework/src/types.ts
+++ b/packages/framework/src/types.ts
@@ -171,6 +171,7 @@ export interface RouteMeta {
   middleware?: string[];
   revalidate?: RouteRevalidate;
   prefetch?: PrefetchStrategy;
+  hasLoader?: boolean;
 }
 
 export interface GroupMeta {

--- a/packages/vite-plugin/src/index.ts
+++ b/packages/vite-plugin/src/index.ts
@@ -160,6 +160,10 @@ export function pracht(options: PrachtPluginOptions = {}): Plugin[] {
       if (dirs.some((dir) => relative.startsWith(dir))) {
         const serverMod = server.moduleGraph.getModuleById(PRACHT_SERVER_MODULE_ID);
         if (serverMod) server.moduleGraph.invalidateModule(serverMod);
+        if (relative.startsWith(resolved.routesDir)) {
+          const clientMod = server.moduleGraph.getModuleById(PRACHT_CLIENT_MODULE_ID);
+          if (clientMod) server.moduleGraph.invalidateModule(clientMod);
+        }
       }
     },
   };

--- a/packages/vite-plugin/src/pages-router.ts
+++ b/packages/vite-plugin/src/pages-router.ts
@@ -9,6 +9,7 @@ export interface ScannedPage {
   isCatchAll: boolean;
   isDynamic: boolean;
   renderMode?: string;
+  hasLoader?: boolean;
 }
 
 export interface PagesRouterOptions {
@@ -54,6 +55,7 @@ function scan(dir: string, root: string, pages: ScannedPage[]): void {
     const routePath = filePathToRoutePath(rel);
     const source = readFileSync(abs, "utf-8");
     const renderMode = extractRenderMode(source);
+    const hasLoader = detectLoaderExport(source);
 
     pages.push({
       absolutePath: abs,
@@ -63,6 +65,7 @@ function scan(dir: string, root: string, pages: ScannedPage[]): void {
       isCatchAll: routePath.split("/").includes("*"),
       isDynamic: routePath.split("/").some((segment) => segment.startsWith(":")),
       renderMode,
+      hasLoader,
     });
   }
 }
@@ -136,6 +139,12 @@ function extractRenderMode(source: string): string | undefined {
   return match ? match[1] : undefined;
 }
 
+const LOADER_EXPORT_RE = /export\s+(?:async\s+)?(?:function|const)\s+loader\b/;
+
+function detectLoaderExport(source: string): boolean {
+  return LOADER_EXPORT_RE.test(source);
+}
+
 export function generatePagesManifestSource(
   pages: ScannedPage[],
   options: PagesRouterOptions & { pagesDirPrefix?: string; useImportSyntax?: boolean },
@@ -166,8 +175,12 @@ export function generatePagesManifestSource(
     const fileRef = useImport
       ? `() => import(${JSON.stringify(filePath)})`
       : JSON.stringify(filePath);
+    const metaParts = [
+      `render: ${JSON.stringify(render)}`,
+      `hasLoader: ${page.hasLoader ? "true" : "false"}`,
+    ];
     routeEntries.push(
-      `    route(${JSON.stringify(page.routePath)}, ${fileRef}, { render: ${JSON.stringify(render)} })`,
+      `    route(${JSON.stringify(page.routePath)}, ${fileRef}, { ${metaParts.join(", ")} })`,
     );
   }
 

--- a/packages/vite-plugin/src/pages-router.ts
+++ b/packages/vite-plugin/src/pages-router.ts
@@ -1,5 +1,6 @@
 import { readdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
 import { basename, extname, join, relative } from "node:path";
+import { detectLoaderExport } from "./route-loader-hints.ts";
 
 export interface ScannedPage {
   absolutePath: string;
@@ -137,12 +138,6 @@ const RENDER_MODE_RE = /export\s+const\s+RENDER_MODE\s*=\s*["'](\w+)["']/;
 function extractRenderMode(source: string): string | undefined {
   const match = RENDER_MODE_RE.exec(source);
   return match ? match[1] : undefined;
-}
-
-const LOADER_EXPORT_RE = /export\s+(?:async\s+)?(?:function|const)\s+loader\b/;
-
-function detectLoaderExport(source: string): boolean {
-  return LOADER_EXPORT_RE.test(source);
 }
 
 export function generatePagesManifestSource(

--- a/packages/vite-plugin/src/plugin-codegen.ts
+++ b/packages/vite-plugin/src/plugin-codegen.ts
@@ -1,4 +1,4 @@
-import { resolve } from "node:path";
+import { dirname, resolve } from "node:path";
 import { PRACHT_CLIENT_MODULE_QUERY } from "./client-module-query.ts";
 import { generatePagesManifestSource, scanPagesDirectory } from "./pages-router.ts";
 import { CLIENT_BROWSER_PATH, readClientBuildAssets } from "./plugin-assets.ts";
@@ -7,6 +7,7 @@ import {
   type PrachtPluginOptions,
   type ResolvedPrachtPluginOptions,
 } from "./plugin-options.ts";
+import { createRouteLoaderHints } from "./route-loader-hints.ts";
 
 export function createPrachtClientModuleSource(
   options: PrachtPluginOptions = {},
@@ -14,6 +15,7 @@ export function createPrachtClientModuleSource(
 ): string {
   const resolved = resolveOptions(options);
   const isPagesMode = !!resolved.pagesDir;
+  const routeLoaderHints = createRouteLoaderHintsForVirtualModules(resolved, buildOptions.root);
 
   const appImport = isPagesMode
     ? generatePagesAppInlineSource(resolved, buildOptions.root)
@@ -39,6 +41,7 @@ export function createPrachtClientModuleSource(
     'import { resolveApp, initClientRouter, readHydrationState } from "@pracht/core";',
     appImport,
     "",
+    `const routeLoaderHints = ${JSON.stringify(routeLoaderHints)};`,
     `const routeModules = {`,
     `  ...import.meta.glob(${JSON.stringify(routeGlob)}, { query: ${JSON.stringify(PRACHT_CLIENT_MODULE_QUERY)} }),`,
     `  ...import.meta.glob(${JSON.stringify(routeTsrxGlob)}),`,
@@ -49,7 +52,9 @@ export function createPrachtClientModuleSource(
     `};`,
     "",
     "const resolvedApp = resolveApp(app);",
+    "applyRouteLoaderHints(resolvedApp, routeLoaderHints);",
     "",
+    ...createApplyRouteLoaderHintsSource(),
     "function normalizeModuleKey(key) {",
     '  return key.split("?")[0].replace(/^\\.?\\//, "");',
     "}",
@@ -103,6 +108,7 @@ export function createPrachtServerModuleSource(
   const resolved = resolveOptions(options);
   const isPagesMode = !!resolved.pagesDir;
   const registrySource = createPrachtRegistryModuleSource(resolved);
+  const routeLoaderHints = createRouteLoaderHintsForVirtualModules(resolved, buildOptions.root);
   const clientBuild = buildOptions.isBuild
     ? readClientBuildAssets(buildOptions.root)
     : { clientEntryUrl: null, cssManifest: {}, jsManifest: {} };
@@ -124,9 +130,12 @@ export function createPrachtServerModuleSource(
     prachtImports,
     appImport,
     "",
+    `const routeLoaderHints = ${JSON.stringify(routeLoaderHints)};`,
+    ...createApplyRouteLoaderHintsSource(),
     registrySource,
     "",
     "export const resolvedApp = resolveApp(app);",
+    "applyRouteLoaderHints(resolvedApp, routeLoaderHints);",
     `export const apiRoutes = resolveApiRoutes(Object.keys(apiModules), ${JSON.stringify(resolved.apiDir)});`,
     `export const buildTarget = ${JSON.stringify(adapter?.id ?? "node")};`,
     `export const clientEntryUrl = ${JSON.stringify(clientBuild.clientEntryUrl ?? CLIENT_BROWSER_PATH)};`,
@@ -142,6 +151,45 @@ export function createPrachtServerModuleSource(
   }
 
   return source.join("\n");
+}
+
+function createApplyRouteLoaderHintsSource(): string[] {
+  return [
+    "function applyRouteLoaderHints(resolvedApp, routeLoaderHints) {",
+    "  for (const route of resolvedApp.routes) {",
+    "    const hint = routeLoaderHints[route.file];",
+    "    if (hint === true) {",
+    "      route.hasLoader = true;",
+    "    } else if (typeof route.hasLoader === 'undefined' && typeof hint === 'boolean') {",
+    "      route.hasLoader = hint;",
+    "    }",
+    "  }",
+    "}",
+    "",
+  ];
+}
+
+function createRouteLoaderHintsForVirtualModules(
+  options: ResolvedPrachtPluginOptions,
+  root = process.cwd(),
+): Record<string, boolean> {
+  if (options.pagesDir) {
+    const pages = scanPagesDirectory(resolve(root, options.pagesDir.slice(1)));
+    const hints: Record<string, boolean> = {};
+    for (const page of pages) {
+      const key = `${options.pagesDir}/${page.relativePath.replace(/\\/g, "/")}`;
+      hints[key] = !!page.hasLoader;
+    }
+    return hints;
+  }
+
+  const appFileAbs = resolve(root, options.appFile.slice(1));
+  const appFileDir = dirname(appFileAbs);
+  const routesDirAbs = resolve(root, options.routesDir.slice(1));
+  return createRouteLoaderHints(routesDirAbs, {
+    appFileDir,
+    rootRelativePrefix: options.routesDir,
+  });
 }
 
 export function createPrachtRegistryModuleSource(options: PrachtPluginOptions = {}): string {

--- a/packages/vite-plugin/src/route-loader-hints.ts
+++ b/packages/vite-plugin/src/route-loader-hints.ts
@@ -1,0 +1,93 @@
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { extname, join, relative } from "node:path";
+
+const ROUTE_EXTENSIONS = new Set([".tsx", ".ts", ".jsx", ".js", ".md", ".mdx"]);
+const LOADER_DECLARATION_RE = /export\s+(?:async\s+)?(?:function|const|let|var)\s+loader\b/;
+const EXPORT_BLOCK_RE = /export\s*\{([^}]*)\}\s*(?:from\s*["'][^"']+["'])?/g;
+const EXPORT_ALL_RE = /export\s+\*\s+from\s*["'][^"']+["']/;
+
+function exportSpecifiersIncludeLoader(specifiers: string): boolean {
+  return specifiers
+    .split(",")
+    .map((specifier) => specifier.trim())
+    .filter(Boolean)
+    .some((specifier) => {
+      const match = /^(?:type\s+)?([A-Za-z_$][\w$]*)(?:\s+as\s+([A-Za-z_$][\w$]*))?$/.exec(
+        specifier,
+      );
+      if (!match) return false;
+      const [, localName, exportedName] = match;
+      return (exportedName ?? localName) === "loader";
+    });
+}
+
+export function detectLoaderExport(source: string): boolean {
+  if (LOADER_DECLARATION_RE.test(source)) return true;
+
+  for (const match of source.matchAll(EXPORT_BLOCK_RE)) {
+    if (exportSpecifiersIncludeLoader(match[1])) {
+      return true;
+    }
+  }
+
+  // `export *` can expose a loader through re-exports. Treat it as a loader
+  // route to avoid skipping route-state fetches incorrectly.
+  return EXPORT_ALL_RE.test(source);
+}
+
+function scanRouteFiles(dir: string, files: string[]): void {
+  let entries: string[];
+  try {
+    entries = readdirSync(dir);
+  } catch {
+    return;
+  }
+
+  for (const entry of entries) {
+    const abs = join(dir, entry);
+    const stat = statSync(abs);
+    if (stat.isDirectory()) {
+      scanRouteFiles(abs, files);
+      continue;
+    }
+
+    if (ROUTE_EXTENSIONS.has(extname(entry))) {
+      files.push(abs);
+    }
+  }
+}
+
+function toPosixPath(path: string): string {
+  return path.replace(/\\/g, "/");
+}
+
+export function createRouteLoaderHints(
+  routesDir: string,
+  options: { appFileDir?: string; rootRelativePrefix?: string } = {},
+): Record<string, boolean> {
+  const files: string[] = [];
+  const hints: Record<string, boolean> = {};
+  scanRouteFiles(routesDir, files);
+
+  for (const file of files) {
+    const hasLoader = detectLoaderExport(readFileSync(file, "utf-8"));
+    const relativeToRoutesDir = toPosixPath(relative(routesDir, file));
+    const routeRootPrefix = options.rootRelativePrefix?.replace(/\/$/, "");
+    const appFileDir = options.appFileDir;
+
+    const keys = new Set<string>();
+    if (appFileDir) {
+      const relativeToAppFile = toPosixPath(relative(appFileDir, file));
+      keys.add(relativeToAppFile.startsWith(".") ? relativeToAppFile : `./${relativeToAppFile}`);
+    }
+    if (routeRootPrefix) {
+      keys.add(`${routeRootPrefix}/${relativeToRoutesDir}`);
+    }
+
+    for (const key of keys) {
+      hints[key] = hasLoader;
+    }
+  }
+
+  return hints;
+}

--- a/packages/vite-plugin/test/client-module-transform.test.ts
+++ b/packages/vite-plugin/test/client-module-transform.test.ts
@@ -5,7 +5,11 @@ import { fileURLToPath } from "node:url";
 import { build, parseAst } from "vite";
 import { afterEach, describe, expect, it } from "vitest";
 
-import { pracht } from "../src/index.ts";
+import {
+  createPrachtClientModuleSource,
+  createPrachtServerModuleSource,
+  pracht,
+} from "../src/index.ts";
 import { stripServerOnlyExportsForClient } from "../src/client-module-transform.ts";
 
 const tempDirs: string[] = [];
@@ -395,6 +399,48 @@ export function Component() {
 });
 
 describe("client route module build", () => {
+  it("embeds route loader hints for manifest routes", () => {
+    const root = makeTempProject();
+    mkdirSync(join(root, "src", "routes"), { recursive: true });
+
+    writeFileSync(join(root, "src", "routes.ts"), "export const app = {};\n");
+    writeFileSync(
+      join(root, "src", "routes", "index.tsx"),
+      [
+        'export { loader } from "./shared";',
+        "export default function Home() { return null; }",
+        "",
+      ].join("\n"),
+    );
+    writeFileSync(join(root, "src", "routes", "shared.ts"), "export async function loader() {}\n");
+    writeFileSync(
+      join(root, "src", "routes", "about.tsx"),
+      "export default function About() { return null; }\n",
+    );
+
+    const clientSource = createPrachtClientModuleSource(
+      {
+        appFile: "/src/routes.ts",
+        routesDir: "/src/routes",
+      },
+      { root },
+    );
+    const serverSource = createPrachtServerModuleSource(
+      {
+        appFile: "/src/routes.ts",
+        routesDir: "/src/routes",
+      },
+      { root },
+    );
+
+    expect(clientSource).toContain('"./routes/index.tsx":true');
+    expect(clientSource).toContain('"/src/routes/index.tsx":true');
+    expect(clientSource).toContain('"./routes/about.tsx":false');
+    expect(clientSource).toContain('"/src/routes/about.tsx":false');
+    expect(serverSource).toContain('"./routes/index.tsx":true');
+    expect(serverSource).toContain('"./routes/about.tsx":false');
+  });
+
   it("excludes imports used only by typed inline loaders from browser bundles", async () => {
     const root = makeTempProject();
     mkdirSync(join(root, "src", "pages"), { recursive: true });

--- a/packages/vite-plugin/test/pages-router.test.ts
+++ b/packages/vite-plugin/test/pages-router.test.ts
@@ -93,7 +93,7 @@ describe("generatePagesManifestSource", () => {
     });
 
     expect(source).not.toContain("shells:");
-    expect(source).toContain('route("/", "./index.mdx", { render: "ssr" })');
+    expect(source).toContain('route("/", "./index.mdx", { render: "ssr", hasLoader: false })');
   });
 });
 

--- a/packages/vite-plugin/test/pages-router.test.ts
+++ b/packages/vite-plugin/test/pages-router.test.ts
@@ -79,6 +79,52 @@ describe("scanPagesDirectory", () => {
       "/*",
     ]);
   });
+
+  it("detects loader exports declared through named re-exports", () => {
+    const pagesDir = makeTempPagesDir();
+
+    writeFileSync(
+      join(pagesDir, "index.tsx"),
+      [
+        "const loader = async () => ({ ok: true });",
+        "export { loader };",
+        "export default function Home() {",
+        "  return null;",
+        "}",
+        "",
+      ].join("\n"),
+    );
+    writeFileSync(
+      join(pagesDir, "about.tsx"),
+      [
+        'export { loader } from "./_shared";',
+        "export default function About() {",
+        "  return null;",
+        "}",
+        "",
+      ].join("\n"),
+    );
+    writeFileSync(
+      join(pagesDir, "docs.tsx"),
+      [
+        'export * from "./_shared";',
+        "export default function Docs() {",
+        "  return null;",
+        "}",
+        "",
+      ].join("\n"),
+    );
+    writeFileSync(
+      join(pagesDir, "_shared.ts"),
+      ["export async function loader() {", "  return { ok: true };", "}", ""].join("\n"),
+    );
+
+    const pages = scanPagesDirectory(pagesDir);
+
+    expect(pages.find((page) => page.routePath === "/")?.hasLoader).toBe(true);
+    expect(pages.find((page) => page.routePath === "/about")?.hasLoader).toBe(true);
+    expect(pages.find((page) => page.routePath === "/docs")?.hasLoader).toBe(true);
+  });
 });
 
 describe("generatePagesManifestSource", () => {


### PR DESCRIPTION
## Summary

Recreates #109. Routes without loaders or middleware were still triggering a route-state network request during client-side navigation and prefetch, returning `{ data: undefined }`. This adds a `hasLoader` flag to route metadata so the client can skip the fetch entirely.

- For `RouteConfig` routes, `hasLoader` is set automatically based on whether `loader` is provided.
- For pages-router routes, `hasLoader` is detected via static analysis (`export function/const loader` plus named/star re-exports).
- For simple `route("/path", file, meta)` routes with potential inline loaders, `hasLoader` defaults to `undefined` which conservatively still fetches (safe fallback).
- A new `applyRouteLoaderHints` pass at codegen time resolves manifest-route file paths to detected hints from the routes directory.

## Testing

- [x] `pnpm e2e`
- [x] `pnpm format`
- [x] `pnpm lint`
- [x] `pnpm test`

## Checklist

- [x] Docs updated if needed — ARCHITECTURE.md and REQUEST_FLOWS.md
- [x] Skills updated if needed — N/A
- [x] Changeset added if published packages changed — `.changeset/skip-empty-loaders.md`