### PR TITLE
Reduce core browser bootstrap

### DIFF
--- a/.changeset/reduce-client-runtime.md
+++ b/.changeset/reduce-client-runtime.md
@@ -1,0 +1,13 @@
+---
+"@pracht/core": patch
+"@pracht/vite-plugin": patch
+"@pracht/adapter-node": patch
+"@pracht/adapter-cloudflare": patch
+"@pracht/adapter-vercel": patch
+---
+
+Reduce the default browser bootstrap by adding lean core client/manifest entries,
+resolving browser route imports through a client-safe core entry, and loading
+prefetch listener setup after the router initializes. Adapters now point
+generated server entries at `@pracht/core/server` so edge worker builds do not
+resolve server imports through the browser condition.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -430,16 +430,34 @@ types.ts        — pure types, no internal deps
     ↑
 app.ts          — route manifest, matching, SSG path building
     ↑
-runtime.ts      — SSR handler, prerendering, client hooks (static import of app.ts)
+runtime-context.ts — hydration state reader and Preact runtime provider
     ↑
-prefetch.ts     — prefetch cache, strategy wiring (imports runtime + app)
+runtime-hooks.ts — public browser hooks/components (Link, Form, useRevalidate, etc.)
     ↑
-router.ts       — client router, hydration bootstrap (imports runtime + prefetch + hydration)
+runtime.ts      — SSR handler and prerendering (static import of app.ts)
+    ↑
+prefetch-cache.ts — bounded route-state cache shared by navigation, forms, and prefetching
+    ↑
+prefetch.ts     — prefetch strategy wiring, loaded by the client router after hydration
+    ↑
+router.ts       — client router, hydration bootstrap (imports runtime-context + prefetch-cache)
 
 hydration.ts    — Preact options hooks for tracking hydration (no internal deps)
+href.ts         — createHref helper layered on buildHref
 forwardRef.ts   — forwardRef helper (no internal deps)
 error-overlay.ts — dev error page HTML (no internal deps)
 ```
+
+The published core package also exposes small browser-oriented entries:
+
+- `@pracht/core/client` is used by `virtual:pracht/client` and contains only
+  the client router bootstrap surface.
+- `@pracht/core/manifest` is used for manifest helper imports after Vite has
+  transformed route module references to strings.
+- `@pracht/core/server` is used by generated server entries and adapters so
+  edge worker builds do not resolve server imports through the browser condition.
+- The root `@pracht/core` export has a browser condition that points at a
+  client-safe public entry for route and shell modules.
 
 **Important:** `runtime.ts` imports `resolveApp` and `buildPathFromSegments` directly from
 `app.ts` via a static import. Earlier versions used `await import("./app.ts")` dynamic
@@ -449,6 +467,11 @@ imports from `types.ts`). The dynamic imports have been replaced with static imp
 
 The only intentional dynamic import in `runtime.ts` is `preact-render-to-string`, which
 is lazy-loaded to keep the SSR-only dependency out of the client bundle.
+
+The client router intentionally dynamic-imports `prefetch.ts` after router
+initialization. Navigation keeps the small shared cache available synchronously,
+but the listener and `IntersectionObserver` setup no longer sits on the critical
+hydration path.
 
 ---
 

--- a/docs/WORKSPACE.md
+++ b/docs/WORKSPACE.md
@@ -79,7 +79,11 @@ described in `VISION_MVP.md`.
 - **Package builds** — `tsdown` compiles `pracht`, `@pracht/vite-plugin`,
   `@pracht/preact-ssr-precompile`, `@pracht/adapter-node`,
   `@pracht/adapter-cloudflare`, and `@pracht/adapter-vercel` from TypeScript to
-  ESM (`dist/index.mjs` + `.d.mts`). The CLI remains plain JS.
+  ESM (`dist/index.mjs` + `.d.mts`). `@pracht/core` also publishes browser,
+  client, manifest, and server subpath entries so the Vite plugin can keep
+  server-only runtime code and route-only browser helpers out of the critical
+  client bootstrap graph while generated server modules avoid the browser export
+  condition. The CLI remains plain JS.
 - **Node adapter** — Translates Node requests to Web `Request` objects, calls
   `handlePrachtRequest()`, and implements ISG stale-while-revalidate with
   background regeneration.

--- a/examples/docs/src/routes/docs/performance.md
+++ b/examples/docs/src/routes/docs/performance.md
@@ -32,6 +32,18 @@ Preact, preact/hooks, and preact-suspense are extracted into a shared `vendor` c
 - Route chunks stay small — they only contain route-specific code.
 - Deploying a route change doesn't invalidate the vendor cache.
 
+## Core Runtime Splitting
+
+The generated client entry imports a lean browser bootstrap from `@pracht/core/client`.
+Route and shell modules still import the normal `@pracht/core` API, but browser
+builds resolve that public API through a client-safe entry so server-only
+runtime code is not part of the default browser graph.
+
+Prefetch listener setup is also loaded after the router is initialized. The
+small route-state cache remains available synchronously for navigation and
+forms, while the hover/focus and viewport observers move out of the hydration
+critical path.
+
 ---
 
 ## CSS Per Page
@@ -66,6 +78,7 @@ None of these optimizations require configuration. A standard pracht app automat
 | Route code splitting | Each route is a separate JS chunk, loaded on demand          |
 | Modulepreload hints  | Browser starts downloading route JS before client entry runs |
 | Vendor extraction    | Preact is cached once, shared across routes                  |
+| Core runtime splitting | Server runtime and prefetch setup stay off the critical path |
 | Per-page CSS         | Only CSS for the matched route/shell is included             |
 | Intent prefetching   | Route data is fetched on hover/focus before click            |
 | Dev error overlay    | Framework-aware errors with auto-reload on fix               |

--- a/examples/docs/src/routes/docs/prefetching.md
+++ b/examples/docs/src/routes/docs/prefetching.md
@@ -12,7 +12,12 @@ next:
 
 ## How It Works
 
-After hydration, pracht sets up document-level listeners that watch for user interaction with internal links. When a prefetch is triggered, the route's server data (the same JSON payload used during client-side navigation) is fetched in the background and cached. When the user actually clicks the link, the cached data is used immediately — no second network request.
+After hydration, pracht loads the prefetch setup and registers document-level
+listeners that watch for user interaction with internal links. When a prefetch
+is triggered, the route's server data (the same JSON payload used during
+client-side navigation) is fetched in the background and cached. When the user
+actually clicks the link, the cached data is used immediately — no second
+network request.
 
 Prefetched data is held in a small client-side LRU cache with a 30-second TTL. Stale entries are discarded and re-fetched on the next interaction.
 

--- a/packages/adapter-cloudflare/src/index.ts
+++ b/packages/adapter-cloudflare/src/index.ts
@@ -8,7 +8,7 @@ import {
   type ModuleRegistry,
   type ResolvedApiRoute,
   type PrachtApp,
-} from "@pracht/core";
+} from "@pracht/core/server";
 
 type HeadersManifest = Record<string, Record<string, string>>;
 
@@ -273,7 +273,7 @@ export function cloudflareAdapter(options: CloudflareServerEntryModuleOptions = 
     ownsDevServer: true,
     edge: true,
     serverImports:
-      'import { applyDefaultSecurityHeaders, handlePrachtRequest, resolveApp, resolveApiRoutes } from "@pracht/core";',
+      'import { applyDefaultSecurityHeaders, handlePrachtRequest, resolveApp, resolveApiRoutes } from "@pracht/core/server";',
     createServerEntryModule() {
       return createCloudflareServerEntryModule(options);
     },

--- a/packages/adapter-cloudflare/tsdown.config.ts
+++ b/packages/adapter-cloudflare/tsdown.config.ts
@@ -5,5 +5,5 @@ export default defineConfig({
   entry: ["src/index.ts"],
   format: "esm",
   dts: true,
-  external: ["@pracht/core", "@pracht/vite-plugin", /^node:/],
+  external: [/^@pracht\/core(\/.*)?$/, "@pracht/vite-plugin", /^node:/],
 });

--- a/packages/adapter-node/src/node-entry.ts
+++ b/packages/adapter-node/src/node-entry.ts
@@ -73,7 +73,7 @@ export function createNodeServerEntryModule(options: NodeServerEntryModuleOption
 export function nodeAdapter(options: NodeServerEntryModuleOptions = {}): PrachtAdapter {
   return {
     id: "node",
-    serverImports: 'import { resolveApp, resolveApiRoutes } from "@pracht/core";',
+    serverImports: 'import { resolveApp, resolveApiRoutes } from "@pracht/core/server";',
     createServerEntryModule() {
       return createNodeServerEntryModule(options);
     },

--- a/packages/adapter-node/src/node-handler.ts
+++ b/packages/adapter-node/src/node-handler.ts
@@ -12,7 +12,7 @@ import {
   type ModuleRegistry,
   type ResolvedApiRoute,
   type PrachtApp,
-} from "@pracht/core";
+} from "@pracht/core/server";
 
 import { regenerateISGPage } from "./node-isg.ts";
 import { createWebRequest, writeNodeResponseHeaders, writeWebResponse } from "./node-request.ts";

--- a/packages/adapter-node/src/node-isg.ts
+++ b/packages/adapter-node/src/node-isg.ts
@@ -1,6 +1,6 @@
 import { mkdir, writeFile } from "node:fs/promises";
 import { dirname } from "node:path";
-import { handlePrachtRequest } from "@pracht/core";
+import { handlePrachtRequest } from "@pracht/core/server";
 import type { NodeAdapterContextArgs, NodeAdapterOptions } from "./node-handler.ts";
 
 export async function regenerateISGPage<TContext>(

--- a/packages/adapter-node/src/node-static.ts
+++ b/packages/adapter-node/src/node-static.ts
@@ -1,6 +1,6 @@
 import { lstat, realpath } from "node:fs/promises";
 import { extname, resolve, sep } from "node:path";
-import type { ISGManifestEntry } from "@pracht/core";
+import type { ISGManifestEntry } from "@pracht/core/server";
 
 export type HeadersManifest = Record<string, Record<string, string>>;
 

--- a/packages/adapter-node/tsdown.config.ts
+++ b/packages/adapter-node/tsdown.config.ts
@@ -5,5 +5,5 @@ export default defineConfig({
   entry: ["src/index.ts"],
   format: "esm",
   dts: true,
-  external: ["@pracht/core", "@pracht/vite-plugin", /^node:/],
+  external: [/^@pracht\/core(\/.*)?$/, "@pracht/vite-plugin", /^node:/],
 });

--- a/packages/adapter-vercel/src/index.ts
+++ b/packages/adapter-vercel/src/index.ts
@@ -5,7 +5,7 @@ import {
   type ModuleRegistry,
   type ResolvedApiRoute,
   type PrachtApp,
-} from "@pracht/core";
+} from "@pracht/core/server";
 
 export interface VercelExecutionContext {
   waitUntil?(promise: Promise<unknown>): void;
@@ -108,7 +108,7 @@ export function vercelAdapter(options: VercelServerEntryModuleOptions = {}): Pra
     id: "vercel",
     edge: true,
     serverImports:
-      'import { handlePrachtRequest, resolveApp, resolveApiRoutes } from "@pracht/core";',
+      'import { handlePrachtRequest, resolveApp, resolveApiRoutes } from "@pracht/core/server";',
     createServerEntryModule() {
       return createVercelServerEntryModule(options);
     },

--- a/packages/adapter-vercel/tsdown.config.ts
+++ b/packages/adapter-vercel/tsdown.config.ts
@@ -5,5 +5,5 @@ export default defineConfig({
   entry: ["src/index.ts"],
   format: "esm",
   dts: true,
-  external: ["@pracht/core", "@pracht/vite-plugin", /^node:/],
+  external: [/^@pracht\/core(\/.*)?$/, "@pracht/vite-plugin", /^node:/],
 });

--- a/packages/framework/package.json
+++ b/packages/framework/package.json
@@ -31,7 +31,24 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.mts",
+      "browser": "./dist/browser.mjs",
       "default": "./dist/index.mjs"
+    },
+    "./browser": {
+      "types": "./dist/browser.d.mts",
+      "default": "./dist/browser.mjs"
+    },
+    "./client": {
+      "types": "./dist/client.d.mts",
+      "default": "./dist/client.mjs"
+    },
+    "./manifest": {
+      "types": "./dist/manifest.d.mts",
+      "default": "./dist/manifest.mjs"
+    },
+    "./server": {
+      "types": "./dist/server.d.mts",
+      "default": "./dist/server.mjs"
     },
     "./error-overlay": {
       "types": "./dist/error-overlay.d.mts",

--- a/packages/framework/src/app.ts
+++ b/packages/framework/src/app.ts
@@ -4,7 +4,6 @@ import type {
   GroupDefinition,
   GroupMeta,
   HrefArgs,
-  HrefFn,
   HrefRouteDefinition,
   ModuleRef,
   ResolvedApiRoute,
@@ -347,11 +346,6 @@ export function buildHref<TRoute extends RouteId>(
   ...args: HrefArgs<TRoute>
 ): string {
   return buildHrefUntyped(routes, String(routeId), args[0] as BuildHrefOptions | undefined);
-}
-
-export function createHref(routes: readonly HrefRouteDefinition[]): HrefFn {
-  return ((routeId: string, options?: BuildHrefOptions) =>
-    buildHrefUntyped(routes, routeId, options)) as HrefFn;
 }
 
 function buildHrefUntyped(

--- a/packages/framework/src/browser.ts
+++ b/packages/framework/src/browser.ts
@@ -3,9 +3,7 @@ export {
   buildPathFromSegments,
   defineApp,
   group,
-  matchApiRoute,
   matchAppRoute,
-  resolveApiRoutes,
   resolveApp,
   route,
   timeRevalidate,
@@ -15,21 +13,20 @@ export { forwardRef } from "./forwardRef.ts";
 export { useIsHydrated } from "./hydration.ts";
 export { Suspense, lazy } from "preact-suspense";
 export {
-  applyDefaultSecurityHeaders,
   Form,
   Link,
-  handlePrachtRequest,
+  PrachtRuntimeProvider,
   readHydrationState,
   startApp,
   useLocation,
   useParams,
   useRevalidate,
   useRouteData,
-  PrachtRuntimeProvider,
-} from "./runtime.ts";
-export { prerenderApp } from "./prerender.ts";
+} from "./runtime-hooks.ts";
+export { fetchPrachtRouteState, parseSafeNavigationUrl } from "./runtime-client-fetch.ts";
 export { initClientRouter, useNavigate } from "./router.ts";
 export { PrachtHttpError } from "./types.ts";
+
 export type {
   ApiConfig,
   ApiRouteArgs,
@@ -94,20 +91,11 @@ export type {
 } from "./types.ts";
 export type {
   FormProps,
-  HandlePrachtRequestOptions,
   LinkProps,
   Location,
-  PrachtRuntimeDiagnosticPhase,
-  PrachtRuntimeDiagnostics,
-  RouteStateResult,
-  SerializedRouteError,
-  StartAppOptions,
   PrachtHydrationState,
-} from "./runtime.ts";
-export type {
-  ISGManifestEntry,
-  PrerenderAppOptions,
-  PrerenderAppResult,
-  PrerenderResult,
-} from "./prerender.ts";
+  StartAppOptions,
+} from "./runtime-hooks.ts";
+export type { RouteStateResult } from "./runtime-client-fetch.ts";
+export type { SerializedRouteError } from "./runtime-errors.ts";
 export type { InitClientRouterOptions, NavigateFn } from "./router.ts";

--- a/packages/framework/src/client.ts
+++ b/packages/framework/src/client.ts
@@ -1,0 +1,6 @@
+export { resolveApp } from "./app.ts";
+export { initClientRouter } from "./router.ts";
+export { readHydrationState } from "./runtime-context.ts";
+
+export type { InitClientRouterOptions, NavigateFn } from "./router.ts";
+export type { PrachtHydrationState } from "./runtime-context.ts";

--- a/packages/framework/src/href.ts
+++ b/packages/framework/src/href.ts
@@ -1,0 +1,7 @@
+import { buildHref } from "./app.ts";
+import type { BuildHrefOptions, HrefFn, HrefRouteDefinition } from "./types.ts";
+
+export function createHref(routes: readonly HrefRouteDefinition[]): HrefFn {
+  return ((routeId: string, options?: BuildHrefOptions) =>
+    buildHref(routes, routeId, options as never)) as HrefFn;
+}

--- a/packages/framework/src/manifest.ts
+++ b/packages/framework/src/manifest.ts
@@ -1,0 +1,16 @@
+export { defineApp, group, route, timeRevalidate } from "./app.ts";
+
+export type {
+  GroupDefinition,
+  GroupMeta,
+  ModuleRef,
+  PrachtApp,
+  PrachtAppConfig,
+  RenderMode,
+  RouteConfig,
+  RouteDefinition,
+  RouteMeta,
+  RouteRevalidate,
+  RouteTreeNode,
+  TimeRevalidatePolicy,
+} from "./types.ts";

--- a/packages/framework/src/prefetch-cache.ts
+++ b/packages/framework/src/prefetch-cache.ts
@@ -1,0 +1,55 @@
+import type { RouteStateResult } from "./runtime-client-fetch.ts";
+
+const CACHE_TTL_MS = 30_000;
+const MAX_PREFETCH_CACHE_ENTRIES = 100;
+const EMPTY_ROUTE_STATE: RouteStateResult = { type: "data", data: undefined };
+
+interface CacheEntry {
+  promise: Promise<RouteStateResult>;
+  timestamp: number;
+}
+
+const prefetchCache = new Map<string, CacheEntry>();
+
+export const EMPTY_ROUTE_STATE_PROMISE: Promise<RouteStateResult> =
+  Promise.resolve(EMPTY_ROUTE_STATE);
+
+export function clearPrefetchCache(): void {
+  prefetchCache.clear();
+}
+
+export function getCachedRouteState(url: string): Promise<RouteStateResult> | null {
+  const entry = prefetchCache.get(url);
+  if (!entry) return null;
+  if (Date.now() - entry.timestamp > CACHE_TTL_MS) {
+    prefetchCache.delete(url);
+    return null;
+  }
+
+  // Refresh insertion order so the map acts as a small LRU cache.
+  prefetchCache.delete(url);
+  prefetchCache.set(url, entry);
+  return entry.promise;
+}
+
+export function cacheRouteState(url: string, promise: Promise<RouteStateResult>): void {
+  sweepPrefetchCache();
+  prefetchCache.set(url, { promise, timestamp: Date.now() });
+  trimMapToSize(prefetchCache, MAX_PREFETCH_CACHE_ENTRIES);
+}
+
+function sweepPrefetchCache(now = Date.now()): void {
+  for (const [url, entry] of prefetchCache) {
+    if (now - entry.timestamp > CACHE_TTL_MS) {
+      prefetchCache.delete(url);
+    }
+  }
+}
+
+export function trimMapToSize<TKey, TValue>(map: Map<TKey, TValue>, maxEntries: number): void {
+  while (map.size > maxEntries) {
+    const first = map.keys().next();
+    if (first.done) return;
+    map.delete(first.value);
+  }
+}

--- a/packages/framework/src/prefetch.ts
+++ b/packages/framework/src/prefetch.ts
@@ -1,45 +1,25 @@
 import { matchAppRoute } from "./app.ts";
+import {
+  cacheRouteState,
+  clearPrefetchCache,
+  EMPTY_ROUTE_STATE_PROMISE,
+  getCachedRouteState,
+  trimMapToSize,
+} from "./prefetch-cache.ts";
 import { fetchPrachtRouteState, routeNeedsServerFetch } from "./runtime-client-fetch.ts";
 import type { RouteStateResult } from "./runtime-client-fetch.ts";
 import type { ResolvedPrachtApp, ResolvedRoute, PrefetchStrategy, RouteMatch } from "./types.ts";
 
 export type ModuleWarmFn = (match: RouteMatch) => void;
 
-const CACHE_TTL_MS = 30_000;
-const MAX_PREFETCH_CACHE_ENTRIES = 100;
 const MAX_MATCH_CACHE_ENTRIES = 250;
-const EMPTY_ROUTE_STATE: RouteStateResult = { type: "data", data: undefined };
-const EMPTY_ROUTE_STATE_PROMISE: Promise<RouteStateResult> = Promise.resolve(EMPTY_ROUTE_STATE);
-
-interface CacheEntry {
-  promise: Promise<RouteStateResult>;
-  timestamp: number;
-}
 
 interface MatchCacheEntry {
   match: RouteMatch | null;
   strategy: PrefetchStrategy;
 }
 
-const prefetchCache = new Map<string, CacheEntry>();
-
-export function clearPrefetchCache(): void {
-  prefetchCache.clear();
-}
-
-export function getCachedRouteState(url: string): Promise<RouteStateResult> | null {
-  const entry = prefetchCache.get(url);
-  if (!entry) return null;
-  if (Date.now() - entry.timestamp > CACHE_TTL_MS) {
-    prefetchCache.delete(url);
-    return null;
-  }
-
-  // Refresh insertion order so the map acts as a small LRU cache.
-  prefetchCache.delete(url);
-  prefetchCache.set(url, entry);
-  return entry.promise;
-}
+export { clearPrefetchCache, getCachedRouteState };
 
 export function prefetchRouteState(url: string, route?: ResolvedRoute): Promise<RouteStateResult> {
   if (route && !routeNeedsServerFetch(route)) return EMPTY_ROUTE_STATE_PROMISE;
@@ -47,10 +27,8 @@ export function prefetchRouteState(url: string, route?: ResolvedRoute): Promise<
   const cached = getCachedRouteState(url);
   if (cached) return cached;
 
-  sweepPrefetchCache();
   const promise = fetchPrachtRouteState(url);
-  prefetchCache.set(url, { promise, timestamp: Date.now() });
-  trimMapToSize(prefetchCache, MAX_PREFETCH_CACHE_ENTRIES);
+  cacheRouteState(url, promise);
   return promise;
 }
 
@@ -205,20 +183,4 @@ export function setupPrefetching(app: ResolvedPrachtApp, warmModules?: ModuleWar
     }
   });
   mutationObserver.observe(document.body, { childList: true, subtree: true });
-}
-
-function sweepPrefetchCache(now = Date.now()): void {
-  for (const [url, entry] of prefetchCache) {
-    if (now - entry.timestamp > CACHE_TTL_MS) {
-      prefetchCache.delete(url);
-    }
-  }
-}
-
-function trimMapToSize<TKey, TValue>(map: Map<TKey, TValue>, maxEntries: number): void {
-  while (map.size > maxEntries) {
-    const first = map.keys().next();
-    if (first.done) return;
-    map.delete(first.value);
-  }
 }

--- a/packages/framework/src/router.ts
+++ b/packages/framework/src/router.ts
@@ -6,7 +6,7 @@ import type { FunctionComponent } from "preact";
 import { buildHref, matchAppRoute } from "./app.ts";
 import { installHydrationMismatchWarning } from "./hydration-mismatch.ts";
 import { markHydrating } from "./hydration.ts";
-import { getCachedRouteState, setupPrefetching } from "./prefetch.ts";
+import { getCachedRouteState } from "./prefetch-cache.ts";
 import type { ModuleWarmFn } from "./prefetch.ts";
 import type {
   NavigateOptions,
@@ -21,12 +21,8 @@ import {
   parseSafeNavigationUrl,
   routeNeedsServerFetch,
 } from "./runtime-client-fetch.ts";
-import {
-  deserializeRouteError,
-  PrachtRuntimeProvider,
-  type SerializedRouteError,
-  type PrachtHydrationState,
-} from "./runtime.ts";
+import { deserializeRouteError, type SerializedRouteError } from "./runtime-errors.ts";
+import { type PrachtHydrationState, PrachtRuntimeProvider } from "./runtime-context.ts";
 import type { RouteStateResult } from "./runtime-client-fetch.ts";
 
 interface RouteRenderState {
@@ -501,7 +497,9 @@ export async function initClientRouter(options: InitClientRouterOptions): Promis
     startRouteImport(match);
     startShellImport(match);
   };
-  setupPrefetching(app, warmModules);
+  void import("./prefetch.ts").then(({ setupPrefetching }) => {
+    setupPrefetching(app, warmModules);
+  });
 }
 
 function resolveBrowserRouteTarget(to: string): BrowserRouteTarget | null {

--- a/packages/framework/src/runtime-context.ts
+++ b/packages/framework/src/runtime-context.ts
@@ -1,0 +1,132 @@
+import { createContext, h } from "preact";
+import type { ComponentChildren } from "preact";
+import { useEffect, useMemo, useState } from "preact/hooks";
+
+import { EMPTY_ROUTE_PARAMS, HYDRATION_STATE_ELEMENT_ID } from "./runtime-constants.ts";
+import type { HrefRouteDefinition, RouteParams } from "./types.ts";
+
+export interface PrachtHydrationState<TData = unknown> {
+  url: string;
+  routeId: string;
+  data: TData;
+  error?: import("./runtime-errors.ts").SerializedRouteError | null;
+  pending?: boolean;
+}
+
+export interface StartAppOptions<TData = unknown> {
+  initialData?: TData;
+}
+
+declare global {
+  var __PRACHT_ROUTE_DEFINITIONS__: readonly HrefRouteDefinition[] | undefined;
+
+  interface Window {
+    __PRACHT_STATE__?: PrachtHydrationState;
+  }
+}
+
+export interface PrachtRuntimeValue {
+  data: unknown;
+  params: RouteParams;
+  routeId: string;
+  routes?: readonly HrefRouteDefinition[];
+  url: string;
+  setData: (data: unknown) => void;
+}
+
+export const RouteDataContext = createContext<PrachtRuntimeValue | undefined>(undefined);
+
+export function PrachtRuntimeProvider<TData>({
+  children,
+  data,
+  params = EMPTY_ROUTE_PARAMS,
+  routeId,
+  routes,
+  stateVersion = 0,
+  url,
+}: {
+  children: ComponentChildren;
+  data: TData;
+  params?: RouteParams;
+  routeId: string;
+  routes?: readonly HrefRouteDefinition[];
+  stateVersion?: number;
+  url: string;
+}) {
+  registerRuntimeRoutes(routes);
+
+  const [routeDataState, setRouteDataState] = useState({
+    data,
+    stateVersion,
+  });
+  const routeData = routeDataState.stateVersion === stateVersion ? routeDataState.data : data;
+
+  useEffect(() => {
+    setRouteDataState({
+      data,
+      stateVersion,
+    });
+  }, [data, routeId, stateVersion, url]);
+
+  const context = useMemo(
+    () => ({
+      data: routeData,
+      params,
+      routeId,
+      routes,
+      setData: (nextData: unknown) =>
+        setRouteDataState({
+          data: nextData as TData,
+          stateVersion,
+        }),
+      url,
+    }),
+    [routeData, params, routeId, routes, stateVersion, url],
+  );
+
+  return h(RouteDataContext.Provider, {
+    value: context,
+    children,
+  });
+}
+
+export function startApp<TData = unknown>(options: StartAppOptions<TData> = {}): TData | undefined {
+  if (typeof window === "undefined") {
+    return options.initialData;
+  }
+
+  if (typeof options.initialData !== "undefined") {
+    return options.initialData;
+  }
+
+  return readHydrationState<TData>()?.data;
+}
+
+export function readHydrationState<TData = unknown>(): PrachtHydrationState<TData> | undefined {
+  if (typeof window === "undefined") {
+    return undefined;
+  }
+
+  if (window.__PRACHT_STATE__) {
+    return window.__PRACHT_STATE__ as PrachtHydrationState<TData>;
+  }
+
+  const element = document.getElementById(HYDRATION_STATE_ELEMENT_ID);
+  if (!(element instanceof HTMLScriptElement)) {
+    return undefined;
+  }
+
+  const raw = element.textContent;
+  if (!raw) {
+    return undefined;
+  }
+
+  const state = JSON.parse(raw) as PrachtHydrationState<TData>;
+  window.__PRACHT_STATE__ = state as PrachtHydrationState;
+  return state;
+}
+
+function registerRuntimeRoutes(routes: readonly HrefRouteDefinition[] | undefined): void {
+  if (!routes) return;
+  globalThis.__PRACHT_ROUTE_DEFINITIONS__ = routes;
+}

--- a/packages/framework/src/runtime-hooks.ts
+++ b/packages/framework/src/runtime-hooks.ts
@@ -1,36 +1,24 @@
-import { createContext, h } from "preact";
-import type { ComponentChildren, JSX } from "preact";
-import { useContext, useEffect, useMemo, useState } from "preact/hooks";
+import { h } from "preact";
+import type { JSX } from "preact";
+import { useContext } from "preact/hooks";
 
 import { buildHref } from "./app.ts";
+import { SAFE_METHODS } from "./runtime-constants.ts";
 import {
-  EMPTY_ROUTE_PARAMS,
-  HYDRATION_STATE_ELEMENT_ID,
-  SAFE_METHODS,
-} from "./runtime-constants.ts";
-import { clearPrefetchCache } from "./prefetch.ts";
-import { deserializeRouteError, type SerializedRouteError } from "./runtime-errors.ts";
+  PrachtRuntimeProvider,
+  readHydrationState,
+  RouteDataContext,
+  startApp,
+  type PrachtHydrationState,
+  type StartAppOptions,
+} from "./runtime-context.ts";
+import { clearPrefetchCache } from "./prefetch-cache.ts";
+import { deserializeRouteError } from "./runtime-errors.ts";
 import { fetchPrachtRouteState, navigateToClientLocation } from "./runtime-client-fetch.ts";
-import type {
-  HrefRouteDefinition,
-  LoaderData,
-  LoaderLike,
-  RouteId,
-  RouteParams,
-  RouteTarget,
-} from "./types.ts";
+import type { LoaderData, LoaderLike, RouteId, RouteParams, RouteTarget } from "./types.ts";
 
-export interface PrachtHydrationState<TData = unknown> {
-  url: string;
-  routeId: string;
-  data: TData;
-  error?: SerializedRouteError | null;
-  pending?: boolean;
-}
-
-export interface StartAppOptions<TData = unknown> {
-  initialData?: TData;
-}
+export { PrachtRuntimeProvider, readHydrationState, startApp };
+export type { PrachtHydrationState, StartAppOptions };
 
 export interface FormProps extends Omit<JSX.HTMLAttributes<HTMLFormElement>, "action" | "method"> {
   action?: string;
@@ -46,115 +34,6 @@ export type LinkProps<TRoute extends RouteId = RouteId> = Omit<
 export interface Location {
   pathname: string;
   search: string;
-}
-
-declare global {
-  var __PRACHT_ROUTE_DEFINITIONS__: readonly HrefRouteDefinition[] | undefined;
-
-  interface Window {
-    __PRACHT_STATE__?: PrachtHydrationState;
-  }
-}
-
-interface PrachtRuntimeValue {
-  data: unknown;
-  params: RouteParams;
-  routeId: string;
-  routes?: readonly HrefRouteDefinition[];
-  url: string;
-  setData: (data: unknown) => void;
-}
-
-const RouteDataContext = createContext<PrachtRuntimeValue | undefined>(undefined);
-
-export function PrachtRuntimeProvider<TData>({
-  children,
-  data,
-  params = EMPTY_ROUTE_PARAMS,
-  routeId,
-  routes,
-  stateVersion = 0,
-  url,
-}: {
-  children: ComponentChildren;
-  data: TData;
-  params?: RouteParams;
-  routeId: string;
-  routes?: readonly HrefRouteDefinition[];
-  stateVersion?: number;
-  url: string;
-}) {
-  registerRuntimeRoutes(routes);
-
-  const [routeDataState, setRouteDataState] = useState({
-    data,
-    stateVersion,
-  });
-  const routeData = routeDataState.stateVersion === stateVersion ? routeDataState.data : data;
-
-  useEffect(() => {
-    setRouteDataState({
-      data,
-      stateVersion,
-    });
-  }, [data, routeId, stateVersion, url]);
-
-  const context = useMemo(
-    () => ({
-      data: routeData,
-      params,
-      routeId,
-      routes,
-      setData: (nextData: unknown) =>
-        setRouteDataState({
-          data: nextData as TData,
-          stateVersion,
-        }),
-      url,
-    }),
-    [routeData, params, routeId, routes, stateVersion, url],
-  );
-
-  return h(RouteDataContext.Provider, {
-    value: context,
-    children,
-  });
-}
-
-export function startApp<TData = unknown>(options: StartAppOptions<TData> = {}): TData | undefined {
-  if (typeof window === "undefined") {
-    return options.initialData;
-  }
-
-  if (typeof options.initialData !== "undefined") {
-    return options.initialData;
-  }
-
-  return readHydrationState<TData>()?.data;
-}
-
-export function readHydrationState<TData = unknown>(): PrachtHydrationState<TData> | undefined {
-  if (typeof window === "undefined") {
-    return undefined;
-  }
-
-  if (window.__PRACHT_STATE__) {
-    return window.__PRACHT_STATE__ as PrachtHydrationState<TData>;
-  }
-
-  const element = document.getElementById(HYDRATION_STATE_ELEMENT_ID);
-  if (!(element instanceof HTMLScriptElement)) {
-    return undefined;
-  }
-
-  const raw = element.textContent;
-  if (!raw) {
-    return undefined;
-  }
-
-  const state = JSON.parse(raw) as PrachtHydrationState<TData>;
-  window.__PRACHT_STATE__ = state as PrachtHydrationState;
-  return state;
 }
 
 export function useRouteData<TLoader extends LoaderLike>(): LoaderData<TLoader>;
@@ -216,11 +95,6 @@ export function Link<TRoute extends RouteId>(props: LinkProps<TRoute>) {
     ...anchorProps,
     href: buildHref(routes, route, { params, search, hash } as never),
   } as JSX.HTMLAttributes<HTMLAnchorElement>);
-}
-
-function registerRuntimeRoutes(routes: readonly HrefRouteDefinition[] | undefined): void {
-  if (!routes) return;
-  globalThis.__PRACHT_ROUTE_DEFINITIONS__ = routes;
 }
 
 export function Form(props: FormProps) {

--- a/packages/framework/src/runtime.ts
+++ b/packages/framework/src/runtime.ts
@@ -10,7 +10,7 @@ import {
   type PrachtRuntimeDiagnosticPhase,
 } from "./runtime-errors.ts";
 import { withDefaultSecurityHeaders } from "./runtime-headers.ts";
-import { PrachtRuntimeProvider } from "./runtime-hooks.ts";
+import { PrachtRuntimeProvider } from "./runtime-context.ts";
 import { buildHtmlDocument, htmlResponse } from "./runtime-html.ts";
 import {
   resolvePageCssUrls,

--- a/packages/framework/src/server.ts
+++ b/packages/framework/src/server.ts
@@ -11,25 +11,14 @@ export {
   timeRevalidate,
 } from "./app.ts";
 export { createHref } from "./href.ts";
-export { forwardRef } from "./forwardRef.ts";
-export { useIsHydrated } from "./hydration.ts";
-export { Suspense, lazy } from "preact-suspense";
 export {
   applyDefaultSecurityHeaders,
-  Form,
-  Link,
   handlePrachtRequest,
-  readHydrationState,
-  startApp,
-  useLocation,
-  useParams,
-  useRevalidate,
-  useRouteData,
   PrachtRuntimeProvider,
 } from "./runtime.ts";
 export { prerenderApp } from "./prerender.ts";
-export { initClientRouter, useNavigate } from "./router.ts";
 export { PrachtHttpError } from "./types.ts";
+
 export type {
   ApiConfig,
   ApiRouteArgs,
@@ -93,16 +82,10 @@ export type {
   PrachtAppConfig,
 } from "./types.ts";
 export type {
-  FormProps,
   HandlePrachtRequestOptions,
-  LinkProps,
-  Location,
   PrachtRuntimeDiagnosticPhase,
   PrachtRuntimeDiagnostics,
-  RouteStateResult,
   SerializedRouteError,
-  StartAppOptions,
-  PrachtHydrationState,
 } from "./runtime.ts";
 export type {
   ISGManifestEntry,
@@ -110,4 +93,3 @@ export type {
   PrerenderAppResult,
   PrerenderResult,
 } from "./prerender.ts";
-export type { InitClientRouterOptions, NavigateFn } from "./router.ts";

--- a/packages/framework/tsdown.config.ts
+++ b/packages/framework/tsdown.config.ts
@@ -2,7 +2,14 @@ import { defineConfig } from "tsdown";
 
 export default defineConfig({
   clean: true,
-  entry: ["src/index.ts", "src/error-overlay.ts"],
+  entry: [
+    "src/index.ts",
+    "src/browser.ts",
+    "src/client.ts",
+    "src/manifest.ts",
+    "src/server.ts",
+    "src/error-overlay.ts",
+  ],
   format: "esm",
   dts: true,
   external: ["preact", "preact/hooks", "preact-render-to-string"],

--- a/packages/vite-plugin/src/index.ts
+++ b/packages/vite-plugin/src/index.ts
@@ -114,7 +114,11 @@ export function pracht(options: PrachtPluginOptions = {}): Plugin[] {
       const normalizedId = toPosixPath(id.split("?")[0]);
       if (normalizedId !== appFileAbs) return null;
 
-      const transformed = code.replace(/\(\)\s*=>\s*import\(\s*(['"])([^'"]+)\1\s*\)/g, "$1$2$1");
+      const withStringModuleRefs = code.replace(
+        /\(\)\s*=>\s*import\(\s*(['"])([^'"]+)\1\s*\)/g,
+        "$1$2$1",
+      );
+      const transformed = rewriteManifestCoreImports(withStringModuleRefs);
       if (transformed === code) return null;
       return { code: transformed, map: null };
     },
@@ -214,6 +218,29 @@ export function pracht(options: PrachtPluginOptions = {}): Plugin[] {
   plugins.push(optimizeDepsEntriesPlugin);
 
   return plugins;
+}
+
+const MANIFEST_CORE_IMPORTS = new Set(["defineApp", "group", "route", "timeRevalidate"]);
+
+function rewriteManifestCoreImports(code: string): string {
+  return code.replace(
+    /import\s+(type\s+)?\{([^}]+)\}\s+from\s+(['"])@pracht\/core\3/g,
+    (match, typeKeyword: string | undefined, specifiers: string, quote: string) => {
+      const valueImports = specifiers
+        .split(",")
+        .map((specifier) => specifier.trim())
+        .filter(Boolean)
+        .filter((specifier) => !specifier.startsWith("type "))
+        .map((specifier) => specifier.split(/\s+as\s+/)[0]?.trim())
+        .filter(Boolean);
+
+      if (!typeKeyword && valueImports.some((specifier) => !MANIFEST_CORE_IMPORTS.has(specifier))) {
+        return match;
+      }
+
+      return `import ${typeKeyword ?? ""}{${specifiers}} from ${quote}@pracht/core/manifest${quote}`;
+    },
+  );
 }
 
 function withPrachtOptimizeDepsEntries(config: UserConfig, prachtEntries: string[]): UserConfig {

--- a/packages/vite-plugin/src/pages-router.ts
+++ b/packages/vite-plugin/src/pages-router.ts
@@ -158,7 +158,7 @@ export function generatePagesManifestSource(
     (f) => basename(f, extname(f)) === "_app" && SHELL_EXTENSIONS.has(extname(f)),
   );
 
-  const lines: string[] = ['import { defineApp, group, route } from "@pracht/core";', ""];
+  const lines: string[] = ['import { defineApp, group, route } from "@pracht/core/manifest";', ""];
 
   const routeEntries: string[] = [];
 

--- a/packages/vite-plugin/src/plugin-adapter.ts
+++ b/packages/vite-plugin/src/plugin-adapter.ts
@@ -45,7 +45,7 @@ export interface PrachtAdapter {
 export function createDefaultNodeAdapter(): PrachtAdapter {
   return {
     id: "node",
-    serverImports: 'import { resolveApp, resolveApiRoutes } from "@pracht/core";',
+    serverImports: 'import { resolveApp, resolveApiRoutes } from "@pracht/core/server";',
     createServerEntryModule() {
       return createNodeServerEntryModule();
     },

--- a/packages/vite-plugin/src/plugin-codegen.ts
+++ b/packages/vite-plugin/src/plugin-codegen.ts
@@ -38,7 +38,7 @@ export function createPrachtClientModuleSource(
     : `${resolved.shellsDir}/**/*.tsrx`;
 
   return [
-    'import { resolveApp, initClientRouter, readHydrationState } from "@pracht/core";',
+    'import { resolveApp, initClientRouter, readHydrationState } from "@pracht/core/client";',
     appImport,
     "",
     `const routeLoaderHints = ${JSON.stringify(routeLoaderHints)};`,
@@ -116,11 +116,11 @@ export function createPrachtServerModuleSource(
 
   // The adapter tells us what extra imports it needs (e.g. handlePrachtRequest).
   // Always import prerenderApp so the CLI uses the same bundled copy of
-  // @pracht/core (and therefore the same Preact context instances) as the
+  // @pracht/core/server (and therefore the same Preact context instances) as the
   // route/shell modules — avoids dual-copy issues during SSG prerendering.
   const prachtImports = adapter?.serverImports
-    ? adapter.serverImports + '\nimport { prerenderApp } from "@pracht/core";'
-    : 'import { resolveApp, resolveApiRoutes, prerenderApp } from "@pracht/core";';
+    ? adapter.serverImports + '\nimport { prerenderApp } from "@pracht/core/server";'
+    : 'import { resolveApp, resolveApiRoutes, prerenderApp } from "@pracht/core/server";';
 
   const appImport = isPagesMode
     ? generatePagesAppInlineSource(resolved, buildOptions.root)

--- a/packages/vite-plugin/src/plugin-dev-ssr.ts
+++ b/packages/vite-plugin/src/plugin-dev-ssr.ts
@@ -17,7 +17,7 @@ export function createDevSSRMiddleware(
 
     try {
       const [framework, serverMod] = await Promise.all([
-        server.ssrLoadModule("@pracht/core"),
+        server.ssrLoadModule("@pracht/core/server"),
         server.ssrLoadModule(PRACHT_SERVER_MODULE_ID),
       ]);
 

--- a/packages/vite-plugin/test/client-module-transform.test.ts
+++ b/packages/vite-plugin/test/client-module-transform.test.ts
@@ -42,6 +42,14 @@ async function buildTempProject(root: string): Promise<void> {
     resolve: {
       alias: [
         {
+          find: "@pracht/core/client",
+          replacement: resolve(repoRoot, "packages/framework/src/client.ts"),
+        },
+        {
+          find: "@pracht/core/manifest",
+          replacement: resolve(repoRoot, "packages/framework/src/manifest.ts"),
+        },
+        {
           find: "@pracht/core",
           replacement: resolve(repoRoot, "packages/framework/src/index.ts"),
         },
@@ -399,6 +407,36 @@ export function Component() {
 });
 
 describe("client route module build", () => {
+  it("uses lean core entries for generated client and manifest code", async () => {
+    const root = makeTempProject();
+    mkdirSync(join(root, "src"), { recursive: true });
+    const plugins = pracht({ appFile: "/src/routes.ts" });
+    const configResolved = findPrachtConfigResolved(plugins);
+    configResolved({ root, command: "build" } as never);
+
+    const clientSource = createPrachtClientModuleSource({ appFile: "/src/routes.ts" }, { root });
+    expect(clientSource).toContain(
+      'import { resolveApp, initClientRouter, readHydrationState } from "@pracht/core/client";',
+    );
+
+    const transform = findPrachtTransform(plugins);
+    const transformed = await callTransform(
+      transform,
+      [
+        'import { defineApp, group, route, timeRevalidate } from "@pracht/core";',
+        "export const app = defineApp({",
+        '  routes: [group({ shell: "public" }, [route("/", () => import("./routes/home.tsx"), { revalidate: timeRevalidate(60) })])],',
+        "});",
+        "",
+      ].join("\n"),
+      join(root, "src", "routes.ts"),
+      { ssr: false },
+    );
+
+    expect(transformed).toContain('from "@pracht/core/manifest"');
+    expect(transformed).toContain('route("/", "./routes/home.tsx"');
+  });
+
   it("embeds route loader hints for manifest routes", () => {
     const root = makeTempProject();
     mkdirSync(join(root, "src", "routes"), { recursive: true });
@@ -574,6 +612,20 @@ function findPrachtConfigResolved(plugins: readonly unknown[]): (config: unknown
     }
   }
   throw new Error("pracht plugin not found");
+}
+
+function findPrachtTransform(plugins: readonly unknown[]): unknown {
+  for (const plugin of plugins) {
+    if (
+      plugin &&
+      typeof plugin === "object" &&
+      (plugin as { name?: string }).name === "pracht" &&
+      typeof (plugin as { transform?: unknown }).transform === "function"
+    ) {
+      return (plugin as { transform: unknown }).transform;
+    }
+  }
+  throw new Error("pracht transform hook not found");
 }
 
 async function callTransform(

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,6 +15,10 @@
     "baseUrl": ".",
     "paths": {
       "@pracht/core": ["./packages/framework/src/index.ts"],
+      "@pracht/core/browser": ["./packages/framework/src/browser.ts"],
+      "@pracht/core/client": ["./packages/framework/src/client.ts"],
+      "@pracht/core/manifest": ["./packages/framework/src/manifest.ts"],
+      "@pracht/core/server": ["./packages/framework/src/server.ts"],
       "@pracht/vite-plugin": ["./packages/vite-plugin/src/index.ts"],
       "@pracht/preact-ssr-precompile": ["./packages/preact-ssr-precompile/src/index.ts"],
       "@pracht/adapter-node": ["./packages/adapter-node/src/index.ts"],


### PR DESCRIPTION
## Summary

- Split `@pracht/core` into lean client, manifest, server, and browser entries so generated client code avoids the server-capable barrel by default.
- Lazy-load prefetch listener setup after router initialization while keeping route-state cache available synchronously.
- Link the relevant issue, if there is one: N/A


Example | client-*.js raw | client-*.js gzip
-- | -- | --
basic | 18.24 KB -> 10.07 KB, -44.8% | 6.62 KB -> 3.83 KB, -42.1%
cloudflare | 18.65 KB -> 10.16 KB, -45.5% | 6.76 KB -> 3.87 KB, -42.7%
pages-router | 16.86 KB -> 9.60 KB, -43.0% | 6.23 KB -> 3.67 KB, -41.0%
tsrx | 15.78 KB -> 14.17 KB, -10.2% | 5.94 KB -> 5.41 KB, -8.9%
docs | 23.49 KB -> 16.51 KB, -29.7% | 7.36 KB -> 4.87 KB, -33.8%
showcase | 18.79 KB -> 10.62 KB, -43.5% | 6.76 KB -> 3.97 KB, -41.3%


