### PR TITLE
Use npm staged publishing

### DIFF
--- a/.github/scripts/stage-packages.mjs
+++ b/.github/scripts/stage-packages.mjs
@@ -82,14 +82,10 @@ function runGit(args) {
 }
 
 function hasLocalGitTag(tagName) {
-  const result = spawnSync(
-    "git",
-    ["rev-parse", "--verify", "--quiet", `refs/tags/${tagName}`],
-    {
-      cwd: root,
-      stdio: "ignore",
-    }
-  );
+  const result = spawnSync("git", ["rev-parse", "--verify", "--quiet", `refs/tags/${tagName}`], {
+    cwd: root,
+    stdio: "ignore",
+  });
   return result.status === 0;
 }
 

--- a/.github/scripts/stage-packages.mjs
+++ b/.github/scripts/stage-packages.mjs
@@ -70,6 +70,40 @@ function distTag(version) {
   return prerelease ? prerelease[1] : "latest";
 }
 
+function runGit(args) {
+  const result = spawnSync("git", args, {
+    cwd: root,
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  process.stdout.write(result.stdout);
+  process.stderr.write(result.stderr);
+  if (result.status !== 0) process.exit(result.status || 1);
+}
+
+function hasLocalGitTag(tagName) {
+  const result = spawnSync(
+    "git",
+    ["rev-parse", "--verify", "--quiet", `refs/tags/${tagName}`],
+    {
+      cwd: root,
+      stdio: "ignore",
+    }
+  );
+  return result.status === 0;
+}
+
+function createGitTag(tagName) {
+  if (hasLocalGitTag(tagName)) {
+    console.log(`Git tag ${tagName} already exists locally.`);
+  } else {
+    runGit(["tag", tagName, "-m", tagName]);
+  }
+
+  // changesets/action parses this line, then pushes the tag and creates the GitHub release.
+  console.log(`New tag: ${tagName}`);
+}
+
 const staged = [];
 for (const packageJsonPath of packageJsonPaths()) {
   const pkg = readJson(packageJsonPath);
@@ -94,7 +128,7 @@ for (const packageJsonPath of packageJsonPaths()) {
   ];
 
   console.log(`Staging ${pkg.name}@${pkg.version} with dist-tag ${tag}...`);
-  const result = spawnSync("npm", args, {
+  const result = spawnSync("pnpm", args, {
     cwd: root,
     encoding: "utf8",
     stdio: ["ignore", "pipe", "pipe"],
@@ -104,6 +138,9 @@ for (const packageJsonPath of packageJsonPaths()) {
   if (result.status !== 0) process.exit(result.status || 1);
 
   const stageId = result.stdout.match(/"stageId"\s*:\s*"([^"]+)"/)?.[1];
+  const tagName = `${pkg.name}@${pkg.version}`;
+  createGitTag(tagName);
+
   staged.push({
     name: pkg.name,
     version: pkg.version,

--- a/.github/scripts/stage-packages.mjs
+++ b/.github/scripts/stage-packages.mjs
@@ -1,0 +1,123 @@
+#!/usr/bin/env node
+import { spawnSync } from "node:child_process";
+import { existsSync, readFileSync, readdirSync } from "node:fs";
+import { dirname, join, relative } from "node:path";
+
+const root = process.cwd();
+const config = JSON.parse(readFileSync(join(root, ".changeset/config.json"), "utf8"));
+const ignored = new Set(config.ignore || []);
+const access = config.access || "public";
+
+function readJson(path) {
+  return JSON.parse(readFileSync(path, "utf8"));
+}
+
+function packageJsonPathsFromPnpmWorkspace() {
+  const workspace = join(root, "pnpm-workspace.yaml");
+  if (!existsSync(workspace)) return [];
+
+  const patterns = [];
+  for (const rawLine of readFileSync(workspace, "utf8").split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (!line.startsWith("- ")) continue;
+    const pattern = line.slice(2).replace(/^['\"]|['\"]$/g, "");
+    if (!pattern || pattern.startsWith("!")) continue;
+    patterns.push(pattern);
+  }
+
+  const paths = [];
+  for (const pattern of patterns) {
+    if (pattern.endsWith("/*")) {
+      const dir = join(root, pattern.slice(0, -2));
+      if (!existsSync(dir)) continue;
+      for (const entry of readdirSync(dir, { withFileTypes: true })) {
+        if (entry.isDirectory()) paths.push(join(dir, entry.name, "package.json"));
+      }
+    } else if (pattern.endsWith("/**")) {
+      // These workspaces are docs/examples and not published packages in this release flow.
+      continue;
+    } else {
+      paths.push(join(root, pattern, "package.json"));
+    }
+  }
+
+  return paths;
+}
+
+function packageJsonPaths() {
+  const paths = new Set(packageJsonPathsFromPnpmWorkspace());
+  paths.add(join(root, "package.json"));
+  return [...paths].filter(existsSync);
+}
+
+function versionExists(name, version) {
+  const result = spawnSync("npm", ["view", `${name}@${version}`, "version", "--json"], {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+
+  if (result.status === 0) return true;
+  const output = `${result.stdout}\n${result.stderr}`;
+  if (output.includes("E404") || output.includes("No match found")) return false;
+
+  process.stdout.write(result.stdout);
+  process.stderr.write(result.stderr);
+  throw new Error(`Could not check npm version for ${name}@${version}`);
+}
+
+function distTag(version) {
+  const prerelease = version.match(/^[^-]+-([0-9A-Za-z-]+)/);
+  return prerelease ? prerelease[1] : "latest";
+}
+
+const staged = [];
+for (const packageJsonPath of packageJsonPaths()) {
+  const pkg = readJson(packageJsonPath);
+  if (!pkg.name || !pkg.version || pkg.private || ignored.has(pkg.name)) continue;
+  if (versionExists(pkg.name, pkg.version)) {
+    console.log(`Skipping ${pkg.name}@${pkg.version}; already published.`);
+    continue;
+  }
+
+  const packageDir = dirname(packageJsonPath);
+  const tag = distTag(pkg.version);
+  const args = [
+    "stage",
+    "publish",
+    packageDir,
+    "--provenance",
+    "--access",
+    pkg.publishConfig?.access || access,
+    "--tag",
+    tag,
+    "--json",
+  ];
+
+  console.log(`Staging ${pkg.name}@${pkg.version} with dist-tag ${tag}...`);
+  const result = spawnSync("npm", args, {
+    cwd: root,
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  process.stdout.write(result.stdout);
+  process.stderr.write(result.stderr);
+  if (result.status !== 0) process.exit(result.status || 1);
+
+  const stageId = result.stdout.match(/"stageId"\s*:\s*"([^"]+)"/)?.[1];
+  staged.push({
+    name: pkg.name,
+    version: pkg.version,
+    path: relative(root, packageDir) || ".",
+    stageId,
+  });
+}
+
+if (staged.length === 0) {
+  console.log("No unpublished packages to stage.");
+} else {
+  console.log("Staged packages:");
+  for (const pkg of staged) {
+    console.log(`- ${pkg.name}@${pkg.version}${pkg.stageId ? ` (${pkg.stageId})` : ""}`);
+  }
+  console.log("Approve staged packages with `npm stage approve <stage-id>` after review.");
+}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,7 @@ jobs:
         run: pnpm install --frozen-lockfile --ignore-scripts
 
       - name: Install npm
-        run: npm install -g npm@11.11.1
+        run: npm install -g npm@11.15.0
 
       - name: Create Release Pull Request
         id: changesets
@@ -89,7 +89,7 @@ jobs:
         run: pnpm install --frozen-lockfile --ignore-scripts
 
       - name: Install npm
-        run: npm install -g npm@11.11.1
+        run: npm install -g npm@11.15.0
 
       - name: Build
         run: pnpm build
@@ -97,7 +97,7 @@ jobs:
       - name: Publish packages
         uses: changesets/action@6a0a831ff30acef54f2c6aa1cbbc1096b066edaf # v1.7.0
         with:
-          publish: pnpm exec changeset publish
+          publish: node .github/scripts/stage-packages.mjs
           commitMode: github-api
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
         with:
-          version: 11
+          version: 11.3.0
 
       - name: Install Node.js
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
@@ -76,7 +76,7 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
         with:
-          version: 11
+          version: 11.3.0
 
       - name: Install Node.js
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
@@ -98,6 +98,7 @@ jobs:
         uses: changesets/action@6a0a831ff30acef54f2c6aa1cbbc1096b066edaf # v1.7.0
         with:
           publish: node .github/scripts/stage-packages.mjs
+          createGithubReleases: true
           commitMode: github-api
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Updates the release workflow to stage npm packages with `npm stage publish` on npm 11.15. Maintainers can review the staged packages and approve them with 2FA before they go live.