### PR TITLE
improve text wrapping and add color-scheme usage

### DIFF
--- a/examples/docs/src/styles/global.css
+++ b/examples/docs/src/styles/global.css
@@ -16,8 +16,16 @@ html {
   scroll-behavior: smooth;
 }
 
+@media (prefers-reduced-motion: reduce) {
+  html {
+    scroll-behavior: auto;
+  }
+}
+
 /* Design Tokens */
 :root {
+  color-scheme: dark;
+
   --bg: #09090b;
   --bg-2: #18181b;
   --bg-3: #27272a;
@@ -404,6 +412,7 @@ code:not(.code-block code) {
   margin: 0 auto 36px;
   line-height: 1.7;
   font-weight: 400;
+  text-wrap: pretty;
 }
 
 .hero-sub strong {
@@ -458,9 +467,11 @@ code:not(.code-block code) {
 .section-title {
   font-size: clamp(26px, 4vw, 36px);
   font-weight: 650;
+  line-height: 1.3;
   letter-spacing: -0.6px;
   color: var(--text);
   margin-bottom: 12px;
+  text-wrap: pretty;
 }
 
 .section-sub {
@@ -468,6 +479,7 @@ code:not(.code-block code) {
   color: var(--text-3);
   max-width: 500px;
   line-height: 1.7;
+  text-wrap: pretty;
 }
 
 .features-grid {


### PR DESCRIPTION
## Summary

- Improves text wrapping on homepage title + sub text elements
- Reduce line height of homepage title
- Define color-scheme: dark to for dark scrollbars to match ds
- Wrap scroll-behavior in prefers-reduced-motion check

|| BEFORE | AFTER |
|--------|--------|--------|
|text-wrap| <img width="692" height="208" alt="Screenshot 2026-05-25 at 7 52 38 AM" src="https://github.com/user-attachments/assets/cc384f1f-b3b5-4164-84c1-6f61453f1fa2" /> | <img width="666" height="205" alt="Screenshot 2026-05-25 at 7 52 05 AM" src="https://github.com/user-attachments/assets/a05f83d4-f591-4d74-b351-8aeccb76b25c" /> |
|color-scheme| <img width="674" height="345" alt="Screenshot 2026-05-25 at 7 52 52 AM" src="https://github.com/user-attachments/assets/47f95dbd-5a60-455c-b2dc-b63dd97d268f" /> | <img width="660" height="348" alt="Screenshot 2026-05-25 at 7 53 05 AM" src="https://github.com/user-attachments/assets/9413c06d-4969-4a63-a9f2-c2803b6a0913" /> |
|line-height| <img width="560" height="369" alt="Screenshot 2026-05-25 at 7 53 38 AM" src="https://github.com/user-attachments/assets/69f43985-93f4-4721-bf41-4e212191f87a" /> | <img width="594" height="459" alt="Screenshot 2026-05-25 at 7 53 51 AM" src="https://github.com/user-attachments/assets/53e45d40-d28c-4f66-8661-871018f0ecf6" /> | 

## Testing

- [ ] `pnpm e2e`
- [ ] `pnpm format`
- [ ] `pnpm lint`
- [ ] `pnpm test`

## Checklist

- [ ] Docs updated if needed
- [ ] Skills updated if needed
- [ ] Changeset added if published packages changed
