### PR TITLE
Warn when Suspense unsuspends with offset during hydration

### DIFF
--- a/.changeset/hydration-suspense-offset-warning.md
+++ b/.changeset/hydration-suspense-offset-warning.md
@@ -1,0 +1,9 @@
+---
+"@pracht/core": patch
+---
+
+Warn in dev when a Suspense boundary resolves during hydration and the
+resolved component renders 0 or >1 top-level DOM nodes. Such returns cause
+sibling offset drift in preact-suspense's in-place hydration swap (see
+preact issue #4442). The warning is appended to the existing hydration
+mismatch banner and is stripped from production builds.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -569,3 +569,34 @@ This means a lazy component inside a Suspense boundary that resolves during
 hydration will see `false` on its first render (because `_hydrated` hasn't
 been flipped yet) and `true` after its effect runs — the same false-to-true
 transition as the rest of the tree.
+
+### Dev-only hydration warnings (`hydration-mismatch.ts`)
+
+In development the client router calls `installHydrationMismatchWarning()`
+which wraps three Preact options to surface common hydration bugs in a single
+visible banner:
+
+- `options.__m` (mismatch) — Preact already calls this when the
+  server-rendered HTML and client vnode disagree. The wrapper appends a list
+  item with the offending component name.
+- `options.__e` (catchError) + `options.__c` (commit) — together they detect
+  Suspense boundaries that resolve **during** hydration but render a number
+  of top-level DOM nodes other than 1. Preact-suspense's hydration path
+  assumes the resolved subtree replaces the server HTML in-place; if the
+  resolved component returns 0 nodes (e.g. `null`) or >1 (a `Fragment` with
+  multiple roots), sibling DOM offsets drift and subsequent updates can bind
+  to the wrong nodes. The wrapper captures each suspending vnode (filtered
+  by the `MODE_HYDRATE` flag, mirroring `hydration.ts`), waits for the
+  post-resolve commit, walks `vnode.__c.__v.__k` to count DOM-bearing
+  descendants, and warns when the count isn't exactly 1. Reads always go
+  through the component instance's current vnode rather than the captured
+  reference, so intermediate wrapper components between the Suspense
+  boundary and the suspending vnode are handled correctly. The reported
+  component name drills past preact-suspense's `Lazy` wrapper (identified
+  by its `displayName === "Lazy"`) so the warning names the resolved user
+  component instead of the wrapper. See
+  [preact issue #4442](https://github.com/preactjs/preact/issues/4442) for
+  background.
+
+The banner is only installed when `import.meta.env.DEV` is true, so the
+overhead — and the wrappers themselves — never ship to production builds.

--- a/packages/framework/src/hydration-mismatch.ts
+++ b/packages/framework/src/hydration-mismatch.ts
@@ -3,26 +3,160 @@ import type { VNode } from "preact";
 
 const HYDRATION_BANNER_ID = "__pracht_hydration_mismatch__";
 
+// Preact flag on vnode.__u for vnodes diffing against existing DOM (hydrate path).
+const MODE_HYDRATE = 1 << 5;
+
+interface PreactOptions {
+  __m?: (vnode: VNode) => void;
+  __e?: (err: unknown, newVNode: VNode, oldVNode: VNode, errorInfo?: unknown) => void;
+  __c?: (vnode: VNode, commitQueue: unknown) => void;
+}
+
+interface InternalVNode {
+  type: VNode["type"] | null;
+  props?: unknown;
+  __u?: number;
+  __h?: unknown;
+  __c?: InternalComponent;
+  __k?: Array<InternalVNode | null | undefined>;
+}
+
+interface InternalComponent {
+  __v?: InternalVNode;
+}
+
 let installed = false;
+let prevMismatch: PreactOptions["__m"];
+let prevCatchError: PreactOptions["__e"];
+let prevCommit: PreactOptions["__c"];
+
+// Vnodes that suspended while hydrating, awaiting a post-resolve DOM count.
+const pendingSuspenseChecks = new Set<InternalVNode>();
+let flushScheduled = false;
 
 export function installHydrationMismatchWarning(): void {
   if (installed) return;
   installed = true;
 
-  const prev = (preactOptions as { __m?: (vnode: VNode) => void }).__m;
-  (preactOptions as { __m?: (vnode: VNode) => void }).__m = function (vnode: VNode) {
+  const opts = preactOptions as PreactOptions;
+  prevMismatch = opts.__m;
+  prevCatchError = opts.__e;
+  prevCommit = opts.__c;
+
+  opts.__m = function (vnode: VNode) {
     appendHydrationWarning(vnode);
-    if (prev) prev(vnode);
+    if (prevMismatch) prevMismatch(vnode);
+  };
+
+  opts.__e = function (err, newVNode, oldVNode, errorInfo) {
+    trackSuspendingVNode(err, newVNode as InternalVNode);
+    if (prevCatchError) prevCatchError(err, newVNode, oldVNode, errorInfo);
+  };
+
+  opts.__c = function (vnode, commitQueue) {
+    if (prevCommit) prevCommit(vnode, commitQueue);
+    scheduleSuspenseCheckFlush();
   };
 }
 
+function trackSuspendingVNode(err: unknown, vnode: InternalVNode): void {
+  if (!vnode) return;
+  if (!err || typeof (err as { then?: unknown }).then !== "function") return;
+  const isHydratingVNode = !!((vnode.__u && vnode.__u & MODE_HYDRATE) || vnode.__h);
+  if (!isHydratingVNode) return;
+
+  const promise = err as PromiseLike<unknown>;
+  const onSettle = () => {
+    pendingSuspenseChecks.add(vnode);
+  };
+  promise.then(onSettle, onSettle);
+}
+
+function scheduleSuspenseCheckFlush(): void {
+  if (flushScheduled) return;
+  if (pendingSuspenseChecks.size === 0) return;
+  flushScheduled = true;
+  queueMicrotask(flushSuspenseChecks);
+}
+
+function flushSuspenseChecks(): void {
+  flushScheduled = false;
+  if (pendingSuspenseChecks.size === 0) return;
+  const checks = Array.from(pendingSuspenseChecks);
+  pendingSuspenseChecks.clear();
+  for (const vnode of checks) {
+    const rendered = currentVNode(vnode);
+    const count = countTopLevelDomNodes(rendered);
+    if (count !== 1) {
+      appendSuspenseOffsetWarning(pickReportableVNode(rendered), count);
+    }
+  }
+}
+
+function currentVNode(vnode: InternalVNode): InternalVNode {
+  return vnode.__c?.__v ?? vnode;
+}
+
+// preact-suspense's `lazy()` returns a function component with
+// `displayName === "Lazy"` that renders exactly one child — the resolved
+// user component. The lazy wrapper is the vnode that threw, so it's also
+// the vnode we captured in __e; for reporting we'd rather show the user's
+// actual component name, so drill past Lazy wrappers when we find one.
+function pickReportableVNode(vnode: InternalVNode): InternalVNode {
+  let current = vnode;
+  for (let depth = 0; depth < 4; depth++) {
+    if (!isLazyWrapperVNode(current)) break;
+    const children = current.__k;
+    if (!Array.isArray(children) || children.length !== 1) break;
+    const child = children[0];
+    if (!child || typeof child.type !== "function") break;
+    current = currentVNode(child);
+  }
+  return current;
+}
+
+function isLazyWrapperVNode(vnode: InternalVNode): boolean {
+  const type = vnode.type;
+  if (typeof type !== "function") return false;
+  const fn = type as { displayName?: string; name?: string };
+  return fn.displayName === "Lazy" || fn.name === "Lazy";
+}
+
+function countTopLevelDomNodes(vnode: InternalVNode | null | undefined): number {
+  if (!vnode || typeof vnode !== "object") return 0;
+  const type = vnode.type;
+  if (type === null) return 1;
+  if (typeof type === "string") return 1;
+  const children = vnode.__k;
+  if (!Array.isArray(children)) return 0;
+  let total = 0;
+  for (const child of children) {
+    total += countTopLevelDomNodes(child);
+  }
+  return total;
+}
+
+function appendSuspenseOffsetWarning(vnode: InternalVNode, count: number): void {
+  if (typeof document === "undefined") return;
+  const name = getVNodeName(vnode as unknown as VNode);
+  const shape = count === 0 ? "rendered 0 DOM nodes" : `rendered ${count} DOM nodes`;
+  const message =
+    `Suspense boundary resolved during hydration: <${name}> ${shape}. ` +
+    `Components that unsuspend during hydration must render exactly one DOM node — ` +
+    `otherwise sibling offsets can drift and later updates may bind to the wrong nodes.`;
+  appendBannerMessage(message);
+}
+
 function appendHydrationWarning(vnode: VNode): void {
+  const componentName = getVNodeName(vnode);
+  const message = `Hydration mismatch detected on <${componentName}>. The server-rendered HTML did not match the client.`;
+  appendBannerMessage(message);
+}
+
+function appendBannerMessage(message: string): void {
   if (typeof document === "undefined") return;
 
-  const componentName = getVNodeName(vnode);
   let banner = document.getElementById(HYDRATION_BANNER_ID);
-  const message = `Hydration mismatch detected on <${componentName}>. The server-rendered HTML did not match the client.`;
-
   if (banner) {
     const list = banner.querySelector(`[data-pracht-mismatch-list]`);
     if (list) {
@@ -78,6 +212,16 @@ function getVNodeName(vnode: VNode | null | undefined): string {
 }
 
 export function _resetHydrationMismatchForTesting(): void {
+  const opts = preactOptions as PreactOptions;
+  if (installed) {
+    opts.__m = prevMismatch;
+    opts.__e = prevCatchError;
+    opts.__c = prevCommit;
+  }
   installed = false;
-  (preactOptions as { __m?: (vnode: VNode) => void }).__m = undefined;
+  prevMismatch = undefined;
+  prevCatchError = undefined;
+  prevCommit = undefined;
+  pendingSuspenseChecks.clear();
+  flushScheduled = false;
 }

--- a/packages/framework/test/hydration-mismatch.test.ts
+++ b/packages/framework/test/hydration-mismatch.test.ts
@@ -1,14 +1,27 @@
 // @vitest-environment jsdom
-import { h, hydrate, options as preactOptions, render } from "preact";
+import { Fragment, h, hydrate, options as preactOptions, render } from "preact";
 import type { VNode } from "preact";
+import { Suspense, lazy } from "preact-suspense";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import {
   _resetHydrationMismatchForTesting,
   installHydrationMismatchWarning,
 } from "../src/hydration-mismatch.ts";
+import {
+  _resetForTesting as _resetHydrationStateForTesting,
+  markHydrating,
+} from "../src/hydration.ts";
 
 const BANNER_ID = "__pracht_hydration_mismatch__";
+
+async function flush(): Promise<void> {
+  await Promise.resolve();
+  await new Promise<void>((r) => requestAnimationFrame(() => r()));
+  await Promise.resolve();
+  await new Promise<void>((r) => requestAnimationFrame(() => r()));
+  await new Promise<void>((r) => setTimeout(r, 0));
+}
 
 describe("installHydrationMismatchWarning", () => {
   let scratch: HTMLDivElement;
@@ -18,6 +31,7 @@ describe("installHydrationMismatchWarning", () => {
     scratch = document.createElement("div");
     document.body.appendChild(scratch);
     _resetHydrationMismatchForTesting();
+    _resetHydrationStateForTesting();
   });
 
   afterEach(() => {
@@ -26,6 +40,7 @@ describe("installHydrationMismatchWarning", () => {
       scratch.remove();
     }
     _resetHydrationMismatchForTesting();
+    _resetHydrationStateForTesting();
   });
 
   it("appends a visible banner with the component name when Preact reports a hydration mismatch", () => {
@@ -99,5 +114,214 @@ describe("installHydrationMismatchWarning", () => {
     const banner = document.getElementById(BANNER_ID);
     expect(banner).not.toBeNull();
     expect(banner!.textContent).toContain("Hydration mismatch");
+  });
+
+  it("does not warn when a component unsuspends during hydration with exactly one DOM node", async () => {
+    installHydrationMismatchWarning();
+
+    scratch.innerHTML = "<div><div>Resolved</div></div>";
+
+    let resolvePromise!: () => void;
+    const promise = new Promise<void>((r) => {
+      resolvePromise = r;
+    });
+    let threw = false;
+
+    function LazyChild() {
+      if (!threw) {
+        threw = true;
+        throw promise;
+      }
+      return h("div", null, "Resolved");
+    }
+
+    function App() {
+      return h(Suspense as any, { fallback: null }, h(LazyChild, null));
+    }
+
+    markHydrating();
+    hydrate(h(App, null), scratch);
+
+    resolvePromise();
+    await flush();
+
+    const banner = document.getElementById(BANNER_ID);
+    expect(banner).toBeNull();
+  });
+
+  it("warns when a component unsuspends during hydration and renders multiple DOM nodes", async () => {
+    installHydrationMismatchWarning();
+
+    scratch.innerHTML = "<div><div>A</div><div>B</div></div>";
+
+    let resolvePromise!: () => void;
+    const promise = new Promise<void>((r) => {
+      resolvePromise = r;
+    });
+    let threw = false;
+
+    function FragmentChild() {
+      if (!threw) {
+        threw = true;
+        throw promise;
+      }
+      return h(Fragment, null, h("div", null, "A"), h("div", null, "B"));
+    }
+
+    function App() {
+      return h(Suspense as any, { fallback: null }, h(FragmentChild, null));
+    }
+
+    markHydrating();
+    hydrate(h(App, null), scratch);
+
+    resolvePromise();
+    await flush();
+
+    const banner = document.getElementById(BANNER_ID);
+    expect(banner).not.toBeNull();
+    expect(banner!.textContent).toContain("Suspense boundary resolved during hydration");
+    expect(banner!.textContent).toContain("rendered 2 DOM nodes");
+  });
+
+  it("warns when a component unsuspends during hydration and renders zero DOM nodes", async () => {
+    installHydrationMismatchWarning();
+
+    scratch.innerHTML = "<div></div>";
+
+    let resolvePromise!: () => void;
+    const promise = new Promise<void>((r) => {
+      resolvePromise = r;
+    });
+    let threw = false;
+
+    function EmptyChild() {
+      if (!threw) {
+        threw = true;
+        throw promise;
+      }
+      return null;
+    }
+
+    function App() {
+      return h(Suspense as any, { fallback: null }, h(EmptyChild, null));
+    }
+
+    markHydrating();
+    hydrate(h(App, null), scratch);
+
+    resolvePromise();
+    await flush();
+
+    const banner = document.getElementById(BANNER_ID);
+    expect(banner).not.toBeNull();
+    expect(banner!.textContent).toContain("Suspense boundary resolved during hydration");
+    expect(banner!.textContent).toContain("rendered 0 DOM nodes");
+  });
+
+  it("reports the resolved user component name, not the lazy() wrapper, on offset issues", async () => {
+    installHydrationMismatchWarning();
+
+    scratch.innerHTML = "<div><div>A</div><div>B</div></div>";
+
+    let resolveImport!: (mod: { default: typeof BadlyShapedPage }) => void;
+    const importPromise = new Promise<{ default: typeof BadlyShapedPage }>((r) => {
+      resolveImport = r;
+    });
+
+    function BadlyShapedPage() {
+      return h(Fragment, null, h("div", null, "A"), h("div", null, "B"));
+    }
+
+    const LazyPage = lazy(() => importPromise);
+
+    function App() {
+      return h(Suspense as any, { fallback: null }, h(LazyPage as any, null));
+    }
+
+    markHydrating();
+    hydrate(h(App, null), scratch);
+
+    resolveImport({ default: BadlyShapedPage });
+    await flush();
+
+    const banner = document.getElementById(BANNER_ID);
+    expect(banner).not.toBeNull();
+    expect(banner!.textContent).toContain("rendered 2 DOM nodes");
+    expect(banner!.textContent).toContain("BadlyShapedPage");
+    expect(banner!.textContent).not.toContain("<Lazy>");
+  });
+
+  it("handles wrapper components between the Suspense boundary and the suspending component", async () => {
+    installHydrationMismatchWarning();
+
+    scratch.innerHTML = "<div><div>A</div><div>B</div></div>";
+
+    let resolveImport!: (mod: { default: typeof BadDeepLeaf }) => void;
+    const importPromise = new Promise<{ default: typeof BadDeepLeaf }>((r) => {
+      resolveImport = r;
+    });
+
+    function BadDeepLeaf() {
+      return h(Fragment, null, h("div", null, "A"), h("div", null, "B"));
+    }
+    const LazyDeepLeaf = lazy(() => importPromise);
+
+    function InnerWrapper(props: { children?: unknown }) {
+      return props.children as any;
+    }
+    function OuterWrapper(props: { children?: unknown }) {
+      return props.children as any;
+    }
+    function App() {
+      return h(
+        Suspense as any,
+        { fallback: null },
+        h(OuterWrapper, null, h(InnerWrapper, null, h(LazyDeepLeaf as any, null))),
+      );
+    }
+
+    markHydrating();
+    hydrate(h(App, null), scratch);
+
+    resolveImport({ default: BadDeepLeaf });
+    await flush();
+
+    const banner = document.getElementById(BANNER_ID);
+    expect(banner).not.toBeNull();
+    expect(banner!.textContent).toContain("rendered 2 DOM nodes");
+    expect(banner!.textContent).toContain("BadDeepLeaf");
+    expect(banner!.textContent).not.toContain("<Lazy>");
+  });
+
+  it("does not warn for promises thrown outside of the hydration phase", async () => {
+    installHydrationMismatchWarning();
+
+    let resolvePromise!: () => void;
+    const promise = new Promise<void>((r) => {
+      resolvePromise = r;
+    });
+    let threw = false;
+
+    function FragmentChild() {
+      if (!threw) {
+        threw = true;
+        throw promise;
+      }
+      return h(Fragment, null, h("div", null, "A"), h("div", null, "B"));
+    }
+
+    function App() {
+      return h(Suspense as any, { fallback: null }, h(FragmentChild, null));
+    }
+
+    // Plain render() — no MODE_HYDRATE on the vnodes.
+    render(h(App, null), scratch);
+
+    resolvePromise();
+    await flush();
+
+    const banner = document.getElementById(BANNER_ID);
+    expect(banner).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary

- Warn in dev when a Suspense boundary resolves **during hydration** and the resolved component renders 0 or >1 top-level DOM nodes. preact-suspense's hydration path swaps the resolved subtree in-place; if the count isn't exactly 1, sibling DOM offsets drift and later updates can bind to the wrong nodes (preact issue [#4442](https://github.com/preactjs/preact/issues/4442)).
- The warning is appended to the existing hydration mismatch banner. It names the resolved user component (drilling past preact-suspense's `Lazy` wrapper) so the message is actionable. Wrapper components between the Suspense boundary and the suspending vnode are handled — DOM children are read via `vnode.__c.__v.__k` so the count survives any number of intermediate components.
- The whole path is `import.meta.env.DEV`-gated via `installHydrationMismatchWarning()` in the client router, so production bundles are unaffected.

## Testing

- [x] `pnpm e2e`
- [x] `pnpm format`
- [x] `pnpm lint`
- [x] `pnpm test`

## Checklist

- [x] Docs updated if needed
- [x] Skills updated if needed — N/A
- [x] Changeset added if published packages changed
