### PR TITLE
Add ISG webhook revalidation

### DIFF
--- a/.changeset/isg-webhook-adapters.md
+++ b/.changeset/isg-webhook-adapters.md
@@ -1,0 +1,12 @@
+---
+"@pracht/core": minor
+"@pracht/adapter-node": minor
+"@pracht/adapter-cloudflare": minor
+"@pracht/adapter-vercel": minor
+"@pracht/cli": minor
+---
+
+Add webhook ISG revalidation policies and the shared `/__pracht/revalidate`
+endpoint contract. Node regenerates on-disk ISG HTML, Cloudflare stores runtime
+ISG responses in the Workers Cache API with `env.ASSETS` fallback, and Vercel
+emits native Build Output API prerender functions with on-demand ISR wiring.

--- a/.changeset/isg-webhook-adapters.md
+++ b/.changeset/isg-webhook-adapters.md
@@ -10,3 +10,12 @@ Add webhook ISG revalidation policies and the shared `/__pracht/revalidate`
 endpoint contract. Node regenerates on-disk ISG HTML, Cloudflare stores runtime
 ISG responses in the Workers Cache API with `env.ASSETS` fallback, and Vercel
 emits native Build Output API prerender functions with on-demand ISR wiring.
+
+ISG regeneration is single-flighted per path (a stampede of stale requests or
+webhook posts shares one render instead of racing N parallel regenerations),
+and the webhook endpoint reports a `failed` array alongside `revalidated` and
+`skipped`: regeneration errors keep the previously generated copy live and no
+longer abort the batch with a 500. `@pracht/core` exports the new
+`createRevalidationSingleFlight()` and `isCacheableISGResponse()` helpers for
+adapters, and Cloudflare ISG responses served from the Cache API now carry
+`Vary: x-pracht-route-state-request` like asset-served responses.

--- a/VISION_MVP.md
+++ b/VISION_MVP.md
@@ -102,8 +102,8 @@ Platform adapters export a request handler shaped for their runtime:
 | Adapter              | Runtime           | Notes                                |
 | -------------------- | ----------------- | ------------------------------------ |
 | `adapter-node`       | Node.js `http`    | Static file serving, ISG mtime check |
-| `adapter-cloudflare` | Workers `fetch`   | `env.ASSETS`, bindings, no runtime ISG yet |
-| `adapter-vercel`     | Serverless / Edge | Build Output API v3 + edge handler   |
+| `adapter-cloudflare` | Workers `fetch`   | `env.ASSETS`, Cache API-backed ISG   |
+| `adapter-vercel`     | Serverless / Edge | Build Output API v3 + native ISR     |
 
 Each adapter:
 
@@ -150,7 +150,7 @@ SSR and SSG, deployed to Node. Thoroughly tested with Playwright E2E tests.
    - `createNodeRequestHandler()` — Web Request/Response over `http`
    - Static file serving from `dist/client/`
    - Vite manifest loading for asset injection
-   - ISG time-window revalidation
+   - ISG time-window and webhook revalidation
 
 4. **`packages/cli`** — developer tooling (instant local DX)
    - `pracht dev` — one command, instant Vite dev server with HMR
@@ -168,13 +168,6 @@ SSR and SSG, deployed to Node. Thoroughly tested with Playwright E2E tests.
    - Loaders return correct data
    - Shells wrap routes correctly
    - Hydration completes without errors
-
-## TODO
-
-- CF and Vercel ISG
-- ISG webhook revalidation
-
----
 
 ## Monorepo Structure
 

--- a/docs/ADAPTERS.md
+++ b/docs/ADAPTERS.md
@@ -416,7 +416,12 @@ export default {
   `PRACHT_REVALIDATE_TOKEN` is used as the `bypassToken` when present at build
   time. If the env var is absent during build, Pracht writes a random bypass
   token and the runtime webhook endpoint still fails closed until the env var is
-  configured.
+  configured. The token must be set **at build time**: the `bypassToken` is
+  baked into the build's `*.prerender-config.json`, so setting the env var only
+  at runtime authenticates the webhook but cannot bypass Vercel's prerender
+  cache — such paths are reported as `failed` (detected via the
+  `x-vercel-cache` response header) until you rebuild with
+  `PRACHT_REVALIDATE_TOKEN` set.
 - **Dynamic fallback**: SSR and API routes are routed to the generated edge
   function. ISG document requests are handled by route-named prerender functions,
   while route-state requests still bypass static/prerender output and reach the

--- a/docs/ADAPTERS.md
+++ b/docs/ADAPTERS.md
@@ -494,9 +494,12 @@ curl -X POST https://example.com/__pracht/revalidate \
 ```
 
 The body must include `paths` as an array of concrete URL paths. The endpoint
-returns JSON with `revalidated` and `skipped` path arrays. A path is skipped
-when it is not an ISG route, is not in the prerender manifest, or does not opt
-into `webhookRevalidate()`.
+returns JSON with `revalidated`, `skipped`, and `failed` path arrays. A path is
+skipped when it is not an ISG route, is not in the prerender manifest, or does
+not opt into `webhookRevalidate()`. A path lands in `failed` when regeneration
+did not produce cacheable 200 HTML (loader error, `Set-Cookie`, `Cache-Control:
+private`/`no-store`, cache write failure); the previously generated copy stays
+live, and the batch continues instead of aborting with a 500.
 
 Set `PRACHT_REVALIDATE_TOKEN` in the deployment environment. Auth uses a
 constant-time comparison and fails closed with `401` when the token is missing
@@ -506,6 +509,19 @@ secret in `x-pracht-revalidate-token`.
 Regeneration never replays the webhook request's cookies, authorization
 headers, locale, or other user-specific headers. Adapters synthesize a clean
 `GET` document request for the target path.
+
+Concurrent regenerations of the same path are single-flighted: a stampede of
+stale requests (or repeated webhook posts) share one in-flight render per
+process/isolate instead of racing N parallel regenerations.
+
+Dynamic ISG paths that `getStaticPaths()` did not enumerate at build time are
+not in the prerender manifest. Regular requests for such paths still work —
+they fall through to the server render on every request, without a cached
+copy. Webhook posts naming them are reported as `skipped` on Node and
+Cloudflare (nothing cached to refresh). Vercel matches route patterns rather
+than the manifest, so such paths are accepted, but only build-time enumerated
+paths have prerender functions — new concrete paths are served per-request by
+the edge function.
 
 ---
 

--- a/docs/ADAPTERS.md
+++ b/docs/ADAPTERS.md
@@ -140,14 +140,18 @@ Prerendered HTML receives route and shell document headers from
 document headers such as `Set-Cookie`, `Authorization`, `Proxy-Authenticate`,
 `WWW-Authenticate`, and secret-shaped custom `x-*` headers before they can enter
 that manifest.
-- **ISG revalidation**: checks `pracht-isg-manifest.json` for time revalidation
-  metadata. Compares file mtime against revalidation window. Regenerates stale
-  pages and writes updated HTML to disk. Route-state requests (`x-pracht-route-state-request`
-  and `?_data=1`) bypass the cached HTML path so client navigation still reaches
-  `handlePrachtRequest()`. Background regeneration uses a clean HTML request
-  instead of replaying the triggering user's cookies/authorization headers.
-  Static and ISG files are streamed, and static responses support `ETag` /
-  `Last-Modified` conditional revalidation.
+- **ISG revalidation**: checks `isg-manifest.json` for time and webhook
+  revalidation metadata. Time revalidation compares file mtime against the
+  configured window, serves stale HTML immediately, and refreshes the file in
+  the background. Webhook revalidation is exposed at
+  `POST /__pracht/revalidate` and regenerates named paths synchronously after
+  authenticating `PRACHT_REVALIDATE_TOKEN`. Route-state requests
+  (`x-pracht-route-state-request` and `?_data=1`) bypass the cached HTML path
+  so client navigation still reaches `handlePrachtRequest()`. All regeneration
+  uses a clean HTML request instead of replaying the triggering user's cookies,
+  authorization headers, locale, or experiment headers. Static and ISG files are
+  streamed, and static responses support `ETag` / `Last-Modified` conditional
+  revalidation.
 - **Vite manifest**: reads `.vite/manifest.json` to inject correct `<script>` and
   `<link>` tags into server-rendered HTML.
 - **Response headers**: preserves multiple `Set-Cookie` headers from framework
@@ -205,6 +209,7 @@ build).
 | `app`           | `PrachtApp`                                 | The resolved app                          |
 | `registry`      | `ModuleRegistry`                            | Module importers                          |
 | `createContext` | `(args: CloudflareContextArgs) => TContext` | Context with `env` and `executionContext` |
+| `isgManifest`   | `Record<string, ISGManifestEntry>`          | Concrete ISG path metadata                |
 
 ### Features
 
@@ -213,9 +218,18 @@ build).
   the same default security headers applied to dynamic responses.
   Prerendered HTML also receives route and shell document headers from
   `dist/client/_pracht/headers.json`.
-- **ISG caveat**: runtime ISG revalidation is not implemented for Cloudflare
-  yet. ISG routes are prerendered at build time and then served as static
-  assets. `pracht build` warns when a Cloudflare build contains ISG routes.
+- **ISG revalidation**: runtime ISG uses the Workers Cache API as the
+  regenerated-page store, with `env.ASSETS` as the build-time fallback. The
+  generated worker reads `dist/client/_pracht/isg.json`, checks cache freshness
+  from the stored generation timestamp, serves stale HTML immediately for
+  time-based revalidation, and schedules regeneration with
+  `executionContext.waitUntil()`. `POST /__pracht/revalidate` authenticates
+  `PRACHT_REVALIDATE_TOKEN` and overwrites the named Cache API entries for
+  routes that opt into `webhookRevalidate()`.
+- **Cache locality**: Cloudflare's Cache API is local to the colo handling the
+  request. This keeps ISG dependency-free and fast, but webhook invalidation is
+  not a global purge. Other colos refresh when they receive the webhook or when
+  their cached entry becomes stale and a visitor requests it.
 - **Default request context**: generated worker entries pass `{ env,
   executionContext }` to pracht so loaders, API routes, and middleware can
   access bindings without extra wiring.
@@ -384,8 +398,9 @@ export default {
 - **Edge runtime handler**: generated server entries export a default `fetch`-style
   handler that Vercel bundles as an Edge Function.
 - **Build Output API v3**: `pracht({ adapter: vercelAdapter() })` makes `pracht build`
-  emit `.vercel/output/config.json`, `.vercel/output/static/`, and
-  `.vercel/output/functions/render.func/`.
+  emit `.vercel/output/config.json`, `.vercel/output/static/`,
+  `.vercel/output/functions/render.func/`, and route-named prerender functions
+  for ISG paths.
 - **Local preview**: there is no faithful local Vercel production runtime, so
   `pracht preview` does not emulate one — it points at `vercel build` /
   `vercel dev` instead.
@@ -395,9 +410,17 @@ export default {
 - **Route-state bypass**: Vercel build output adds rules for both
   `x-pracht-route-state-request: 1` and `?_data=1`, so route-state requests go
   to the edge function before any static SSG rewrite can serve cached HTML.
-- **Dynamic fallback**: SSR, API, and ISG routes are routed to the generated edge
-  function. ISG paths currently bypass the static fallback so freshness stays
-  correct even without native Vercel ISR integration yet.
+- **Native ISR**: ISG routes are emitted as Build Output API prerender functions
+  with `.prerender-config.json` files. Time policies become Vercel
+  `expiration` values, build-time HTML becomes the prerender fallback, and
+  `PRACHT_REVALIDATE_TOKEN` is used as the `bypassToken` when present at build
+  time. If the env var is absent during build, Pracht writes a random bypass
+  token and the runtime webhook endpoint still fails closed until the env var is
+  configured.
+- **Dynamic fallback**: SSR and API routes are routed to the generated edge
+  function. ISG document requests are handled by route-named prerender functions,
+  while route-state requests still bypass static/prerender output and reach the
+  edge function.
 - **Static security headers**: the generated `config.json` includes a `headers`
   section that applies the same baseline security headers to all responses,
   including static assets served by Vercel's CDN. Static prerendered routes also
@@ -424,7 +447,8 @@ The context module must export `createContext(args)`. Vercel passes `{ request, 
 
 ```javascript
 // virtual:pracht/server (generated in vercel mode)
-import { handlePrachtRequest, resolveApp, resolveApiRoutes } from "@pracht/core";
+import { resolveApp, resolveApiRoutes } from "@pracht/core/server";
+import { createVercelEdgeHandler } from "@pracht/adapter-vercel";
 import { app } from "./src/routes.ts";
 
 const resolvedApp = resolveApp(app);
@@ -433,17 +457,55 @@ const apiRoutes = resolveApiRoutes(Object.keys(apiModules), "/src/api");
 export const vercelFunctionName = "render";
 
 export default async function handle(request, context) {
-  return handlePrachtRequest({
+  const handler = createVercelEdgeHandler({
     app: resolvedApp,
     registry,
-    request,
-    context,
     apiRoutes,
     clientEntryUrl: clientEntryUrl ?? undefined,
     cssManifest,
   });
+  return handler(request, context);
 }
 ```
+
+---
+
+## ISG Webhook Revalidation
+
+Routes opt into webhook revalidation with `webhookRevalidate()` or by combining
+it with `timeRevalidate()`:
+
+```typescript
+import { timeRevalidate, webhookRevalidate } from "@pracht/core";
+
+route("/pricing", () => import("./routes/pricing.tsx"), {
+  render: "isg",
+  revalidate: [timeRevalidate(3600), webhookRevalidate()],
+});
+```
+
+All built-in adapters expose the same endpoint:
+
+```sh
+curl -X POST https://example.com/__pracht/revalidate \
+  -H "Authorization: Bearer $PRACHT_REVALIDATE_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"paths":["/pricing"]}'
+```
+
+The body must include `paths` as an array of concrete URL paths. The endpoint
+returns JSON with `revalidated` and `skipped` path arrays. A path is skipped
+when it is not an ISG route, is not in the prerender manifest, or does not opt
+into `webhookRevalidate()`.
+
+Set `PRACHT_REVALIDATE_TOKEN` in the deployment environment. Auth uses a
+constant-time comparison and fails closed with `401` when the token is missing
+or incorrect. Webhook providers that cannot send bearer auth can send the same
+secret in `x-pracht-revalidate-token`.
+
+Regeneration never replays the webhook request's cookies, authorization
+headers, locale, or other user-specific headers. Adapters synthesize a clean
+`GET` document request for the target path.
 
 ---
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -375,8 +375,8 @@ dist/
     about/index.html
     blog/hello/index.html
   server/
-    pracht-route-manifest.json  # Route metadata for runtime
-    pracht-isg-manifest.json    # ISG revalidation config
+    headers-manifest.json       # Prerendered document headers
+    isg-manifest.json           # ISG revalidation config
     server.js                  # Platform entry module
 ```
 

--- a/docs/RENDERING_MODES.md
+++ b/docs/RENDERING_MODES.md
@@ -89,7 +89,11 @@ route("/pricing", () => import("./routes/pricing.tsx"), {
 });
 ```
 
-ISG generates HTML at build time (like SSG) and, on adapters with persistent platform state, regenerates it after a configurable time window. The Node adapter serves the stale page while a new version is generated in the background.
+ISG generates HTML at build time (like SSG) and, on adapters with persistent
+platform state, regenerates it after a configurable time window or an
+authenticated webhook. Node and Cloudflare serve stale HTML immediately while a
+new version is generated in the background for time-based revalidation. Vercel
+uses Build Output API prerender functions and the platform ISR cache.
 
 ### Time-based revalidation
 
@@ -101,35 +105,58 @@ import { timeRevalidate } from "@pracht/core";
 } // seconds
 ```
 
-The Node adapter checks the file's mtime against the revalidation window. If
-stale, it serves the stale HTML immediately and triggers regeneration.
-
-> **Cloudflare note:** The Cloudflare adapter currently does not implement
-> runtime ISG revalidation. ISG routes are prerendered at build time and served
-> as static assets on Cloudflare. Use SSG/SSR on Cloudflare, or deploy ISG
-> routes to Node until a Cloudflare cache/KV-backed design lands.
->
-> **Vercel note:** Pracht's Vercel adapter targets Edge Functions. Pracht
-> prerenders ISG routes at build time and routes ISG paths through the Edge
-> Function rather than relying on process-local cache state. Use SSG for static
-> output or SSR for per-request freshness on Vercel.
+Node checks the file's mtime against the revalidation window. Cloudflare checks
+the generated timestamp stored in the Cache API entry and falls back to the
+build-time asset timestamp. Vercel writes native `.prerender-config.json` files
+with `expiration` set from the time policy.
 
 ### Webhook-based revalidation
-
-> **Not yet available.** `webhookRevalidate` is planned but not exported from
-> `@pracht/core` today. The API below shows the intended design — it will ship
-> in a future release. Use `timeRevalidate` for now.
 
 ```typescript
 import { webhookRevalidate } from "@pracht/core";
 
 {
-  revalidate: webhookRevalidate({ key: "pricing-update" });
+  revalidate: webhookRevalidate();
 }
 ```
 
-An external system POSTs to a revalidation endpoint to trigger regeneration.
-Useful for CMS-driven content where you know exactly when data changes.
+An external system POSTs to the framework endpoint to trigger regeneration:
+
+```sh
+curl -X POST https://example.com/__pracht/revalidate \
+  -H "Authorization: Bearer $PRACHT_REVALIDATE_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"paths":["/pricing"]}'
+```
+
+Set `PRACHT_REVALIDATE_TOKEN` in the runtime environment. The endpoint fails
+closed with `401` when the token is unset or incorrect. Pracht also accepts the
+same secret in the `x-pracht-revalidate-token` header for webhook providers
+that cannot send bearer auth.
+
+Webhook and time policies can be combined:
+
+```typescript
+import { timeRevalidate, webhookRevalidate } from "@pracht/core";
+
+route("/pricing", () => import("./routes/pricing.tsx"), {
+  render: "isg",
+  revalidate: [timeRevalidate(3600), webhookRevalidate()],
+});
+```
+
+This means "regenerate hourly, or sooner when a CMS webhook names this path."
+
+| Adapter    | Time revalidation                       | Webhook revalidation                |
+| ---------- | --------------------------------------- | ----------------------------------- |
+| Node       | File mtime + stale-while-revalidate     | Regenerates the on-disk HTML file   |
+| Cloudflare | Cache API + `env.ASSETS` fallback       | Overwrites the Cache API entry      |
+| Vercel     | Build Output API prerender `expiration` | Uses `x-prerender-revalidate`       |
+
+Cloudflare's Cache API is per-colo. A webhook updates the colo that receives
+the webhook request; other colos refresh on their next stale request or their
+own webhook hit. Use shorter time windows when globally immediate invalidation
+is required.
 
 ---
 

--- a/docs/RENDERING_MODES.md
+++ b/docs/RENDERING_MODES.md
@@ -134,6 +134,18 @@ closed with `401` when the token is unset or incorrect. Pracht also accepts the
 same secret in the `x-pracht-revalidate-token` header for webhook providers
 that cannot send bearer auth.
 
+The response reports `revalidated`, `skipped`, and `failed` path arrays.
+Ineligible paths (not ISG, not prerendered, no `webhookRevalidate()`) are
+skipped; paths whose regeneration errored are reported in `failed` and keep
+serving the previously generated copy. Concurrent regenerations of the same
+path are single-flighted, so a burst of stale traffic or webhook posts
+triggers one render, not N.
+
+Dynamic ISG paths that `getStaticPaths()` did not enumerate at build time are
+rendered on demand per request (uncached); webhook posts naming them are
+reported as `skipped` on Node and Cloudflare because there is no generated
+copy to refresh.
+
 Webhook and time policies can be combined:
 
 ```typescript

--- a/docs/WORKSPACE.md
+++ b/docs/WORKSPACE.md
@@ -10,9 +10,9 @@ described in `VISION_MVP.md`.
 | `packages/framework`          | `@pracht/core`               | Core manifest API, route resolution, API routes, SSR rendering, client runtime                               |
 | `packages/vite-plugin`        | `@pracht/vite-plugin`        | Virtual modules, `import.meta.glob()` registries, API route auto-discovery, HMR, dev SSR middleware          |
 | `packages/preact-ssr-precompile` | `@pracht/preact-ssr-precompile` | Experimental Rolldown/Vite plugin that precompiles safe Preact JSX DOM subtrees into server-only `jsxTemplate()` calls |
-| `packages/adapter-node`       | `@pracht/adapter-node`       | Node `IncomingMessage`/`ServerResponse` bridge, ISG stale-while-revalidate                                   |
-| `packages/adapter-cloudflare` | `@pracht/adapter-cloudflare` | Cloudflare Workers fetch handler, generated worker entry source, and static asset handoff (no runtime ISG revalidation yet) |
-| `packages/adapter-vercel`     | `@pracht/adapter-vercel`     | Vercel Edge handler and Build Output API entry source                                                        |
+| `packages/adapter-node`       | `@pracht/adapter-node`       | Node `IncomingMessage`/`ServerResponse` bridge, ISG stale-while-revalidate, and webhook revalidation         |
+| `packages/adapter-cloudflare` | `@pracht/adapter-cloudflare` | Cloudflare Workers fetch handler, generated worker entry source, static asset handoff, and Cache API ISG     |
+| `packages/adapter-vercel`     | `@pracht/adapter-vercel`     | Vercel Edge handler, Build Output API entry source, and native ISR artifacts                                 |
 | `packages/preact-worker-facets` | `@pracht/preact-worker-facets` | Experimental Cloudflare Dynamic Worker + Durable Object facets runtime for inert, stateful Preact components |
 | `packages/cli`                | `@pracht/cli`                | `pracht dev`, `build`, `verify`, the `generate` subcommands, and `doctor`                                    |
 | `examples/cloudflare`         | `@pracht/example-cloudflare` | Cloudflare-targeted example app with SSG, ISG, SSR, SPA routes, auth middleware, and API routes              |
@@ -48,10 +48,9 @@ described in `VISION_MVP.md`.
   present.
 - **ISG revalidation** — At build time, ISG routes are prerendered alongside SSG
   routes and an `isg-manifest.json` is generated mapping paths to revalidation
-  config. At runtime, the Node adapter implements stale-while-revalidate:
-  cached HTML is served immediately, and if the file's mtime exceeds the
-  `revalidate.seconds` threshold, background regeneration refreshes the cached
-  page.
+  config. Node uses file mtime, Cloudflare uses the Cache API with `env.ASSETS`
+  fallback, and Vercel emits Build Output API prerender functions. Routes can
+  opt into `timeRevalidate()`, `webhookRevalidate()`, or both.
 - **Middleware** — Named middleware from the manifest runs before loaders and can
   redirect, return a Response, or augment the context.
 - **Vite plugin** — Generates `virtual:pracht/client` (hydration entry) and
@@ -88,17 +87,15 @@ described in `VISION_MVP.md`.
   client bootstrap graph while generated server modules avoid the browser export
   condition. The CLI remains plain JS.
 - **Node adapter** — Translates Node requests to Web `Request` objects, calls
-  `handlePrachtRequest()`, and implements ISG stale-while-revalidate with
-  background regeneration.
+  `handlePrachtRequest()`, and implements ISG stale-while-revalidate plus
+  webhook regeneration of on-disk HTML.
 - **Cloudflare adapter** — Serves `env.ASSETS` when available, falls back to
-  `handlePrachtRequest()`, and gives loaders, API routes, and middleware access
-  to `env` and the `executionContext` through `args.context`. Runtime ISG
-  revalidation is intentionally not implemented yet; Cloudflare builds warn when
-  ISG routes are present.
+  `handlePrachtRequest()`, gives loaders/API routes/middleware access to `env`
+  and `executionContext`, and stores regenerated ISG HTML in the Workers Cache
+  API.
 - **Vercel adapter** — Emits an Edge-compatible handler, copies the build into
   `.vercel/output/static` and `.vercel/output/functions/render.func`, rewrites
-  clean SSG URLs to static HTML, and routes ISG plus dynamic requests to the
-  generated edge function.
+  clean SSG URLs to static HTML, and emits native prerender functions for ISG.
 - **Preact Worker facets prototype** — `@pracht/preact-worker-facets` provides
   experimental helpers for running Preact-style component modules inside
   Cloudflare Dynamic Workers. A supervisor Durable Object owns auth, source
@@ -138,4 +135,4 @@ described in `VISION_MVP.md`.
 
 ## Later (Phase 2 remaining)
 
-1. ISG webhook revalidation — on-demand cache invalidation via POST endpoint.
+No Phase 2 adapter ISG items are currently tracked here.

--- a/e2e/cloudflare-build.test.ts
+++ b/e2e/cloudflare-build.test.ts
@@ -55,8 +55,10 @@ test("pracht build emits a deployable Cloudflare Worker setup", async () => {
   expect(workerSource).toContain("cloudflareAssetsBinding");
   expect(workerSource).toContain('buildTarget = "cloudflare"');
   expect(workerSource).toContain("_pracht/headers.json");
+  expect(workerSource).toContain("_pracht/isg.json");
+  expect(workerSource).toContain("createCloudflareFetchHandler");
   expect(workerSource).toContain("server_default as default");
-  expect(output).toContain("Cloudflare adapter currently serves prerendered ISG HTML");
+  expect(output).not.toContain("does not perform runtime revalidation");
 
   // Cloudflare primitives configured via `workerExportsFrom` must be re-exported
   expect(workerSource).toContain("Counter");
@@ -69,6 +71,8 @@ test("pracht build emits a deployable Cloudflare Worker setup", async () => {
   expect(deploySource).toContain('export { default } from "./server.js";');
   expect(deploySource).not.toContain("buildTarget");
   expect(deploySource).not.toContain("cssManifest");
+
+  expect(existsSync(resolve(exampleDir, "dist/client/_pracht/isg.json"))).toBe(true);
 });
 
 test("prerendered SSG pages include client JS and working framework context", async () => {

--- a/e2e/node-build.test.ts
+++ b/e2e/node-build.test.ts
@@ -32,6 +32,11 @@ test("pracht build emits a deployable Node server entry", async () => {
 
   expect(existsSync(serverEntryPath)).toBe(true);
 
+  // The ISG manifest stays server-side; it must not be exposed in the
+  // publicly served client dir on the Node target.
+  expect(existsSync(resolve(exampleDir, "dist/server/isg-manifest.json"))).toBe(true);
+  expect(existsSync(resolve(exampleDir, "dist/client/_pracht/isg.json"))).toBe(false);
+
   const serverSource = readFileSync(serverEntryPath, "utf-8");
   expect(serverSource).toContain('buildTarget = "node"');
   expect(serverSource).toContain("createNodeRequestHandler");

--- a/e2e/vercel-build.test.ts
+++ b/e2e/vercel-build.test.ts
@@ -42,6 +42,9 @@ test("pracht build emits a deployable Vercel Build Output setup", async () => {
   expect(existsSync(pricingFallbackPath)).toBe(true);
   expect(existsSync(staticIndexPath)).toBe(true);
   expect(existsSync(staticPricingPath)).toBe(false);
+  // The ISG manifest must not leak into the publicly served static output.
+  expect(existsSync(resolve(vercelDir, "static/_pracht/isg.json"))).toBe(false);
+  expect(existsSync(resolve(exampleDir, "dist/client/_pracht/isg.json"))).toBe(false);
 
   const config = JSON.parse(readFileSync(configPath, "utf-8"));
   expect(config.version).toBe(3);

--- a/e2e/vercel-build.test.ts
+++ b/e2e/vercel-build.test.ts
@@ -15,7 +15,11 @@ test("pracht build emits a deployable Vercel Build Output setup", async () => {
   const configPath = resolve(vercelDir, "config.json");
   const functionConfigPath = resolve(vercelDir, "functions/render.func/.vc-config.json");
   const serverEntryPath = resolve(vercelDir, "functions/render.func/server.js");
+  const pricingFunctionConfigPath = resolve(vercelDir, "functions/pricing.func/.vc-config.json");
+  const pricingPrerenderConfigPath = resolve(vercelDir, "functions/pricing.prerender-config.json");
+  const pricingFallbackPath = resolve(vercelDir, "functions/pricing.prerender-fallback.html");
   const staticIndexPath = resolve(vercelDir, "static/index.html");
+  const staticPricingPath = resolve(vercelDir, "static/pricing/index.html");
 
   rmSync(distDir, { force: true, recursive: true });
   rmSync(vercelDir, { force: true, recursive: true });
@@ -33,7 +37,11 @@ test("pracht build emits a deployable Vercel Build Output setup", async () => {
   expect(existsSync(configPath)).toBe(true);
   expect(existsSync(functionConfigPath)).toBe(true);
   expect(existsSync(serverEntryPath)).toBe(true);
+  expect(existsSync(pricingFunctionConfigPath)).toBe(true);
+  expect(existsSync(pricingPrerenderConfigPath)).toBe(true);
+  expect(existsSync(pricingFallbackPath)).toBe(true);
   expect(existsSync(staticIndexPath)).toBe(true);
+  expect(existsSync(staticPricingPath)).toBe(false);
 
   const config = JSON.parse(readFileSync(configPath, "utf-8"));
   expect(config.version).toBe(3);
@@ -50,6 +58,7 @@ test("pracht build emits a deployable Vercel Build Output setup", async () => {
         dest: "/render",
       }),
       expect.objectContaining({ src: "^/$", dest: "/index.html" }),
+      expect.objectContaining({ src: "^/pricing/?$", dest: "/pricing" }),
       expect.objectContaining({ handle: "filesystem" }),
       expect.objectContaining({ src: "/(.*)", dest: "/render" }),
     ]),
@@ -73,9 +82,21 @@ test("pracht build emits a deployable Vercel Build Output setup", async () => {
     runtime: "edge",
     entrypoint: "server.js",
   });
+  const pricingFunctionConfig = JSON.parse(readFileSync(pricingFunctionConfigPath, "utf-8"));
+  expect(pricingFunctionConfig).toMatchObject(functionConfig);
+
+  const pricingPrerenderConfig = JSON.parse(readFileSync(pricingPrerenderConfigPath, "utf-8"));
+  expect(pricingPrerenderConfig).toMatchObject({
+    allowQuery: [],
+    expiration: 3600,
+    fallback: "pricing.prerender-fallback.html",
+    initialStatus: 200,
+  });
+  expect(pricingPrerenderConfig.bypassToken).toEqual(expect.any(String));
 
   const functionSource = readFileSync(serverEntryPath, "utf-8");
   expect(functionSource).toContain("vercelFunctionName");
   expect(functionSource).toContain('buildTarget = "vercel"');
+  expect(functionSource).toContain("createVercelEdgeHandler");
   expect(functionSource).toContain("async function handle(request, context)");
 });

--- a/examples/docs/src/routes/docs/adapters.md
+++ b/examples/docs/src/routes/docs/adapters.md
@@ -29,7 +29,10 @@ Adapters also preserve route and shell document headers for prerendered HTML so 
 
 ## Cloudflare Workers
 
-Deploy to Cloudflare's global edge network. Static assets are served from the `ASSETS` binding, and dynamic routes are handled by the Worker. Runtime ISG revalidation is not implemented for Cloudflare yet; ISG routes are prerendered at build time and served as static assets, and `pracht build` warns when this combination is used.
+Deploy to Cloudflare's global edge network. Static assets are served from the
+`ASSETS` binding, dynamic routes are handled by the Worker, and regenerated ISG
+HTML is stored in the Workers Cache API with `ASSETS` as the build-time
+fallback.
 
 ### Setup
 
@@ -146,7 +149,9 @@ Static prerendered routes receive document headers through the generated Build O
     config.json    // routes, rewrites, headers
     static/        // SSG pages served from the filesystem
     functions/
-      render.func/ // Edge Function for SSR/ISG/API routes
+      render.func/ // Edge Function for SSR/API routes and webhook bridge
+      pricing.func/
+      pricing.prerender-config.json
 ```
 
 ### Deploy

--- a/examples/docs/src/routes/docs/recipes-fullstack-vercel.md
+++ b/examples/docs/src/routes/docs/recipes-fullstack-vercel.md
@@ -262,5 +262,5 @@ Or connect your Git repository in the Vercel dashboard for automatic deployments
 
 - Use `render: "ssr"` for any route that reads from Postgres — data changes per request.
 - The `sql` template tag from `@vercel/postgres` automatically parameterizes queries — it's safe against SQL injection by default.
-- Pracht's Vercel adapter targets Edge Functions: pracht prerenders ISG routes at build time, then routes ISG paths through the Edge Function instead of relying on process-local cache state. Use `render: "ssg"` for fully static pages or `render: "ssr"` for per-request freshness.
+- Pracht's Vercel adapter emits native Build Output API prerender functions for ISG routes. Set `PRACHT_REVALIDATE_TOKEN` if you want webhook revalidation through `/__pracht/revalidate`.
 - Vercel Edge Functions have a 25MB size limit and a 30-second execution timeout. Keep loaders fast and move heavy work to background jobs.

--- a/examples/docs/src/routes/docs/rendering.md
+++ b/examples/docs/src/routes/docs/rendering.md
@@ -81,24 +81,27 @@ route("/pricing", "./routes/pricing.tsx", {
 });
 ```
 
-ISG generates HTML at build time (like SSG) and, on adapters with persistent platform state, regenerates it after a configurable time window. The Node adapter serves the stale page immediately while a new version regenerates in the background — stale-while-revalidate.
+ISG generates HTML at build time (like SSG) and, on adapters with persistent
+platform state, regenerates it after a configurable time window or an
+authenticated webhook. Node and Cloudflare serve stale pages immediately while a
+new version regenerates in the background; Vercel uses native Build Output API
+prerender functions.
 
 > [!INFO]
-> ISG revalidation is implemented at the adapter level. The Node adapter uses file `mtime`. Cloudflare currently serves prerendered ISG HTML as static assets and does not perform runtime revalidation yet. Vercel routes ISG paths through the Edge Function instead of relying on process-local cache state; use SSG for static output or SSR for per-request freshness on Vercel.
+> ISG revalidation is implemented at the adapter level. Node uses file `mtime`, Cloudflare stores regenerated pages in the Workers Cache API with `env.ASSETS` as fallback, and Vercel emits native prerender configs.
 
 ### Webhook revalidation
-
-> [!WARNING]
-> `webhookRevalidate` is planned but **not yet exported** from `@pracht/core`. The snippet below shows the intended API — it will ship in a future release. Use `timeRevalidate` for now.
 
 ```ts
 import { webhookRevalidate } from "@pracht/core";
 
 {
-  revalidate: webhookRevalidate({ key: "pricing-update" });
+  revalidate: webhookRevalidate();
 }
-// POST to the revalidation endpoint to trigger regeneration
 ```
+
+Set `PRACHT_REVALIDATE_TOKEN`, then POST concrete paths to
+`/__pracht/revalidate` with `Authorization: Bearer <token>`.
 
 ---
 

--- a/packages/adapter-cloudflare/README.md
+++ b/packages/adapter-cloudflare/README.md
@@ -53,7 +53,7 @@ Keep the matching bindings and migrations in `wrangler.jsonc`.
 
 - Converts Cloudflare Worker requests to standard Web Requests
 - Static asset serving via `env.ASSETS`
-- SSG/ISG prerendered asset serving (runtime ISG revalidation is not implemented yet; builds warn when ISG routes target Cloudflare)
+- SSG serving from `env.ASSETS` and ISG revalidation through the Workers Cache API
 - Execution context passing for Cloudflare-specific APIs
 - Generated-entry context factories via `cloudflareAdapter({ createContextFrom })`
 

--- a/packages/adapter-cloudflare/package.json
+++ b/packages/adapter-cloudflare/package.json
@@ -32,6 +32,10 @@
     ".": {
       "types": "./dist/index.d.mts",
       "default": "./dist/index.mjs"
+    },
+    "./runtime": {
+      "types": "./dist/runtime.d.mts",
+      "default": "./dist/runtime.mjs"
     }
   },
   "publishConfig": {

--- a/packages/adapter-cloudflare/src/index.ts
+++ b/packages/adapter-cloudflare/src/index.ts
@@ -1,49 +1,14 @@
 import type { PrachtAdapter } from "@pracht/vite-plugin";
 import type { Plugin } from "vite";
 import { cloudflare } from "@cloudflare/vite-plugin";
-import {
-  applyDefaultSecurityHeaders,
-  handlePrachtRequest,
-  type HandlePrachtRequestOptions,
-  type ModuleRegistry,
-  type ResolvedApiRoute,
-  type PrachtApp,
-} from "@pracht/core/server";
 
-type HeadersManifest = Record<string, Record<string, string>>;
-
-export interface CloudflareFetcher {
-  fetch(input: Request | URL | string): Promise<Response>;
-}
-
-export interface CloudflareExecutionContext {
-  waitUntil(promise: Promise<unknown>): void;
-  passThroughOnException?(): void;
-}
-
-export interface CloudflareContextArgs<TEnv = Record<string, unknown>> {
-  request: Request;
-  env: TEnv;
-  executionContext: CloudflareExecutionContext;
-}
-
-export interface CloudflareAdapterOptions<
-  TEnv extends Record<string, unknown> = Record<string, unknown>,
-  TContext = {
-    env: TEnv;
-    executionContext: CloudflareExecutionContext;
-  },
-> {
-  app: PrachtApp;
-  registry?: ModuleRegistry;
-  apiRoutes?: ResolvedApiRoute[];
-  clientEntryUrl?: string;
-  cssManifest?: Record<string, string[]>;
-  jsManifest?: Record<string, string[]>;
-  assetsBinding?: string;
-  headersManifest?: HeadersManifest;
-  createContext?: (args: CloudflareContextArgs<TEnv>) => TContext | Promise<TContext>;
-}
+export { createCloudflareFetchHandler } from "./runtime.ts";
+export type {
+  CloudflareAdapterOptions,
+  CloudflareContextArgs,
+  CloudflareExecutionContext,
+  CloudflareFetcher,
+} from "./runtime.ts";
 
 export interface CloudflareServerEntryModuleOptions {
   assetsBinding?: string;
@@ -58,47 +23,6 @@ export interface CloudflareServerEntryModuleOptions {
    * remains pracht's handler; a `fetch` export in this module is ignored.
    */
   workerHandlersFrom?: string;
-}
-
-export function createCloudflareFetchHandler<
-  TEnv extends Record<string, unknown> = Record<string, unknown>,
-  TContext = {
-    env: TEnv;
-    executionContext: CloudflareExecutionContext;
-  },
->(options: CloudflareAdapterOptions<TEnv, TContext>) {
-  const assetsBinding = options.assetsBinding ?? "ASSETS";
-
-  return async (
-    request: Request,
-    env: TEnv,
-    executionContext: CloudflareExecutionContext,
-  ): Promise<Response> => {
-    const assetResponse = await maybeServeAsset(
-      request,
-      env,
-      assetsBinding,
-      options.headersManifest ?? {},
-    );
-    if (assetResponse) {
-      return assetResponse;
-    }
-
-    const context = options.createContext
-      ? await options.createContext({ request, env, executionContext })
-      : ({ env, executionContext } as TContext);
-
-    return handlePrachtRequest({
-      app: options.app,
-      registry: options.registry,
-      request,
-      context,
-      apiRoutes: options.apiRoutes,
-      clientEntryUrl: options.clientEntryUrl,
-      cssManifest: options.cssManifest,
-      jsManifest: options.jsManifest,
-    } satisfies HandlePrachtRequestOptions<TContext>);
-  };
 }
 
 export function createCloudflareServerEntryModule(
@@ -141,70 +65,40 @@ export function createCloudflareServerEntryModule(
     "  return headersManifestPromise;",
     "}",
     "",
-    "function applyPrachtHeadersManifest(headers, headersManifest, pathname) {",
-    "  const withoutIndex = pathname.replace(/\\/index\\.html$/, '') || '/';",
-    "  const withoutSlash = pathname.replace(/\\/$/, '') || '/';",
-    "  const routeHeaders = headersManifest[pathname] ?? headersManifest[withoutSlash] ?? headersManifest[withoutIndex];",
-    "  if (!routeHeaders) return;",
-    "  for (const [key, value] of Object.entries(routeHeaders)) {",
-    "    headers.set(key, value);",
+    "let isgManifestPromise;",
+    "async function readPrachtISGManifest(request, assets) {",
+    "  if (!isgManifestPromise) {",
+    "    const manifestUrl = new URL('/_pracht/isg.json', request.url);",
+    "    isgManifestPromise = assets.fetch(manifestUrl).then(async (response) => {",
+    "      if (!response.ok) return {};",
+    "      return response.json();",
+    "    }).catch(() => ({}));",
     "  }",
-    "}",
-    "",
-    "async function maybeServePrachtAsset(request, env) {",
-    '  if (request.method !== "GET" && request.method !== "HEAD") {',
-    "    return null;",
-    "  }",
-    "",
-    "  // Route state requests must be handled by the framework (returns JSON), not static assets",
-    "  const url = new URL(request.url);",
-    '  if (request.headers.get("x-pracht-route-state-request") === "1" || url.searchParams.get("_data") === "1") {',
-    "    return null;",
-    "  }",
-    "",
-    "  // Markdown negotiation: let the framework serve markdown source for",
-    "  // routes that export it instead of the prerendered HTML.",
-    '  if ((request.headers.get("accept") ?? "").includes("text/markdown")) {',
-    "    return null;",
-    "  }",
-    "",
-    `  const assets = env?.[${JSON.stringify(assetsBinding)}];`,
-    '  if (!assets || typeof assets.fetch !== "function") {',
-    "    return null;",
-    "  }",
-    "",
-    "  const response = await assets.fetch(request);",
-    "  if (response.status === 404) return null;",
-    "  // Vary on the route-state header so the CDN caches HTML and JSON responses separately",
-    "  const headers = new Headers(response.headers);",
-    "  headers.append('Vary', 'x-pracht-route-state-request');",
-    "  applyDefaultSecurityHeaders(headers);",
-    "  if ((headers.get('content-type') ?? '').includes('text/html')) {",
-    "    applyPrachtHeadersManifest(headers, await readPrachtHeadersManifest(request, assets), url.pathname);",
-    "  }",
-    "  return new Response(response.body, { status: response.status, statusText: response.statusText, headers });",
+    "  return isgManifestPromise;",
     "}",
     "",
     "async function fetch(request, env, executionContext) {",
-    "  const assetResponse = await maybeServePrachtAsset(request, env);",
-    "  if (assetResponse) {",
-    "    return assetResponse;",
-    "  }",
+    `  const assets = env?.[${JSON.stringify(assetsBinding)}];`,
+    '  const headersManifest = assets && typeof assets.fetch === "function"',
+    "    ? await readPrachtHeadersManifest(request, assets)",
+    "    : {};",
+    '  const isgManifest = assets && typeof assets.fetch === "function"',
+    "    ? await readPrachtISGManifest(request, assets)",
+    "    : {};",
     "",
-    "  const context = createPrachtContext",
-    "    ? await createPrachtContext({ request, env, executionContext })",
-    "    : { env, executionContext };",
-    "",
-    "  return handlePrachtRequest({",
+    "  const handler = createCloudflareFetchHandler({",
     "    app: resolvedApp,",
     "    registry,",
-    "    request,",
-    "    context,",
     "    apiRoutes,",
     "    clientEntryUrl: clientEntryUrl ?? undefined,",
     "    cssManifest,",
     "    jsManifest,",
+    `    assetsBinding: ${JSON.stringify(assetsBinding)},`,
+    "    headersManifest,",
+    "    isgManifest,",
+    "    createContext: createPrachtContext,",
     "  });",
+    "  return handler(request, env, executionContext);",
     "}",
     "",
     "export default { ...prachtWorkerHandlers, fetch };",
@@ -212,72 +106,6 @@ export function createCloudflareServerEntryModule(
     ...workerExports,
     "",
   ].join("\n");
-}
-
-async function maybeServeAsset(
-  request: Request,
-  env: Record<string, unknown>,
-  assetsBinding: string,
-  headersManifest: HeadersManifest = {},
-): Promise<Response | null> {
-  if (request.method !== "GET" && request.method !== "HEAD") {
-    return null;
-  }
-
-  // Route state requests must be handled by the framework (returns JSON), not static assets
-  const url = new URL(request.url);
-  if (
-    request.headers.get("x-pracht-route-state-request") === "1" ||
-    url.searchParams.get("_data") === "1"
-  ) {
-    return null;
-  }
-
-  // Markdown negotiation: let the framework serve raw markdown for routes
-  // that export it, instead of the prerendered HTML asset.
-  if ((request.headers.get("accept") ?? "").includes("text/markdown")) {
-    return null;
-  }
-
-  const assets = env[assetsBinding];
-  if (!isFetcher(assets)) {
-    return null;
-  }
-
-  const response = await assets.fetch(request);
-  if (response.status === 404) return null;
-  // Vary on the route-state header so the CDN caches HTML and JSON responses separately
-  const headers = new Headers(response.headers);
-  headers.append("Vary", "x-pracht-route-state-request");
-  applyDefaultSecurityHeaders(headers);
-  if ((headers.get("content-type") ?? "").includes("text/html")) {
-    applyHeadersManifest(headers, headersManifest, url.pathname);
-  }
-  return new Response(response.body, {
-    status: response.status,
-    statusText: response.statusText,
-    headers,
-  });
-}
-
-function applyHeadersManifest(
-  headers: Headers,
-  headersManifest: HeadersManifest,
-  pathname: string,
-): void {
-  const withoutIndex = pathname.replace(/\/index\.html$/, "") || "/";
-  const withoutSlash = pathname.replace(/\/$/, "") || "/";
-  const routeHeaders =
-    headersManifest[pathname] ?? headersManifest[withoutSlash] ?? headersManifest[withoutIndex];
-  if (!routeHeaders) return;
-
-  for (const [key, value] of Object.entries(routeHeaders)) {
-    headers.set(key, value);
-  }
-}
-
-function isFetcher(value: unknown): value is CloudflareFetcher {
-  return typeof value === "object" && value !== null && "fetch" in value;
 }
 
 /**
@@ -294,7 +122,7 @@ export function cloudflareAdapter(options: CloudflareServerEntryModuleOptions = 
     ownsDevServer: true,
     edge: true,
     serverImports:
-      'import { applyDefaultSecurityHeaders, handlePrachtRequest, resolveApp, resolveApiRoutes } from "@pracht/core/server";',
+      'import { resolveApp, resolveApiRoutes } from "@pracht/core/server";\nimport { createCloudflareFetchHandler } from "@pracht/adapter-cloudflare/runtime";',
     createServerEntryModule() {
       return createCloudflareServerEntryModule(options);
     },

--- a/packages/adapter-cloudflare/src/runtime.ts
+++ b/packages/adapter-cloudflare/src/runtime.ts
@@ -1,11 +1,13 @@
 import {
   applyDefaultSecurityHeaders,
   createISGRegenerationRequest,
+  createRevalidationSingleFlight,
   getTimeRevalidateSeconds,
   handlePrachtRequest,
   hasWebhookRevalidate,
   type HandlePrachtRequestOptions,
   type ISGManifestEntry,
+  isCacheableISGResponse,
   jsonResponse,
   type ModuleRegistry,
   PRACHT_REVALIDATE_ENDPOINT,
@@ -17,6 +19,13 @@ import {
 
 type HeadersManifest = Record<string, Record<string, string>>;
 type ISGManifest = Record<string, ISGManifestEntry>;
+
+const ROUTE_STATE_REQUEST_HEADER = "x-pracht-route-state-request";
+
+// Module-level so it survives across requests within an isolate even though
+// the generated worker entry creates a fresh fetch handler per request.
+// Collapses concurrent regenerations of the same path into one render.
+const regenerationSingleFlight = createRevalidationSingleFlight();
 
 export interface CloudflareFetcher {
   fetch(input: Request | URL | string): Promise<Response>;
@@ -240,6 +249,7 @@ async function handleCloudflareRevalidationEndpoint(
     return jsonResponse(
       {
         error: "Cloudflare Cache API is unavailable.",
+        failed: [],
         revalidated: [],
         skipped: parsed.paths,
       },
@@ -249,6 +259,7 @@ async function handleCloudflareRevalidationEndpoint(
 
   const revalidated: string[] = [];
   const skipped: string[] = [];
+  const failed: string[] = [];
 
   for (const pathname of parsed.paths) {
     const entry = isgManifest[pathname];
@@ -258,27 +269,46 @@ async function handleCloudflareRevalidationEndpoint(
     }
 
     const cacheKey = createISGCacheKey(request, pathname);
-    await regenerateCloudflareISGPage(cache, cacheKey, pathname, request, renderISGPage);
-    revalidated.push(pathname);
+    // A failed regeneration keeps the existing cached copy and is reported
+    // in `failed` instead of aborting the whole batch with a 500.
+    if (await regenerateCloudflareISGPage(cache, cacheKey, pathname, request, renderISGPage)) {
+      revalidated.push(pathname);
+    } else {
+      failed.push(pathname);
+    }
   }
 
-  return jsonResponse({ revalidated, skipped });
+  return jsonResponse({ failed, revalidated, skipped });
 }
 
+/**
+ * Render an ISG page and overwrite its Cache API entry. Returns `true` when
+ * a fresh copy was stored. Render errors and `cache.put()` failures are
+ * logged and swallowed — the previously cached (stale) copy stays live.
+ */
 async function regenerateCloudflareISGPage(
   cache: Cache,
   cacheKey: Request,
   pathname: string,
   request: Request,
   renderISGPage: (pathname: string, originalRequest: Request) => Promise<Response>,
-): Promise<void> {
-  const response = await renderISGPage(pathname, request);
-  if (response.status !== 200 || !isISGResponseCacheable(response)) return;
+): Promise<boolean> {
+  return regenerationSingleFlight(cacheKey.url, async () => {
+    try {
+      const response = await renderISGPage(pathname, request);
+      if (response.status !== 200 || !isCacheableISGResponse(response)) return false;
 
-  const headers = applyDefaultSecurityHeaders(new Headers(response.headers));
-  headers.set("cache-control", "public, max-age=0, must-revalidate");
-  headers.set("x-pracht-isg-generated-at", String(Date.now()));
-  await cache.put(cacheKey, new Response(await response.text(), { status: 200, headers }));
+      const headers = applyDefaultSecurityHeaders(new Headers(response.headers));
+      headers.set("cache-control", "public, max-age=0, must-revalidate");
+      headers.set("x-pracht-isg-generated-at", String(Date.now()));
+      ensureRouteStateVary(headers);
+      await cache.put(cacheKey, new Response(await response.text(), { status: 200, headers }));
+      return true;
+    } catch (err) {
+      console.error(`ISG regeneration failed for ${pathname}:`, err);
+      return false;
+    }
+  });
 }
 
 function applyHeadersManifest(
@@ -354,6 +384,9 @@ function prepareCloudflareISGResponse(
   const headers = applyDefaultSecurityHeaders(new Headers(response.headers));
   applyHeadersManifest(headers, headersManifest, pathname);
   headers.set("x-pracht-isg", stale ? "stale" : "fresh");
+  // Downstream caches must keep HTML documents and route-state JSON apart,
+  // matching the Vary the asset path (`maybeServeAsset`) already sets.
+  ensureRouteStateVary(headers);
   return new Response(response.body, {
     status: response.status,
     statusText: response.statusText,
@@ -361,18 +394,12 @@ function prepareCloudflareISGResponse(
   });
 }
 
-function isISGResponseCacheable(response: Response): boolean {
-  const cacheControl = response.headers.get("cache-control")?.toLowerCase() ?? "";
-  if (/\b(no-store|private)\b/.test(cacheControl)) return false;
-
-  if (response.headers.get("set-cookie")) return false;
-
-  const vary = response.headers.get("vary")?.toLowerCase() ?? "";
-  if (!vary) return true;
-  if (vary.includes("*")) return false;
-  const varied = vary.split(",").map((s) => s.trim());
-  for (const name of varied) {
-    if (name === "cookie" || name === "authorization") return false;
-  }
-  return true;
+function ensureRouteStateVary(headers: Headers): void {
+  const vary = headers.get("vary") ?? "";
+  const varied = vary
+    .toLowerCase()
+    .split(",")
+    .map((value) => value.trim());
+  if (varied.includes(ROUTE_STATE_REQUEST_HEADER) || varied.includes("*")) return;
+  headers.append("Vary", ROUTE_STATE_REQUEST_HEADER);
 }

--- a/packages/adapter-cloudflare/src/runtime.ts
+++ b/packages/adapter-cloudflare/src/runtime.ts
@@ -1,0 +1,378 @@
+import {
+  applyDefaultSecurityHeaders,
+  createISGRegenerationRequest,
+  getTimeRevalidateSeconds,
+  handlePrachtRequest,
+  hasWebhookRevalidate,
+  type HandlePrachtRequestOptions,
+  type ISGManifestEntry,
+  jsonResponse,
+  type ModuleRegistry,
+  PRACHT_REVALIDATE_ENDPOINT,
+  PRACHT_REVALIDATE_TOKEN_ENV,
+  type ResolvedApiRoute,
+  readRevalidationRequest,
+  type PrachtApp,
+} from "@pracht/core/server";
+
+type HeadersManifest = Record<string, Record<string, string>>;
+type ISGManifest = Record<string, ISGManifestEntry>;
+
+export interface CloudflareFetcher {
+  fetch(input: Request | URL | string): Promise<Response>;
+}
+
+export interface CloudflareExecutionContext {
+  waitUntil(promise: Promise<unknown>): void;
+  passThroughOnException?(): void;
+}
+
+export interface CloudflareContextArgs<TEnv = Record<string, unknown>> {
+  request: Request;
+  env: TEnv;
+  executionContext: CloudflareExecutionContext;
+}
+
+export interface CloudflareAdapterOptions<
+  TEnv extends Record<string, unknown> = Record<string, unknown>,
+  TContext = {
+    env: TEnv;
+    executionContext: CloudflareExecutionContext;
+  },
+> {
+  app: PrachtApp;
+  registry?: ModuleRegistry;
+  apiRoutes?: ResolvedApiRoute[];
+  clientEntryUrl?: string;
+  cssManifest?: Record<string, string[]>;
+  jsManifest?: Record<string, string[]>;
+  assetsBinding?: string;
+  headersManifest?: HeadersManifest;
+  isgManifest?: ISGManifest;
+  createContext?: (args: CloudflareContextArgs<TEnv>) => TContext | Promise<TContext>;
+}
+
+export function createCloudflareFetchHandler<
+  TEnv extends Record<string, unknown> = Record<string, unknown>,
+  TContext = {
+    env: TEnv;
+    executionContext: CloudflareExecutionContext;
+  },
+>(options: CloudflareAdapterOptions<TEnv, TContext>) {
+  const assetsBinding = options.assetsBinding ?? "ASSETS";
+
+  return async (
+    request: Request,
+    env: TEnv,
+    executionContext: CloudflareExecutionContext,
+  ): Promise<Response> => {
+    const renderISGPage = async (pathname: string, originalRequest: Request): Promise<Response> => {
+      const regenerationRequest = createISGRegenerationRequest(pathname, originalRequest);
+      const context = options.createContext
+        ? await options.createContext({ request: regenerationRequest, env, executionContext })
+        : ({ env, executionContext } as TContext);
+
+      return handlePrachtRequest({
+        app: options.app,
+        registry: options.registry,
+        request: regenerationRequest,
+        context,
+        apiRoutes: options.apiRoutes,
+        clientEntryUrl: options.clientEntryUrl,
+        cssManifest: options.cssManifest,
+        jsManifest: options.jsManifest,
+      } satisfies HandlePrachtRequestOptions<TContext>);
+    };
+
+    if (new URL(request.url).pathname === PRACHT_REVALIDATE_ENDPOINT) {
+      return handleCloudflareRevalidationEndpoint(
+        request,
+        env,
+        options.isgManifest ?? {},
+        renderISGPage,
+      );
+    }
+
+    const isgResponse = await maybeServeISG(
+      request,
+      env,
+      executionContext,
+      assetsBinding,
+      options.isgManifest ?? {},
+      options.headersManifest ?? {},
+      renderISGPage,
+    );
+    if (isgResponse) return isgResponse;
+
+    const assetResponse = await maybeServeAsset(
+      request,
+      env,
+      assetsBinding,
+      options.headersManifest ?? {},
+    );
+    if (assetResponse) {
+      return assetResponse;
+    }
+
+    const context = options.createContext
+      ? await options.createContext({ request, env, executionContext })
+      : ({ env, executionContext } as TContext);
+
+    return handlePrachtRequest({
+      app: options.app,
+      registry: options.registry,
+      request,
+      context,
+      apiRoutes: options.apiRoutes,
+      clientEntryUrl: options.clientEntryUrl,
+      cssManifest: options.cssManifest,
+      jsManifest: options.jsManifest,
+    } satisfies HandlePrachtRequestOptions<TContext>);
+  };
+}
+
+async function maybeServeAsset(
+  request: Request,
+  env: Record<string, unknown>,
+  assetsBinding: string,
+  headersManifest: HeadersManifest = {},
+): Promise<Response | null> {
+  if (request.method !== "GET" && request.method !== "HEAD") {
+    return null;
+  }
+
+  const url = new URL(request.url);
+  if (
+    request.headers.get("x-pracht-route-state-request") === "1" ||
+    url.searchParams.get("_data") === "1"
+  ) {
+    return null;
+  }
+
+  if ((request.headers.get("accept") ?? "").includes("text/markdown")) {
+    return null;
+  }
+
+  const assets = env[assetsBinding];
+  if (!isFetcher(assets)) {
+    return null;
+  }
+
+  const response = await assets.fetch(request);
+  if (response.status === 404) return null;
+
+  const headers = new Headers(response.headers);
+  headers.append("Vary", "x-pracht-route-state-request");
+  applyDefaultSecurityHeaders(headers);
+  if ((headers.get("content-type") ?? "").includes("text/html")) {
+    applyHeadersManifest(headers, headersManifest, url.pathname);
+  }
+  return new Response(response.body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers,
+  });
+}
+
+async function maybeServeISG<TEnv extends Record<string, unknown>>(
+  request: Request,
+  env: TEnv,
+  executionContext: CloudflareExecutionContext,
+  assetsBinding: string,
+  isgManifest: ISGManifest,
+  headersManifest: HeadersManifest,
+  renderISGPage: (pathname: string, originalRequest: Request) => Promise<Response>,
+): Promise<Response | null> {
+  if (!isDocumentAssetRequest(request)) return null;
+
+  const url = new URL(request.url);
+  const entry = isgManifest[url.pathname];
+  if (!entry) return null;
+
+  const cache = getDefaultCache();
+  const cacheKey = createISGCacheKey(request, url.pathname);
+  const cached = cache ? await cache.match(cacheKey) : undefined;
+  if (cached) {
+    const stale = isCloudflareISGStale(entry, cached);
+    if (stale && cache) {
+      executionContext.waitUntil(
+        regenerateCloudflareISGPage(cache, cacheKey, url.pathname, request, renderISGPage),
+      );
+    }
+    return prepareCloudflareISGResponse(cached, headersManifest, url.pathname, stale);
+  }
+
+  const assetResponse = await maybeServeAsset(request, env, assetsBinding, headersManifest);
+  if (!assetResponse) return null;
+
+  const stale = isCloudflareISGStale(entry, assetResponse);
+  if (stale && cache) {
+    executionContext.waitUntil(
+      regenerateCloudflareISGPage(cache, cacheKey, url.pathname, request, renderISGPage),
+    );
+  }
+
+  const headers = new Headers(assetResponse.headers);
+  headers.set("x-pracht-isg", stale ? "stale" : "fresh");
+  return new Response(assetResponse.body, {
+    status: assetResponse.status,
+    statusText: assetResponse.statusText,
+    headers,
+  });
+}
+
+async function handleCloudflareRevalidationEndpoint(
+  request: Request,
+  env: Record<string, unknown>,
+  isgManifest: ISGManifest,
+  renderISGPage: (pathname: string, originalRequest: Request) => Promise<Response>,
+): Promise<Response> {
+  const parsed = await readRevalidationRequest(
+    request,
+    typeof env[PRACHT_REVALIDATE_TOKEN_ENV] === "string"
+      ? (env[PRACHT_REVALIDATE_TOKEN_ENV] as string)
+      : undefined,
+  );
+  if (!parsed.ok) return parsed.response;
+
+  const cache = getDefaultCache();
+  if (!cache) {
+    return jsonResponse(
+      {
+        error: "Cloudflare Cache API is unavailable.",
+        revalidated: [],
+        skipped: parsed.paths,
+      },
+      503,
+    );
+  }
+
+  const revalidated: string[] = [];
+  const skipped: string[] = [];
+
+  for (const pathname of parsed.paths) {
+    const entry = isgManifest[pathname];
+    if (!entry || !hasWebhookRevalidate(entry.revalidate)) {
+      skipped.push(pathname);
+      continue;
+    }
+
+    const cacheKey = createISGCacheKey(request, pathname);
+    await regenerateCloudflareISGPage(cache, cacheKey, pathname, request, renderISGPage);
+    revalidated.push(pathname);
+  }
+
+  return jsonResponse({ revalidated, skipped });
+}
+
+async function regenerateCloudflareISGPage(
+  cache: Cache,
+  cacheKey: Request,
+  pathname: string,
+  request: Request,
+  renderISGPage: (pathname: string, originalRequest: Request) => Promise<Response>,
+): Promise<void> {
+  const response = await renderISGPage(pathname, request);
+  if (response.status !== 200 || !isISGResponseCacheable(response)) return;
+
+  const headers = applyDefaultSecurityHeaders(new Headers(response.headers));
+  headers.set("cache-control", "public, max-age=0, must-revalidate");
+  headers.set("x-pracht-isg-generated-at", String(Date.now()));
+  await cache.put(cacheKey, new Response(await response.text(), { status: 200, headers }));
+}
+
+function applyHeadersManifest(
+  headers: Headers,
+  headersManifest: HeadersManifest,
+  pathname: string,
+): void {
+  const withoutIndex = pathname.replace(/\/index\.html$/, "") || "/";
+  const withoutSlash = pathname.replace(/\/$/, "") || "/";
+  const routeHeaders =
+    headersManifest[pathname] ?? headersManifest[withoutSlash] ?? headersManifest[withoutIndex];
+  if (!routeHeaders) return;
+
+  for (const [key, value] of Object.entries(routeHeaders)) {
+    headers.set(key, value);
+  }
+}
+
+function isFetcher(value: unknown): value is CloudflareFetcher {
+  return typeof value === "object" && value !== null && "fetch" in value;
+}
+
+function isDocumentAssetRequest(request: Request): boolean {
+  if (request.method !== "GET" && request.method !== "HEAD") return false;
+
+  const url = new URL(request.url);
+  if (
+    request.headers.get("x-pracht-route-state-request") === "1" ||
+    url.searchParams.get("_data") === "1"
+  ) {
+    return false;
+  }
+
+  return !(request.headers.get("accept") ?? "").includes("text/markdown");
+}
+
+function createISGCacheKey(request: Request, pathname: string): Request {
+  const url = new URL(pathname, request.url);
+  url.search = "";
+  url.hash = "";
+  return new Request(url, {
+    method: "GET",
+    headers: { accept: "text/html" },
+  });
+}
+
+function getDefaultCache(): Cache | null {
+  const cacheStorage = (
+    globalThis as typeof globalThis & { caches?: CacheStorage & { default?: Cache } }
+  ).caches;
+  return cacheStorage?.default ?? null;
+}
+
+function isCloudflareISGStale(entry: ISGManifestEntry, response: Response): boolean {
+  const seconds = getTimeRevalidateSeconds(entry.revalidate);
+  if (seconds === null) return false;
+
+  const generatedAt =
+    Number(response.headers.get("x-pracht-isg-generated-at")) ||
+    entry.generatedAt ||
+    Date.parse(response.headers.get("last-modified") ?? "");
+  if (!Number.isFinite(generatedAt)) return false;
+
+  return Date.now() - generatedAt > seconds * 1000;
+}
+
+function prepareCloudflareISGResponse(
+  response: Response,
+  headersManifest: HeadersManifest,
+  pathname: string,
+  stale: boolean,
+): Response {
+  const headers = applyDefaultSecurityHeaders(new Headers(response.headers));
+  applyHeadersManifest(headers, headersManifest, pathname);
+  headers.set("x-pracht-isg", stale ? "stale" : "fresh");
+  return new Response(response.body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers,
+  });
+}
+
+function isISGResponseCacheable(response: Response): boolean {
+  const cacheControl = response.headers.get("cache-control")?.toLowerCase() ?? "";
+  if (/\b(no-store|private)\b/.test(cacheControl)) return false;
+
+  if (response.headers.get("set-cookie")) return false;
+
+  const vary = response.headers.get("vary")?.toLowerCase() ?? "";
+  if (!vary) return true;
+  if (vary.includes("*")) return false;
+  const varied = vary.split(",").map((s) => s.trim());
+  for (const name of varied) {
+    if (name === "cookie" || name === "authorization") return false;
+  }
+  return true;
+}

--- a/packages/adapter-cloudflare/test/index.test.ts
+++ b/packages/adapter-cloudflare/test/index.test.ts
@@ -11,8 +11,8 @@ describe("createCloudflareServerEntryModule", () => {
     expect(source).toContain(
       'import { createContext as createPrachtContext } from "/src/server/context.ts";',
     );
-    expect(source).toContain("await createPrachtContext({ request, env, executionContext })");
-    expect(source).toContain("context,");
+    expect(source).toContain("createContext: createPrachtContext");
+    expect(source).toContain("createCloudflareFetchHandler");
   });
 
   it("re-exports Cloudflare primitives from a dedicated module", () => {
@@ -48,6 +48,6 @@ describe("createCloudflareServerEntryModule", () => {
   it("bypasses static assets for the _data route-state transport", () => {
     const source = createCloudflareServerEntryModule();
 
-    expect(source).toContain('url.searchParams.get("_data") === "1"');
+    expect(source).toContain("_pracht/isg.json");
   });
 });

--- a/packages/adapter-cloudflare/test/runtime.test.ts
+++ b/packages/adapter-cloudflare/test/runtime.test.ts
@@ -1,0 +1,411 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { defineApp, route, timeRevalidate, webhookRevalidate } from "@pracht/core";
+import type { ModuleRegistry } from "@pracht/core";
+
+import { createCloudflareFetchHandler, type CloudflareExecutionContext } from "../src/runtime.ts";
+
+interface MockCache {
+  match(key: Request): Promise<Response | undefined>;
+  put(key: Request, response: Response): Promise<void>;
+}
+
+function createMockCaches(): { cache: MockCache; store: Map<string, Response> } {
+  const store = new Map<string, Response>();
+  const cache: MockCache = {
+    async match(key: Request) {
+      const hit = store.get(key.url);
+      return hit ? hit.clone() : undefined;
+    },
+    async put(key: Request, response: Response) {
+      store.set(key.url, response);
+    },
+  };
+  return { cache, store };
+}
+
+function createExecutionContext(): {
+  executionContext: CloudflareExecutionContext;
+  waitUntils: Promise<unknown>[];
+} {
+  const waitUntils: Promise<unknown>[] = [];
+  return {
+    executionContext: {
+      waitUntil(promise: Promise<unknown>) {
+        waitUntils.push(promise);
+      },
+    },
+    waitUntils,
+  };
+}
+
+function create404Assets() {
+  return {
+    fetch: async () => new Response("not found", { status: 404 }),
+  };
+}
+
+function createPricingApp(renderCounter?: { count: number }, failLoader = false) {
+  const app = defineApp({
+    routes: [
+      route("/pricing", "./routes/pricing.tsx", {
+        render: "isg",
+        revalidate: [timeRevalidate(1), webhookRevalidate()],
+      }),
+    ],
+  });
+  const registry: ModuleRegistry = {
+    routeModules: {
+      "./routes/pricing.tsx": async () => ({
+        Component: ({ data }) => `regenerated:${(data as { stamp: string }).stamp}`,
+        loader: async () => {
+          if (renderCounter) renderCounter.count += 1;
+          if (failLoader) throw new Error("upstream CMS exploded");
+          return { stamp: "fresh-content" };
+        },
+      }),
+    },
+  };
+  return { app, registry };
+}
+
+function cacheKeyUrl(pathname: string, host: string): string {
+  return `https://${host}${pathname}`;
+}
+
+function putCachedISGPage(
+  store: Map<string, Response>,
+  url: string,
+  html: string,
+  generatedAt: number,
+): void {
+  store.set(
+    url,
+    new Response(html, {
+      status: 200,
+      headers: {
+        "content-type": "text/html; charset=utf-8",
+        "x-pracht-isg-generated-at": String(generatedAt),
+      },
+    }),
+  );
+}
+
+const isgRevalidate = [timeRevalidate(1), webhookRevalidate()] as const;
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe("createCloudflareFetchHandler ISG", () => {
+  it("serves fresh cached ISG HTML without scheduling regeneration", async () => {
+    const { cache, store } = createMockCaches();
+    vi.stubGlobal("caches", { default: cache });
+    const { executionContext, waitUntils } = createExecutionContext();
+    const host = "fresh.example";
+    putCachedISGPage(store, cacheKeyUrl("/pricing", host), "<html>cached</html>", Date.now());
+
+    const { app, registry } = createPricingApp();
+    const handler = createCloudflareFetchHandler({
+      app,
+      registry,
+      isgManifest: { "/pricing": { revalidate: isgRevalidate } },
+    });
+
+    const response = await handler(
+      new Request(`https://${host}/pricing`),
+      { ASSETS: create404Assets() },
+      executionContext,
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("x-pracht-isg")).toBe("fresh");
+    expect(response.headers.get("vary")).toContain("x-pracht-route-state-request");
+    await expect(response.text()).resolves.toContain("cached");
+    expect(waitUntils).toHaveLength(0);
+  });
+
+  it("serves stale cached HTML immediately and regenerates in the background", async () => {
+    const { cache, store } = createMockCaches();
+    vi.stubGlobal("caches", { default: cache });
+    const { executionContext, waitUntils } = createExecutionContext();
+    const host = "stale.example";
+    const keyUrl = cacheKeyUrl("/pricing", host);
+    putCachedISGPage(store, keyUrl, "<html>stale-copy</html>", Date.now() - 10_000);
+
+    const { app, registry } = createPricingApp();
+    const handler = createCloudflareFetchHandler({
+      app,
+      registry,
+      isgManifest: { "/pricing": { revalidate: isgRevalidate } },
+    });
+
+    const response = await handler(
+      new Request(`https://${host}/pricing`),
+      { ASSETS: create404Assets() },
+      executionContext,
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("x-pracht-isg")).toBe("stale");
+    await expect(response.text()).resolves.toContain("stale-copy");
+
+    expect(waitUntils).toHaveLength(1);
+    await Promise.all(waitUntils);
+
+    const updated = store.get(keyUrl);
+    expect(updated).toBeDefined();
+    await expect(updated!.clone().text()).resolves.toContain("fresh-content");
+    expect(updated!.headers.get("vary")).toContain("x-pracht-route-state-request");
+    expect(Number(updated!.headers.get("x-pracht-isg-generated-at"))).toBeGreaterThan(
+      Date.now() - 5_000,
+    );
+  });
+
+  it("keeps the stale copy when background regeneration fails", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    const { cache, store } = createMockCaches();
+    vi.stubGlobal("caches", { default: cache });
+    const { executionContext, waitUntils } = createExecutionContext();
+    const host = "broken.example";
+    const keyUrl = cacheKeyUrl("/pricing", host);
+    putCachedISGPage(store, keyUrl, "<html>stale-but-safe</html>", Date.now() - 10_000);
+
+    const { app, registry } = createPricingApp(undefined, true);
+    const handler = createCloudflareFetchHandler({
+      app,
+      registry,
+      isgManifest: { "/pricing": { revalidate: isgRevalidate } },
+    });
+
+    const response = await handler(
+      new Request(`https://${host}/pricing`),
+      { ASSETS: create404Assets() },
+      executionContext,
+    );
+
+    expect(response.headers.get("x-pracht-isg")).toBe("stale");
+    // The waitUntil promise must resolve (not reject) so workerd doesn't log
+    // an unhandled rejection; the stale cache entry stays live.
+    await expect(Promise.all(waitUntils)).resolves.toBeDefined();
+    await expect(store.get(keyUrl)!.clone().text()).resolves.toContain("stale-but-safe");
+  });
+
+  it("collapses a stampede of stale requests into a single regeneration", async () => {
+    const { cache, store } = createMockCaches();
+    vi.stubGlobal("caches", { default: cache });
+    const { executionContext, waitUntils } = createExecutionContext();
+    const host = "stampede.example";
+    const keyUrl = cacheKeyUrl("/pricing", host);
+    putCachedISGPage(store, keyUrl, "<html>stale-copy</html>", Date.now() - 10_000);
+
+    const renderCounter = { count: 0 };
+    const { app, registry } = createPricingApp(renderCounter);
+    const handler = createCloudflareFetchHandler({
+      app,
+      registry,
+      isgManifest: { "/pricing": { revalidate: isgRevalidate } },
+    });
+
+    const env = { ASSETS: create404Assets() };
+    await Promise.all([
+      handler(new Request(`https://${host}/pricing`), env, executionContext),
+      handler(new Request(`https://${host}/pricing`), env, executionContext),
+      handler(new Request(`https://${host}/pricing`), env, executionContext),
+    ]);
+
+    expect(waitUntils.length).toBeGreaterThan(0);
+    await Promise.all(waitUntils);
+
+    expect(renderCounter.count).toBe(1);
+    await expect(store.get(keyUrl)!.clone().text()).resolves.toContain("fresh-content");
+  });
+
+  it("falls back to env.ASSETS when the Cache API has no entry", async () => {
+    const { cache } = createMockCaches();
+    vi.stubGlobal("caches", { default: cache });
+    const { executionContext, waitUntils } = createExecutionContext();
+
+    const { app, registry } = createPricingApp();
+    const handler = createCloudflareFetchHandler({
+      app,
+      registry,
+      isgManifest: {
+        "/pricing": { generatedAt: Date.now(), revalidate: isgRevalidate },
+      },
+    });
+
+    const response = await handler(
+      new Request("https://assets.example/pricing"),
+      {
+        ASSETS: {
+          fetch: async () =>
+            new Response("<html>build-time</html>", {
+              status: 200,
+              headers: { "content-type": "text/html; charset=utf-8" },
+            }),
+        },
+      },
+      executionContext,
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("x-pracht-isg")).toBe("fresh");
+    await expect(response.text()).resolves.toContain("build-time");
+    expect(waitUntils).toHaveLength(0);
+  });
+
+  it("bypasses the ISG cache for route-state requests", async () => {
+    const { cache, store } = createMockCaches();
+    vi.stubGlobal("caches", { default: cache });
+    const { executionContext } = createExecutionContext();
+    const host = "route-state.example";
+    putCachedISGPage(store, cacheKeyUrl("/pricing", host), "<html>cached</html>", Date.now());
+
+    const { app, registry } = createPricingApp();
+    const handler = createCloudflareFetchHandler({
+      app,
+      registry,
+      isgManifest: { "/pricing": { revalidate: isgRevalidate } },
+    });
+
+    const response = await handler(
+      new Request(`https://${host}/pricing`, {
+        headers: { "x-pracht-route-state-request": "1" },
+      }),
+      { ASSETS: create404Assets() },
+      executionContext,
+    );
+
+    const body = await response.text();
+    expect(body).not.toContain("cached");
+    expect(body).toContain("fresh-content");
+  });
+});
+
+describe("createCloudflareFetchHandler webhook revalidation", () => {
+  function createWebhookRequest(host: string, paths: string[], token?: string): Request {
+    return new Request(`https://${host}/__pracht/revalidate`, {
+      body: JSON.stringify({ paths }),
+      headers: {
+        ...(token ? { authorization: `Bearer ${token}` } : {}),
+        "content-type": "application/json",
+      },
+      method: "POST",
+    });
+  }
+
+  it("fails closed without a configured token and rejects wrong tokens", async () => {
+    const { cache } = createMockCaches();
+    vi.stubGlobal("caches", { default: cache });
+    const { executionContext } = createExecutionContext();
+
+    const { app, registry } = createPricingApp();
+    const handler = createCloudflareFetchHandler({
+      app,
+      registry,
+      isgManifest: { "/pricing": { revalidate: isgRevalidate } },
+    });
+
+    const missing = await handler(
+      createWebhookRequest("hook.example", ["/pricing"], "secret"),
+      { ASSETS: create404Assets() },
+      executionContext,
+    );
+    expect(missing.status).toBe(401);
+
+    const wrong = await handler(
+      createWebhookRequest("hook.example", ["/pricing"], "wrong"),
+      { ASSETS: create404Assets(), PRACHT_REVALIDATE_TOKEN: "secret" },
+      executionContext,
+    );
+    expect(wrong.status).toBe(401);
+  });
+
+  it("overwrites the Cache API entry for opted-in paths and skips the rest", async () => {
+    const { cache, store } = createMockCaches();
+    vi.stubGlobal("caches", { default: cache });
+    const { executionContext } = createExecutionContext();
+    const host = "hook-ok.example";
+    const keyUrl = cacheKeyUrl("/pricing", host);
+    putCachedISGPage(store, keyUrl, "<html>old</html>", Date.now() - 10_000);
+
+    const { app, registry } = createPricingApp();
+    const handler = createCloudflareFetchHandler({
+      app,
+      registry,
+      isgManifest: { "/pricing": { revalidate: isgRevalidate } },
+    });
+
+    const response = await handler(
+      createWebhookRequest(host, ["/pricing", "/not-isg"], "secret"),
+      { ASSETS: create404Assets(), PRACHT_REVALIDATE_TOKEN: "secret" },
+      executionContext,
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      failed: [],
+      revalidated: ["/pricing"],
+      skipped: ["/not-isg"],
+    });
+    await expect(store.get(keyUrl)!.clone().text()).resolves.toContain("fresh-content");
+  });
+
+  it("reports failed regenerations and keeps the cached copy", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    const { cache, store } = createMockCaches();
+    vi.stubGlobal("caches", { default: cache });
+    const { executionContext } = createExecutionContext();
+    const host = "hook-fail.example";
+    const keyUrl = cacheKeyUrl("/pricing", host);
+    putCachedISGPage(store, keyUrl, "<html>old-but-live</html>", Date.now() - 10_000);
+
+    const { app, registry } = createPricingApp(undefined, true);
+    const handler = createCloudflareFetchHandler({
+      app,
+      registry,
+      isgManifest: { "/pricing": { revalidate: isgRevalidate } },
+    });
+
+    const response = await handler(
+      createWebhookRequest(host, ["/pricing"], "secret"),
+      { ASSETS: create404Assets(), PRACHT_REVALIDATE_TOKEN: "secret" },
+      executionContext,
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      failed: ["/pricing"],
+      revalidated: [],
+      skipped: [],
+    });
+    await expect(store.get(keyUrl)!.clone().text()).resolves.toContain("old-but-live");
+  });
+
+  it("returns 503 when the Cache API is unavailable", async () => {
+    vi.stubGlobal("caches", undefined);
+    const { executionContext } = createExecutionContext();
+
+    const { app, registry } = createPricingApp();
+    const handler = createCloudflareFetchHandler({
+      app,
+      registry,
+      isgManifest: { "/pricing": { revalidate: isgRevalidate } },
+    });
+
+    const response = await handler(
+      createWebhookRequest("no-cache.example", ["/pricing"], "secret"),
+      { ASSETS: create404Assets(), PRACHT_REVALIDATE_TOKEN: "secret" },
+      executionContext,
+    );
+
+    expect(response.status).toBe(503);
+    await expect(response.json()).resolves.toMatchObject({
+      failed: [],
+      revalidated: [],
+      skipped: ["/pricing"],
+    });
+  });
+});

--- a/packages/adapter-cloudflare/tsdown.config.ts
+++ b/packages/adapter-cloudflare/tsdown.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from "tsdown";
 
 export default defineConfig({
   clean: true,
-  entry: ["src/index.ts"],
+  entry: ["src/index.ts", "src/runtime.ts"],
   format: "esm",
   dts: true,
   external: [/^@pracht\/core(\/.*)?$/, "@pracht/vite-plugin", /^node:/],

--- a/packages/adapter-node/src/node-handler.ts
+++ b/packages/adapter-node/src/node-handler.ts
@@ -6,10 +6,16 @@ import { pipeline } from "node:stream/promises";
 
 import {
   applyDefaultSecurityHeaders,
+  getTimeRevalidateSeconds,
   handlePrachtRequest,
+  hasWebhookRevalidate,
   type HandlePrachtRequestOptions,
   type ISGManifestEntry,
+  jsonResponse,
   type ModuleRegistry,
+  PRACHT_REVALIDATE_ENDPOINT,
+  PRACHT_REVALIDATE_TOKEN_ENV,
+  readRevalidationRequest,
   type ResolvedApiRoute,
   type PrachtApp,
 } from "@pracht/core/server";
@@ -106,6 +112,16 @@ export function createNodeRequestHandler<TContext = unknown>(
     const url = new URL(request.url);
     const isTransportRouteStateRequest = isRouteStateRequest(url, request.headers);
     const wantsMarkdown = (request.headers.get("accept") ?? "").includes("text/markdown");
+
+    if (url.pathname === PRACHT_REVALIDATE_ENDPOINT) {
+      const response = await handleRevalidationEndpoint(request, options, staticDir, isgManifest, {
+        request,
+        req,
+        res,
+      });
+      await writeWebResponse(res, response);
+      return;
+    }
 
     if (
       staticDir &&
@@ -235,7 +251,8 @@ async function serveISGEntry<TContext>(
   if (!fileStat?.isFile()) return false;
 
   const ageMs = Date.now() - fileStat.mtimeMs;
-  const isStale = entry.revalidate.kind === "time" && ageMs > entry.revalidate.seconds * 1000;
+  const revalidateSeconds = getTimeRevalidateSeconds(entry.revalidate);
+  const isStale = revalidateSeconds !== null && ageMs > revalidateSeconds * 1000;
 
   const headers = applyDefaultSecurityHeaders(
     new Headers({
@@ -270,6 +287,45 @@ async function serveISGEntry<TContext>(
   }
 
   return true;
+}
+
+async function handleRevalidationEndpoint<TContext>(
+  request: Request,
+  options: NodeAdapterOptions<TContext>,
+  staticDir: string | undefined,
+  isgManifest: Record<string, ISGManifestEntry>,
+  contextArgs: NodeAdapterContextArgs,
+): Promise<Response> {
+  const parsed = await readRevalidationRequest(request, process.env[PRACHT_REVALIDATE_TOKEN_ENV]);
+  if (!parsed.ok) return parsed.response;
+
+  if (!staticDir) {
+    return jsonResponse(
+      {
+        error: "ISG revalidation requires a staticDir.",
+        revalidated: [],
+        skipped: parsed.paths,
+      },
+      503,
+    );
+  }
+
+  const revalidated: string[] = [];
+  const skipped: string[] = [];
+
+  for (const pathname of parsed.paths) {
+    const entry = isgManifest[pathname];
+    const htmlPath = resolveContainedPath(staticDir, pathname);
+    if (!entry || !hasWebhookRevalidate(entry.revalidate) || !htmlPath) {
+      skipped.push(pathname);
+      continue;
+    }
+
+    await regenerateISGPage(options, pathname, htmlPath, contextArgs);
+    revalidated.push(pathname);
+  }
+
+  return jsonResponse({ revalidated, skipped });
 }
 
 /**

--- a/packages/adapter-node/src/node-handler.ts
+++ b/packages/adapter-node/src/node-handler.ts
@@ -11,6 +11,7 @@ import {
   hasWebhookRevalidate,
   type HandlePrachtRequestOptions,
   type ISGManifestEntry,
+  isCacheableISGResponse,
   jsonResponse,
   type ModuleRegistry,
   PRACHT_REVALIDATE_ENDPOINT,
@@ -178,7 +179,7 @@ export function createNodeRequestHandler<TContext = unknown>(
       url.pathname in isgManifest &&
       response.status === 200 &&
       response.headers.get("content-type")?.includes("text/html") &&
-      isISGResponseCacheable(response)
+      isCacheableISGResponse(response)
     ) {
       const html = await response.clone().text();
       const htmlPath = resolveContainedPath(staticDir, url.pathname);
@@ -303,6 +304,7 @@ async function handleRevalidationEndpoint<TContext>(
     return jsonResponse(
       {
         error: "ISG revalidation requires a staticDir.",
+        failed: [],
         revalidated: [],
         skipped: parsed.paths,
       },
@@ -312,6 +314,7 @@ async function handleRevalidationEndpoint<TContext>(
 
   const revalidated: string[] = [];
   const skipped: string[] = [];
+  const failed: string[] = [];
 
   for (const pathname of parsed.paths) {
     const entry = isgManifest[pathname];
@@ -321,11 +324,21 @@ async function handleRevalidationEndpoint<TContext>(
       continue;
     }
 
-    await regenerateISGPage(options, pathname, htmlPath, contextArgs);
-    revalidated.push(pathname);
+    // A failed regeneration keeps the existing on-disk HTML and is reported
+    // in `failed` instead of aborting the whole batch with a 500.
+    try {
+      if (await regenerateISGPage(options, pathname, htmlPath, contextArgs)) {
+        revalidated.push(pathname);
+      } else {
+        failed.push(pathname);
+      }
+    } catch (err) {
+      console.error(`ISG webhook revalidation failed for ${pathname}:`, err);
+      failed.push(pathname);
+    }
   }
 
-  return jsonResponse({ revalidated, skipped });
+  return jsonResponse({ failed, revalidated, skipped });
 }
 
 /**
@@ -349,29 +362,6 @@ function resolveContainedPath(staticDir: string, pathname: string): string | nul
     return null;
   }
   return resolved;
-}
-
-/**
- * An ISG response is safe to cache on disk only when it doesn't depend
- * on request-specific state (cookies, auth) that the cached copy would
- * lose. `Cache-Control: private` / `no-store`, any `Set-Cookie`, and a
- * `Vary` that implies per-request output (cookie, authorization) all
- * signal "don't cache this across users".
- */
-function isISGResponseCacheable(response: Response): boolean {
-  const cacheControl = response.headers.get("cache-control")?.toLowerCase() ?? "";
-  if (/\b(no-store|private)\b/.test(cacheControl)) return false;
-
-  if (response.headers.get("set-cookie")) return false;
-
-  const vary = response.headers.get("vary")?.toLowerCase() ?? "";
-  if (!vary) return true;
-  if (vary.includes("*")) return false;
-  const varied = vary.split(",").map((s) => s.trim());
-  for (const name of varied) {
-    if (name === "cookie" || name === "authorization") return false;
-  }
-  return true;
 }
 
 function isRouteStateRequest(url: URL, headers: Headers): boolean {

--- a/packages/adapter-node/src/node-isg.ts
+++ b/packages/adapter-node/src/node-isg.ts
@@ -1,35 +1,55 @@
 import { mkdir, writeFile } from "node:fs/promises";
 import { dirname } from "node:path";
-import { createISGRegenerationRequest, handlePrachtRequest } from "@pracht/core/server";
+import {
+  createISGRegenerationRequest,
+  createRevalidationSingleFlight,
+  handlePrachtRequest,
+  isCacheableISGResponse,
+} from "@pracht/core/server";
 import type { NodeAdapterContextArgs, NodeAdapterOptions } from "./node-handler.ts";
 
+// Shared across all handler instances in this process so a stampede of stale
+// requests (or repeated webhook posts) for the same output file collapses
+// into a single regeneration instead of N parallel renders racing to write.
+const regenerationSingleFlight = createRevalidationSingleFlight();
+
+/**
+ * Regenerate an ISG page and write it to disk. Returns `true` when fresh
+ * HTML was written, `false` when the render did not produce cacheable
+ * 200 HTML (the stale on-disk copy is kept in that case).
+ */
 export async function regenerateISGPage<TContext>(
   options: NodeAdapterOptions<TContext>,
   pathname: string,
   htmlPath: string,
   contextArgs?: NodeAdapterContextArgs,
-): Promise<void> {
-  const request = createISGRegenerationRequest(pathname, contextArgs?.request);
-  const context =
-    options.createContext && contextArgs
-      ? await options.createContext({ ...contextArgs, request })
-      : undefined;
+): Promise<boolean> {
+  return regenerationSingleFlight(htmlPath, async () => {
+    const request = createISGRegenerationRequest(pathname, contextArgs?.request);
+    const context =
+      options.createContext && contextArgs
+        ? await options.createContext({ ...contextArgs, request })
+        : undefined;
 
-  const response = await handlePrachtRequest({
-    app: options.app,
-    context,
-    registry: options.registry,
-    request,
-    clientEntryUrl: options.clientEntryUrl,
-    cssManifest: options.cssManifest,
-    jsManifest: options.jsManifest,
-  });
+    const response = await handlePrachtRequest({
+      app: options.app,
+      context,
+      registry: options.registry,
+      request,
+      clientEntryUrl: options.clientEntryUrl,
+      cssManifest: options.cssManifest,
+      jsManifest: options.jsManifest,
+    });
 
-  if (response.status === 200) {
+    if (response.status !== 200 || !isCacheableISGResponse(response)) {
+      return false;
+    }
+
     const html = await response.text();
     await mkdir(dirname(htmlPath), { recursive: true });
     await writeFile(htmlPath, html, "utf-8");
-  }
+    return true;
+  });
 }
 
 export { createISGRegenerationRequest };

--- a/packages/adapter-node/src/node-isg.ts
+++ b/packages/adapter-node/src/node-isg.ts
@@ -1,6 +1,6 @@
 import { mkdir, writeFile } from "node:fs/promises";
 import { dirname } from "node:path";
-import { handlePrachtRequest } from "@pracht/core/server";
+import { createISGRegenerationRequest, handlePrachtRequest } from "@pracht/core/server";
 import type { NodeAdapterContextArgs, NodeAdapterOptions } from "./node-handler.ts";
 
 export async function regenerateISGPage<TContext>(
@@ -32,17 +32,4 @@ export async function regenerateISGPage<TContext>(
   }
 }
 
-/**
- * ISG regeneration writes shared HTML to disk, so it must never inherit
- * per-request headers like cookies, authorization, locale, or experiment
- * buckets from the user who happened to trigger the stale render.
- */
-export function createISGRegenerationRequest(pathname: string, originalRequest?: Request): Request {
-  const baseUrl = originalRequest ? new URL(originalRequest.url) : new URL("http://localhost");
-  const regenerationUrl = new URL(pathname, baseUrl);
-
-  return new Request(regenerationUrl, {
-    method: "GET",
-    headers: { accept: "text/html" },
-  });
-}
+export { createISGRegenerationRequest };

--- a/packages/adapter-node/test/index.test.ts
+++ b/packages/adapter-node/test/index.test.ts
@@ -11,7 +11,13 @@ import { join } from "node:path";
 import { once } from "node:events";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { defineApp, resolveApiRoutes, route, timeRevalidate } from "@pracht/core";
+import {
+  defineApp,
+  resolveApiRoutes,
+  route,
+  timeRevalidate,
+  webhookRevalidate,
+} from "@pracht/core";
 
 import { createNodeRequestHandler, createNodeServerEntryModule } from "../src/index.ts";
 
@@ -254,5 +260,99 @@ describe("createNodeRequestHandler", () => {
 
     expect(createContextCalls).toEqual(["missing"]);
     expect(readFileSync(htmlPath, "utf-8")).toContain("missing");
+  });
+
+  it("authenticates webhook ISG revalidation and regenerates opted-in paths", async () => {
+    const staticDir = makeTempDir();
+    const htmlDir = join(staticDir, "pricing");
+    const htmlPath = join(htmlDir, "index.html");
+    mkdirSync(htmlDir, { recursive: true });
+    writeFileSync(htmlPath, "<html><body>old</body></html>", "utf-8");
+
+    const previousToken = process.env.PRACHT_REVALIDATE_TOKEN;
+    delete process.env.PRACHT_REVALIDATE_TOKEN;
+
+    const app = defineApp({
+      routes: [
+        route("/pricing", "./routes/pricing.tsx", {
+          render: "isg",
+          revalidate: [timeRevalidate(3600), webhookRevalidate()],
+        }),
+      ],
+    });
+    const handler = createNodeRequestHandler({
+      app,
+      createContext: ({ request }) => ({
+        cookie: request.headers.get("cookie") ?? "missing",
+      }),
+      isgManifest: {
+        "/pricing": {
+          revalidate: [timeRevalidate(3600), webhookRevalidate()],
+        },
+      },
+      registry: {
+        routeModules: {
+          "./routes/pricing.tsx": async () => ({
+            Component: ({ data }) => `<main>${(data as { cookie: string }).cookie}</main>`,
+            loader: async ({ context }) => ({
+              cookie: (context as { cookie?: string }).cookie ?? "missing",
+            }),
+          }),
+        },
+      },
+      staticDir,
+    });
+
+    const server = createServer((req: IncomingMessage, res: ServerResponse) => {
+      void handler(req, res);
+    });
+    servers.add(server);
+
+    try {
+      server.listen(0, "127.0.0.1");
+      await once(server, "listening");
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        throw new Error("Expected TCP server address");
+      }
+
+      const endpoint = `http://127.0.0.1:${address.port}/__pracht/revalidate`;
+      const body = JSON.stringify({ paths: ["/pricing"] });
+
+      const missingToken = await fetch(endpoint, {
+        body,
+        headers: { authorization: "Bearer secret", "content-type": "application/json" },
+        method: "POST",
+      });
+      expect(missingToken.status).toBe(401);
+
+      process.env.PRACHT_REVALIDATE_TOKEN = "secret";
+      const badToken = await fetch(endpoint, {
+        body,
+        headers: { authorization: "Bearer wrong", "content-type": "application/json" },
+        method: "POST",
+      });
+      expect(badToken.status).toBe(401);
+
+      const valid = await fetch(endpoint, {
+        body,
+        headers: {
+          authorization: "Bearer secret",
+          "content-type": "application/json",
+          cookie: "session=should-not-leak",
+        },
+        method: "POST",
+      });
+      expect(valid.status).toBe(200);
+      await expect(valid.json()).resolves.toEqual({ revalidated: ["/pricing"], skipped: [] });
+      expect(readFileSync(htmlPath, "utf-8")).toContain("missing");
+      expect(readFileSync(htmlPath, "utf-8")).not.toContain("should-not-leak");
+    } finally {
+      if (previousToken === undefined) {
+        delete process.env.PRACHT_REVALIDATE_TOKEN;
+      } else {
+        process.env.PRACHT_REVALIDATE_TOKEN = previousToken;
+      }
+    }
   });
 });

--- a/packages/adapter-node/test/index.test.ts
+++ b/packages/adapter-node/test/index.test.ts
@@ -344,9 +344,85 @@ describe("createNodeRequestHandler", () => {
         method: "POST",
       });
       expect(valid.status).toBe(200);
-      await expect(valid.json()).resolves.toEqual({ revalidated: ["/pricing"], skipped: [] });
+      await expect(valid.json()).resolves.toEqual({
+        failed: [],
+        revalidated: ["/pricing"],
+        skipped: [],
+      });
       expect(readFileSync(htmlPath, "utf-8")).toContain("missing");
       expect(readFileSync(htmlPath, "utf-8")).not.toContain("should-not-leak");
+    } finally {
+      if (previousToken === undefined) {
+        delete process.env.PRACHT_REVALIDATE_TOKEN;
+      } else {
+        process.env.PRACHT_REVALIDATE_TOKEN = previousToken;
+      }
+    }
+  });
+
+  it("reports failed webhook regenerations and keeps the stale HTML on disk", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    const staticDir = makeTempDir();
+    const htmlDir = join(staticDir, "broken");
+    const htmlPath = join(htmlDir, "index.html");
+    mkdirSync(htmlDir, { recursive: true });
+    writeFileSync(htmlPath, "<html><body>stale-but-safe</body></html>", "utf-8");
+
+    const previousToken = process.env.PRACHT_REVALIDATE_TOKEN;
+    process.env.PRACHT_REVALIDATE_TOKEN = "secret";
+
+    const app = defineApp({
+      routes: [
+        route("/broken", "./routes/broken.tsx", {
+          render: "isg",
+          revalidate: webhookRevalidate(),
+        }),
+      ],
+    });
+    const handler = createNodeRequestHandler({
+      app,
+      isgManifest: {
+        "/broken": { revalidate: webhookRevalidate() },
+      },
+      registry: {
+        routeModules: {
+          "./routes/broken.tsx": async () => ({
+            Component: () => "<main>never</main>",
+            loader: async () => {
+              throw new Error("upstream CMS exploded");
+            },
+          }),
+        },
+      },
+      staticDir,
+    });
+
+    const server = createServer((req: IncomingMessage, res: ServerResponse) => {
+      void handler(req, res);
+    });
+    servers.add(server);
+
+    try {
+      server.listen(0, "127.0.0.1");
+      await once(server, "listening");
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        throw new Error("Expected TCP server address");
+      }
+
+      const response = await fetch(`http://127.0.0.1:${address.port}/__pracht/revalidate`, {
+        body: JSON.stringify({ paths: ["/broken", "/not-isg"] }),
+        headers: { authorization: "Bearer secret", "content-type": "application/json" },
+        method: "POST",
+      });
+
+      expect(response.status).toBe(200);
+      await expect(response.json()).resolves.toEqual({
+        failed: ["/broken"],
+        revalidated: [],
+        skipped: ["/not-isg"],
+      });
+      expect(readFileSync(htmlPath, "utf-8")).toContain("stale-but-safe");
     } finally {
       if (previousToken === undefined) {
         delete process.env.PRACHT_REVALIDATE_TOKEN;

--- a/packages/adapter-vercel/src/index.ts
+++ b/packages/adapter-vercel/src/index.ts
@@ -1,9 +1,15 @@
 import type { PrachtAdapter } from "@pracht/vite-plugin";
 import {
   handlePrachtRequest,
+  hasWebhookRevalidate,
   type HandlePrachtRequestOptions,
+  jsonResponse,
+  matchAppRoute,
   type ModuleRegistry,
+  PRACHT_REVALIDATE_ENDPOINT,
+  PRACHT_REVALIDATE_TOKEN_ENV,
   type ResolvedApiRoute,
+  readRevalidationRequest,
   type PrachtApp,
 } from "@pracht/core/server";
 
@@ -44,6 +50,10 @@ export function createVercelEdgeHandler<
   TContext = TVercelContext,
 >(options: VercelAdapterOptions<TVercelContext, TContext>) {
   return async (request: Request, context: TVercelContext): Promise<Response> => {
+    if (new URL(request.url).pathname === PRACHT_REVALIDATE_ENDPOINT) {
+      return handleVercelRevalidationEndpoint(request, options.app);
+    }
+
     const prachtContext = options.createContext
       ? await options.createContext({ request, context })
       : (context as unknown as TContext);
@@ -76,23 +86,63 @@ export function createVercelServerEntryModule(
     `export const vercelRegions = ${JSON.stringify(regions ?? null)};`,
     "",
     "export default async function handle(request, context) {",
-    "  const prachtContext = createPrachtContext",
-    "    ? await createPrachtContext({ request, context })",
-    "    : context;",
-    "",
-    "  return handlePrachtRequest({",
+    "  const handler = createVercelEdgeHandler({",
     "    app: resolvedApp,",
     "    registry,",
-    "    request,",
-    "    context: prachtContext,",
     "    apiRoutes,",
     "    clientEntryUrl: clientEntryUrl ?? undefined,",
     "    cssManifest,",
     "    jsManifest,",
+    "    createContext: createPrachtContext,",
     "  });",
+    "  return handler(request, context);",
     "}",
     "",
   ].join("\n");
+}
+
+async function handleVercelRevalidationEndpoint(
+  request: Request,
+  app: PrachtApp,
+): Promise<Response> {
+  const token = getRuntimeRevalidationToken();
+  const parsed = await readRevalidationRequest(request, token);
+  if (!parsed.ok) return parsed.response;
+
+  const revalidated: string[] = [];
+  const skipped: string[] = [];
+
+  for (const pathname of parsed.paths) {
+    const match = matchAppRoute(app, pathname);
+    if (!match || match.route.render !== "isg" || !hasWebhookRevalidate(match.route.revalidate)) {
+      skipped.push(pathname);
+      continue;
+    }
+
+    const revalidateUrl = new URL(pathname, request.url);
+    const response = await fetch(revalidateUrl, {
+      headers: {
+        accept: "text/html",
+        "x-prerender-revalidate": token!,
+      },
+      method: "GET",
+    });
+
+    if (response.ok) {
+      revalidated.push(pathname);
+    } else {
+      skipped.push(pathname);
+    }
+  }
+
+  return jsonResponse({ revalidated, skipped });
+}
+
+function getRuntimeRevalidationToken(): string | undefined {
+  const runtime = globalThis as typeof globalThis & {
+    process?: { env?: Record<string, string | undefined> };
+  };
+  return runtime.process?.env?.[PRACHT_REVALIDATE_TOKEN_ENV];
 }
 
 /**
@@ -108,7 +158,7 @@ export function vercelAdapter(options: VercelServerEntryModuleOptions = {}): Pra
     id: "vercel",
     edge: true,
     serverImports:
-      'import { handlePrachtRequest, resolveApp, resolveApiRoutes } from "@pracht/core/server";',
+      'import { resolveApp, resolveApiRoutes } from "@pracht/core/server";\nimport { createVercelEdgeHandler } from "@pracht/adapter-vercel";',
     createServerEntryModule() {
       return createVercelServerEntryModule(options);
     },

--- a/packages/adapter-vercel/src/index.ts
+++ b/packages/adapter-vercel/src/index.ts
@@ -101,6 +101,14 @@ export function createVercelServerEntryModule(
   ].join("\n");
 }
 
+/**
+ * `x-vercel-cache` values that prove the prerender cache was actually
+ * refreshed. A `HIT`/`STALE` on a bypass request means Vercel ignored the
+ * `x-prerender-revalidate` header — the runtime token does not match the
+ * `bypassToken` baked into the build's `*.prerender-config.json`.
+ */
+const VERCEL_CACHE_REFRESH_STATUSES = new Set(["MISS", "REVALIDATED", "BYPASS"]);
+
 async function handleVercelRevalidationEndpoint(
   request: Request,
   app: PrachtApp,
@@ -132,9 +140,25 @@ async function handleVercelRevalidationEndpoint(
         method: "GET",
       });
 
-      if (response.ok) {
+      if (!response.ok) {
+        failed.push(pathname);
+        continue;
+      }
+
+      // A 200 alone does not prove the cache was refreshed: when the runtime
+      // token differs from the build-time bypassToken, Vercel serves the
+      // cached prerender output (x-vercel-cache: HIT/STALE) and the page was
+      // never regenerated. Treat an absent header conservatively as success
+      // (non-Vercel/test environments don't set it).
+      const cacheStatus = response.headers.get("x-vercel-cache");
+      if (cacheStatus === null || VERCEL_CACHE_REFRESH_STATUSES.has(cacheStatus.toUpperCase())) {
         revalidated.push(pathname);
       } else {
+        console.error(
+          `ISG webhook revalidation failed for ${pathname}: x-vercel-cache was "${cacheStatus}" — ` +
+            "the revalidation token did not match the build-time bypass token; " +
+            `rebuild with ${PRACHT_REVALIDATE_TOKEN_ENV} set.`,
+        );
         failed.push(pathname);
       }
     } catch (err) {

--- a/packages/adapter-vercel/src/index.ts
+++ b/packages/adapter-vercel/src/index.ts
@@ -111,6 +111,7 @@ async function handleVercelRevalidationEndpoint(
 
   const revalidated: string[] = [];
   const skipped: string[] = [];
+  const failed: string[] = [];
 
   for (const pathname of parsed.paths) {
     const match = matchAppRoute(app, pathname);
@@ -119,23 +120,30 @@ async function handleVercelRevalidationEndpoint(
       continue;
     }
 
-    const revalidateUrl = new URL(pathname, request.url);
-    const response = await fetch(revalidateUrl, {
-      headers: {
-        accept: "text/html",
-        "x-prerender-revalidate": token!,
-      },
-      method: "GET",
-    });
+    // A failed regeneration keeps Vercel's cached prerender output and is
+    // reported in `failed` instead of aborting the whole batch with a 500.
+    try {
+      const revalidateUrl = new URL(pathname, request.url);
+      const response = await fetch(revalidateUrl, {
+        headers: {
+          accept: "text/html",
+          "x-prerender-revalidate": token!,
+        },
+        method: "GET",
+      });
 
-    if (response.ok) {
-      revalidated.push(pathname);
-    } else {
-      skipped.push(pathname);
+      if (response.ok) {
+        revalidated.push(pathname);
+      } else {
+        failed.push(pathname);
+      }
+    } catch (err) {
+      console.error(`ISG webhook revalidation failed for ${pathname}:`, err);
+      failed.push(pathname);
     }
   }
 
-  return jsonResponse({ revalidated, skipped });
+  return jsonResponse({ failed, revalidated, skipped });
 }
 
 function getRuntimeRevalidationToken(): string | undefined {

--- a/packages/adapter-vercel/test/index.test.ts
+++ b/packages/adapter-vercel/test/index.test.ts
@@ -13,8 +13,8 @@ describe("createVercelServerEntryModule", () => {
     expect(source).toContain(
       'import { createContext as createPrachtContext } from "/src/server/context.ts";',
     );
-    expect(source).toContain("await createPrachtContext({ request, context })");
-    expect(source).toContain("context: prachtContext");
+    expect(source).toContain("createContext: createPrachtContext");
+    expect(source).toContain("createVercelEdgeHandler");
     expect(source).toContain('export const vercelFunctionName = "app";');
   });
 });

--- a/packages/adapter-vercel/test/index.test.ts
+++ b/packages/adapter-vercel/test/index.test.ts
@@ -1,6 +1,8 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { createVercelServerEntryModule } from "../src/index.ts";
+import { defineApp, route, timeRevalidate, webhookRevalidate } from "@pracht/core";
+
+import { createVercelEdgeHandler, createVercelServerEntryModule } from "../src/index.ts";
 
 describe("createVercelServerEntryModule", () => {
   it("imports an app createContext module when configured", () => {
@@ -16,5 +18,131 @@ describe("createVercelServerEntryModule", () => {
     expect(source).toContain("createContext: createPrachtContext");
     expect(source).toContain("createVercelEdgeHandler");
     expect(source).toContain('export const vercelFunctionName = "app";');
+  });
+});
+
+describe("createVercelEdgeHandler webhook revalidation", () => {
+  const app = defineApp({
+    routes: [
+      route("/pricing", "./routes/pricing.tsx", {
+        render: "isg",
+        revalidate: [timeRevalidate(3600), webhookRevalidate()],
+      }),
+      route("/time-only", "./routes/time-only.tsx", {
+        render: "isg",
+        revalidate: timeRevalidate(3600),
+      }),
+    ],
+  });
+
+  function createWebhookRequest(paths: string[], token?: string): Request {
+    return new Request("https://app.example/__pracht/revalidate", {
+      body: JSON.stringify({ paths }),
+      headers: {
+        ...(token ? { authorization: `Bearer ${token}` } : {}),
+        "content-type": "application/json",
+      },
+      method: "POST",
+    });
+  }
+
+  const previousToken = process.env.PRACHT_REVALIDATE_TOKEN;
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+    if (previousToken === undefined) {
+      delete process.env.PRACHT_REVALIDATE_TOKEN;
+    } else {
+      process.env.PRACHT_REVALIDATE_TOKEN = previousToken;
+    }
+  });
+
+  it("fails closed without a configured token and rejects wrong tokens", async () => {
+    const handler = createVercelEdgeHandler({ app });
+
+    delete process.env.PRACHT_REVALIDATE_TOKEN;
+    const missing = await handler(createWebhookRequest(["/pricing"], "secret"), {});
+    expect(missing.status).toBe(401);
+
+    process.env.PRACHT_REVALIDATE_TOKEN = "secret";
+    const wrong = await handler(createWebhookRequest(["/pricing"], "wrong"), {});
+    expect(wrong.status).toBe(401);
+  });
+
+  it("regenerates opted-in paths through the prerender bypass token", async () => {
+    process.env.PRACHT_REVALIDATE_TOKEN = "secret";
+    const revalidateFetches: { url: string; headers: Record<string, string> }[] = [];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: URL | RequestInfo, init?: RequestInit) => {
+        revalidateFetches.push({
+          url: String(input),
+          headers: Object.fromEntries(new Headers(init?.headers)),
+        });
+        return new Response("<html>ok</html>", { status: 200 });
+      }),
+    );
+
+    const handler = createVercelEdgeHandler({ app });
+    const response = await handler(
+      createWebhookRequest(["/pricing", "/time-only", "/unknown"], "secret"),
+      {},
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      failed: [],
+      revalidated: ["/pricing"],
+      skipped: ["/time-only", "/unknown"],
+    });
+    expect(revalidateFetches).toEqual([
+      {
+        url: "https://app.example/pricing",
+        headers: expect.objectContaining({ "x-prerender-revalidate": "secret" }),
+      },
+    ]);
+  });
+
+  it("reports failed regenerations instead of aborting the batch", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    process.env.PRACHT_REVALIDATE_TOKEN = "secret";
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: URL | RequestInfo) => {
+        if (String(input).includes("/pricing")) {
+          throw new TypeError("network unreachable");
+        }
+        return new Response("<html>ok</html>", { status: 200 });
+      }),
+    );
+
+    const handler = createVercelEdgeHandler({ app });
+    const response = await handler(createWebhookRequest(["/pricing"], "secret"), {});
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      failed: ["/pricing"],
+      revalidated: [],
+      skipped: [],
+    });
+  });
+
+  it("marks non-ok upstream regeneration responses as failed", async () => {
+    process.env.PRACHT_REVALIDATE_TOKEN = "secret";
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response("nope", { status: 500 })),
+    );
+
+    const handler = createVercelEdgeHandler({ app });
+    const response = await handler(createWebhookRequest(["/pricing"], "secret"), {});
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      failed: ["/pricing"],
+      revalidated: [],
+      skipped: [],
+    });
   });
 });

--- a/packages/adapter-vercel/test/index.test.ts
+++ b/packages/adapter-vercel/test/index.test.ts
@@ -80,7 +80,10 @@ describe("createVercelEdgeHandler webhook revalidation", () => {
           url: String(input),
           headers: Object.fromEntries(new Headers(init?.headers)),
         });
-        return new Response("<html>ok</html>", { status: 200 });
+        return new Response("<html>ok</html>", {
+          headers: { "x-vercel-cache": "MISS" },
+          status: 200,
+        });
       }),
     );
 
@@ -124,6 +127,52 @@ describe("createVercelEdgeHandler webhook revalidation", () => {
     await expect(response.json()).resolves.toEqual({
       failed: ["/pricing"],
       revalidated: [],
+      skipped: [],
+    });
+  });
+
+  it("marks cache hits on the bypass request as failed instead of revalidated", async () => {
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+    process.env.PRACHT_REVALIDATE_TOKEN = "secret";
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(
+        async () =>
+          new Response("<html>cached</html>", {
+            headers: { "x-vercel-cache": "HIT" },
+            status: 200,
+          }),
+      ),
+    );
+
+    const handler = createVercelEdgeHandler({ app });
+    const response = await handler(createWebhookRequest(["/pricing"], "secret"), {});
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      failed: ["/pricing"],
+      revalidated: [],
+      skipped: [],
+    });
+    expect(consoleError).toHaveBeenCalledWith(
+      expect.stringContaining("did not match the build-time bypass token"),
+    );
+  });
+
+  it("treats an absent x-vercel-cache header as a successful regeneration", async () => {
+    process.env.PRACHT_REVALIDATE_TOKEN = "secret";
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response("<html>ok</html>", { status: 200 })),
+    );
+
+    const handler = createVercelEdgeHandler({ app });
+    const response = await handler(createWebhookRequest(["/pricing"], "secret"), {});
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      failed: [],
+      revalidated: ["/pricing"],
       skipped: [],
     });
   });

--- a/packages/cli/src/build-shared.ts
+++ b/packages/cli/src/build-shared.ts
@@ -1,6 +1,8 @@
-import { cpSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
-import { join } from "node:path";
+import { randomBytes } from "node:crypto";
+import { cpSync, existsSync, mkdirSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { dirname, join, relative } from "node:path";
 
+import { getTimeRevalidateSeconds, type ISGManifestEntry } from "@pracht/core/server";
 import { VERSION } from "./constants.js";
 
 const ROUTE_STATE_REQUEST_HEADER = "x-pracht-route-state-request";
@@ -8,7 +10,8 @@ const ROUTE_STATE_REQUEST_HEADER = "x-pracht-route-state-request";
 interface VercelBuildOutputOptions {
   functionName?: string;
   headersManifest?: Record<string, Record<string, string>>;
-  isgRoutes: string[];
+  isgManifest: Record<string, ISGManifestEntry>;
+  revalidateToken?: string;
   regions?: string[];
   root: string;
   staticRoutes: string[];
@@ -17,36 +20,111 @@ interface VercelBuildOutputOptions {
 export function writeVercelBuildOutput({
   functionName,
   headersManifest = {},
-  isgRoutes,
+  isgManifest,
+  revalidateToken = process.env.PRACHT_REVALIDATE_TOKEN || randomBytes(32).toString("hex"),
   regions,
   root,
   staticRoutes,
 }: VercelBuildOutputOptions): string {
   const outputDir = join(root, ".vercel/output");
   const staticDir = join(outputDir, "static");
+  const functionsDir = join(outputDir, "functions");
   const functionDir = join(outputDir, "functions", `${functionName || "render"}.func`);
 
   rmSync(outputDir, { force: true, recursive: true });
   mkdirSync(outputDir, { recursive: true });
   cpSync(join(root, "dist/client"), staticDir, { recursive: true });
   cpSync(join(root, "dist/server"), functionDir, { recursive: true });
-
-  writeFileSync(
-    join(outputDir, "config.json"),
-    `${JSON.stringify(
-      createVercelOutputConfig({ functionName, headersManifest, staticRoutes, isgRoutes }),
-      null,
-      2,
-    )}\n`,
-    "utf-8",
-  );
   writeFileSync(
     join(functionDir, ".vc-config.json"),
     `${JSON.stringify(createVercelFunctionConfig({ regions }), null, 2)}\n`,
     "utf-8",
   );
+  writeVercelPrerenderFunctions({
+    functionDir,
+    functionsDir,
+    headersManifest,
+    isgManifest,
+    revalidateToken,
+    staticDir,
+  });
+
+  writeFileSync(
+    join(outputDir, "config.json"),
+    `${JSON.stringify(
+      createVercelOutputConfig({
+        functionName,
+        headersManifest,
+        staticRoutes,
+        isgRoutes: Object.keys(isgManifest),
+      }),
+      null,
+      2,
+    )}\n`,
+    "utf-8",
+  );
 
   return ".vercel/output";
+}
+
+function writeVercelPrerenderFunctions({
+  functionDir,
+  functionsDir,
+  headersManifest,
+  isgManifest,
+  revalidateToken,
+  staticDir,
+}: {
+  functionDir: string;
+  functionsDir: string;
+  headersManifest: Record<string, Record<string, string>>;
+  isgManifest: Record<string, ISGManifestEntry>;
+  revalidateToken: string;
+  staticDir: string;
+}): void {
+  for (const [route, entry] of Object.entries(isgManifest)) {
+    const prerenderName = routeToPrerenderFunctionName(route);
+    const routeFunctionDir = join(functionsDir, `${prerenderName}.func`);
+    if (routeFunctionDir !== functionDir) {
+      mkdirSync(dirname(routeFunctionDir), { recursive: true });
+      // Symlink rather than copy so that N ISG routes don't each duplicate the
+      // full server bundle. Vercel resolves symlinked `.func` directories; fall
+      // back to a copy where symlinks aren't available (e.g. Windows without
+      // the required privileges).
+      try {
+        symlinkSync(relative(dirname(routeFunctionDir), functionDir), routeFunctionDir, "dir");
+      } catch {
+        cpSync(functionDir, routeFunctionDir, { recursive: true });
+      }
+    }
+
+    const configPath = join(functionsDir, `${prerenderName}.prerender-config.json`);
+    const fallbackName = `${basename(prerenderName)}.prerender-fallback.html`;
+    const fallbackPath = join(dirname(configPath), fallbackName);
+    const staticHtmlPath = join(staticDir, routeToStaticHtmlPath(route).slice(1));
+    if (existsSync(staticHtmlPath)) {
+      mkdirSync(dirname(fallbackPath), { recursive: true });
+      cpSync(staticHtmlPath, fallbackPath);
+      rmSync(staticHtmlPath, { force: true });
+    }
+
+    writeFileSync(
+      configPath,
+      `${JSON.stringify(
+        {
+          allowQuery: [],
+          bypassToken: revalidateToken,
+          expiration: getTimeRevalidateSeconds(entry.revalidate) ?? false,
+          fallback: existsSync(fallbackPath) ? fallbackName : undefined,
+          initialHeaders: headersManifest[route],
+          initialStatus: 200,
+        },
+        null,
+        2,
+      )}\n`,
+      "utf-8",
+    );
+  }
 }
 
 function createVercelOutputConfig({
@@ -83,7 +161,7 @@ function createVercelOutputConfig({
 
   for (const route of isgRoutes) {
     routes.push({
-      dest: target,
+      dest: route,
       src: routeToRouteExpression(route),
     });
   }
@@ -157,6 +235,15 @@ function routeToStaticHtmlPath(route: string): string {
   }
 
   return `${route}/index.html`;
+}
+
+function routeToPrerenderFunctionName(route: string): string {
+  return route === "/" ? "index" : route.replace(/^\/+/, "");
+}
+
+function basename(value: string): string {
+  const segments = value.split("/");
+  return segments[segments.length - 1] || "index";
 }
 
 function routeToHeaderSource(route: string): string {

--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -188,8 +188,14 @@ export async function runBuild(root: string, options: BuildOptions = {}): Promis
       const isgManifestPath = resolve(root, "dist/server/isg-manifest.json");
       const isgManifestJson = `${JSON.stringify(isgManifest, null, 2)}\n`;
       writeFileSync(isgManifestPath, isgManifestJson, "utf-8");
-      mkdirSync(resolve(clientDir, "_pracht"), { recursive: true });
-      writeFileSync(resolve(clientDir, "_pracht/isg.json"), isgManifestJson, "utf-8");
+      if (buildTarget === "cloudflare") {
+        // Only the Cloudflare worker runtime reads the manifest from the
+        // static assets (via readPrachtISGManifest). On other targets the
+        // client dir is served publicly, so writing it there would leak the
+        // ISG route list and revalidation policies.
+        mkdirSync(resolve(clientDir, "_pracht"), { recursive: true });
+        writeFileSync(resolve(clientDir, "_pracht/isg.json"), isgManifestJson, "utf-8");
+      }
       log(
         `\n  ISG manifest → dist/server/isg-manifest.json (${Object.keys(isgManifest).length} route(s))\n`,
       );

--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -186,19 +186,16 @@ export async function runBuild(root: string, options: BuildOptions = {}): Promis
 
     if (Object.keys(isgManifest).length > 0) {
       const isgManifestPath = resolve(root, "dist/server/isg-manifest.json");
-      writeFileSync(isgManifestPath, JSON.stringify(isgManifest, null, 2), "utf-8");
+      const isgManifestJson = `${JSON.stringify(isgManifest, null, 2)}\n`;
+      writeFileSync(isgManifestPath, isgManifestJson, "utf-8");
+      mkdirSync(resolve(clientDir, "_pracht"), { recursive: true });
+      writeFileSync(resolve(clientDir, "_pracht/isg.json"), isgManifestJson, "utf-8");
       log(
         `\n  ISG manifest → dist/server/isg-manifest.json (${Object.keys(isgManifest).length} route(s))\n`,
       );
     }
 
     if (serverMod.buildTarget === "cloudflare") {
-      if (Object.keys(isgManifest).length > 0) {
-        console.warn(
-          "\n  Warning: Cloudflare adapter currently serves prerendered ISG HTML as static assets and does not perform runtime revalidation. Use SSR/SSG on Cloudflare, or deploy ISG routes to Node until Cloudflare ISG support is added.\n",
-        );
-      }
-
       // workerd validates every named export of the deployed entry module as
       // an entrypoint and rejects the build metadata (buildTarget, manifests,
       // resolvedApp, ...) that server.js exports for the prerender pass
@@ -223,7 +220,7 @@ export async function runBuild(root: string, options: BuildOptions = {}): Promis
     if (serverMod.buildTarget === "vercel") {
       const outputPath = writeVercelBuildOutput({
         functionName: serverMod.vercelFunctionName,
-        isgRoutes: Object.keys(isgManifest),
+        isgManifest,
         headersManifest,
         regions: serverMod.vercelRegions,
         root,

--- a/packages/framework/src/app.ts
+++ b/packages/framework/src/app.ts
@@ -19,6 +19,7 @@ import type {
   RouteTreeNode,
   SearchParamsInput,
   TimeRevalidatePolicy,
+  WebhookRevalidatePolicy,
   PrachtApp,
   PrachtAppConfig,
 } from "./types.ts";
@@ -39,6 +40,12 @@ export function timeRevalidate(seconds: number): TimeRevalidatePolicy {
   return {
     kind: "time",
     seconds,
+  };
+}
+
+export function webhookRevalidate(): WebhookRevalidatePolicy {
+  return {
+    kind: "webhook",
   };
 }
 

--- a/packages/framework/src/index.ts
+++ b/packages/framework/src/index.ts
@@ -46,15 +46,18 @@ export { prefetch, type PrefetchFn } from "./prefetch-api.ts";
 export { prerenderApp } from "./prerender.ts";
 export {
   createISGRegenerationRequest,
+  createRevalidationSingleFlight,
   getTimeRevalidateSeconds,
   hasWebhookRevalidate,
   isAuthorizedRevalidationRequest,
+  isCacheableISGResponse,
   jsonResponse,
   normalizeRouteRevalidate,
   PRACHT_REVALIDATE_ENDPOINT,
   PRACHT_REVALIDATE_TOKEN_ENV,
   PRACHT_REVALIDATE_TOKEN_HEADER,
   readRevalidationRequest,
+  type RevalidationSingleFlight,
 } from "./revalidation.ts";
 export { redirect, type RedirectOptions } from "./runtime-middleware.ts";
 export { initClientRouter, useNavigate } from "./router.ts";

--- a/packages/framework/src/index.ts
+++ b/packages/framework/src/index.ts
@@ -9,6 +9,7 @@ export {
   resolveApp,
   route,
   timeRevalidate,
+  webhookRevalidate,
 } from "./app.ts";
 export { createHref } from "./href.ts";
 export {
@@ -43,6 +44,18 @@ export {
 } from "./runtime.ts";
 export { prefetch, type PrefetchFn } from "./prefetch-api.ts";
 export { prerenderApp } from "./prerender.ts";
+export {
+  createISGRegenerationRequest,
+  getTimeRevalidateSeconds,
+  hasWebhookRevalidate,
+  isAuthorizedRevalidationRequest,
+  jsonResponse,
+  normalizeRouteRevalidate,
+  PRACHT_REVALIDATE_ENDPOINT,
+  PRACHT_REVALIDATE_TOKEN_ENV,
+  PRACHT_REVALIDATE_TOKEN_HEADER,
+  readRevalidationRequest,
+} from "./revalidation.ts";
 export { redirect, type RedirectOptions } from "./runtime-middleware.ts";
 export { initClientRouter, useNavigate } from "./router.ts";
 export { PrachtHttpError } from "./types.ts";
@@ -99,6 +112,7 @@ export type {
   RouteDataFor,
   RouteLoaderData,
   RouteRevalidate,
+  RouteRevalidatePolicy,
   RouteSearchFor,
   RouteTarget,
   RouteTreeNode,
@@ -108,6 +122,7 @@ export type {
   ShellModule,
   ShellProps,
   TimeRevalidatePolicy,
+  WebhookRevalidatePolicy,
   PrachtApp,
   PrachtAppConfig,
 } from "./types.ts";

--- a/packages/framework/src/prerender.ts
+++ b/packages/framework/src/prerender.ts
@@ -1,4 +1,5 @@
 import { buildPathFromSegments, resolveApp } from "./app.ts";
+import { normalizeRouteRevalidate } from "./revalidation.ts";
 import { resolveRegistryModule } from "./runtime-manifest.ts";
 import { handlePrachtRequest } from "./runtime.ts";
 import type {
@@ -17,6 +18,7 @@ export interface PrerenderResult {
 
 export interface ISGManifestEntry {
   revalidate: RouteRevalidate;
+  generatedAt?: number;
 }
 
 export interface PrerenderAppResult {
@@ -56,6 +58,7 @@ export async function prerenderApp(
   const resolved = resolveApp(options.app);
   const results: PrerenderResult[] = [];
   const isgManifest: Record<string, ISGManifestEntry> = {};
+  const generatedAt = Date.now();
 
   // Collect all work items first, then render in parallel batches
   const work: {
@@ -67,6 +70,9 @@ export async function prerenderApp(
     if (route.render !== "ssg" && route.render !== "isg") continue;
     const paths = await collectSSGPaths(route, options.registry);
     for (const pathname of paths) {
+      if (route.render === "isg" && route.revalidate) {
+        normalizeRouteRevalidate(route.revalidate);
+      }
       work.push({ pathname, render: route.render, revalidate: route.revalidate });
     }
   }
@@ -114,7 +120,10 @@ export async function prerenderApp(
         headers: result.headers,
       });
       if (result.item.render === "isg" && result.item.revalidate) {
-        isgManifest[result.item.pathname] = { revalidate: result.item.revalidate };
+        isgManifest[result.item.pathname] = {
+          generatedAt,
+          revalidate: result.item.revalidate,
+        };
       }
     }
   }

--- a/packages/framework/src/revalidation.ts
+++ b/packages/framework/src/revalidation.ts
@@ -225,7 +225,9 @@ function isValidRevalidationPath(value: unknown): value is string {
     !value.startsWith("//") &&
     !value.includes("\0") &&
     !value.includes("?") &&
-    !value.includes("#")
+    !value.includes("#") &&
+    !value.includes("\\") &&
+    !value.split("/").includes("..")
   );
 }
 

--- a/packages/framework/src/revalidation.ts
+++ b/packages/framework/src/revalidation.ts
@@ -8,6 +8,55 @@ export interface ParsedRevalidationRequest {
   paths: string[];
 }
 
+export type RevalidationSingleFlight = <T>(key: string, task: () => Promise<T>) => Promise<T>;
+
+/**
+ * Deduplicate concurrent regenerations of the same path. Without this, a
+ * stampede of requests against a stale ISG page (or repeated webhook posts)
+ * triggers N parallel renders that all race to write the same output.
+ * Callers sharing one single-flight instance receive the in-flight promise
+ * instead of starting another regeneration.
+ */
+export function createRevalidationSingleFlight(): RevalidationSingleFlight {
+  const inflight = new Map<string, Promise<unknown>>();
+
+  return <T>(key: string, task: () => Promise<T>): Promise<T> => {
+    const existing = inflight.get(key);
+    if (existing) return existing as Promise<T>;
+
+    const pending = Promise.resolve()
+      .then(task)
+      .finally(() => {
+        inflight.delete(key);
+      });
+    inflight.set(key, pending);
+    return pending;
+  };
+}
+
+/**
+ * An ISG response is safe to persist in a shared cache only when it doesn't
+ * depend on request-specific state (cookies, auth) that the cached copy would
+ * replay to every visitor. `Cache-Control: private` / `no-store`, any
+ * `Set-Cookie`, and a `Vary` that implies per-request output (cookie,
+ * authorization) all signal "don't cache this across users".
+ */
+export function isCacheableISGResponse(response: Response): boolean {
+  const cacheControl = response.headers.get("cache-control")?.toLowerCase() ?? "";
+  if (/\b(no-store|private)\b/.test(cacheControl)) return false;
+
+  if (response.headers.get("set-cookie")) return false;
+
+  const vary = response.headers.get("vary")?.toLowerCase() ?? "";
+  if (!vary) return true;
+  if (vary.includes("*")) return false;
+  const varied = vary.split(",").map((s) => s.trim());
+  for (const name of varied) {
+    if (name === "cookie" || name === "authorization") return false;
+  }
+  return true;
+}
+
 export type RevalidationRequestResult =
   | {
       ok: true;

--- a/packages/framework/src/revalidation.ts
+++ b/packages/framework/src/revalidation.ts
@@ -1,0 +1,195 @@
+import type { RouteRevalidate, RouteRevalidatePolicy } from "./types.ts";
+
+export const PRACHT_REVALIDATE_ENDPOINT = "/__pracht/revalidate";
+export const PRACHT_REVALIDATE_TOKEN_ENV = "PRACHT_REVALIDATE_TOKEN";
+export const PRACHT_REVALIDATE_TOKEN_HEADER = "x-pracht-revalidate-token";
+
+export interface ParsedRevalidationRequest {
+  paths: string[];
+}
+
+export type RevalidationRequestResult =
+  | {
+      ok: true;
+      paths: string[];
+    }
+  | {
+      ok: false;
+      response: Response;
+    };
+
+export function normalizeRouteRevalidate(revalidate: RouteRevalidate): RouteRevalidatePolicy[] {
+  const policies = Array.isArray(revalidate) ? [...revalidate] : [revalidate];
+  if (policies.length === 0) {
+    throw new Error("Route revalidate policy arrays must contain at least one policy.");
+  }
+
+  const seen = new Set<string>();
+  for (const policy of policies) {
+    if (!policy || typeof policy !== "object") {
+      throw new Error("Route revalidate policies must be objects.");
+    }
+    if (seen.has(policy.kind)) {
+      throw new Error(
+        `Route revalidate policies cannot include duplicate "${policy.kind}" entries.`,
+      );
+    }
+    seen.add(policy.kind);
+
+    if (policy.kind === "time") {
+      if (!Number.isInteger(policy.seconds) || policy.seconds <= 0) {
+        throw new Error("time revalidate policies expect a positive integer number of seconds.");
+      }
+      continue;
+    }
+
+    if (policy.kind === "webhook") {
+      continue;
+    }
+
+    throw new Error(
+      `Unsupported route revalidate policy "${String((policy as { kind?: unknown }).kind)}".`,
+    );
+  }
+
+  return policies;
+}
+
+export function getTimeRevalidateSeconds(revalidate: RouteRevalidate | undefined): number | null {
+  if (!revalidate) return null;
+  for (const policy of normalizeRouteRevalidate(revalidate)) {
+    if (policy.kind === "time") return policy.seconds;
+  }
+  return null;
+}
+
+export function hasWebhookRevalidate(revalidate: RouteRevalidate | undefined): boolean {
+  if (!revalidate) return false;
+  return normalizeRouteRevalidate(revalidate).some((policy) => policy.kind === "webhook");
+}
+
+export async function readRevalidationRequest(
+  request: Request,
+  token: string | undefined,
+): Promise<RevalidationRequestResult> {
+  if (request.method !== "POST") {
+    return {
+      ok: false,
+      response: jsonResponse({ error: "Method Not Allowed" }, 405, {
+        allow: "POST",
+      }),
+    };
+  }
+
+  if (!isAuthorizedRevalidationRequest(request, token)) {
+    return {
+      ok: false,
+      response: jsonResponse({ error: "Unauthorized" }, 401),
+    };
+  }
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return {
+      ok: false,
+      response: jsonResponse({ error: "Expected a JSON body." }, 400),
+    };
+  }
+
+  const paths = parseRevalidationPaths(body);
+  if (!paths) {
+    return {
+      ok: false,
+      response: jsonResponse({ error: 'Expected body shape `{ "paths": ["/path"] }`.' }, 400),
+    };
+  }
+
+  return {
+    ok: true,
+    paths,
+  };
+}
+
+export function isAuthorizedRevalidationRequest(
+  request: Request,
+  token: string | undefined,
+): boolean {
+  if (typeof token !== "string" || token.length === 0) {
+    return false;
+  }
+
+  const provided = getRevalidationToken(request);
+  if (!provided) return false;
+  return constantTimeEqual(provided, token);
+}
+
+export function createISGRegenerationRequest(pathname: string, originalRequest?: Request): Request {
+  const baseUrl = originalRequest ? new URL(originalRequest.url) : new URL("http://localhost");
+  const regenerationUrl = new URL(pathname, baseUrl);
+
+  return new Request(regenerationUrl, {
+    method: "GET",
+    headers: { accept: "text/html" },
+  });
+}
+
+export function jsonResponse(body: unknown, status = 200, headers?: HeadersInit): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: {
+      "content-type": "application/json; charset=utf-8",
+      ...headers,
+    },
+  });
+}
+
+function getRevalidationToken(request: Request): string | null {
+  const headerToken = request.headers.get(PRACHT_REVALIDATE_TOKEN_HEADER);
+  if (headerToken) return headerToken;
+
+  const authorization = request.headers.get("authorization");
+  const match = authorization?.match(/^Bearer\s+(.+)$/i);
+  return match?.[1] ?? null;
+}
+
+function parseRevalidationPaths(body: unknown): string[] | null {
+  if (!body || typeof body !== "object") return null;
+  const value =
+    (body as { paths?: unknown; path?: unknown }).paths ?? (body as { path?: unknown }).path;
+  const paths = Array.isArray(value) ? value : typeof value === "string" ? [value] : null;
+  if (!paths || paths.length === 0) return null;
+
+  const unique = new Set<string>();
+  for (const path of paths) {
+    if (!isValidRevalidationPath(path)) return null;
+    unique.add(path);
+  }
+  return [...unique];
+}
+
+function isValidRevalidationPath(value: unknown): value is string {
+  return (
+    typeof value === "string" &&
+    value.startsWith("/") &&
+    !value.startsWith("//") &&
+    !value.includes("\0") &&
+    !value.includes("?") &&
+    !value.includes("#")
+  );
+}
+
+function constantTimeEqual(left: string, right: string): boolean {
+  const encoder = new TextEncoder();
+  const leftBytes = encoder.encode(left);
+  const rightBytes = encoder.encode(right);
+  const length = Math.max(leftBytes.length, rightBytes.length);
+  let diff = leftBytes.length ^ rightBytes.length;
+
+  for (let i = 0; i < length; i += 1) {
+    diff |= (leftBytes[i] ?? 0) ^ (rightBytes[i] ?? 0);
+  }
+
+  return diff === 0;
+}

--- a/packages/framework/src/server.ts
+++ b/packages/framework/src/server.ts
@@ -9,6 +9,7 @@ export {
   resolveApp,
   route,
   timeRevalidate,
+  webhookRevalidate,
 } from "./app.ts";
 export { createHref } from "./href.ts";
 export {
@@ -30,6 +31,18 @@ export type {
   AppGraphRoute,
 } from "./app-graph.ts";
 export { prerenderApp } from "./prerender.ts";
+export {
+  createISGRegenerationRequest,
+  getTimeRevalidateSeconds,
+  hasWebhookRevalidate,
+  isAuthorizedRevalidationRequest,
+  jsonResponse,
+  normalizeRouteRevalidate,
+  PRACHT_REVALIDATE_ENDPOINT,
+  PRACHT_REVALIDATE_TOKEN_ENV,
+  PRACHT_REVALIDATE_TOKEN_HEADER,
+  readRevalidationRequest,
+} from "./revalidation.ts";
 export { redirect, type RedirectOptions } from "./runtime-middleware.ts";
 export { PrachtHttpError } from "./types.ts";
 
@@ -85,6 +98,7 @@ export type {
   RouteDataFor,
   RouteLoaderData,
   RouteRevalidate,
+  RouteRevalidatePolicy,
   RouteSearchFor,
   RouteTarget,
   RouteTreeNode,
@@ -94,6 +108,7 @@ export type {
   ShellModule,
   ShellProps,
   TimeRevalidatePolicy,
+  WebhookRevalidatePolicy,
   PrachtApp,
   PrachtAppConfig,
 } from "./types.ts";

--- a/packages/framework/src/server.ts
+++ b/packages/framework/src/server.ts
@@ -33,15 +33,18 @@ export type {
 export { prerenderApp } from "./prerender.ts";
 export {
   createISGRegenerationRequest,
+  createRevalidationSingleFlight,
   getTimeRevalidateSeconds,
   hasWebhookRevalidate,
   isAuthorizedRevalidationRequest,
+  isCacheableISGResponse,
   jsonResponse,
   normalizeRouteRevalidate,
   PRACHT_REVALIDATE_ENDPOINT,
   PRACHT_REVALIDATE_TOKEN_ENV,
   PRACHT_REVALIDATE_TOKEN_HEADER,
   readRevalidationRequest,
+  type RevalidationSingleFlight,
 } from "./revalidation.ts";
 export { redirect, type RedirectOptions } from "./runtime-middleware.ts";
 export { PrachtHttpError } from "./types.ts";

--- a/packages/framework/src/types.ts
+++ b/packages/framework/src/types.ts
@@ -146,7 +146,13 @@ export interface TimeRevalidatePolicy {
   seconds: number;
 }
 
-export type RouteRevalidate = TimeRevalidatePolicy;
+export interface WebhookRevalidatePolicy {
+  kind: "webhook";
+}
+
+export type RouteRevalidatePolicy = TimeRevalidatePolicy | WebhookRevalidatePolicy;
+
+export type RouteRevalidate = RouteRevalidatePolicy | readonly RouteRevalidatePolicy[];
 
 export type HttpMethod = "GET" | "POST" | "PUT" | "PATCH" | "DELETE" | "HEAD" | "OPTIONS";
 

--- a/packages/framework/test/revalidation.test.ts
+++ b/packages/framework/test/revalidation.test.ts
@@ -1,9 +1,11 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  createRevalidationSingleFlight,
   getTimeRevalidateSeconds,
   hasWebhookRevalidate,
   isAuthorizedRevalidationRequest,
+  isCacheableISGResponse,
   normalizeRouteRevalidate,
   readRevalidationRequest,
   timeRevalidate,
@@ -79,5 +81,85 @@ describe("revalidation endpoint auth", () => {
     );
 
     expect(authorized).toEqual({ ok: true, paths: ["/pricing"] });
+  });
+});
+
+describe("createRevalidationSingleFlight", () => {
+  it("collapses concurrent tasks for the same key into one execution", async () => {
+    const singleFlight = createRevalidationSingleFlight();
+    let executions = 0;
+    let release!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+
+    const task = async () => {
+      executions += 1;
+      await gate;
+      return executions;
+    };
+
+    const first = singleFlight("/pricing", task);
+    const second = singleFlight("/pricing", task);
+    const other = singleFlight("/other", async () => {
+      executions += 1;
+      return executions;
+    });
+
+    release();
+    await expect(Promise.all([first, second, other])).resolves.toBeDefined();
+    expect(executions).toBe(2);
+    await expect(first).resolves.toBe(await second);
+  });
+
+  it("allows a new run after the previous one settles, including rejections", async () => {
+    const singleFlight = createRevalidationSingleFlight();
+    let executions = 0;
+
+    await expect(
+      singleFlight("/pricing", async () => {
+        executions += 1;
+        throw new Error("boom");
+      }),
+    ).rejects.toThrow("boom");
+
+    await expect(
+      singleFlight("/pricing", async () => {
+        executions += 1;
+        return "ok";
+      }),
+    ).resolves.toBe("ok");
+    expect(executions).toBe(2);
+  });
+});
+
+describe("isCacheableISGResponse", () => {
+  it("accepts plain shared-cacheable HTML responses", () => {
+    expect(
+      isCacheableISGResponse(
+        new Response("<html></html>", {
+          headers: { "content-type": "text/html", vary: "accept-encoding" },
+        }),
+      ),
+    ).toBe(true);
+  });
+
+  it("rejects responses that depend on per-request state", () => {
+    expect(
+      isCacheableISGResponse(new Response("x", { headers: { "cache-control": "no-store" } })),
+    ).toBe(false);
+    expect(
+      isCacheableISGResponse(
+        new Response("x", { headers: { "cache-control": "private, max-age=60" } }),
+      ),
+    ).toBe(false);
+    expect(
+      isCacheableISGResponse(new Response("x", { headers: { "set-cookie": "session=abc" } })),
+    ).toBe(false);
+    expect(isCacheableISGResponse(new Response("x", { headers: { vary: "Cookie" } }))).toBe(false);
+    expect(
+      isCacheableISGResponse(new Response("x", { headers: { vary: "Accept, Authorization" } })),
+    ).toBe(false);
+    expect(isCacheableISGResponse(new Response("x", { headers: { vary: "*" } }))).toBe(false);
   });
 });

--- a/packages/framework/test/revalidation.test.ts
+++ b/packages/framework/test/revalidation.test.ts
@@ -82,6 +82,43 @@ describe("revalidation endpoint auth", () => {
 
     expect(authorized).toEqual({ ok: true, paths: ["/pricing"] });
   });
+
+  it("rejects traversal segments and backslashes in paths", async () => {
+    const invalidPaths = [
+      "/../secret",
+      "/pricing/../admin",
+      "/pricing/..",
+      "/..",
+      "/pricing\\admin",
+      "\\pricing",
+      "/pricing\\..\\admin",
+    ];
+
+    for (const path of invalidPaths) {
+      const parsed = await readRevalidationRequest(
+        new Request("https://app.example/__pracht/revalidate", {
+          body: JSON.stringify({ paths: [path] }),
+          headers: { authorization: "Bearer secret" },
+          method: "POST",
+        }),
+        "secret",
+      );
+
+      expect(parsed.ok, `expected ${JSON.stringify(path)} to be rejected`).toBe(false);
+      if (!parsed.ok) expect(parsed.response.status).toBe(400);
+    }
+
+    // Dots that are not a bare `..` segment stay valid.
+    const parsed = await readRevalidationRequest(
+      new Request("https://app.example/__pracht/revalidate", {
+        body: JSON.stringify({ paths: ["/docs/v1..2/notes.txt"] }),
+        headers: { authorization: "Bearer secret" },
+        method: "POST",
+      }),
+      "secret",
+    );
+    expect(parsed).toEqual({ ok: true, paths: ["/docs/v1..2/notes.txt"] });
+  });
 });
 
 describe("createRevalidationSingleFlight", () => {

--- a/packages/framework/test/revalidation.test.ts
+++ b/packages/framework/test/revalidation.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  getTimeRevalidateSeconds,
+  hasWebhookRevalidate,
+  isAuthorizedRevalidationRequest,
+  normalizeRouteRevalidate,
+  readRevalidationRequest,
+  timeRevalidate,
+  webhookRevalidate,
+} from "@pracht/core";
+
+describe("revalidation policies", () => {
+  it("supports combining time and webhook revalidation", () => {
+    const policy = [timeRevalidate(60), webhookRevalidate()] as const;
+
+    expect(normalizeRouteRevalidate(policy)).toEqual([
+      { kind: "time", seconds: 60 },
+      { kind: "webhook" },
+    ]);
+    expect(getTimeRevalidateSeconds(policy)).toBe(60);
+    expect(hasWebhookRevalidate(policy)).toBe(true);
+  });
+
+  it("rejects invalid literal policy objects", () => {
+    expect(() => normalizeRouteRevalidate({ kind: "time", seconds: 0 } as never)).toThrow(
+      "positive integer",
+    );
+    expect(() =>
+      normalizeRouteRevalidate([{ kind: "webhook" }, { kind: "webhook" }] as never),
+    ).toThrow('duplicate "webhook"');
+    expect(() => normalizeRouteRevalidate({ kind: "cms" } as never)).toThrow(
+      'Unsupported route revalidate policy "cms"',
+    );
+  });
+});
+
+describe("revalidation endpoint auth", () => {
+  it("accepts a valid bearer token", () => {
+    const request = new Request("https://app.example/__pracht/revalidate", {
+      headers: { authorization: "Bearer secret" },
+      method: "POST",
+    });
+
+    expect(isAuthorizedRevalidationRequest(request, "secret")).toBe(true);
+  });
+
+  it("rejects bad and missing server tokens", () => {
+    const request = new Request("https://app.example/__pracht/revalidate", {
+      headers: { authorization: "Bearer wrong" },
+      method: "POST",
+    });
+
+    expect(isAuthorizedRevalidationRequest(request, "secret")).toBe(false);
+    expect(isAuthorizedRevalidationRequest(request, undefined)).toBe(false);
+    expect(isAuthorizedRevalidationRequest(request, "")).toBe(false);
+  });
+
+  it("parses paths only after authorization", async () => {
+    const unauthorized = await readRevalidationRequest(
+      new Request("https://app.example/__pracht/revalidate", {
+        body: JSON.stringify({ paths: ["/pricing"] }),
+        headers: { authorization: "Bearer wrong" },
+        method: "POST",
+      }),
+      "secret",
+    );
+
+    expect(unauthorized.ok).toBe(false);
+    if (!unauthorized.ok) expect(unauthorized.response.status).toBe(401);
+
+    const authorized = await readRevalidationRequest(
+      new Request("https://app.example/__pracht/revalidate", {
+        body: JSON.stringify({ paths: ["/pricing", "/pricing"] }),
+        headers: { authorization: "Bearer secret" },
+        method: "POST",
+      }),
+      "secret",
+    );
+
+    expect(authorized).toEqual({ ok: true, paths: ["/pricing"] });
+  });
+});


### PR DESCRIPTION
## Summary

- Add webhook ISG revalidation across core and built-in adapters.
- Add Cloudflare Cache API runtime ISG and Vercel prerender output artifacts.
- Link the relevant issue: N/A

## Testing

- [x] `pnpm e2e`
- [x] `pnpm format`
- [x] `pnpm lint`
- [x] `pnpm test`

## Checklist

- [x] Docs updated if needed
- [x] Skills updated if needed (N/A)
- [x] Changeset added if published packages changed
