### PR TITLE
fix(adapter-node): enforce canonical origin for absolute request targets

### DIFF
--- a/.changeset/canonical-origin-absolute-targets.md
+++ b/.changeset/canonical-origin-absolute-targets.md
@@ -1,0 +1,5 @@
+---
+"@pracht/adapter-node": patch
+---
+
+Harden `canonicalOrigin` request URL handling by normalizing absolute-form and network-path request targets to their path/query/hash before resolving against the canonical origin.

--- a/docs/ADAPTERS.md
+++ b/docs/ADAPTERS.md
@@ -86,7 +86,9 @@ The adapter factory calls the entry module generator internally to create a virt
 ### Trusted proxy configuration
 
 Set `canonicalOrigin` to pin `request.url` to your known public origin and
-avoid depending on `Host` / forwarded host headers at all:
+avoid depending on `Host` / forwarded host headers at all. Absolute-form
+(`http://...`) and network-path (`//...`) request targets are normalized to
+path/query/hash before resolving against the canonical origin:
 
 ```typescript
 createNodeRequestHandler({

--- a/packages/adapter-node/src/node-request.ts
+++ b/packages/adapter-node/src/node-request.ts
@@ -10,7 +10,7 @@ export async function createWebRequest(
   options: { trustProxy: boolean; canonicalOrigin?: string; maxBodySize?: number },
 ): Promise<Request> {
   const baseUrl = resolveRequestBase(req, options);
-  const url = new URL(req.url ?? "/", baseUrl);
+  const url = new URL(normalizeRequestTarget(req.url, options), baseUrl);
   const method = req.method ?? "GET";
   const headers = createHeaders(req.headers);
   const init: RequestInit = {
@@ -28,6 +28,29 @@ export async function createWebRequest(
   }
 
   return new Request(url, init);
+}
+
+function normalizeRequestTarget(
+  rawTarget: string | undefined,
+  options: { canonicalOrigin?: string },
+): string {
+  const target = rawTarget ?? "/";
+
+  if (!options.canonicalOrigin) {
+    return target;
+  }
+
+  if (target.startsWith("//")) {
+    const networkPathUrl = new URL(`https:${target}`);
+    return `${networkPathUrl.pathname}${networkPathUrl.search}${networkPathUrl.hash}`;
+  }
+
+  if (/^[a-zA-Z][a-zA-Z\d+.-]*:\/\//.test(target)) {
+    const absoluteUrl = new URL(target);
+    return `${absoluteUrl.pathname}${absoluteUrl.search}${absoluteUrl.hash}`;
+  }
+
+  return target;
 }
 
 export async function writeWebResponse(res: ServerResponse, response: Response): Promise<void> {

--- a/packages/adapter-node/test/security.test.ts
+++ b/packages/adapter-node/test/security.test.ts
@@ -85,6 +85,48 @@ describe("createWebRequest canonicalOrigin", () => {
 
     expect(request.url).toBe("https://app.example.com/dashboard?tab=1");
   });
+
+  it("strips absolute-form request targets down to path when canonicalOrigin is set", async () => {
+    const request = await createWebRequest(
+      {
+        headers: {
+          host: "app.example.com",
+        },
+        method: "GET",
+        req: undefined,
+        socket: {},
+        url: "http://evil.example/reset?token=abs",
+        async *[Symbol.asyncIterator]() {},
+      } as unknown as IncomingMessage,
+      {
+        canonicalOrigin: "https://app.example.com",
+        trustProxy: false,
+      },
+    );
+
+    expect(request.url).toBe("https://app.example.com/reset?token=abs");
+  });
+
+  it("strips network-path request targets down to path when canonicalOrigin is set", async () => {
+    const request = await createWebRequest(
+      {
+        headers: {
+          host: "app.example.com",
+        },
+        method: "GET",
+        req: undefined,
+        socket: {},
+        url: "//evil.example/reset?token=network",
+        async *[Symbol.asyncIterator]() {},
+      } as unknown as IncomingMessage,
+      {
+        canonicalOrigin: "https://app.example.com",
+        trustProxy: false,
+      },
+    );
+
+    expect(request.url).toBe("https://app.example.com/reset?token=network");
+  });
 });
 
 describe("createISGRegenerationRequest", () => {


### PR DESCRIPTION
### Motivation
- The Node adapter exposed a security gap where `canonicalOrigin` could be bypassed if `req.url` was an absolute-form (`http://...`) or network-path (`//...`) request target, allowing an attacker-controlled origin to replace the canonical base when constructing `request.url`. 
- The change aims to ensure `request.url` is pinned to a configured canonical origin for all request-target forms while preserving existing origin-form behavior.

### Description
- Replace the direct `new URL(req.url, baseUrl)` usage with `new URL(normalizeRequestTarget(req.url, options), baseUrl)` and add `normalizeRequestTarget` to strip absolute-form and network-path targets to their `path/search/hash` when `canonicalOrigin` is set (in `packages/adapter-node/src/node-request.ts`).
- Add two security tests that assert absolute-form and network-path request targets are normalized to the canonical origin in `packages/adapter-node/test/security.test.ts`.
- Update `docs/ADAPTERS.md` to document that absolute-form and network-path targets are normalized when `canonicalOrigin` is enabled.
- Add a `.changeset/canonical-origin-absolute-targets.md` changeset to record the patch for `@pracht/adapter-node`.

### Testing
- Attempted to run the full checklist `pnpm run e2e && pnpm run format && pnpm run lint && pnpm run test`, but the run failed during the e2e webserver startup due to unresolved built workspace entrypoints in this environment. 
- Ran `pnpm -F @pracht/cli build` then `pnpm run e2e`, but the e2e run still failed while Vite attempted to resolve internal workspace packages (environment package resolution issue). 
- Ran `pnpm run format` and `pnpm run lint` successfully and they passed. 
- Ran `pnpm run test` / the Vitest suite where some CLI-related tests failed due to unresolved local package entrypoints, and `pnpm vitest run packages/adapter-node/test/security.test.ts` also failed in this environment because the test runner could not resolve `@pracht/core/server`, preventing local verification of the new tests here; these resolution failures are environmental and unrelated to the logical change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a06d69efeb4832fb25e507649b9258b)