### PR TITLE
Make middleware wrap-around with next()

### DIFF
--- a/.changeset/method-aware-redirect-helper.md
+++ b/.changeset/method-aware-redirect-helper.md
@@ -1,0 +1,5 @@
+---
+"@pracht/core": patch
+---
+
+Make the `redirect()` helper method-aware when given a request or method so unsafe HTTP methods default to 303 redirects instead of 302.

--- a/.changeset/middleware-wrap-around.md
+++ b/.changeset/middleware-wrap-around.md
@@ -1,0 +1,49 @@
+---
+"@pracht/core": minor
+"@pracht/cli": minor
+---
+
+**Breaking:** Middleware is now wrap-around (Hono/Koa/Astro shape). The
+`MiddlewareFn` signature changes from `(args) => MiddlewareResult` to
+`(args, next) => Promise<Response>`.
+
+```ts
+// Before
+export const middleware: MiddlewareFn = async ({ request }) => {
+  if (!hasSession(request)) return { redirect: "/login" };
+  return { context: { user: "jovi" } };
+};
+
+// After
+import { redirect, type MiddlewareFn } from "@pracht/core";
+
+export const middleware: MiddlewareFn = async ({ context, request }, next) => {
+  if (!hasSession(request)) return redirect("/login");
+  (context as { user?: string }).user = "jovi";
+  return next();
+};
+```
+
+Why: middleware can now wrap `try / catch / finally` around the rest of the
+request, which is the standard shape for tracing, logging, and observability
+libraries (Honeycomb, OpenTelemetry, Sentry). It also matches what users
+arriving from honox / Hono / Astro / SvelteKit / Koa expect.
+
+Migration notes:
+
+- Replace `return { redirect: "/path" }` with `return redirect("/path")`
+  using the new `redirect` helper exported from `@pracht/core`.
+- Replace `return { context: { ... } }` with direct mutation of
+  `args.context`. Context is shared by reference between middleware and
+  the loader/handler.
+- Replace bare `return` (continue) with `return next()`.
+- Middleware that returns a `Response` directly still works as a
+  short-circuit.
+- The `MiddlewareResult` type is removed; `MiddlewareNext` is exported.
+- One `AbortSignal` is now shared per request across all middleware and
+  the loader/handler instead of a fresh 30s timer per phase. This makes
+  long-running middleware count toward the same overall budget as the
+  loader/handler, which matches how most users reason about per-request
+  timeouts.
+
+The CLI's `pracht generate middleware` scaffold emits the new signature.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -205,20 +205,24 @@ pattern that forces URL structure to mirror component hierarchy.
 
 ### 4. Middleware
 
-Server-side functions that run before loaders:
+Server-side wrap-around functions that surround loaders and API handlers via
+a `next()` callback:
 
 ```typescript
 // src/middleware/auth.ts
-import type { MiddlewareFn } from "@pracht/core";
+import { redirect, type MiddlewareFn } from "@pracht/core";
 
-export const middleware: MiddlewareFn = async ({ request }) => {
+export const middleware: MiddlewareFn = async ({ request }, next) => {
   const session = await getSession(request);
-  if (!session) return { redirect: "/login" };
+  if (!session) return redirect("/login", { request });
+  return next();
 };
 ```
 
 Middleware is named in the manifest and applied per route or group. It can
-redirect, set context, or throw errors.
+short-circuit with a Response, mutate `args.context`, or wrap the rest of
+the request in `try / catch / finally` for logging and tracing. See
+[ROUTING.md](./ROUTING.md#middleware) for the full contract.
 
 ### 5. Module Registry
 

--- a/docs/ROUTING.md
+++ b/docs/ROUTING.md
@@ -244,17 +244,62 @@ present.
 
 ## Middleware
 
-Middleware runs server-side before the loader. It can redirect, modify context,
-or throw errors.
+Middleware wraps the rest of the request — loaders, API handlers, and any
+inner middleware — using a `next()` function. It can redirect, mutate
+context, short-circuit with a custom Response, or wrap the inner handler in
+`try / catch / finally`.
 
 ```typescript
 // src/middleware/auth.ts
-export const middleware: MiddlewareFn = async ({ request }) => {
+import { redirect, type MiddlewareFn } from "@pracht/core";
+
+export const middleware: MiddlewareFn = async ({ request }, next) => {
   const session = await getSession(request);
-  if (!session) return { redirect: "/login" };
-  // Returning void continues to the loader
+  if (!session) return redirect("/login", { request });
+  return next();
 };
 ```
+
+Calling `await next()` runs the rest of the chain (and the loader/handler)
+and resolves to the final `Response`. Middleware that returns without
+calling `next()` short-circuits the request — the loader/handler never
+runs.
+
+### Mutating context
+
+Middleware can read and mutate `args.context` directly. Earlier middleware
+sets values, later middleware (and the loader/API handler) sees them on the
+same object:
+
+```ts
+export const middleware: MiddlewareFn = async ({ context, request }, next) => {
+  (context as { user?: User }).user = await getSession(request);
+  return next();
+};
+```
+
+### try / catch / finally
+
+Because middleware wraps the handler, request-scoped logging, tracing, and
+timing all live in a single middleware:
+
+```ts
+export const middleware: MiddlewareFn = async ({ context, request }, next) => {
+  const span = startSpan({ url: request.url });
+  let response: Response | undefined;
+  try {
+    response = await next();
+    return response;
+  } catch (err) {
+    span.recordError(err);
+    throw err;
+  } finally {
+    span.end({ status: response?.status ?? 500 });
+  }
+};
+```
+
+### Applying middleware
 
 Apply middleware to routes or groups:
 

--- a/examples/basic/src/middleware/auth.ts
+++ b/examples/basic/src/middleware/auth.ts
@@ -1,14 +1,16 @@
-import type { MiddlewareFn } from "@pracht/core";
+import { redirect, type MiddlewareFn } from "@pracht/core";
 
 // ⚠️ NOT FOR PRODUCTION — This is a minimal example only.
 // A real implementation should:
 //   - Verify the session token with a cryptographic signature (e.g. HMAC)
 //   - Check token expiry
 //   - Set cookie attributes: HttpOnly, Secure, SameSite=Lax, Path=/
-export const middleware: MiddlewareFn = async ({ request }) => {
+export const middleware: MiddlewareFn = async ({ request }, next) => {
   const hasSession = request.headers.get("cookie")?.includes("session=") ?? false;
 
   if (!hasSession) {
-    return { redirect: "/" };
+    return redirect("/", { request });
   }
+
+  return next();
 };

--- a/examples/cloudflare/src/middleware/auth.ts
+++ b/examples/cloudflare/src/middleware/auth.ts
@@ -1,9 +1,11 @@
-import type { MiddlewareFn } from "@pracht/core";
+import { redirect, type MiddlewareFn } from "@pracht/core";
 
-export const middleware: MiddlewareFn = async ({ request }) => {
+export const middleware: MiddlewareFn = async ({ request }, next) => {
   const hasSession = request.headers.get("cookie")?.includes("session=") ?? false;
 
   if (!hasSession) {
-    return { redirect: "/" };
+    return redirect("/", { request });
   }
+
+  return next();
 };

--- a/examples/docs/src/routes.ts
+++ b/examples/docs/src/routes.ts
@@ -95,6 +95,10 @@ export const app = defineApp({
         id: "recipes-testing",
         render: "ssg",
       }),
+      route("/docs/recipes/logging", () => import("./routes/docs/recipes-logging.md"), {
+        id: "recipes-logging",
+        render: "ssg",
+      }),
       route("/docs/recipes/fullstack-cloudflare", "./routes/docs/recipes-fullstack-cloudflare.md", {
         id: "recipes-fullstack-cloudflare",
         render: "ssg",

--- a/examples/docs/src/routes/docs/middleware.md
+++ b/examples/docs/src/routes/docs/middleware.md
@@ -12,20 +12,45 @@ next:
 
 ## Defining Middleware
 
-Middleware modules live in `src/middleware/` and export a `middleware` function:
+Middleware wraps the rest of the request — loaders, API handlers, and any
+inner middleware — using a `next()` function. Modules live in
+`src/middleware/` and export a `middleware` function:
 
 ```ts [src/middleware/auth.ts]
-import type { MiddlewareFn } from "@pracht/core";
+import { redirect, type MiddlewareFn } from "@pracht/core";
 
-export const middleware: MiddlewareFn = async ({ request }) => {
+export const middleware: MiddlewareFn = async ({ request }, next) => {
   const session = await getSession(request);
 
-  // Redirect unauthenticated users
+  // Short-circuit: return without calling next()
   if (!session) {
-    return { redirect: "/login" };
+    return redirect("/login", { request });
   }
 
-  // Return void to continue to the loader
+  // Continue to the rest of the chain (and the loader/handler)
+  return next();
+};
+```
+
+Calling `await next()` runs the rest of the request and resolves to the final
+`Response`. That means middleware can wrap try/catch/finally around the whole
+request — useful for logging, tracing, and timing:
+
+```ts [src/middleware/trace.ts]
+import type { MiddlewareFn } from "@pracht/core";
+
+export const middleware: MiddlewareFn = async ({ request }, next) => {
+  const span = startSpan({ url: request.url, method: request.method });
+  try {
+    const response = await next();
+    span.setAttribute("status", response.status);
+    return response;
+  } catch (err) {
+    span.recordError(err);
+    throw err;
+  } finally {
+    span.end();
+  }
 };
 ```
 
@@ -68,11 +93,30 @@ Middleware from groups and routes is combined. A route inside a group with `["au
 
 ## Middleware Results
 
-| Return                            | Effect                                    |
-| --------------------------------- | ----------------------------------------- |
-| `undefined` / `void`              | Continue to the next middleware or loader |
-| `{ redirect: "/path" }`           | HTTP 302 redirect                         |
-| `{ response: new Response(...) }` | Short-circuit with a custom response      |
+Middleware always returns a `Response`. There are two ways to produce one:
+
+| Return                | Effect                                                                |
+| --------------------- | --------------------------------------------------------------------- |
+| `return next()`       | Continue to the next middleware (or loader/handler) and return its response |
+| `return redirect(...)` | Short-circuit with a redirect; pass `{ request }` for method-aware 302/303 defaults |
+| `return new Response(...)` | Short-circuit with any custom response                          |
+
+If middleware returns without calling `next()`, the rest of the chain — and
+the loader/handler — is skipped.
+
+### Mutating context
+
+Middleware can read and mutate `args.context` directly. Earlier middleware
+sets values, later middleware (and the loader/API handler) sees them:
+
+```ts
+export const middleware: MiddlewareFn = async ({ context, request }, next) => {
+  (context as { user?: User }).user = await getSession(request);
+  return next();
+};
+```
+
+The `context` object is shared by reference — there's no merge step.
 
 ---
 

--- a/examples/docs/src/routes/docs/migrate-nextjs.md
+++ b/examples/docs/src/routes/docs/migrate-nextjs.md
@@ -278,12 +278,13 @@ export const config = { matcher: ["/dashboard/:path*", "/settings/:path*"] };
 ```
 
 ```ts [src/middleware/auth.ts]
-// pracht — named middleware
-import type { MiddlewareFn } from "@pracht/core";
+// pracht — named, wrap-around middleware
+import { redirect, type MiddlewareFn } from "@pracht/core";
 
-export const middleware: MiddlewareFn = async ({ request }) => {
+export const middleware: MiddlewareFn = async ({ request }, next) => {
   const session = await getSession(request);
-  if (!session) return { redirect: "/login" };
+  if (!session) return redirect("/login", { request });
+  return next();
 };
 ```
 

--- a/examples/docs/src/routes/docs/recipes-auth.md
+++ b/examples/docs/src/routes/docs/recipes-auth.md
@@ -78,19 +78,20 @@ async function sign(data: string): Promise<string> {
 This middleware redirects unauthenticated users to the login page. Apply it to any route group that requires auth.
 
 ```ts [src/middleware/auth.ts]
-import type { MiddlewareFn } from "@pracht/core";
+import { redirect, type MiddlewareFn } from "@pracht/core";
 import { getSession } from "../server/session";
 
-export const middleware: MiddlewareFn = async ({ request }) => {
+export const middleware: MiddlewareFn = async ({ request }, next) => {
   const session = await getSession(request);
   if (!session) {
     const loginUrl = `/login?redirect=${encodeURIComponent(new URL(request.url).pathname)}`;
-    return { redirect: loginUrl };
+    return redirect(loginUrl, { request });
   }
 
   // Pass user info downstream via a header (loaders can read it)
   request.headers.set("x-user-id", session.userId);
   request.headers.set("x-user-email", session.email);
+  return next();
 };
 ```
 
@@ -285,8 +286,8 @@ const ALLOWED = new Set<string>([
   // add trusted cross-origin callers here (e.g. "https://admin.example.com")
 ]);
 
-export const middleware: MiddlewareFn = ({ request, url }) => {
-  if (!UNSAFE.has(request.method)) return;
+export const middleware: MiddlewareFn = ({ request, url }, next) => {
+  if (!UNSAFE.has(request.method)) return next();
 
   const origin = request.headers.get("origin");
   if (origin === null) {
@@ -294,12 +295,12 @@ export const middleware: MiddlewareFn = ({ request, url }) => {
     // the check. Sec-Fetch-Site tells us when the browser itself marked the
     // request as same-origin or user-initiated.
     const site = request.headers.get("sec-fetch-site");
-    if (site === "same-origin" || site === "none") return;
+    if (site === "same-origin" || site === "none") return next();
     return new Response("Forbidden: missing Origin", { status: 403 });
   }
 
-  if (origin === url.origin) return;
-  if (ALLOWED.has(origin)) return;
+  if (origin === url.origin) return next();
+  if (ALLOWED.has(origin)) return next();
 
   return new Response(`Forbidden: origin ${origin} not allowed`, { status: 403 });
 };

--- a/examples/docs/src/routes/docs/recipes-fullstack-cloudflare.md
+++ b/examples/docs/src/routes/docs/recipes-fullstack-cloudflare.md
@@ -3,8 +3,8 @@ title: Full-Stack Cloudflare
 lead: Build a full-stack app on Cloudflare with D1 (SQLite), KV, and R2. This recipe covers project setup, database migrations, and wiring bindings into your loaders and API routes.
 breadcrumb: Full-Stack Cloudflare
 prev:
-  href: /docs/recipes/testing
-  title: Testing
+  href: /docs/recipes/logging
+  title: Logging
 next:
   href: /docs/recipes/fullstack-vercel
   title: Full-Stack Vercel

--- a/examples/docs/src/routes/docs/recipes-i18n.md
+++ b/examples/docs/src/routes/docs/recipes-i18n.md
@@ -68,10 +68,10 @@ Create middleware that detects the locale and makes it available to loaders. You
 The cleanest approach for SEO — each locale has its own URL namespace like `/fr/about` or `/en/about`.
 
 ```ts [src/middleware/i18n.ts]
-import type { MiddlewareFn } from "@pracht/core";
+import { redirect, type MiddlewareFn } from "@pracht/core";
 import { supportedLocales, defaultLocale } from "../i18n";
 
-export const middleware: MiddlewareFn = async ({ request, url }) => {
+export const middleware: MiddlewareFn = async ({ request, url }, next) => {
   // Extract locale from first URL segment: /fr/about -> "fr"
   const segments = url.pathname.split("/").filter(Boolean);
   const maybeLocale = segments[0];
@@ -79,7 +79,7 @@ export const middleware: MiddlewareFn = async ({ request, url }) => {
   if (supportedLocales.includes(maybeLocale)) {
     // Locale found in URL — pass it through via headers
     request.headers.set("x-locale", maybeLocale);
-    return;
+    return next();
   }
 
   // No locale in URL — detect from Accept-Language or default
@@ -92,7 +92,7 @@ export const middleware: MiddlewareFn = async ({ request, url }) => {
   const locale = preferred ?? defaultLocale;
 
   // Redirect to prefixed URL
-  return { redirect: `/${locale}${url.pathname}` };
+  return redirect(`/${locale}${url.pathname}`, { request });
 };
 ```
 
@@ -104,12 +104,13 @@ If you prefer clean URLs without a locale prefix, store the preference in a cook
 import type { MiddlewareFn } from "@pracht/core";
 import { supportedLocales, defaultLocale } from "../i18n";
 
-export const middleware: MiddlewareFn = async ({ request }) => {
+export const middleware: MiddlewareFn = async ({ request }, next) => {
   const cookies = request.headers.get("cookie") ?? "";
   const match = cookies.match(/locale=(\w+)/);
   const locale = match && supportedLocales.includes(match[1]) ? match[1] : defaultLocale;
 
   request.headers.set("x-locale", locale);
+  return next();
 };
 ```
 

--- a/examples/docs/src/routes/docs/recipes-logging.md
+++ b/examples/docs/src/routes/docs/recipes-logging.md
@@ -1,0 +1,235 @@
+---
+title: Logging & Observability
+lead: Capture request duration, status, and failures from loaders and API routes with one wrap-around middleware — no per-handler instrumentation.
+breadcrumb: Logging
+prev:
+  href: /docs/recipes/testing
+  title: Testing
+next:
+  href: /docs/recipes/fullstack-cloudflare
+  title: Full-Stack Cloudflare
+---
+
+## Recommended Shape
+
+Pracht middleware wraps the rest of the request via `next()`, so a single
+middleware can `try / catch / finally` around every loader and API handler.
+This is the right place for Honeycomb-style request logging, OpenTelemetry
+spans, or anything that needs to observe the final status and any thrown
+error.
+
+- **Manifest apps** (those with `routes.ts`): use a tracing/logging middleware
+  registered with `defineApp`. One middleware covers loaders, API routes, and
+  inner middleware in one wrapper.
+- **Pages router** apps: there is no manifest, so wrap individual API
+  handlers with a small higher-order function instead.
+- **Adapter-level wrappers** are only needed when you want to observe the
+  outer HTTP cycle including framework-internal failures, since pracht
+  converts loader/handler errors into responses before they leave its
+  runtime.
+
+---
+
+## Create a Request Logger in Context
+
+Adapters can import a context factory with `createContextFrom`. This is a
+good place to create a request id and logger instance shared by loaders,
+middleware, and API handlers.
+
+```ts [vite.config.ts]
+import { nodeAdapter } from "@pracht/adapter-node";
+import { pracht } from "@pracht/vite-plugin";
+import { defineConfig } from "vite";
+
+export default defineConfig({
+  plugins: [
+    pracht({
+      adapter: nodeAdapter({ createContextFrom: "/src/server/context.ts" }),
+    }),
+  ],
+});
+```
+
+```ts [src/server/context.ts]
+import { createRequestLogger } from "./logger";
+
+export function createContext({ request }: { request: Request }) {
+  const url = new URL(request.url);
+  const requestId = request.headers.get("x-request-id") ?? crypto.randomUUID();
+
+  return {
+    logger: createRequestLogger({
+      method: request.method,
+      path: url.pathname,
+      requestId,
+    }),
+    requestId,
+  };
+}
+```
+
+Register the context type once so `args.context.logger` is typed everywhere:
+
+```ts [src/env.d.ts]
+import type { RequestLogger } from "./server/logger";
+
+declare module "@pracht/core" {
+  interface Register {
+    context: {
+      logger: RequestLogger;
+      requestId: string;
+    };
+  }
+}
+```
+
+---
+
+## Wrap-Around Logging Middleware
+
+Register the middleware once in the manifest. Apply it globally for API
+routes via `api.middleware`, and on a group/route for page routes:
+
+```ts [src/routes.ts]
+import { defineApp, group, route } from "@pracht/core";
+
+export const app = defineApp({
+  middleware: {
+    requestLog: "./middleware/request-log.ts",
+  },
+  api: {
+    middleware: ["requestLog"],
+  },
+  routes: [
+    group({ middleware: ["requestLog"] }, [
+      route("/dashboard", "./routes/dashboard.tsx", { render: "ssr" }),
+      route("/projects/:id", "./routes/project.tsx", { render: "ssr" }),
+    ]),
+  ],
+});
+```
+
+```ts [src/middleware/request-log.ts]
+import type { MiddlewareFn } from "@pracht/core";
+
+export const middleware: MiddlewareFn = async ({ context, request, route, url }, next) => {
+  const startedAt = performance.now();
+  let response: Response | undefined;
+  let thrown: unknown;
+
+  try {
+    response = await next();
+    return response;
+  } catch (error) {
+    thrown = error;
+    throw error;
+  } finally {
+    const durationMs = Math.round(performance.now() - startedAt);
+    const status = response?.status ?? 500;
+
+    context.logger.event({
+      durationMs,
+      error: serializeError(thrown),
+      method: request.method,
+      path: url.pathname,
+      requestId: context.requestId,
+      route: route.path,
+      status,
+    });
+
+    // Hand the flush off to the runtime so the response can return
+    // immediately. On Cloudflare this keeps the worker alive long enough
+    // for the events to ship; on Node the helper just awaits the promise.
+    deferFlush(context, context.logger.flush());
+  }
+};
+
+function serializeError(error: unknown) {
+  if (!error) return undefined;
+  if (error instanceof Error) {
+    return { message: error.message, name: error.name, stack: error.stack };
+  }
+  return { message: String(error), name: "Error" };
+}
+
+// Cloudflare's executionContext.waitUntil keeps the worker alive past the
+// response. On Node there's no equivalent — `await` would delay the
+// response, and bare fire-and-forget would lose unhandled rejections, so
+// just attach a catch handler.
+function deferFlush(context: { executionContext?: { waitUntil(p: Promise<unknown>): void } }, flushPromise: Promise<unknown>) {
+  if (context.executionContext?.waitUntil) {
+    context.executionContext.waitUntil(
+      flushPromise.catch((err) => console.error("[pracht] log flush failed", err)),
+    );
+    return;
+  }
+  flushPromise.catch((err) => console.error("[pracht] log flush failed", err));
+}
+```
+
+This is the same `try / catch / finally` shape Hono and Koa users are
+accustomed to. The middleware sees the final response status and any thrown
+error, and `finally` runs as part of the request — exactly what
+Honeycomb / Beeline-style libraries need.
+
+> **Cloudflare:** the `fetch` handler returns once the middleware does, and
+> the worker can be torn down at any point afterward. `await flush()` inside
+> `finally` works but blocks the response on the flush; bare fire-and-forget
+> risks the worker terminating mid-flight. The recommended pattern is
+> `context.executionContext.waitUntil(flushPromise)` — the response goes out
+> immediately and the runtime keeps the worker alive until the flush
+> resolves. The `deferFlush` helper above handles both runtimes.
+
+---
+
+## Pages Router: Higher-Order Wrapper
+
+The pages router does not use the manifest, so register logging by wrapping
+individual handlers:
+
+```ts [src/lib/with-request-logging.ts]
+import type { ApiRouteHandler } from "@pracht/core";
+
+export function withRequestLogging(handler: ApiRouteHandler): ApiRouteHandler {
+  return async (args) => {
+    const startedAt = performance.now();
+    let response: Response | undefined;
+    let thrown: unknown;
+
+    try {
+      response = await handler(args);
+      return response;
+    } catch (error) {
+      thrown = error;
+      throw error;
+    } finally {
+      args.context.logger.event({
+        durationMs: Math.round(performance.now() - startedAt),
+        error: thrown ? String(thrown) : undefined,
+        method: args.request.method,
+        path: args.url.pathname,
+        requestId: args.context.requestId,
+        route: args.route.path,
+        status: response?.status ?? 500,
+      });
+      // On Cloudflare, prefer
+      // `args.context.executionContext.waitUntil(args.context.logger.flush())`
+      // so the response is not blocked on the flush. On Node, `await` is fine.
+      await args.context.logger.flush();
+    }
+  };
+}
+```
+
+```ts [src/api/projects.ts]
+import { withRequestLogging } from "../lib/with-request-logging";
+
+export const POST = withRequestLogging(async ({ request, context }) => {
+  const body = await request.json();
+  context.logger.event({ action: "project.create" });
+  const project = await createProject(body);
+  return Response.json({ project }, { status: 201 });
+});
+```
+
+Multiple wrappers compose: `withRequestLogging(withAuth(handler))`.

--- a/examples/docs/src/routes/docs/recipes-testing.md
+++ b/examples/docs/src/routes/docs/recipes-testing.md
@@ -6,8 +6,8 @@ prev:
   href: /docs/recipes/forms
   title: Forms
 next:
-  href: /docs/recipes/fullstack-cloudflare
-  title: Full-Stack Cloudflare
+  href: /docs/recipes/logging
+  title: Logging
 ---
 
 ## Recommended Setup
@@ -119,40 +119,55 @@ describe("contact API route", () => {
 
 ## Testing Middleware
 
-Middleware functions can be tested in isolation. They either return `void` (continue) or an object with `redirect`.
+Middleware always returns a `Response`. To test it in isolation, pass a fake
+`next` that resolves to a sentinel response — then assert on whether the
+middleware short-circuited (returned its own response) or called through
+(returned the sentinel).
 
 ```ts [src/middleware/auth.test.ts]
 import { describe, it, expect } from "vitest";
 import { middleware } from "./auth";
 
 describe("auth middleware", () => {
+  const ok = new Response("ok", { status: 200 });
+  const next = async () => ok;
+
   it("redirects when no session cookie is present", async () => {
     const request = new Request("http://localhost/dashboard");
-    const result = await middleware({
-      request,
-      url: new URL(request.url),
-      params: {},
-      signal: AbortSignal.timeout(5000),
-    });
+    const response = await middleware(
+      {
+        request,
+        url: new URL(request.url),
+        params: {},
+        context: {},
+        signal: AbortSignal.timeout(5000),
+        route: { path: "/dashboard" } as any,
+      },
+      next,
+    );
 
-    expect(result).toEqual({
-      redirect: expect.stringContaining("/login"),
-    });
+    expect(response.status).toBe(302);
+    expect(response.headers.get("location")).toMatch(/\/login/);
   });
 
-  it("continues when session is valid", async () => {
+  it("continues to the handler when session is valid", async () => {
     const request = new Request("http://localhost/dashboard", {
       headers: { cookie: "session=valid-token-here" },
     });
 
-    const result = await middleware({
-      request,
-      url: new URL(request.url),
-      params: {},
-      signal: AbortSignal.timeout(5000),
-    });
+    const response = await middleware(
+      {
+        request,
+        url: new URL(request.url),
+        params: {},
+        context: {},
+        signal: AbortSignal.timeout(5000),
+        route: { path: "/dashboard" } as any,
+      },
+      next,
+    );
 
-    expect(result).toBeUndefined();
+    expect(response).toBe(ok);
   });
 });
 ```

--- a/examples/docs/src/routes/docs/routing.md
+++ b/examples/docs/src/routes/docs/routing.md
@@ -182,19 +182,21 @@ Shell document headers merge with route-level `headers` exports. Route headers t
 
 ## Middleware
 
-Middleware runs server-side before the loader. It can redirect, modify context, or throw errors.
+Middleware wraps the rest of the request — loaders, API handlers, and inner
+middleware — using a `next()` callback. It can redirect, mutate context,
+short-circuit, or wrap the handler in `try / catch / finally`.
 
 ```ts [src/middleware/auth.ts]
-import type { MiddlewareFn } from "@pracht/core";
+import { redirect, type MiddlewareFn } from "@pracht/core";
 
-export const middleware: MiddlewareFn = async ({ request }) => {
+export const middleware: MiddlewareFn = async ({ request }, next) => {
   const session = await getSession(request);
-  if (!session) return { redirect: "/login" };
-  // Return void to continue to the loader
+  if (!session) return redirect("/login", { request });
+  return next();
 };
 ```
 
-Middleware stacks within groups — a route inside a group with `["auth"]` that also declares `["rateLimit"]` runs both in order.
+Middleware stacks within groups — a route inside a group with `["auth"]` that also declares `["rateLimit"]` runs both in order. See [Middleware](/docs/middleware) for the full guide.
 
 ---
 

--- a/examples/docs/src/shells/docs.tsx
+++ b/examples/docs/src/shells/docs.tsx
@@ -22,6 +22,7 @@ import {
   IconBrandGithub,
   IconSparkles,
   IconPresentationAnalytics,
+  IconActivity,
 } from "@tabler/icons-preact";
 import "../styles/global.css";
 
@@ -69,6 +70,7 @@ const NAV = [
       { href: "/docs/recipes/csp", Icon: IconShield, title: "CSP" },
       { href: "/docs/recipes/forms", Icon: IconForms, title: "Forms" },
       { href: "/docs/recipes/testing", Icon: IconTestPipe, title: "Testing" },
+      { href: "/docs/recipes/logging", Icon: IconActivity, title: "Logging" },
       {
         href: "/docs/recipes/fullstack-cloudflare",
         Icon: IconCloud,

--- a/examples/showcase/src/middleware/auth.ts
+++ b/examples/showcase/src/middleware/auth.ts
@@ -1,9 +1,11 @@
-import type { MiddlewareFn } from "@pracht/core";
+import { redirect, type MiddlewareFn } from "@pracht/core";
 
-export const middleware: MiddlewareFn = async ({ request }) => {
+export const middleware: MiddlewareFn = async ({ request }, next) => {
   const hasSession = request.headers.get("cookie")?.includes("session=") ?? false;
 
   if (!hasSession) {
-    return { redirect: "/" };
+    return redirect("/", { request });
   }
+
+  return next();
 };

--- a/packages/cli/src/commands/generate-source.ts
+++ b/packages/cli/src/commands/generate-source.ts
@@ -62,8 +62,8 @@ export function buildMiddlewareModuleSource(): string {
   return [
     'import type { MiddlewareFn } from "@pracht/core";',
     "",
-    "export const middleware: MiddlewareFn = async (_args) => {",
-    "  return;",
+    "export const middleware: MiddlewareFn = async (_args, next) => {",
+    "  return next();",
     "};",
     "",
   ].join("\n");

--- a/packages/cli/test/pracht-cli.test.js
+++ b/packages/cli/test/pracht-cli.test.js
@@ -130,8 +130,8 @@ export function Shell({ children }: ShellProps) {
       "src/middleware/auth.ts",
       `import type { MiddlewareFn } from "@pracht/core";
 
-export const middleware: MiddlewareFn = async () => {
-  return;
+export const middleware: MiddlewareFn = async (_args, next) => {
+  return next();
 };
 `,
     );
@@ -706,8 +706,8 @@ export function Shell({ children }: ShellProps) {
     "src/middleware/auth.ts",
     `import type { MiddlewareFn } from "@pracht/core";
 
-export const middleware: MiddlewareFn = async () => {
-  return;
+export const middleware: MiddlewareFn = async (_args, next) => {
+  return next();
 };
 `,
   );

--- a/packages/framework/src/browser.ts
+++ b/packages/framework/src/browser.ts
@@ -25,6 +25,7 @@ export {
 } from "./runtime-hooks.ts";
 export { fetchPrachtRouteState, parseSafeNavigationUrl } from "./runtime-client-fetch.ts";
 export { initClientRouter, useNavigate } from "./router.ts";
+export { redirect, type RedirectOptions } from "./runtime-middleware.ts";
 export { PrachtHttpError } from "./types.ts";
 
 export type {
@@ -56,7 +57,7 @@ export type {
   MiddlewareArgs,
   MiddlewareFn,
   MiddlewareModule,
-  MiddlewareResult,
+  MiddlewareNext,
   ModuleImporter,
   ModuleRef,
   NavigateOptions,

--- a/packages/framework/src/index.ts
+++ b/packages/framework/src/index.ts
@@ -28,6 +28,7 @@ export {
   PrachtRuntimeProvider,
 } from "./runtime.ts";
 export { prerenderApp } from "./prerender.ts";
+export { redirect, type RedirectOptions } from "./runtime-middleware.ts";
 export { initClientRouter, useNavigate } from "./router.ts";
 export { PrachtHttpError } from "./types.ts";
 export type {
@@ -59,7 +60,7 @@ export type {
   MiddlewareArgs,
   MiddlewareFn,
   MiddlewareModule,
-  MiddlewareResult,
+  MiddlewareNext,
   ModuleImporter,
   ModuleRef,
   NavigateOptions,

--- a/packages/framework/src/runtime-middleware.ts
+++ b/packages/framework/src/runtime-middleware.ts
@@ -1,10 +1,11 @@
 import { parseSafeNavigationUrl } from "./runtime-client-fetch.ts";
 import { SAFE_METHODS } from "./runtime-constants.ts";
-import { applyHeaders, withDefaultSecurityHeaders } from "./runtime-headers.ts";
+import { applyHeaders } from "./runtime-headers.ts";
 import { resolveRegistryModule } from "./runtime-manifest.ts";
 import type {
   BaseRouteArgs,
   HeadMetadata,
+  MiddlewareArgs,
   MiddlewareModule,
   ModuleRegistry,
   ResolvedApiRoute,
@@ -14,6 +15,16 @@ import type {
 
 const DEFAULT_REDIRECT_STATUS_SAFE = 302;
 const DEFAULT_REDIRECT_STATUS_UNSAFE = 303;
+const REDIRECT_VALIDATION_BASE = "https://invalid.pracht.local/";
+
+export type RedirectOptions =
+  | number
+  | {
+      baseUrl?: string | URL;
+      method?: string;
+      request?: Request;
+      status?: number;
+    };
 
 /**
  * Build a safe redirect response from middleware/loader output. Rejects
@@ -50,6 +61,46 @@ export function buildRedirectResponse(
   });
 }
 
+/**
+ * Convenience helper for middleware (and loaders/handlers) to short-circuit
+ * with a redirect Response. Validates the target's scheme and rejects
+ * CR/LF injection. Pass the current request (or method) when the default
+ * status should follow HTTP method safety: safe methods default to 302,
+ * unsafe methods default to 303.
+ *
+ * ```ts
+ * export const middleware: MiddlewareFn = async ({ request }, next) => {
+ *   if (!hasSession(request)) return redirect("/login", { request });
+ *   return next();
+ * };
+ * ```
+ */
+export function redirect(target: string, options: RedirectOptions = {}): Response {
+  if (typeof options === "number") {
+    return buildRedirectResponse(target, {
+      baseUrl: REDIRECT_VALIDATION_BASE,
+      status: options,
+    });
+  }
+
+  return buildRedirectResponse(target, {
+    baseUrl: options.baseUrl ?? options.request?.url ?? REDIRECT_VALIDATION_BASE,
+    method: options.method ?? options.request?.method,
+    status: options.status,
+  });
+}
+
+/**
+ * Run the middleware chain wrap-around-style. Each middleware receives
+ * `next` and may call it at most once. Calling `next()` invokes the rest
+ * of the chain (downstream middleware then `terminal`) and resolves to
+ * the final `Response`. A middleware that returns without calling `next()`
+ * short-circuits with whatever Response it returned.
+ *
+ * Module imports are kicked off concurrently up front; execution stays
+ * sequential because middleware may mutate `args.context` and ordering
+ * is part of the public contract.
+ */
 export async function runMiddlewareChain<TContext>(options: {
   context: TContext;
   middlewareFiles: string[];
@@ -57,11 +108,15 @@ export async function runMiddlewareChain<TContext>(options: {
   registry: ModuleRegistry;
   request: Request;
   route: BaseRouteArgs<TContext>["route"] | ResolvedApiRoute;
+  signal: AbortSignal;
   url: URL;
-}): Promise<
-  { context: TContext; response?: undefined } | { response: Response; context?: undefined }
-> {
-  let context = options.context;
+  terminal: () => Promise<Response>;
+}): Promise<Response> {
+  const { middlewareFiles, terminal } = options;
+
+  if (middlewareFiles.length === 0) {
+    return terminal();
+  }
 
   // Kick off module resolution for every middleware in parallel. Execution
   // below still runs sequentially — middleware may mutate context and the
@@ -69,50 +124,53 @@ export async function runMiddlewareChain<TContext>(options: {
   // have no inter-dependency, so waiting for them one-by-one is pure
   // latency for no benefit. On cold starts where middleware ships as its
   // own chunks this can meaningfully reduce TTFB.
-  const modulePromises = options.middlewareFiles.map((mwFile) =>
+  const modulePromises = middlewareFiles.map((mwFile) =>
     resolveRegistryModule<MiddlewareModule>(options.registry.middlewareModules, mwFile),
   );
   // Suppress unhandled-rejection warnings for promises that may not be
-  // awaited if an earlier middleware short-circuits with a response.
+  // awaited if an earlier middleware short-circuits without calling next().
   for (const p of modulePromises) {
     p.catch(() => {});
   }
 
-  for (const modulePromise of modulePromises) {
-    const mwModule = await modulePromise;
-    if (!mwModule?.middleware) continue;
+  const dispatch = async (i: number): Promise<Response> => {
+    if (i >= middlewareFiles.length) {
+      return terminal();
+    }
+    const mwModule = await modulePromises[i];
+    if (!mwModule?.middleware) {
+      return dispatch(i + 1);
+    }
 
-    const result = await mwModule.middleware({
+    let calledNext = false;
+    const next = (): Promise<Response> => {
+      if (calledNext) {
+        throw new Error(`Middleware "${middlewareFiles[i]}" called next() multiple times`);
+      }
+      calledNext = true;
+      return dispatch(i + 1);
+    };
+
+    const args: MiddlewareArgs<TContext> = {
       request: options.request,
       params: options.params,
-      context,
-      signal: AbortSignal.timeout(30_000),
+      context: options.context,
+      signal: options.signal,
       url: options.url,
       route: options.route as BaseRouteArgs<TContext>["route"],
-    });
+    };
 
-    if (!result) continue;
-    if (result instanceof Response) {
-      return { response: withDefaultSecurityHeaders(result) };
+    const response = await mwModule.middleware(args, next);
+    if (!(response instanceof Response)) {
+      throw new Error(
+        `Middleware "${middlewareFiles[i]}" did not return a Response. ` +
+          "Middleware must return the result of next() or a short-circuit Response.",
+      );
     }
-    if ("redirect" in result) {
-      const status = "status" in result ? result.status : undefined;
-      return {
-        response: withDefaultSecurityHeaders(
-          buildRedirectResponse(result.redirect, {
-            baseUrl: options.request.url,
-            method: options.request.method,
-            status,
-          }),
-        ),
-      };
-    }
-    if ("context" in result) {
-      context = { ...context, ...result.context } as TContext;
-    }
-  }
+    return response;
+  };
 
-  return { context };
+  return dispatch(0);
 }
 
 export async function mergeHeadMetadata(

--- a/packages/framework/src/runtime.ts
+++ b/packages/framework/src/runtime.ts
@@ -202,20 +202,10 @@ export async function handlePrachtRequest<TContext>(
         );
       }
 
-      try {
-        const middlewareResult = await runMiddlewareChain({
-          context: (options.context ?? {}) as TContext,
-          middlewareFiles: apiMiddlewareFiles,
-          params: apiMatch.params,
-          registry,
-          request: options.request,
-          route: apiMatch.route,
-          url,
-        });
-        if (middlewareResult.response) {
-          return middlewareResult.response;
-        }
+      const requestSignal = AbortSignal.timeout(30_000);
+      const apiContext = (options.context ?? {}) as TContext;
 
+      const apiTerminal = async (): Promise<Response> => {
         currentPhase = "api";
         const apiModule = await resolveRegistryModule<ApiRouteModule>(
           registry.apiModules,
@@ -230,24 +220,37 @@ export async function handlePrachtRequest<TContext>(
         const handler = apiModule[method] ?? apiModule.default;
 
         if (!handler) {
-          return withDefaultSecurityHeaders(
-            new Response("Method not allowed", {
-              status: 405,
-              headers: { "content-type": "text/plain; charset=utf-8" },
-            }),
-          );
+          return new Response("Method not allowed", {
+            status: 405,
+            headers: { "content-type": "text/plain; charset=utf-8" },
+          });
         }
 
         const apiRouteArgs: ApiRouteArgs<TContext> = {
           request: options.request,
           params: apiMatch.params,
-          context: middlewareResult.context,
-          signal: AbortSignal.timeout(30_000),
+          context: apiContext,
+          signal: requestSignal,
           url,
           route: apiMatch.route,
         };
 
-        return withDefaultSecurityHeaders(await handler(apiRouteArgs));
+        return handler(apiRouteArgs);
+      };
+
+      try {
+        const response = await runMiddlewareChain({
+          context: apiContext,
+          middlewareFiles: apiMiddlewareFiles,
+          params: apiMatch.params,
+          registry,
+          request: options.request,
+          route: apiMatch.route,
+          signal: requestSignal,
+          url,
+          terminal: apiTerminal,
+        });
+        return withDefaultSecurityHeaders(response);
       } catch (error: unknown) {
         return renderApiErrorResponse({
           error,
@@ -314,11 +317,13 @@ export async function handlePrachtRequest<TContext>(
     );
   }
 
-  let routeArgs: BaseRouteArgs<TContext> = {
+  const requestSignal = AbortSignal.timeout(30_000);
+  const pageContext = (options.context ?? {}) as TContext;
+  const routeArgs: BaseRouteArgs<TContext> = {
     request: options.request,
     params: match.params,
-    context: (options.context ?? {}) as TContext,
-    signal: AbortSignal.timeout(30_000),
+    context: pageContext,
+    signal: requestSignal,
     url,
     route: match.route,
   };
@@ -337,18 +342,7 @@ export async function handlePrachtRequest<TContext>(
     //   • data-module resolution (separate loader file) (needs routeModule)
     //
     // Only the loader itself still waits for middleware, because it
-    // receives the merged context. This removes one serial await from
-    // every request (typically the shell module load after the loader).
-    const middlewarePromise = runMiddlewareChain({
-      context: routeArgs.context,
-      middlewareFiles: match.route.middlewareFiles,
-      params: match.params,
-      registry,
-      request: options.request,
-      route: match.route,
-      url,
-    });
-
+    // receives the (potentially middleware-mutated) context.
     const routeModulePromise = resolveRegistryModule<RouteModule>(
       registry.routeModules,
       match.route.file,
@@ -370,164 +364,173 @@ export async function handlePrachtRequest<TContext>(
     shellModulePromise.catch(() => {});
     dataFunctionsPromise.catch(() => {});
 
-    // --- Middleware chain ---
-    const middlewareResult = await middlewarePromise;
-    if (middlewareResult.response) {
-      return normalizePageResponse(middlewareResult.response, { isRouteStateRequest });
-    }
-
-    routeArgs = {
-      ...routeArgs,
-      context: middlewareResult.context,
-    };
-
-    currentPhase = "render";
-    routeModule = await routeModulePromise;
-    if (!routeModule) {
-      throw new Error("Route module not found");
-    }
-
-    // Markdown-for-Agents negotiation: if the route exposes raw markdown and
-    // the client prefers `text/markdown`, skip render and return the source.
-    if (
-      !isRouteStateRequest &&
-      typeof routeModule.markdown === "string" &&
-      prefersMarkdown(options.request.headers.get("accept"))
-    ) {
-      return markdownResponse(routeModule.markdown);
-    }
-
-    currentPhase = "loader";
-    const { loader, loaderFile: resolvedLoaderFile } = await dataFunctionsPromise;
-    loaderFile = resolvedLoaderFile;
-
-    const loaderResult = loader ? await loader(routeArgs) : undefined;
-
-    // Allow loaders to return a Response directly (e.g. for redirects)
-    if (loaderResult instanceof Response) {
-      return normalizePageResponse(loaderResult, { isRouteStateRequest });
-    }
-
-    const data = loaderResult;
-
-    if (isRouteStateRequest) {
-      return withRouteResponseHeaders(Response.json({ data }), { isRouteStateRequest: true });
-    }
-
-    // Shell import was kicked off up front; this await is usually already
-    // resolved by the time we get here (it runs in parallel with the loader).
-    currentPhase = "render";
-    shellModule = await shellModulePromise;
-
-    // head and document headers are independent; run them concurrently.
-    const [head, documentHeaders] = await Promise.all([
-      mergeHeadMetadata(shellModule, routeModule, routeArgs, data),
-      mergeDocumentHeaders(shellModule, routeModule, routeArgs, data),
-    ]);
-
-    const cssUrls = resolvePageCssUrls(
-      options.cssManifest,
-      match.route.shellFile,
-      match.route.file,
-    );
-    const modulePreloadUrls = resolvePageJsUrls(
-      options.jsManifest,
-      match.route.shellFile,
-      match.route.file,
-    );
-
-    if (match.route.render === "spa") {
-      let body = "";
-      const Shell = shellModule?.Shell as FunctionComponent | undefined;
-      const Loading = shellModule?.Loading as FunctionComponent | undefined;
-      const loadingTree =
-        Shell != null
-          ? h(Shell, null, Loading ? h(Loading, null) : null)
-          : Loading
-            ? h(Loading, null)
-            : null;
-
-      if (loadingTree) {
-        const tree = h(
-          PrachtRuntimeProvider as FunctionComponent<Record<string, unknown>>,
-          {
-            data: null,
-            params: match.params,
-            routeId: match.route.id ?? "",
-            routes: resolvedApp.routes,
-            url: requestPath,
-          },
-          loadingTree,
-        );
-        const renderFn = await getRenderToStringAsync();
-        body = await renderFn(tree);
+    const pageTerminal = async (): Promise<Response> => {
+      currentPhase = "render";
+      routeModule = await routeModulePromise;
+      if (!routeModule) {
+        throw new Error("Route module not found");
       }
+
+      // Markdown-for-Agents negotiation: if the route exposes raw markdown
+      // and the client prefers `text/markdown`, skip render and return the
+      // source.
+      if (
+        !isRouteStateRequest &&
+        typeof routeModule.markdown === "string" &&
+        prefersMarkdown(options.request.headers.get("accept"))
+      ) {
+        return markdownResponse(routeModule.markdown);
+      }
+
+      currentPhase = "loader";
+      const { loader, loaderFile: resolvedLoaderFile } = await dataFunctionsPromise;
+      loaderFile = resolvedLoaderFile;
+
+      const loaderResult = loader ? await loader(routeArgs) : undefined;
+
+      // Allow loaders to return a Response directly (e.g. for redirects)
+      if (loaderResult instanceof Response) {
+        return loaderResult;
+      }
+
+      const data = loaderResult;
+
+      if (isRouteStateRequest) {
+        return Response.json({ data });
+      }
+
+      // Shell import was kicked off up front; this await is usually already
+      // resolved by the time we get here (it runs in parallel with the loader).
+      currentPhase = "render";
+      shellModule = await shellModulePromise;
+
+      // head and document headers are independent; run them concurrently.
+      const [head, documentHeaders] = await Promise.all([
+        mergeHeadMetadata(shellModule, routeModule, routeArgs, data),
+        mergeDocumentHeaders(shellModule, routeModule, routeArgs, data),
+      ]);
+
+      const cssUrls = resolvePageCssUrls(
+        options.cssManifest,
+        match.route.shellFile,
+        match.route.file,
+      );
+      const modulePreloadUrls = resolvePageJsUrls(
+        options.jsManifest,
+        match.route.shellFile,
+        match.route.file,
+      );
+
+      if (match.route.render === "spa") {
+        let body = "";
+        const Shell = shellModule?.Shell as FunctionComponent | undefined;
+        const Loading = shellModule?.Loading as FunctionComponent | undefined;
+        const loadingTree =
+          Shell != null
+            ? h(Shell, null, Loading ? h(Loading, null) : null)
+            : Loading
+              ? h(Loading, null)
+              : null;
+
+        if (loadingTree) {
+          const tree = h(
+            PrachtRuntimeProvider as FunctionComponent<Record<string, unknown>>,
+            {
+              data: null,
+              params: match.params,
+              routeId: match.route.id ?? "",
+              routes: resolvedApp.routes,
+              url: requestPath,
+            },
+            loadingTree,
+          );
+          const renderFn = await getRenderToStringAsync();
+          body = await renderFn(tree);
+        }
+
+        return htmlResponse(
+          buildHtmlDocument({
+            head,
+            body,
+            hydrationState: {
+              url: requestPath,
+              routeId: match.route.id ?? "",
+              data: null,
+              error: null,
+              pending: true,
+            },
+            clientEntryUrl: options.clientEntryUrl,
+            cssUrls,
+            modulePreloadUrls,
+            routeStatePreloadUrl: loader ? buildRouteStateUrl(requestPath) : undefined,
+          }),
+          200,
+          documentHeaders,
+        );
+      }
+
+      const DefaultComponent =
+        typeof routeModule.default === "function" ? routeModule.default : undefined;
+      const Component = (routeModule.Component ?? DefaultComponent) as
+        | FunctionComponent
+        | undefined;
+      if (!Component) {
+        throw new Error("Route has no Component or default export");
+      }
+
+      const Shell = shellModule?.Shell as FunctionComponent<Record<string, unknown>> | undefined;
+      const Comp = Component as FunctionComponent<Record<string, unknown>>;
+      const componentProps = { data, params: match.params };
+
+      const componentTree = Shell
+        ? h(Shell, null, h(Comp, componentProps))
+        : h(Comp, componentProps);
+
+      const tree = h(
+        PrachtRuntimeProvider as FunctionComponent<Record<string, unknown>>,
+        {
+          data,
+          params: match.params,
+          routeId: match.route.id ?? "",
+          routes: resolvedApp.routes,
+          url: requestPath,
+        },
+        componentTree,
+      );
+      const renderToString = await getRenderToStringAsync();
+      const ssrContent = await renderToString(tree);
 
       return htmlResponse(
         buildHtmlDocument({
           head,
-          body,
+          body: ssrContent,
           hydrationState: {
             url: requestPath,
             routeId: match.route.id ?? "",
-            data: null,
+            data,
             error: null,
-            pending: true,
           },
           clientEntryUrl: options.clientEntryUrl,
           cssUrls,
           modulePreloadUrls,
-          routeStatePreloadUrl: loader ? buildRouteStateUrl(requestPath) : undefined,
         }),
         200,
         documentHeaders,
       );
-    }
+    };
 
-    const DefaultComponent =
-      typeof routeModule.default === "function" ? routeModule.default : undefined;
-    const Component = (routeModule.Component ?? DefaultComponent) as FunctionComponent | undefined;
-    if (!Component) {
-      throw new Error("Route has no Component or default export");
-    }
-
-    const Shell = shellModule?.Shell as FunctionComponent<Record<string, unknown>> | undefined;
-    const Comp = Component as FunctionComponent<Record<string, unknown>>;
-    const componentProps = { data, params: match.params };
-
-    const componentTree = Shell ? h(Shell, null, h(Comp, componentProps)) : h(Comp, componentProps);
-
-    const tree = h(
-      PrachtRuntimeProvider as FunctionComponent<Record<string, unknown>>,
-      {
-        data,
-        params: match.params,
-        routeId: match.route.id ?? "",
-        routes: resolvedApp.routes,
-        url: requestPath,
-      },
-      componentTree,
-    );
-    const renderToString = await getRenderToStringAsync();
-    const ssrContent = await renderToString(tree);
-
-    return htmlResponse(
-      buildHtmlDocument({
-        head,
-        body: ssrContent,
-        hydrationState: {
-          url: requestPath,
-          routeId: match.route.id ?? "",
-          data,
-          error: null,
-        },
-        clientEntryUrl: options.clientEntryUrl,
-        cssUrls,
-        modulePreloadUrls,
-      }),
-      200,
-      documentHeaders,
-    );
+    const response = await runMiddlewareChain({
+      context: pageContext,
+      middlewareFiles: match.route.middlewareFiles,
+      params: match.params,
+      registry,
+      request: options.request,
+      route: match.route,
+      signal: requestSignal,
+      url,
+      terminal: pageTerminal,
+    });
+    return normalizePageResponse(response, { isRouteStateRequest });
   } catch (error: unknown) {
     return renderRouteErrorResponse({
       error,

--- a/packages/framework/src/server.ts
+++ b/packages/framework/src/server.ts
@@ -17,6 +17,7 @@ export {
   PrachtRuntimeProvider,
 } from "./runtime.ts";
 export { prerenderApp } from "./prerender.ts";
+export { redirect, type RedirectOptions } from "./runtime-middleware.ts";
 export { PrachtHttpError } from "./types.ts";
 
 export type {
@@ -48,7 +49,7 @@ export type {
   MiddlewareArgs,
   MiddlewareFn,
   MiddlewareModule,
-  MiddlewareResult,
+  MiddlewareNext,
   ModuleImporter,
   ModuleRef,
   NavigateOptions,

--- a/packages/framework/src/types.ts
+++ b/packages/framework/src/types.ts
@@ -357,15 +357,12 @@ export interface ShellModule<TContext = any> {
   headers?: (args: BaseRouteArgs<TContext>) => MaybePromise<HeadersInit>;
 }
 
-export type MiddlewareResult<TContext = any> =
-  | void
-  | Response
-  | { redirect: string; status?: number }
-  | { context: Partial<TContext> };
+export type MiddlewareNext = () => Promise<Response>;
 
 export type MiddlewareFn<TContext = any> = (
   args: MiddlewareArgs<TContext>,
-) => MaybePromise<MiddlewareResult<TContext>>;
+  next: MiddlewareNext,
+) => MaybePromise<Response>;
 
 export interface MiddlewareModule<TContext = any> {
   middleware: MiddlewareFn<TContext>;

--- a/packages/framework/test/runtime.test.ts
+++ b/packages/framework/test/runtime.test.ts
@@ -7,6 +7,7 @@ import {
   defineApp,
   handlePrachtRequest,
   prerenderApp,
+  redirect,
   resolveApiRoutes,
   route,
   timeRevalidate,
@@ -79,9 +80,10 @@ describe("handlePrachtRequest API middleware", () => {
         },
         middlewareModules: {
           "./middleware/api-auth.ts": async () => ({
-            middleware: async () => ({
-              context: { allowed: true },
-            }),
+            middleware: async ({ context }, next) => {
+              (context as { allowed?: boolean }).allowed = true;
+              return next();
+            },
           }),
         },
       },
@@ -90,6 +92,266 @@ describe("handlePrachtRequest API middleware", () => {
 
     expect(response.status).toBe(200);
     await expect(response.json()).resolves.toEqual({ allowed: true });
+  });
+
+  it("uses 303 for API middleware redirects on unsafe methods", async () => {
+    const app = defineApp({
+      api: {
+        middleware: ["apiAuth"],
+      },
+      middleware: {
+        apiAuth: "./middleware/api-auth.ts",
+      },
+      routes: [route("/", "./routes/home.tsx")],
+    });
+
+    const response = await handlePrachtRequest({
+      apiRoutes: resolveApiRoutes(["/src/api/submit.ts"]),
+      app,
+      registry: {
+        apiModules: {
+          "/src/api/submit.ts": async () => ({
+            POST: async () => Response.json({ ok: true }),
+          }),
+        },
+        middlewareModules: {
+          "./middleware/api-auth.ts": async () => ({
+            middleware: async ({ request }) => redirect("/login", { request }),
+          }),
+        },
+      },
+      request: new Request("http://localhost/api/submit", {
+        method: "POST",
+      }),
+    });
+
+    expect(response.status).toBe(303);
+    expect(response.headers.get("location")).toBe("/login");
+  });
+});
+
+describe("middleware wrap-around contract", () => {
+  it("middleware that returns next() observes the terminal response", async () => {
+    const app = defineApp({
+      middleware: { trace: "./middleware/trace.ts" },
+      routes: [route("/", "./routes/home.tsx", { middleware: ["trace"], render: "ssr" })],
+    });
+
+    let observedStatus: number | undefined;
+    const response = await handlePrachtRequest({
+      app,
+      registry: {
+        middlewareModules: {
+          "./middleware/trace.ts": async () => ({
+            middleware: async (_args, next) => {
+              const res = await next();
+              observedStatus = res.status;
+              return res;
+            },
+          }),
+        },
+        routeModules: {
+          "./routes/home.tsx": async () => ({
+            Component: () => h("main", null, "ok"),
+          }),
+        },
+      },
+      request: new Request("http://localhost/"),
+    });
+
+    expect(response.status).toBe(200);
+    expect(observedStatus).toBe(200);
+  });
+
+  it("middleware can wrap try/catch/finally around next()", async () => {
+    const app = defineApp({
+      middleware: { wrap: "./middleware/wrap.ts" },
+      routes: [route("/", "./routes/home.tsx", { middleware: ["wrap"], render: "ssr" })],
+    });
+
+    const events: string[] = [];
+    const response = await handlePrachtRequest({
+      app,
+      debugErrors: true,
+      registry: {
+        middlewareModules: {
+          "./middleware/wrap.ts": async () => ({
+            middleware: async (_args, next) => {
+              events.push("start");
+              try {
+                return await next();
+              } catch (err) {
+                events.push(`catch:${(err as Error).message}`);
+                throw err;
+              } finally {
+                events.push("finally");
+              }
+            },
+          }),
+        },
+        routeModules: {
+          "./routes/home.tsx": async () => ({
+            Component: () => h("main", null, "ok"),
+            loader: async () => {
+              throw new Error("boom");
+            },
+          }),
+        },
+      },
+      request: new Request("http://localhost/"),
+    });
+
+    expect(response.status).toBe(500);
+    expect(events).toEqual(["start", "catch:boom", "finally"]);
+  });
+
+  it("middleware that does not call next() short-circuits the chain", async () => {
+    const app = defineApp({
+      middleware: { gate: "./middleware/gate.ts" },
+      routes: [route("/dashboard", "./routes/dashboard.tsx", { middleware: ["gate"] })],
+    });
+
+    let loaderRan = false;
+    const response = await handlePrachtRequest({
+      app,
+      registry: {
+        middlewareModules: {
+          "./middleware/gate.ts": async () => ({
+            middleware: async () =>
+              new Response("nope", { status: 401, headers: { "content-type": "text/plain" } }),
+          }),
+        },
+        routeModules: {
+          "./routes/dashboard.tsx": async () => ({
+            Component: () => h("main", null, "dashboard"),
+            loader: async () => {
+              loaderRan = true;
+              return null;
+            },
+          }),
+        },
+      },
+      request: new Request("http://localhost/dashboard"),
+    });
+
+    expect(response.status).toBe(401);
+    expect(loaderRan).toBe(false);
+  });
+
+  it("throws when middleware calls next() multiple times", async () => {
+    const app = defineApp({
+      middleware: { bad: "./middleware/bad.ts" },
+      routes: [route("/", "./routes/home.tsx", { middleware: ["bad"], render: "ssr" })],
+    });
+
+    const response = await handlePrachtRequest({
+      app,
+      debugErrors: true,
+      registry: {
+        middlewareModules: {
+          "./middleware/bad.ts": async () => ({
+            middleware: async (_args, next) => {
+              await next();
+              return next();
+            },
+          }),
+        },
+        routeModules: {
+          "./routes/home.tsx": async () => ({
+            Component: () => h("main", null, "ok"),
+          }),
+        },
+      },
+      request: new Request("http://localhost/", {
+        headers: { "x-pracht-route-state-request": "1" },
+      }),
+    });
+
+    expect(response.status).toBe(500);
+    const body = await response.json();
+    expect((body as { error: { message: string } }).error.message).toMatch(
+      /next\(\) multiple times/,
+    );
+  });
+
+  it("throws when middleware does not return a Response", async () => {
+    const app = defineApp({
+      middleware: { bad: "./middleware/bad.ts" },
+      routes: [route("/", "./routes/home.tsx", { middleware: ["bad"], render: "ssr" })],
+    });
+
+    const response = await handlePrachtRequest({
+      app,
+      debugErrors: true,
+      registry: {
+        middlewareModules: {
+          "./middleware/bad.ts": async () => ({
+            middleware: async () => undefined as unknown as Response,
+          }),
+        },
+        routeModules: {
+          "./routes/home.tsx": async () => ({
+            Component: () => h("main", null, "ok"),
+          }),
+        },
+      },
+      request: new Request("http://localhost/", {
+        headers: { "x-pracht-route-state-request": "1" },
+      }),
+    });
+
+    expect(response.status).toBe(500);
+    const body = await response.json();
+    expect((body as { error: { message: string } }).error.message).toMatch(
+      /did not return a Response/,
+    );
+  });
+
+  it("middleware sees mutations from earlier middleware in the chain", async () => {
+    const app = defineApp({
+      middleware: {
+        first: "./middleware/first.ts",
+        second: "./middleware/second.ts",
+      },
+      routes: [
+        route("/dashboard", "./routes/dashboard.tsx", {
+          middleware: ["first", "second"],
+          render: "ssr",
+        }),
+      ],
+    });
+
+    let observed: { user?: string; trace?: string } = {};
+    const response = await handlePrachtRequest({
+      app,
+      context: {} as { user?: string; trace?: string },
+      registry: {
+        middlewareModules: {
+          "./middleware/first.ts": async () => ({
+            middleware: async ({ context }, next) => {
+              (context as { user?: string }).user = "jovi";
+              return next();
+            },
+          }),
+          "./middleware/second.ts": async () => ({
+            middleware: async ({ context }, next) => {
+              (context as { trace?: string }).trace = "abc";
+              observed = { ...(context as { user?: string; trace?: string }) };
+              return next();
+            },
+          }),
+        },
+        routeModules: {
+          "./routes/dashboard.tsx": async () => ({
+            Component: () => h("main", null, "dashboard"),
+          }),
+        },
+      },
+      request: new Request("http://localhost/dashboard"),
+    });
+
+    expect(response.status).toBe(200);
+    expect(observed).toEqual({ user: "jovi", trace: "abc" });
   });
 });
 
@@ -431,7 +693,7 @@ describe("handlePrachtRequest cache variance", () => {
       registry: {
         middlewareModules: {
           "./middleware/auth.ts": async () => ({
-            middleware: async () => ({ redirect: "/" }),
+            middleware: async ({ request }) => redirect("/", { request }),
           }),
         },
         routeModules: {
@@ -1190,7 +1452,10 @@ describe("handlePrachtRequest ErrorBoundary", () => {
         },
         middlewareModules: {
           "./middleware/auth.ts": async () => ({
-            middleware: async () => ({ context: { user: "jovi" } }),
+            middleware: async ({ context }, next) => {
+              (context as { user?: string }).user = "jovi";
+              return next();
+            },
           }),
         },
         routeModules: {
@@ -1539,9 +1804,13 @@ describe("handlePrachtRequest pipeline parallelism", () => {
       importStarted[id] = true;
       await gates[id].promise;
       return {
-        middleware: async ({ context }: { context: Record<string, boolean> }) => {
+        middleware: async (
+          { context }: { context: Record<string, boolean> },
+          next: () => Promise<Response>,
+        ) => {
           executionOrder.push(id);
-          return { context: { ...context, [`${id}-ran`]: true } };
+          context[`${id}-ran`] = true;
+          return next();
         },
       };
     };
@@ -1607,10 +1876,13 @@ describe("handlePrachtRequest pipeline parallelism", () => {
       registry: {
         middlewareModules: {
           "./middleware/auth.ts": async () => ({
-            middleware: async ({ context }: { context: Record<string, unknown> }) => {
+            middleware: async (
+              _args: { context: Record<string, unknown> },
+              next: () => Promise<Response>,
+            ) => {
               middlewareStarted = true;
               await mwGate.promise;
-              return { context };
+              return next();
             },
           }),
         },

--- a/packages/framework/test/security.test.ts
+++ b/packages/framework/test/security.test.ts
@@ -4,6 +4,7 @@ import {
   buildPathFromSegments,
   defineApp,
   handlePrachtRequest,
+  redirect,
   resolveApiRoutes,
   resolveApp,
   route,
@@ -64,8 +65,33 @@ describe("buildRedirectResponse", () => {
   });
 });
 
+describe("redirect helper", () => {
+  it("defaults to 302 without request method context", () => {
+    expect(redirect("/login").status).toBe(302);
+  });
+
+  it("defaults to 303 for unsafe methods when method is provided", () => {
+    expect(redirect("/login", { method: "POST" }).status).toBe(303);
+  });
+
+  it("defaults to 303 for unsafe methods when request is provided", () => {
+    const response = redirect("/login", {
+      request: new Request("http://localhost/dashboard", { method: "POST" }),
+    });
+    expect(response.status).toBe(303);
+  });
+
+  it("honors explicit numeric status overrides", () => {
+    expect(redirect("/login", 307).status).toBe(307);
+  });
+
+  it("honors explicit option status overrides", () => {
+    expect(redirect("/login", { method: "POST", status: 307 }).status).toBe(307);
+  });
+});
+
 describe("middleware redirect integration", () => {
-  it("rejects javascript: returned from middleware", async () => {
+  it("rejects javascript: returned from middleware via the redirect() helper", async () => {
     const app = defineApp({
       middleware: { auth: "./middleware/auth.ts" },
       routes: [route("/dashboard", "./routes/dashboard.tsx", { middleware: ["auth"] })],
@@ -76,7 +102,7 @@ describe("middleware redirect integration", () => {
       registry: {
         middlewareModules: {
           "./middleware/auth.ts": async () => ({
-            middleware: async () => ({ redirect: "javascript:alert(1)" }),
+            middleware: async () => redirect("javascript:alert(1)"),
           }),
         },
         routeModules: {
@@ -86,8 +112,8 @@ describe("middleware redirect integration", () => {
       request: new Request("http://localhost/dashboard"),
     });
 
-    // Framework responds with 500 (route error) rather than honoring the
-    // unsafe scheme.
+    // The redirect() helper throws on unsafe schemes, which surfaces as a
+    // route error (500) rather than honoring the dangerous Location.
     expect(response.status).toBeGreaterThanOrEqual(500);
     expect(response.headers.get("location")).toBeNull();
   });

--- a/skills/add-auth/SKILL.md
+++ b/skills/add-auth/SKILL.md
@@ -98,21 +98,22 @@ Notes:
 `src/middleware/auth.ts`:
 
 ```ts
-import type { MiddlewareFn } from "@pracht/core";
+import { redirect, type MiddlewareFn } from "@pracht/core";
 import { getSession } from "../server/session";
 
-export const middleware: MiddlewareFn = async ({ request, url }) => {
+export const middleware: MiddlewareFn = async ({ request, url }, next) => {
   const session = await getSession(request);
   if (!session) {
-    const next = encodeURIComponent(url.pathname + url.search);
-    return { redirect: `/login?redirect=${next}` };
+    const target = encodeURIComponent(url.pathname + url.search);
+    return redirect(`/login?redirect=${target}`, { request });
   }
   request.headers.set("x-user-id", session.userId);
   request.headers.set("x-user-email", session.email);
+  return next();
 };
 ```
 
-This is a **Gate** (returns `redirect` on failure). Cross-reference
+This is a **Gate** (short-circuits with a redirect on failure). Cross-reference
 `audit-auth` for the distinction between Gate and Augmenter.
 
 ## Step 4: Login / logout API routes

--- a/skills/add-i18n/SKILL.md
+++ b/skills/add-i18n/SKILL.md
@@ -84,11 +84,12 @@ export function t(locale: string, key: TranslationKey): string {
 import type { MiddlewareFn } from "@pracht/core";
 import { defaultLocale, supportedLocales } from "../i18n";
 
-export const middleware: MiddlewareFn = ({ request, url }) => {
+export const middleware: MiddlewareFn = ({ request, url }, next) => {
   const segments = url.pathname.split("/").filter(Boolean);
   const maybe = segments[0] ?? "";
   const locale = (supportedLocales as readonly string[]).includes(maybe) ? maybe : defaultLocale;
   request.headers.set("x-locale", locale);
+  return next();
 };
 ```
 
@@ -98,12 +99,13 @@ export const middleware: MiddlewareFn = ({ request, url }) => {
 import type { MiddlewareFn } from "@pracht/core";
 import { defaultLocale, supportedLocales } from "../i18n";
 
-export const middleware: MiddlewareFn = ({ request }) => {
+export const middleware: MiddlewareFn = ({ request }, next) => {
   const cookie = request.headers.get("cookie") ?? "";
   const m = cookie.match(/locale=([^;]+)/);
   const requested = m?.[1] ?? defaultLocale;
   const locale = (supportedLocales as readonly string[]).includes(requested) ? requested : defaultLocale;
   request.headers.set("x-locale", locale);
+  return next();
 };
 ```
 
@@ -113,11 +115,12 @@ export const middleware: MiddlewareFn = ({ request }) => {
 import type { MiddlewareFn } from "@pracht/core";
 import { defaultLocale, supportedLocales } from "../i18n";
 
-export const middleware: MiddlewareFn = ({ request }) => {
+export const middleware: MiddlewareFn = ({ request }, next) => {
   const header = request.headers.get("accept-language") ?? "";
   const preferred = header.split(",").map(p => p.split(";")[0]?.trim().toLowerCase().slice(0, 2));
   const match = preferred.find(p => (supportedLocales as readonly string[]).includes(p));
   request.headers.set("x-locale", match ?? defaultLocale);
+  return next();
 };
 ```
 

--- a/skills/add-observability/SKILL.md
+++ b/skills/add-observability/SKILL.md
@@ -78,13 +78,20 @@ import { initObservability } from "../server/observability";
 
 initObservability();
 
-export const middleware: MiddlewareFn = async ({ request, route }) => {
-  return await Sentry.startSpan(
-    { name: `${request.method} ${route?.path ?? new URL(request.url).pathname}`, op: "http.server" },
-    async () => undefined,
+export const middleware: MiddlewareFn = async ({ request, route }, next) => {
+  return Sentry.startSpan(
+    {
+      name: `${request.method} ${route?.path ?? new URL(request.url).pathname}`,
+      op: "http.server",
+    },
+    () => next(),
   );
 };
 ```
+
+Pracht middleware is wrap-around: `await next()` invokes the rest of the
+request and resolves to the final `Response`, so the span naturally covers
+the loader/handler and ends when they finish.
 
 Register it in `defineApp({ middleware: { observability: "./..." } })` (the
 top-level `middleware` field is a *registry* keyed by name — not an ordered

--- a/skills/audit-redirects/SKILL.md
+++ b/skills/audit-redirects/SKILL.md
@@ -28,7 +28,7 @@ boundary. This skill audits the **server-side** decision to redirect at all.
 
 Grep for every redirect-issuing site:
 
-- Middleware returning `{ redirect: ... }`.
+- Middleware returning `redirect(...)` (or any 3xx `Response` with a `Location`).
 - Loaders that throw a redirect or return a `Response` with `302`/`303`/`307`/`308`.
 - API handlers building responses with a `location` header.
 - `useNavigate()(value)` and `<a href={value}>` where `value` is dynamic.
@@ -81,7 +81,7 @@ For each `open`/`risky` finding, propose a fix snippet, e.g.:
 ```ts
 const raw = url.searchParams.get("redirect") ?? "/dashboard";
 const safe = raw.startsWith("/") && !raw.startsWith("//") ? raw : "/dashboard";
-return { redirect: safe };
+return redirect(safe, { request });
 ```
 
 ## Step 5: Cross-check with the client guard

--- a/skills/debug/SKILL.md
+++ b/skills/debug/SKILL.md
@@ -76,12 +76,14 @@ Work through these in order, stopping when you find the root cause:
 
 - Verify middleware is registered in `defineApp({ middleware: { ... } })`.
 - Verify middleware is applied to the route/group: `middleware: ["name"]`.
-- Check middleware return values:
-  - `void` / `undefined` → continue to loader
-  - `{ redirect: "/path" }` → redirect
-  - `Response` object → short-circuit
-  - `{ context: { ... } }` → augment context
-- Middleware runs server-side only, before loaders.
+- Middleware is wrap-around: it must always return a `Response`, either by
+  calling `await next()` (to continue down the chain) or short-circuiting.
+- Common bugs:
+  - Forgetting `return next()` → `Middleware "..." did not return a Response`
+  - Calling `next()` twice → `Middleware "..." called next() multiple times`
+  - Mutating a non-object `context` → mutations don't propagate; always pass
+    an object as the request context.
+- Middleware runs server-side only, wrapping loaders and API handlers.
 
 ### 6. API route issues
 

--- a/skills/migrate-nextjs/SKILL.md
+++ b/skills/migrate-nextjs/SKILL.md
@@ -287,12 +287,12 @@ export const config = { matcher: ["/dashboard/:path*"] };
 **Pracht (`src/middleware/auth.ts`):**
 
 ```ts
-import type { MiddlewareFn } from "@pracht/core";
+import { redirect, type MiddlewareFn } from "@pracht/core";
 
-export const middleware: MiddlewareFn = async ({ request }) => {
+export const middleware: MiddlewareFn = async ({ request }, next) => {
   const session = request.headers.get("cookie")?.includes("session");
-  if (!session) return { redirect: "/login" };
-  // Return void to continue
+  if (!session) return redirect("/login", { request });
+  return next();
 };
 ```
 
@@ -307,8 +307,10 @@ group({ middleware: ["auth"] }, [
 Key transforms:
 
 - Path matching moves from `config.matcher` to manifest group/route assignment
-- `NextResponse.redirect()` → `return { redirect: "/path" }`
-- `NextResponse.next()` → `return` (void)
+- `NextResponse.redirect()` → `return redirect("/path", { request })`
+- `NextResponse.next()` → `return next()`
+- Pracht middleware is **wrap-around** (Hono/Koa/Astro shape), so you can
+  also `await next()` and observe the response — useful for tracing.
 
 ### Phase 7: Wire the route manifest
 

--- a/skills/scaffold-tests/SKILL.md
+++ b/skills/scaffold-tests/SKILL.md
@@ -141,17 +141,42 @@ import { describe, it, expect } from "vitest";
 import { middleware } from "./<middleware-file>";
 
 describe("<name> middleware", () => {
+  const ok = new Response("ok", { status: 200 });
+  const next = async () => ok;
+
   it("redirects unauthenticated requests", async () => {
     const request = new Request("http://localhost/dashboard");
-    const result = await middleware({
-      request,
-      params: {},
-      context: {} as never,
-      url: new URL(request.url),
-      signal: AbortSignal.timeout(5000),
-      route: {} as never,
+    const response = await middleware(
+      {
+        request,
+        params: {},
+        context: {} as never,
+        url: new URL(request.url),
+        signal: AbortSignal.timeout(5000),
+        route: {} as never,
+      },
+      next,
+    );
+    expect(response.status).toBe(302);
+    expect(response.headers.get("location")).toMatch(/^\/login/);
+  });
+
+  it("calls through when authenticated", async () => {
+    const request = new Request("http://localhost/dashboard", {
+      headers: { cookie: "session=valid" },
     });
-    expect(result).toEqual({ redirect: expect.stringMatching(/^\/login/) });
+    const response = await middleware(
+      {
+        request,
+        params: {},
+        context: {} as never,
+        url: new URL(request.url),
+        signal: AbortSignal.timeout(5000),
+        route: {} as never,
+      },
+      next,
+    );
+    expect(response).toBe(ok);
   });
 });
 ```

--- a/skills/scaffold/SKILL.md
+++ b/skills/scaffold/SKILL.md
@@ -97,12 +97,18 @@ export function head() {
 
 ### Middleware
 
-```ts
-import type { MiddlewareFn } from "@pracht/core";
+Middleware wraps the rest of the request via `next()`:
 
-export const middleware: MiddlewareFn = async ({ request }) => {
-  // Return void to continue, { redirect: "/path" } to redirect,
-  // a Response to short-circuit, or { context: { ... } } to augment context.
+```ts
+import { redirect, type MiddlewareFn } from "@pracht/core";
+
+export const middleware: MiddlewareFn = async ({ context, request }, next) => {
+  // Mutate context, validate auth, etc.
+  // - Call `return next()` to continue
+  // - Return `redirect("/path", { request })` to short-circuit with a redirect
+  // - Return any `Response` to short-circuit
+  // - Wrap `await next()` in try/catch/finally for tracing/logging
+  return next();
 };
 ```
 


### PR DESCRIPTION
## Summary

- Middleware now uses the wrap-around `(args, next) => Promise<Response>` shape (Hono/Koa/Astro/SvelteKit). Calling `await next()` runs the rest of the chain and resolves to the inner Response, so middleware can wrap loaders and API handlers in `try / catch / finally` — exactly what tracing/logging libraries (Honeycomb, OpenTelemetry, Sentry) need.
- Adds a `redirect(target, options?)` helper exported from both server and browser entries. The helper is method-aware: when given a `request` or `method`, it defaults to 302 for safe methods and 303 for unsafe methods. Numeric status overrides are also supported.
- Replaces `MiddlewareResult`'s `{ redirect, context, response }` shapes with direct mutation of `args.context` and `redirect()` / raw `Response` returns. Single shared `AbortSignal` per request instead of per-phase 30s timers.
- Updates every example app, doc page, skill, and CLI scaffold to the new contract; adds a new `/docs/recipes/logging` recipe with the Cloudflare-aware `executionContext.waitUntil(flush())` pattern.
- Two changesets: `@pracht/core` minor for the breaking middleware contract, plus a patch for the method-aware `redirect()` helper.

### Migration (before / after)

```ts
// Before
export const middleware: MiddlewareFn = async ({ request }) => {
  if (!hasSession(request)) return { redirect: "/login" };
  return { context: { user: "jovi" } };
};

// After
import { redirect, type MiddlewareFn } from "@pracht/core";

export const middleware: MiddlewareFn = async ({ context, request }, next) => {
  if (!hasSession(request)) return redirect("/login", { request });
  (context as { user?: string }).user = "jovi";
  return next();
};
```

## Testing

- [x] `pnpm e2e` — 56 passed
- [x] `pnpm format`
- [x] `pnpm lint` — 0 warnings, 0 errors
- [x] `pnpm test` — 252 passed (including 6 new tests for the wrap-around contract: composition order, try/catch/finally, short-circuit, double-`next()` guard, missing-Response guard, context mutation propagation)

## Checklist

- [x] Docs updated if needed — `docs/ROUTING.md`, `docs/ARCHITECTURE.md`, plus 7 doc pages under `examples/docs/src/routes/docs/`
- [x] Skills updated if needed — 7 skills (`scaffold`, `debug`, `migrate-nextjs`, `add-auth`, `audit-redirects`, `scaffold-tests`, `add-observability`)
- [x] Changeset added if published packages changed — `middleware-wrap-around.md` (minor) and `method-aware-redirect-helper.md` (patch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)