### PR TITLE
fix(core): fail-closed on unresolved function ModuleRef values

### DIFF
--- a/.changeset/five-snakes-act.md
+++ b/.changeset/five-snakes-act.md
@@ -1,0 +1,7 @@
+---
+"@pracht/core": patch
+---
+
+Fail closed when unresolved function-based `ModuleRef` values reach runtime.
+
+`defineApp`/`route` now throw an explicit error for function module refs that were not rewritten by the Vite manifest transform, preventing empty-path fallback that could bypass middleware resolution.

--- a/docs/ROUTING.md
+++ b/docs/ROUTING.md
@@ -63,6 +63,12 @@ Defines a single route:
 | `file` | `ModuleRef` | Module reference — `() => import("./path")` or string  |
 | `meta` | `RouteMeta` | Optional: render mode, shell, middleware, revalidation |
 
+> [!IMPORTANT]
+> Function module refs must use the exact inline form `() => import("./path")`
+> in your app manifest so the Vite plugin can rewrite them to string paths.
+> If a function ref reaches runtime, Pracht throws an error instead of
+> silently resolving it to prevent fail-open route or middleware behavior.
+
 ### `group(meta, routes)`
 
 Groups routes with shared configuration:

--- a/packages/framework/src/app.ts
+++ b/packages/framework/src/app.ts
@@ -72,16 +72,17 @@ export function route(
  * Resolve a ModuleRef to a string file path.
  * When the vite plugin is active, import functions are transformed to strings
  * at build time, so this typically receives strings. When called without the
- * transform (e.g. in tests), functions pass through as empty strings.
+ * transform, unresolved function refs are rejected.
  */
 function resolveModuleRef(ref: ModuleRef): string;
 function resolveModuleRef(ref: ModuleRef | undefined): string | undefined;
 function resolveModuleRef(ref: ModuleRef | undefined): string | undefined {
   if (ref === undefined) return undefined;
   if (typeof ref === "string") return ref;
-  // Function refs are transformed to strings by the vite plugin.
-  // Without the plugin, we can't extract the path — return empty string.
-  return "";
+  throw new Error(
+    "Invalid ModuleRef: expected a string path, but received a function at runtime. " +
+      'Use a plain string path (e.g. "./routes/home.tsx"), or ensure the Vite plugin rewrites inline `() => import("./file")` refs in the app manifest.',
+  );
 }
 
 export function group(meta: GroupMeta, routes: RouteTreeNode[]): GroupDefinition {


### PR DESCRIPTION
### Motivation

- The public `ModuleRef` API accepts function-based refs but the Vite transform only rewrites a narrow inline pattern, so some valid function refs reach runtime and were previously coerced to `""`, which can drop middleware or map routes to the wrong module. 
- That fail-open behavior is a security risk because named middleware (e.g. `auth`) can be omitted when a middleware ref resolves to an empty string. 
- The fix ensures unresolved function refs fail closed and surfaces a clear error to users instead of silently continuing.

### Description

- Replace the empty-string fallback in `resolveModuleRef` with a runtime error by throwing an explicit `Error` when a `ModuleRef` is a function at runtime, instead of returning `""` (`packages/framework/src/app.ts`).
- Add a prominent note to the routing docs explaining that function refs must use the exact inline manifest form `() => import("./path")` so the Vite plugin can rewrite them (`docs/ROUTING.md`).
- Add a patch changeset to record the behavior change for the published `@pracht/core` package (`.changeset/five-snakes-act.md`).

### Testing

- `pnpm run format` completed successfully.
- `pnpm run lint` completed successfully.
- `pnpm run e2e` could not be completed in this environment because the Playwright web server failed to start due to a missing `packages/cli/dist/index.mjs` artifact, so e2e is marked as not run/successful here.
- `pnpm run test` was executed but the test run failed in this environment due to missing built package/dist artifacts and related resolution errors; unit test suites ran but overall the CI test command exited with failures unrelated to the change (missing `packages/cli/dist/index.mjs` and package entry resolution issues).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a06dd066928832f8bb444ec97feefe4)