### PR TITLE
fix: run loaders before markdown negotiation

### DIFF
--- a/.changeset/fix-markdown-loader-bypass.md
+++ b/.changeset/fix-markdown-loader-bypass.md
@@ -1,0 +1,5 @@
+---
+"@pracht/core": patch
+---
+
+Fix Markdown-for-Agents negotiation so route loaders and document headers still run before returning markdown responses, preventing loader auth/header bypass.

--- a/docs/DATA_LOADING.md
+++ b/docs/DATA_LOADING.md
@@ -32,8 +32,9 @@ export. Named route exports such as `loader`, `head`, `headers`, `markdown`,
 
 A `markdown` string export opts the route into Markdown-for-Agents content
 negotiation: when a request arrives with `Accept: text/markdown`, the runtime
-returns the raw markdown source with `Content-Type: text/markdown` instead of
-rendering the component.
+still executes middleware, the route loader, and document header resolution
+first, then returns the raw markdown source with `Content-Type: text/markdown`
+instead of rendering the component.
 
 ### LoaderArgs
 

--- a/packages/framework/src/runtime-negotiation.ts
+++ b/packages/framework/src/runtime-negotiation.ts
@@ -40,11 +40,9 @@ export function prefersMarkdown(accept: string | null): boolean {
   return md.quality >= html.quality;
 }
 
-export function markdownResponse(source: string): Response {
-  const headers = new Headers({
-    "content-type": "text/markdown; charset=utf-8",
-    "cache-control": "public, max-age=0, must-revalidate",
-  });
+export function markdownResponse(source: string, initHeaders?: HeadersInit): Response {
+  const headers = new Headers(initHeaders);
+  headers.set("content-type", "text/markdown; charset=utf-8");
   appendVaryHeader(headers, "Accept");
   applyDefaultSecurityHeaders(headers);
   return new Response(source, { status: 200, headers });

--- a/packages/framework/src/runtime.ts
+++ b/packages/framework/src/runtime.ts
@@ -371,17 +371,6 @@ export async function handlePrachtRequest<TContext>(
         throw new Error("Route module not found");
       }
 
-      // Markdown-for-Agents negotiation: if the route exposes raw markdown
-      // and the client prefers `text/markdown`, skip render and return the
-      // source.
-      if (
-        !isRouteStateRequest &&
-        typeof routeModule.markdown === "string" &&
-        prefersMarkdown(options.request.headers.get("accept"))
-      ) {
-        return markdownResponse(routeModule.markdown);
-      }
-
       currentPhase = "loader";
       const { loader, loaderFile: resolvedLoaderFile } = await dataFunctionsPromise;
       loaderFile = resolvedLoaderFile;
@@ -409,6 +398,16 @@ export async function handlePrachtRequest<TContext>(
         mergeHeadMetadata(shellModule, routeModule, routeArgs, data),
         mergeDocumentHeaders(shellModule, routeModule, routeArgs, data),
       ]);
+
+      // Markdown-for-Agents negotiation must run after loader + header
+      // resolution so auth redirects/401s and cache policies still apply.
+      if (
+        !isRouteStateRequest &&
+        typeof routeModule.markdown === "string" &&
+        prefersMarkdown(options.request.headers.get("accept"))
+      ) {
+        return markdownResponse(routeModule.markdown, documentHeaders);
+      }
 
       const cssUrls = resolvePageCssUrls(
         options.cssManifest,

--- a/packages/framework/test/runtime-negotiation.test.ts
+++ b/packages/framework/test/runtime-negotiation.test.ts
@@ -98,4 +98,37 @@ describe("handlePrachtRequest markdown negotiation", () => {
     expect(response.status).toBe(200);
     expect(response.headers.get("content-type")?.includes("text/html")).toBe(true);
   });
+
+  it("runs loader and preserves document headers before returning markdown", async () => {
+    let loaderCalls = 0;
+    const response = await handlePrachtRequest({
+      app,
+      registry: {
+        routeModules: {
+          "./routes/home.md": async () => ({
+            markdown: "# Home\n",
+            loader: () => {
+              loaderCalls += 1;
+              return { ok: true };
+            },
+            headers: () => ({
+              "cache-control": "private, no-store",
+              "x-route-headers": "yes",
+            }),
+            Component: () => null,
+          }),
+        },
+      },
+      request: new Request("http://localhost/", {
+        headers: { accept: "text/markdown" },
+      }),
+    });
+
+    expect(loaderCalls).toBe(1);
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toBe("text/markdown; charset=utf-8");
+    expect(response.headers.get("cache-control")).toBe("private, no-store");
+    expect(response.headers.get("x-route-headers")).toBe("yes");
+    expect(await response.text()).toBe("# Home\n");
+  });
 });


### PR DESCRIPTION
### Motivation

- Prevent a security bypass where requests with `Accept: text/markdown` returned a route's raw markdown before route loaders and document headers ran, exposing protected content and skipping loader-based auth and route cache headers. 
- Ensure Markdown-for-Agents behavior preserves existing authorization and caching semantics by running the normal loader/header pipeline first.

### Description

- Move Markdown negotiation in `handlePrachtRequest` to run after loader execution and `mergeDocumentHeaders`, ensuring loader redirects/401s and route/shell headers apply (changed `packages/framework/src/runtime.ts`).
- Change `markdownResponse` to accept initial headers and preserve those headers instead of unconditionally forcing `public, max-age=0, must-revalidate` (changed `packages/framework/src/runtime-negotiation.ts`).
- Add a regression test that verifies loaders run and route headers (e.g. `cache-control: private, no-store`) are preserved for markdown responses (changed `packages/framework/test/runtime-negotiation.test.ts`).
- Update documentation to clarify that markdown negotiation happens only after middleware, loaders, and document header resolution, and add a patch changeset for `@pracht/core` (changed `docs/DATA_LOADING.md` and `.changeset/fix-markdown-loader-bypass.md`).

### Testing

- Ran `pnpm run format`, which succeeded.
- Ran `pnpm run lint`, which succeeded.
- Ran the modified unit tests with `pnpm vitest run packages/framework/test/runtime-negotiation.test.ts`, and the suite passed (all tests green including the new regression test).
- `pnpm run test` and `pnpm run e2e` were attempted but failed in this environment due to missing built CLI artifacts (`packages/cli/dist/index.mjs`) and unrelated workspace test timeouts, so full workspace CI is expected to run in CI where build artifacts are available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a06d71b320c832f9a2fde12809afac6)