### PR TITLE
fix(adapter-node): isolate ISG regeneration from request context

### DIFF
--- a/.changeset/fair-mails-jump.md
+++ b/.changeset/fair-mails-jump.md
@@ -1,0 +1,5 @@
+---
+"@pracht/adapter-node": patch
+---
+
+Harden ISG stale background regeneration so it no longer reuses request context that can carry per-user data into shared cached HTML.

--- a/docs/ADAPTERS.md
+++ b/docs/ADAPTERS.md
@@ -143,7 +143,8 @@ that manifest.
   pages and writes updated HTML to disk. Route-state requests (`x-pracht-route-state-request`
   and `?_data=1`) bypass the cached HTML path so client navigation still reaches
   `handlePrachtRequest()`. Background regeneration uses a clean HTML request
-  instead of replaying the triggering user's cookies/authorization headers.
+  instead of replaying the triggering user's cookies/authorization headers, and
+  skips app `createContext()` to avoid per-request context in shared ISG output.
   Static and ISG files are streamed, and static responses support `ETag` /
   `Last-Modified` conditional revalidation.
 - **Vite manifest**: reads `.vite/manifest.json` to inject correct `<script>` and

--- a/packages/adapter-node/src/node-handler.ts
+++ b/packages/adapter-node/src/node-handler.ts
@@ -264,9 +264,11 @@ async function serveISGEntry<TContext>(
   }
 
   if (isStale) {
-    regenerateISGPage(options, pathname, htmlPath, contextArgs).catch((err) => {
-      console.error(`ISG regeneration failed for ${pathname}:`, err);
-    });
+    regenerateISGPage(options, pathname, htmlPath, { request: contextArgs.request }).catch(
+      (err) => {
+        console.error(`ISG regeneration failed for ${pathname}:`, err);
+      },
+    );
   }
 
   return true;

--- a/packages/adapter-node/src/node-isg.ts
+++ b/packages/adapter-node/src/node-isg.ts
@@ -3,21 +3,21 @@ import { dirname } from "node:path";
 import { handlePrachtRequest } from "@pracht/core/server";
 import type { NodeAdapterContextArgs, NodeAdapterOptions } from "./node-handler.ts";
 
+export interface ISGRegenerationContextArgs {
+  request?: NodeAdapterContextArgs["request"];
+}
+
 export async function regenerateISGPage<TContext>(
   options: NodeAdapterOptions<TContext>,
   pathname: string,
   htmlPath: string,
-  contextArgs?: NodeAdapterContextArgs,
+  contextArgs?: ISGRegenerationContextArgs,
 ): Promise<void> {
   const request = createISGRegenerationRequest(pathname, contextArgs?.request);
-  const context =
-    options.createContext && contextArgs
-      ? await options.createContext({ ...contextArgs, request })
-      : undefined;
 
   const response = await handlePrachtRequest({
     app: options.app,
-    context,
+    context: undefined,
     registry: options.registry,
     request,
     clientEntryUrl: options.clientEntryUrl,

--- a/packages/adapter-node/test/index.test.ts
+++ b/packages/adapter-node/test/index.test.ts
@@ -190,7 +190,7 @@ describe("createNodeRequestHandler", () => {
     ]);
   });
 
-  it("reuses createContext during stale ISG regeneration with a clean request", async () => {
+  it("does not reuse createContext during stale ISG regeneration", async () => {
     const staticDir = makeTempDir();
     const htmlDir = join(staticDir, "isg");
     const htmlPath = join(htmlDir, "index.html");
@@ -252,7 +252,7 @@ describe("createNodeRequestHandler", () => {
 
     await waitFor(() => readFileSync(htmlPath, "utf-8").includes("missing"));
 
-    expect(createContextCalls).toEqual(["missing"]);
+    expect(createContextCalls).toEqual([]);
     expect(readFileSync(htmlPath, "utf-8")).toContain("missing");
   });
 });


### PR DESCRIPTION
### Motivation

- Prevent stale ISG background regeneration from inheriting the triggering HTTP/Node context or request headers that can leak per-user data into a path-keyed public HTML cache.

### Description

- Stop passing the full `NodeAdapterContextArgs` into background regeneration and only forward an optional web `Request` base when needed by `createISGRegenerationRequest`.
- Skip calling the app `createContext()` during background ISG regeneration and call `handlePrachtRequest()` with `context: undefined` so no per-request context can influence the cached output. 
- Ensure the regeneration `Request` is header-clean (only `Accept: text/html`) to avoid replaying `Cookie`/`Authorization`/other sensitive headers.
- Update the adapter docs, add a patch changeset for `@pracht/adapter-node`, and adjust the adapter-node test to assert `createContext()` is not reused during stale background regeneration.

### Testing

- Ran `pnpm run format` which completed successfully. 
- Ran `pnpm run lint` which completed successfully. 
- Attempted `pnpm run e2e` but it failed in this environment due to a missing built CLI artifact (`packages/cli/dist/index.mjs`).
- Ran the workspace tests with `pnpm run test` which also failed in this environment for the same missing/unfinished package build and unresolved package entrypoints (see failing `@pracht/cli` tests and package entry resolution errors for `@pracht/core`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a06d9470a30832fa59cf5f9dc335ffd)