### PR TITLE
Fix docs blockquote rendering: parse child tokens for marked v18

### DIFF
--- a/examples/docs/vite-plugin-md.ts
+++ b/examples/docs/vite-plugin-md.ts
@@ -215,17 +215,21 @@ function createRenderer(): Renderer {
     return '<div class="doc-sep"></div>';
   };
 
-  renderer.blockquote = function ({ text }: { text: string }) {
+  renderer.blockquote = function ({ tokens }: { tokens: import("marked").Tokens.Generic[] }) {
+    // In marked v18 the blockquote callback receives the unparsed inline
+    // markdown as `text`; we have to render the child tokens ourselves to
+    // get HTML (otherwise `**bold**` and `` `code` `` come out raw).
+    const inner = this.parser.parse(tokens);
     // Support GitHub-style alerts: > [!NOTE] or > [!INFO]
-    const noteMatch = text.match(/^\s*<p>\[!(NOTE|INFO|TIP|WARNING)\]\s*/);
+    const noteMatch = inner.match(/^\s*<p>\[!(NOTE|INFO|TIP|WARNING)\]\s*/);
     if (noteMatch) {
       const type = noteMatch[1].toLowerCase();
       const cssClass = type === "info" ? "callout-info" : "callout-note";
       const icon = type === "info" ? "\u2139\uFE0F" : "\uD83D\uDCA1";
-      const content = text.replace(/^\s*<p>\[!(NOTE|INFO|TIP|WARNING)\]\s*/, "<p>");
+      const content = inner.replace(/^\s*<p>\[!(NOTE|INFO|TIP|WARNING)\]\s*/, "<p>");
       return `<div class="callout ${cssClass}"><span class="callout-icon">${icon}</span><span>${content}</span></div>`;
     }
-    return `<blockquote>${text}</blockquote>`;
+    return `<blockquote>${inner}</blockquote>`;
   };
 
   return renderer;


### PR DESCRIPTION
## Summary

- Docs `<blockquote>` rendering was broken: `examples/docs/vite-plugin-md.ts` passed marked v18's raw `text` argument straight into HTML, so `**bold**` and `` `code` `` came out as literal characters and every `> [!NOTE]/[!INFO]/[!WARNING]` callout silently fell through to an unstyled blockquote (the `[!NOTE]` regex expected `<p>[!NOTE]` which never matched). Fixed by rendering child tokens via `this.parser.parse(tokens)` before the alert match.

## Testing

- [x] `pnpm e2e` (56/56 passed)
- [x] `pnpm format`
- [ ] `pnpm lint` — full repo `oxlint .` OOMs locally (pre-existing); changed file lints clean via `oxlint examples/docs/vite-plugin-md.ts`
- [x] `pnpm test` (252/252 passed)

## Checklist

- [x] Docs updated if needed — fix is in the docs build itself; no doc content changes required
- [ ] Skills updated if needed — N/A
- [ ] Changeset added if published packages changed — N/A (`examples/docs` is private)