### PR TITLE
Harden release publishing workflow

### DIFF
--- a/.github/scripts/has-unpublished-packages.mjs
+++ b/.github/scripts/has-unpublished-packages.mjs
@@ -1,0 +1,88 @@
+import { appendFileSync } from "node:fs";
+import { readdir, readFile } from "node:fs/promises";
+import path from "node:path";
+
+const ignoredDirectories = new Set([
+  ".git",
+  "dist",
+  "node_modules",
+]);
+
+async function findPackageManifests(directory) {
+  const entries = await readdir(directory, { withFileTypes: true });
+  const manifests = [];
+
+  for (const entry of entries) {
+    const fullPath = path.join(directory, entry.name);
+
+    if (entry.isDirectory()) {
+      if (!ignoredDirectories.has(entry.name)) {
+        manifests.push(...await findPackageManifests(fullPath));
+      }
+    } else if (entry.isFile() && entry.name === "package.json") {
+      const pkg = JSON.parse(await readFile(fullPath, "utf8"));
+
+      if (!pkg.private && pkg.name && pkg.version) {
+        manifests.push({ name: pkg.name, version: pkg.version });
+      }
+    }
+  }
+
+  return manifests;
+}
+
+async function hasPublishedVersion(pkg) {
+  const response = await fetch(
+    `https://registry.npmjs.org/${encodeURIComponent(pkg.name)}`,
+    { headers: { accept: "application/vnd.npm.install-v1+json" } },
+  );
+
+  if (response.status === 404) {
+    return false;
+  }
+
+  if (!response.ok) {
+    throw new Error(
+      `Failed to query ${pkg.name}: ${response.status} ${response.statusText}`,
+    );
+  }
+
+  const metadata = await response.json();
+  return Object.prototype.hasOwnProperty.call(
+    metadata.versions ?? {},
+    pkg.version,
+  );
+}
+
+async function main() {
+  const packages = (await findPackageManifests(process.cwd()))
+    .sort((a, b) => a.name.localeCompare(b.name));
+  let hasUnpublished = false;
+
+  for (const pkg of packages) {
+    const isPublished = await hasPublishedVersion(pkg);
+
+    if (isPublished) {
+      console.log(`${pkg.name}@${pkg.version} is already published`);
+    } else {
+      console.log(`${pkg.name}@${pkg.version} is not published yet`);
+      hasUnpublished = true;
+    }
+  }
+
+  const output = [
+    `has_unpublished=${String(hasUnpublished)}`,
+    `should_publish=${String(hasUnpublished)}`,
+  ].join("\n") + "\n";
+
+  if (process.env.GITHUB_OUTPUT) {
+    appendFileSync(process.env.GITHUB_OUTPUT, output);
+  } else {
+    process.stdout.write(output);
+  }
+}
+
+main().catch(error => {
+  console.error(error);
+  process.exit(1);
+});

--- a/.github/scripts/has-unpublished-packages.mjs
+++ b/.github/scripts/has-unpublished-packages.mjs
@@ -2,11 +2,7 @@ import { appendFileSync } from "node:fs";
 import { readdir, readFile } from "node:fs/promises";
 import path from "node:path";
 
-const ignoredDirectories = new Set([
-  ".git",
-  "dist",
-  "node_modules",
-]);
+const ignoredDirectories = new Set([".git", "dist", "node_modules"]);
 
 async function findPackageManifests(directory) {
   const entries = await readdir(directory, { withFileTypes: true });
@@ -17,7 +13,7 @@ async function findPackageManifests(directory) {
 
     if (entry.isDirectory()) {
       if (!ignoredDirectories.has(entry.name)) {
-        manifests.push(...await findPackageManifests(fullPath));
+        manifests.push(...(await findPackageManifests(fullPath)));
       }
     } else if (entry.isFile() && entry.name === "package.json") {
       const pkg = JSON.parse(await readFile(fullPath, "utf8"));
@@ -32,31 +28,26 @@ async function findPackageManifests(directory) {
 }
 
 async function hasPublishedVersion(pkg) {
-  const response = await fetch(
-    `https://registry.npmjs.org/${encodeURIComponent(pkg.name)}`,
-    { headers: { accept: "application/vnd.npm.install-v1+json" } },
-  );
+  const response = await fetch(`https://registry.npmjs.org/${encodeURIComponent(pkg.name)}`, {
+    headers: { accept: "application/vnd.npm.install-v1+json" },
+  });
 
   if (response.status === 404) {
     return false;
   }
 
   if (!response.ok) {
-    throw new Error(
-      `Failed to query ${pkg.name}: ${response.status} ${response.statusText}`,
-    );
+    throw new Error(`Failed to query ${pkg.name}: ${response.status} ${response.statusText}`);
   }
 
   const metadata = await response.json();
-  return Object.prototype.hasOwnProperty.call(
-    metadata.versions ?? {},
-    pkg.version,
-  );
+  return Object.prototype.hasOwnProperty.call(metadata.versions ?? {}, pkg.version);
 }
 
 async function main() {
-  const packages = (await findPackageManifests(process.cwd()))
-    .sort((a, b) => a.name.localeCompare(b.name));
+  const packages = (await findPackageManifests(process.cwd())).sort((a, b) =>
+    a.name.localeCompare(b.name),
+  );
   let hasUnpublished = false;
 
   for (const pkg of packages) {
@@ -70,10 +61,10 @@ async function main() {
     }
   }
 
-  const output = [
-    `has_unpublished=${String(hasUnpublished)}`,
-    `should_publish=${String(hasUnpublished)}`,
-  ].join("\n") + "\n";
+  const output =
+    [`has_unpublished=${String(hasUnpublished)}`, `should_publish=${String(hasUnpublished)}`].join(
+      "\n",
+    ) + "\n";
 
   if (process.env.GITHUB_OUTPUT) {
     appendFileSync(process.env.GITHUB_OUTPUT, output);
@@ -82,7 +73,7 @@ async function main() {
   }
 }
 
-main().catch(error => {
+main().catch((error) => {
   console.error(error);
   process.exit(1);
 });

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,21 +5,29 @@ on:
     branches:
       - main
 
+concurrency: ${{ github.workflow }}-${{ github.ref }}
+
 jobs:
   release:
     name: Release
+    outputs:
+      has_changesets: ${{ steps.changesets.outputs.hasChangesets }}
+      should_publish: ${{ steps.publish-check.outputs.should_publish }}
     permissions:
       contents: write
-      id-token: write
       issues: read
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Install pnpm
         uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
+        with:
+          version: 10.28.1
 
       - name: Install Node.js
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
@@ -29,18 +37,94 @@ jobs:
           registry-url: "https://registry.npmjs.org"
 
       - name: Install dependencies
-        run: pnpm install --ignore-scripts
+        run: pnpm install --frozen-lockfile --ignore-scripts
 
       - name: Install npm
-        run: npm install -g npm@11.11.0
+        run: npm install -g npm@11.11.1
+
+      - name: Create Release Pull Request
+        id: changesets
+        uses: changesets/action@6a0a831ff30acef54f2c6aa1cbbc1096b066edaf # v1.7.0
+        with:
+          version: pnpm run version
+          commitMode: github-api
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Check whether any package still needs publishing
+        if: steps.changesets.outputs.hasChangesets == 'false'
+        id: publish-check
+        shell: bash
+        run: |
+          SHOULD_PUBLISH=false
+
+          while IFS= read -r SPEC; do
+            echo "Checking whether ${SPEC} is already on npm"
+            if npm view "${SPEC}" version >/dev/null 2>&1; then
+              continue
+            fi
+
+            SHOULD_PUBLISH=true
+            echo "${SPEC} still needs publishing"
+          done < <(node --input-type=module <<'NODE'
+          import { readdirSync, readFileSync } from "node:fs";
+          import { join } from "node:path";
+
+          for (const entry of readdirSync("packages", { withFileTypes: true })) {
+            if (!entry.isDirectory()) continue;
+
+            const packageJson = JSON.parse(
+              readFileSync(join("packages", entry.name, "package.json"), "utf8"),
+            );
+
+            if (!packageJson.private) {
+              console.log(`${packageJson.name}@${packageJson.version}`);
+            }
+          }
+          NODE
+          )
+
+          echo "should_publish=${SHOULD_PUBLISH}" >> "$GITHUB_OUTPUT"
+
+  publish:
+    name: Publish
+    needs: release
+    if: needs.release.outputs.should_publish == 'true'
+    permissions:
+      contents: write
+      id-token: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
+        with:
+          version: 10.28.1
+
+      - name: Install Node.js
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+        with:
+          node-version: 22
+          cache: pnpm
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile --ignore-scripts
+
+      - name: Install npm
+        run: npm install -g npm@11.11.1
 
       - name: Build
         run: pnpm build
 
-      - name: Publish/Create PR
+      - name: Publish packages
         uses: changesets/action@6a0a831ff30acef54f2c6aa1cbbc1096b066edaf # v1.7.0
         with:
-          version: pnpm run version
-          publish: pnpm changeset publish
+          publish: pnpm exec changeset publish
+          commitMode: github-api
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ jobs:
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version: 22
-          cache: pnpm
+          package-manager-cache: false
           registry-url: "https://registry.npmjs.org"
 
       - name: Install dependencies
@@ -109,7 +109,7 @@ jobs:
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version: 22
-          cache: pnpm
+          package-manager-cache: false
           registry-url: "https://registry.npmjs.org"
 
       - name: Install dependencies

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,40 +51,10 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Check whether any package still needs publishing
+      - name: Check for unpublished package versions
         if: steps.changesets.outputs.hasChangesets == 'false'
         id: publish-check
-        shell: bash
-        run: |
-          SHOULD_PUBLISH=false
-
-          while IFS= read -r SPEC; do
-            echo "Checking whether ${SPEC} is already on npm"
-            if npm view "${SPEC}" version >/dev/null 2>&1; then
-              continue
-            fi
-
-            SHOULD_PUBLISH=true
-            echo "${SPEC} still needs publishing"
-          done < <(node --input-type=module <<'NODE'
-          import { readdirSync, readFileSync } from "node:fs";
-          import { join } from "node:path";
-
-          for (const entry of readdirSync("packages", { withFileTypes: true })) {
-            if (!entry.isDirectory()) continue;
-
-            const packageJson = JSON.parse(
-              readFileSync(join("packages", entry.name, "package.json"), "utf8"),
-            );
-
-            if (!packageJson.private) {
-              console.log(`${packageJson.name}@${packageJson.version}`);
-            }
-          }
-          NODE
-          )
-
-          echo "should_publish=${SHOULD_PUBLISH}" >> "$GITHUB_OUTPUT"
+        run: node .github/scripts/has-unpublished-packages.mjs
 
   publish:
     name: Publish


### PR DESCRIPTION
## Summary

- Split release PR creation from npm publishing so the OIDC publish permission is only granted to the publish job.
- Harden checkout/install/publish behavior with disabled persisted credentials, frozen lockfile installs, ignored dependency scripts, pinned npm, and Changesets `commitMode: github-api`.
- Add release workflow concurrency and skip the publish job when every package version is already available on npm.

## Testing

- [x] `pnpm e2e`
- [x] `pnpm format`
- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `pnpm build`
- [x] YAML parse check for `.github/workflows/release.yml`
- [x] Local publish-check script dry run

## Checklist

- [x] Docs updated if needed (N/A — workflow-only change)
- [x] Skills updated if needed (N/A)
- [x] Changeset added if published packages changed (N/A — no package contents changed)
