### PR TITLE
Bump preact-suspense to 0.3 and fix hydration suspension counter

### DIFF
--- a/.changeset/preact-suspense-0-3.md
+++ b/.changeset/preact-suspense-0-3.md
@@ -1,0 +1,5 @@
+---
+"@pracht/core": patch
+---
+
+Bump `preact-suspense` to `^0.3.0`. The new version installs its `options.__e` hook lazily in the `Suspense` constructor (instead of at module load), which would otherwise let preact-suspense's catch-error wrapper sit in front of pracht's hydration suspension counter and short-circuit on Suspense ancestors before our counter could see them. Eagerly construct one throwaway `Suspense` instance during `hydration.ts` module init so preact-suspense's hook is in place before pracht wraps it.

--- a/packages/framework/package.json
+++ b/packages/framework/package.json
@@ -63,7 +63,7 @@
     "prepublishOnly": "npm run build"
   },
   "dependencies": {
-    "preact-suspense": "^0.2.0"
+    "preact-suspense": "^0.3.0"
   },
   "peerDependencies": {
     "preact": "^10.0.0",

--- a/packages/framework/src/hydration.ts
+++ b/packages/framework/src/hydration.ts
@@ -1,5 +1,6 @@
 import { options } from "preact";
 import { useEffect, useState } from "preact/hooks";
+import { Suspense } from "preact-suspense";
 
 // Preact internal flag on vnode.__u. Set by the hydrate() diff path on every
 // vnode that is actually hydrating against existing DOM. Fresh mounts and
@@ -10,6 +11,13 @@ const MODE_HYDRATE = 1 << 5;
 let _hydrating = false;
 let _suspensionCount = 0;
 let _hydrated = false;
+
+// preact-suspense >=0.3 installs its options.__e patch lazily inside the
+// Suspense constructor. Construct one throwaway instance now so its patch
+// runs before we capture the chain below — otherwise our wrapper would sit
+// behind preact-suspense's, which short-circuits on Suspense ancestors and
+// would never let our suspension counter see hydration promises.
+new (Suspense as any)({});
 
 // options.__e (_catchError) — count thrown promises that belong to the
 // initial hydration pass. We must NOT count promises thrown from vnodes that

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -264,8 +264,8 @@ importers:
         specifier: ^6.0.0
         version: 6.6.7(preact@10.29.1)
       preact-suspense:
-        specifier: ^0.2.0
-        version: 0.2.0(preact@10.29.1)
+        specifier: ^0.3.0
+        version: 0.3.0(preact@10.29.1)
 
   packages/preact-ssr-precompile:
     dependencies:
@@ -2390,8 +2390,8 @@ packages:
     peerDependencies:
       preact: '>=10 || >= 11.0.0-0'
 
-  preact-suspense@0.2.0:
-    resolution: {integrity: sha512-AyBb6lJa1+JbbDaGyBDxxJx+P/MG0nw3X/z2rZaF5h5qU6MX8TBGWxWOG/h50ob7fMkKX9+or2Qp8Mvlda3G9w==}
+  preact-suspense@0.3.0:
+    resolution: {integrity: sha512-mKcwdDwvpEtRQ8dG8eNN2//GRxP84bI6q+j4D+WVkF8fSc7Aikk3sAhCj6SpGG8gyFUxE+Nu5ej6vqzPFqe8dg==}
     peerDependencies:
       preact: ^10.0.0
 
@@ -4731,7 +4731,7 @@ snapshots:
     dependencies:
       preact: 10.29.1
 
-  preact-suspense@0.2.0(preact@10.29.1):
+  preact-suspense@0.3.0(preact@10.29.1):
     dependencies:
       preact: 10.29.1
 


### PR DESCRIPTION
## Summary

- Bumps `preact-suspense` from `^0.2.0` to `^0.3.0` in `@pracht/core`.
- preact-suspense 0.3 installs its `options.__e` hook lazily inside the `Suspense` constructor instead of at module load. With the previous ordering, preact-suspense's catch-error wrapper ended up sitting in front of pracht's hydration suspension counter and short-circuited on every Suspense ancestor, so `useIsHydrated` flipped to `true` before nested hydration promises had settled (one hydration test reproduced this).
- Fix: eagerly construct one throwaway `Suspense` instance at the top of `hydration.ts` so preact-suspense's hook is installed before pracht captures the chain and wraps it. All 8 hydration tests + the full e2e suite pass.

## Testing

- [x] `pnpm e2e`
- [x] `pnpm format`
- [x] `pnpm lint`
- [x] `pnpm test`

## Checklist

- [x] Docs updated if needed (N/A — internal fix, public API unchanged)
- [x] Skills updated if needed (N/A)
- [x] Changeset added if published packages changed