### PR TITLE
create-pracht polish: Tailwind option, templates, git init, and a Node Dockerfile

### DIFF
--- a/.changeset/create-pracht-polish.md
+++ b/.changeset/create-pracht-polish.md
@@ -1,0 +1,10 @@
+---
+"create-pracht": minor
+---
+
+Polish the starter CLI:
+
+- Add a Tailwind CSS option — a yes/no prompt plus `--tailwind` / `--no-tailwind` flags — that wires `tailwindcss` and `@tailwindcss/vite` into `vite.config.ts`, generates `src/styles/global.css`, and imports it from the shell.
+- Add a `--template=minimal|tailwind` flag as the non-interactive umbrella (minimal is the current output, tailwind adds the Tailwind wiring).
+- Initialize a git repository with an "Initial commit from create-pracht" commit after scaffolding, skipped with `--no-git`, when git is unavailable, or when the target directory is already inside a repository.
+- Generate a multi-stage `Dockerfile` and `.dockerignore` for Node adapter scaffolds, and document `docker build` in the generated README.

--- a/README.md
+++ b/README.md
@@ -82,6 +82,8 @@ Same render modes, same adapters — just let the filesystem drive.
 npm create pracht@latest my-app
 ```
 
+The prompts cover the target directory, hosting adapter (Node.js, Cloudflare Workers, Vercel), router (manifest or pages), and optional Tailwind CSS. For non-interactive runs pass flags instead — e.g. `--template=tailwind` (or `--template=minimal`), `--adapter=node`, `--no-git`, `--yes`. See [packages/start/README.md](packages/start/README.md) for the full list.
+
 The starter gives you:
 
 - `pracht dev` — local SSR + HMR
@@ -90,6 +92,7 @@ The starter gives you:
 - `pracht generate route|shell|middleware|api` — framework-native scaffolding
 - `pracht verify` — fast framework-aware checks with `--changed` and `--json`
 - `pracht doctor` — app wiring checks with optional JSON output
+- Optional Tailwind CSS wiring, a git repo with an initial commit, and (for the Node adapter) a multi-stage `Dockerfile`
 
 ## Repo map
 

--- a/packages/start/README.md
+++ b/packages/start/README.md
@@ -16,7 +16,9 @@ npm run dev
 - Prompts for the target folder.
 - Detects the active package manager from the current environment.
 - Lets the user choose between the Node.js, Cloudflare, and Vercel adapters.
+- Optionally wires up Tailwind CSS (`tailwindcss` + `@tailwindcss/vite`, a global stylesheet, and the shell import).
 - Scaffolds a minimal app with a route manifest or pages router, shell, home route, sample API route, runnable project README, and agent instructions.
+- Initializes a git repository with an initial commit (skipped with `--no-git`, when git is unavailable, or when the target is already inside a repository).
 - `--dry-run` uses pinned fallback versions and does not require npm registry access.
 
 ## Usage
@@ -25,7 +27,21 @@ npm run dev
 node ./packages/start/bin/create-pracht.js
 node ./packages/start/bin/create-pracht.js my-app --adapter=node --skip-install
 node ./packages/start/bin/create-pracht.js my-app --adapter=vercel --skip-install
+node ./packages/start/bin/create-pracht.js my-app --template=tailwind --yes
+node ./packages/start/bin/create-pracht.js my-app --adapter=node --no-tailwind --no-git --yes
 ```
+
+## Options
+
+- `--adapter=node|cf|vercel` — choose the hosting adapter (default: node).
+- `--router=manifest|pages` — choose the routing system (default: manifest).
+- `--template=minimal|tailwind` — non-interactive template selection; `minimal` is the default output, `tailwind` is minimal plus Tailwind CSS wiring.
+- `--tailwind` / `--no-tailwind` — enable or disable Tailwind CSS without going through the prompt.
+- `--no-git` — skip `git init` and the initial commit.
+- `--skip-install` — skip dependency installation.
+- `--yes`, `-y` — accept defaults (node adapter, manifest router, no Tailwind) and skip all prompts.
+- `--json` — output a JSON summary instead of prose.
+- `--dry-run` — list the files that would be created without writing anything.
 
 ## Generated Files
 
@@ -35,6 +51,16 @@ node ./packages/start/bin/create-pracht.js my-app --adapter=vercel --skip-instal
 - `src/routes/home.tsx`
 - `src/shells/public.tsx`
 - `src/api/health.ts`
+- `.gitignore`
+
+Node scaffolds also include:
+
+- `Dockerfile` — multi-stage build (install → build → slim runtime) that runs `node dist/server/server.js`
+- `.dockerignore`
+
+Tailwind scaffolds also include:
+
+- `src/styles/global.css` — the Tailwind entry stylesheet, imported by the shell
 
 Cloudflare scaffolds also include:
 

--- a/packages/start/src/index.js
+++ b/packages/start/src/index.js
@@ -18,6 +18,8 @@ const FALLBACK_VERSION_RANGES = {
   "@pracht/cli": "^1.3.1",
   "@pracht/core": "^0.5.0",
   "@pracht/vite-plugin": "^0.3.2",
+  "@tailwindcss/vite": "^4.1.0",
+  tailwindcss: "^4.1.0",
   vercel: "latest",
 };
 
@@ -68,12 +70,19 @@ export async function run(argv = process.argv.slice(2)) {
   const dir = options.dir ?? (options.yes ? DEFAULT_DIRECTORY : null);
   const adapterId = options.adapter ?? (options.yes ? "node" : null);
   const router = options.router ?? (options.yes ? "manifest" : null);
+  const tailwind = options.tailwind ?? (options.yes ? false : null);
 
   let resolvedDir = dir;
   let resolvedAdapter = adapterId;
   let resolvedRouter = router;
+  let resolvedTailwind = tailwind;
 
-  if (resolvedDir == null || resolvedAdapter == null || resolvedRouter == null) {
+  if (
+    resolvedDir == null ||
+    resolvedAdapter == null ||
+    resolvedRouter == null ||
+    resolvedTailwind == null
+  ) {
     const readline = createInterface({
       input: process.stdin,
       output: process.stdout,
@@ -83,6 +92,7 @@ export async function run(argv = process.argv.slice(2)) {
       resolvedDir = resolvedDir ?? (await promptForDirectory(readline));
       resolvedAdapter = resolvedAdapter ?? (await promptForAdapter(readline));
       resolvedRouter = resolvedRouter ?? (await promptForRouter(readline));
+      resolvedTailwind = resolvedTailwind ?? (await promptForTailwind(readline));
     } finally {
       readline.close();
     }
@@ -99,6 +109,7 @@ export async function run(argv = process.argv.slice(2)) {
       projectName: toPackageName(basename(targetDir)),
       resolveRemoteVersions: false,
       router: resolvedRouter,
+      tailwind: resolvedTailwind,
     });
 
     const fileList = Object.keys(files).sort();
@@ -111,6 +122,7 @@ export async function run(argv = process.argv.slice(2)) {
           dryRun: true,
           files: fileList,
           router: resolvedRouter,
+          tailwind: resolvedTailwind,
         }),
       );
     } else {
@@ -128,6 +140,7 @@ export async function run(argv = process.argv.slice(2)) {
     adapter: ADAPTERS[resolvedAdapter],
     packageManager,
     router: resolvedRouter,
+    tailwind: resolvedTailwind,
     targetDir,
   });
 
@@ -138,6 +151,23 @@ export async function run(argv = process.argv.slice(2)) {
     installSucceeded = await installDependencies(targetDir, packageManager);
   }
 
+  let gitInitialized = false;
+  if (options.git) {
+    const gitResult = await initGitRepository(targetDir);
+    gitInitialized = gitResult.initialized;
+
+    if (gitResult.initialized) {
+      log("");
+      log("Initialized a git repository with an initial commit.");
+    } else if (gitResult.reason === "existing-repo") {
+      log("");
+      log("Skipped git init — the target directory is already inside a git repository.");
+    } else if (gitResult.reason === "git-not-found") {
+      log("");
+      log("Skipped git init — git is not available on this machine.");
+    }
+  }
+
   if (options.json) {
     const files = await buildProjectFiles({
       adapter: ADAPTERS[resolvedAdapter],
@@ -145,6 +175,7 @@ export async function run(argv = process.argv.slice(2)) {
       projectName: toPackageName(basename(targetDir)),
       resolveRemoteVersions: false,
       router: resolvedRouter,
+      tailwind: resolvedTailwind,
     });
 
     console.log(
@@ -152,8 +183,10 @@ export async function run(argv = process.argv.slice(2)) {
         adapter: resolvedAdapter,
         directory: resolvedDir,
         files: Object.keys(files).sort(),
+        gitInitialized,
         installed: options.skipInstall ? false : installSucceeded,
         router: resolvedRouter,
+        tailwind: resolvedTailwind,
       }),
     );
   } else {
@@ -167,13 +200,20 @@ export async function run(argv = process.argv.slice(2)) {
   }
 }
 
-export async function scaffoldProject({ adapter, packageManager, router = "manifest", targetDir }) {
+export async function scaffoldProject({
+  adapter,
+  packageManager,
+  router = "manifest",
+  tailwind = false,
+  targetDir,
+}) {
   const packageName = toPackageName(basename(targetDir));
   const files = await buildProjectFiles({
     adapter,
     packageManager,
     projectName: packageName,
     router,
+    tailwind,
   });
 
   await mkdir(targetDir, { recursive: true });
@@ -207,15 +247,43 @@ export function parseArgs(argv) {
     adapter: undefined,
     dir: undefined,
     dryRun: false,
+    git: true,
     json: false,
     router: undefined,
     skipInstall: false,
+    tailwind: undefined,
     yes: false,
   };
 
   for (const arg of argv) {
     if (arg === "--skip-install") {
       options.skipInstall = true;
+      continue;
+    }
+
+    if (arg === "--tailwind") {
+      options.tailwind = true;
+      continue;
+    }
+
+    if (arg === "--no-tailwind") {
+      options.tailwind = false;
+      continue;
+    }
+
+    if (arg === "--no-git") {
+      options.git = false;
+      continue;
+    }
+
+    if (arg.startsWith("--template=")) {
+      const value = normalizeTemplate(arg.slice("--template=".length));
+      if (!value) {
+        throw new ValidationError(
+          `Invalid template: ${arg.slice("--template=".length)}. Use minimal or tailwind.`,
+        );
+      }
+      options.tailwind = value === "tailwind";
       continue;
     }
 
@@ -322,6 +390,33 @@ async function promptForRouter(readline) {
   }
 }
 
+async function promptForTailwind(readline) {
+  while (true) {
+    const answer = await readline.question("Use Tailwind CSS? (y/N): ");
+    const normalized = normalizeYesNo(answer.trim() || "no");
+
+    if (normalized != null) {
+      return normalized;
+    }
+
+    console.log("Answer y/yes or n/no.");
+  }
+}
+
+function normalizeYesNo(value) {
+  const normalized = value.toLowerCase();
+
+  if (normalized === "y" || normalized === "yes") {
+    return true;
+  }
+
+  if (normalized === "n" || normalized === "no") {
+    return false;
+  }
+
+  return null;
+}
+
 async function ensureTargetDirectory(targetDir) {
   const error = await validateTargetDirectory(targetDir);
 
@@ -343,6 +438,20 @@ async function validateTargetDirectory(targetDir) {
   const entries = await readdir(targetDir);
   if (entries.length > 0) {
     return "Target directory already exists and is not empty.";
+  }
+
+  return null;
+}
+
+function normalizeTemplate(value) {
+  const normalized = value.toLowerCase();
+
+  if (normalized === "minimal") {
+    return "minimal";
+  }
+
+  if (normalized === "tailwind") {
+    return "tailwind";
   }
 
   return null;
@@ -406,6 +515,7 @@ async function buildProjectFiles({
   projectName,
   resolveRemoteVersions = true,
   router,
+  tailwind = false,
 }) {
   const packagesToResolve = [
     "@pracht/cli",
@@ -416,26 +526,33 @@ async function buildProjectFiles({
   if (adapter.id === "vercel") {
     packagesToResolve.push("vercel");
   }
+  if (tailwind) {
+    packagesToResolve.push("tailwindcss", "@tailwindcss/vite");
+  }
 
   const versions = await resolveVersions(packagesToResolve, { remote: resolveRemoteVersions });
 
   const files = {
     ".gitignore": "dist\nnode_modules\n.wrangler\n.vercel\n.env*\n!.env.example\n.dev.vars\n",
-    "README.md": createReadme({ adapter, packageManager, projectName, router }),
-    "package.json": createPackageJson({ adapter, projectName, versions }),
+    "README.md": createReadme({ adapter, packageManager, projectName, router, tailwind }),
+    "package.json": createPackageJson({ adapter, projectName, tailwind, versions }),
     "src/api/health.ts": createHealthRoute(adapter),
-    "vite.config.ts": createViteConfig(adapter, router),
+    "vite.config.ts": createViteConfig(adapter, router, tailwind),
     "tsconfig.json": createBaseTSConfig(adapter),
-    "AGENTS.md": createAgentInstructions({ adapter, packageManager, router }),
+    "AGENTS.md": createAgentInstructions({ adapter, packageManager, router, tailwind }),
   };
 
   if (router === "pages") {
-    files["src/pages/_app.tsx"] = createShellFile(projectName);
+    files["src/pages/_app.tsx"] = createShellFile(projectName, tailwind);
     files["src/pages/index.tsx"] = createPagesHomeRoute(adapter);
   } else {
     files["src/routes.ts"] = createRoutesFile();
     files["src/routes/home.tsx"] = createHomeRoute(adapter);
-    files["src/shells/public.tsx"] = createShellFile(projectName);
+    files["src/shells/public.tsx"] = createShellFile(projectName, tailwind);
+  }
+
+  if (tailwind) {
+    files["src/styles/global.css"] = '@import "tailwindcss";\n';
   }
 
   if (adapter.id === "cloudflare") {
@@ -443,10 +560,15 @@ async function buildProjectFiles({
     files["src/env.d.ts"] = createCloudflareEnvDeclaration();
   }
 
+  if (adapter.id === "node") {
+    files["Dockerfile"] = createDockerfile(packageManager);
+    files[".dockerignore"] = createDockerignore();
+  }
+
   return files;
 }
 
-function createPackageJson({ adapter, projectName, versions }) {
+function createPackageJson({ adapter, projectName, tailwind, versions }) {
   const scripts = {
     build: "pracht build",
     dev: "pracht dev",
@@ -474,6 +596,11 @@ function createPackageJson({ adapter, projectName, versions }) {
     devDependencies.vercel = versions["vercel"];
   }
 
+  if (tailwind) {
+    devDependencies["@tailwindcss/vite"] = versions["@tailwindcss/vite"];
+    devDependencies.tailwindcss = versions["tailwindcss"];
+  }
+
   return `${JSON.stringify(
     {
       dependencies: {
@@ -492,7 +619,7 @@ function createPackageJson({ adapter, projectName, versions }) {
   )}\n`;
 }
 
-function createViteConfig(adapter, router) {
+function createViteConfig(adapter, router, tailwind) {
   const ADAPTER_IMPORTS = {
     node: { fn: "nodeAdapter", pkg: "@pracht/adapter-node" },
     cloudflare: { fn: "cloudflareAdapter", pkg: "@pracht/adapter-cloudflare" },
@@ -506,16 +633,23 @@ function createViteConfig(adapter, router) {
       ? `{ pagesDir: "/src/pages", adapter: ${info.fn}() }`
       : `{ adapter: ${info.fn}() }`;
 
-  return [
+  const plugins = tailwind
+    ? `[pracht(${prachtOptions}), tailwindcss()]`
+    : `[pracht(${prachtOptions})]`;
+
+  const lines = [
     'import { defineConfig } from "vite";',
     'import { pracht } from "@pracht/vite-plugin";',
     `import { ${info.fn} } from "${info.pkg}";`,
-    "",
-    "export default defineConfig({",
-    `  plugins: [pracht(${prachtOptions})],`,
-    "});",
-    "",
-  ].join("\n");
+  ];
+
+  if (tailwind) {
+    lines.push('import tailwindcss from "@tailwindcss/vite";');
+  }
+
+  lines.push("", "export default defineConfig({", `  plugins: ${plugins},`, "});", "");
+
+  return lines.join("\n");
 }
 
 function createRoutesFile() {
@@ -534,9 +668,15 @@ function createRoutesFile() {
   ].join("\n");
 }
 
-function createShellFile(projectName) {
+function createShellFile(projectName, tailwind = false) {
+  const lines = ['import type { ShellProps } from "@pracht/core";'];
+
+  if (tailwind) {
+    lines.push('import "../styles/global.css";');
+  }
+
   return [
-    'import type { ShellProps } from "@pracht/core";',
+    ...lines,
     "",
     "export function Shell({ children }: ShellProps) {",
     "  return (",
@@ -705,7 +845,80 @@ function createCloudflareEnvDeclaration() {
   ].join("\n");
 }
 
-function createAgentInstructions({ adapter, packageManager, router }) {
+function createDockerfile(packageManager) {
+  const COMMANDS = {
+    npm: {
+      build: "npm run build",
+      install: "npm install",
+      lockfile: "package-lock.json*",
+      prune: "npm prune --omit=dev",
+      setup: null,
+    },
+    pnpm: {
+      build: "pnpm build",
+      install: "pnpm install",
+      lockfile: "pnpm-lock.yaml*",
+      prune: "pnpm prune --prod",
+      setup: "corepack enable pnpm",
+    },
+    yarn: {
+      build: "yarn build",
+      install: "yarn install",
+      lockfile: "yarn.lock*",
+      prune: "yarn install --production --ignore-scripts --prefer-offline",
+      setup: "corepack enable yarn",
+    },
+  };
+
+  // The runtime image ships Node.js, so bun scaffolds fall back to npm inside Docker.
+  const commands = COMMANDS[packageManager] ?? COMMANDS.npm;
+
+  const lines = ["# syntax=docker/dockerfile:1", "", "FROM node:22-alpine AS base", "WORKDIR /app"];
+
+  if (commands.setup) {
+    lines.push(`RUN ${commands.setup}`);
+  }
+
+  lines.push(
+    "",
+    "FROM base AS deps",
+    `COPY package.json ${commands.lockfile} ./`,
+    `RUN ${commands.install}`,
+    "",
+    "FROM deps AS build",
+    "COPY . .",
+    `RUN ${commands.build}`,
+    `RUN ${commands.prune}`,
+    "",
+    "FROM node:22-alpine AS runtime",
+    "WORKDIR /app",
+    "ENV NODE_ENV=production",
+    "ENV PORT=3000",
+    "COPY --from=build /app/package.json ./package.json",
+    "COPY --from=build /app/node_modules ./node_modules",
+    "COPY --from=build /app/dist ./dist",
+    "EXPOSE 3000",
+    'CMD ["node", "dist/server/server.js"]',
+    "",
+  );
+
+  return lines.join("\n");
+}
+
+function createDockerignore() {
+  return [
+    "node_modules",
+    "dist",
+    ".git",
+    ".env*",
+    "!.env.example",
+    "Dockerfile",
+    ".dockerignore",
+    "",
+  ].join("\n");
+}
+
+function createAgentInstructions({ adapter, packageManager, router, tailwind }) {
   const runCmd = packageManager === "npm" ? "npm run" : packageManager;
 
   const lines = [
@@ -756,6 +969,14 @@ function createAgentInstructions({ adapter, packageManager, router }) {
   lines.push("- `src/api/` — API route handlers");
   lines.push(`- \`vite.config.ts\` — Vite config with the ${adapter.label} adapter`);
 
+  if (tailwind) {
+    lines.push("- `src/styles/global.css` — Tailwind CSS entry stylesheet, imported by the shell");
+  }
+
+  if (adapter.id === "node") {
+    lines.push("- `Dockerfile` — multi-stage container build that runs the built server");
+  }
+
   if (adapter.id === "cloudflare") {
     lines.push("- `wrangler.jsonc` — Cloudflare Workers configuration");
     lines.push("- `src/env.d.ts` — TypeScript types for Cloudflare bindings");
@@ -766,7 +987,7 @@ function createAgentInstructions({ adapter, packageManager, router }) {
   return lines.join("\n");
 }
 
-function createReadme({ adapter, packageManager, projectName, router }) {
+function createReadme({ adapter, packageManager, projectName, router, tailwind }) {
   const installCommand = packageManager === "npm" ? "npm install" : `${packageManager} install`;
   const devCommand = packageManager === "npm" ? "npm run dev" : `${packageManager} dev`;
   const startCommand = packageManager === "npm" ? "npm run start" : `${packageManager} start`;
@@ -816,7 +1037,77 @@ function createReadme({ adapter, packageManager, projectName, router }) {
 
   lines.push("- `src/api/health.ts` is a sample API route.");
 
+  if (tailwind) {
+    lines.push("- `src/styles/global.css` is the Tailwind CSS entry, imported by the shell.");
+  }
+
+  if (adapter.id === "node") {
+    lines.push("");
+    lines.push("## Docker");
+    lines.push("");
+    lines.push("A multi-stage `Dockerfile` builds the app and runs the Node server:");
+    lines.push("");
+    lines.push("```bash");
+    lines.push(`docker build -t ${projectName} .`);
+    lines.push(`docker run -p 3000:3000 ${projectName}`);
+    lines.push("```");
+  }
+
   return `${lines.join("\n")}\n`;
+}
+
+export async function initGitRepository(targetDir) {
+  if (!(await execCommand("git", ["--version"]))) {
+    return { initialized: false, reason: "git-not-found" };
+  }
+
+  if (await execCommand("git", ["rev-parse", "--is-inside-work-tree"], targetDir)) {
+    return { initialized: false, reason: "existing-repo" };
+  }
+
+  if (!(await execCommand("git", ["init"], targetDir))) {
+    return { initialized: false, reason: "init-failed" };
+  }
+
+  if (!(await execCommand("git", ["add", "-A"], targetDir))) {
+    return { initialized: false, reason: "commit-failed" };
+  }
+
+  // Fall back to a scoped identity when the user has no git identity configured,
+  // so the initial commit still succeeds (e.g. on fresh machines or CI).
+  const hasIdentity = await execCommand("git", ["config", "user.email"], targetDir);
+  const identityArgs = hasIdentity
+    ? []
+    : ["-c", "user.name=create-pracht", "-c", "user.email=create-pracht@localhost"];
+
+  const committed = await execCommand(
+    "git",
+    [...identityArgs, "commit", "-m", "Initial commit from create-pracht"],
+    targetDir,
+  );
+
+  if (!committed) {
+    return { initialized: false, reason: "commit-failed" };
+  }
+
+  return { initialized: true };
+}
+
+function execCommand(command, args, cwd) {
+  return new Promise((resolveExec) => {
+    const child = spawn(command, args, {
+      cwd,
+      stdio: "ignore",
+    });
+
+    child.on("close", (code) => {
+      resolveExec(code === 0);
+    });
+
+    child.on("error", () => {
+      resolveExec(false);
+    });
+  });
 }
 
 async function installDependencies(targetDir, packageManager) {
@@ -868,13 +1159,16 @@ Usage:
   create-pracht [directory] [options]
 
 Options:
-  --adapter=node|cf|vercel   Choose hosting adapter (default: node)
-  --router=manifest|pages    Choose routing system (default: manifest)
-  --skip-install             Skip dependency installation
-  --yes, -y                  Accept defaults, skip all prompts
-  --json                     Output JSON summary instead of prose
-  --dry-run                  Show which files would be created without writing
-  -h, --help                 Show this help message
+  --adapter=node|cf|vercel     Choose hosting adapter (default: node)
+  --router=manifest|pages      Choose routing system (default: manifest)
+  --template=minimal|tailwind  Choose starter template (minimal, or minimal + Tailwind CSS)
+  --tailwind / --no-tailwind   Enable or disable Tailwind CSS wiring (default: prompt)
+  --no-git                     Skip git init and the initial commit
+  --skip-install               Skip dependency installation
+  --yes, -y                    Accept defaults, skip all prompts
+  --json                       Output JSON summary instead of prose
+  --dry-run                    Show which files would be created without writing
+  -h, --help                   Show this help message
 `);
 }
 

--- a/packages/start/test/index.test.js
+++ b/packages/start/test/index.test.js
@@ -1,11 +1,27 @@
+import { execFileSync } from "node:child_process";
 import { existsSync } from "node:fs";
 import { mkdtemp, readFile, readlink } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
-import { ValidationError, getPackageManager, parseArgs, scaffoldProject } from "../src/index.js";
+import {
+  ValidationError,
+  getPackageManager,
+  initGitRepository,
+  parseArgs,
+  run,
+  scaffoldProject,
+} from "../src/index.js";
+
+const NODE_ADAPTER = {
+  description: "Node.js server with a generated server entry",
+  id: "node",
+  label: "Node.js",
+  packageName: "@pracht/adapter-node",
+  short: "node",
+};
 
 describe("create-pracht", () => {
   it("detects the package manager from the npm user agent", () => {
@@ -44,6 +60,23 @@ describe("create-pracht", () => {
     expect(gitignore).toContain(".dev.vars");
     expect(routes).toContain('route("/", "./routes/home.tsx"');
     expect(existsSync(join(targetDir, "wrangler.jsonc"))).toBe(false);
+
+    const dockerfile = await readFile(join(targetDir, "Dockerfile"), "utf-8");
+    const dockerignore = await readFile(join(targetDir, ".dockerignore"), "utf-8");
+    const readme = await readFile(join(targetDir, "README.md"), "utf-8");
+    expect(dockerfile).toContain("FROM node:22-alpine AS base");
+    expect(dockerfile).toContain("corepack enable pnpm");
+    expect(dockerfile).toContain("RUN pnpm install");
+    expect(dockerfile).toContain("RUN pnpm build");
+    expect(dockerfile).toContain('CMD ["node", "dist/server/server.js"]');
+    expect(dockerignore).toContain("node_modules");
+    expect(dockerignore).toContain(".env*");
+    expect(readme).toContain("docker build");
+
+    const viteConfig = await readFile(join(targetDir, "vite.config.ts"), "utf-8");
+    expect(viteConfig).not.toContain("tailwindcss");
+    expect(existsSync(join(targetDir, "src/styles/global.css"))).toBe(false);
+    expect(packageJson).not.toContain("tailwindcss");
 
     const agents = await readFile(join(targetDir, "AGENTS.md"), "utf-8");
     expect(agents).toContain("manifest routing");
@@ -107,6 +140,8 @@ describe("create-pracht", () => {
     expect(packageJson).not.toContain('"@cloudflare/vite-plugin"');
     expect(wranglerConfig).toContain('"main": "dist/server/server.js"');
     expect(existsSync(join(targetDir, "wrangler.jsonc"))).toBe(true);
+    expect(existsSync(join(targetDir, "Dockerfile"))).toBe(false);
+    expect(existsSync(join(targetDir, ".dockerignore"))).toBe(false);
 
     const tsconfig = await readFile(join(targetDir, "tsconfig.json"), "utf-8");
     expect(tsconfig).toMatchInlineSnapshot(`
@@ -169,6 +204,8 @@ describe("create-pracht", () => {
     expect(readme).toContain("configured for Vercel");
     expect(readme).toContain("pnpm deploy");
     expect(existsSync(join(targetDir, "wrangler.jsonc"))).toBe(false);
+    expect(existsSync(join(targetDir, "Dockerfile"))).toBe(false);
+    expect(existsSync(join(targetDir, ".dockerignore"))).toBe(false);
 
     const tsconfig = await readFile(join(targetDir, "tsconfig.json"), "utf-8");
     expect(tsconfig).toMatchInlineSnapshot(`
@@ -228,6 +265,156 @@ describe("create-pracht", () => {
     expect(agents).toContain("src/pages/");
   });
 
+  it("scaffolds a tailwind starter with the manifest router", async () => {
+    const root = await mkdtemp(join(tmpdir(), "pracht-start-tailwind-"));
+    const targetDir = join(root, "my-tailwind-app");
+
+    await scaffoldProject({
+      adapter: NODE_ADAPTER,
+      packageManager: "pnpm",
+      tailwind: true,
+      targetDir,
+    });
+
+    const packageJson = await readFile(join(targetDir, "package.json"), "utf-8");
+    const viteConfig = await readFile(join(targetDir, "vite.config.ts"), "utf-8");
+    const globalCss = await readFile(join(targetDir, "src/styles/global.css"), "utf-8");
+    const shell = await readFile(join(targetDir, "src/shells/public.tsx"), "utf-8");
+    const readme = await readFile(join(targetDir, "README.md"), "utf-8");
+
+    expect(packageJson).toMatch(/"tailwindcss": "\^\d+\.\d+\.\d+"/);
+    expect(packageJson).toMatch(/"@tailwindcss\/vite": "\^\d+\.\d+\.\d+"/);
+    expect(viteConfig).toContain('import tailwindcss from "@tailwindcss/vite";');
+    expect(viteConfig).toContain("plugins: [pracht({ adapter: nodeAdapter() }), tailwindcss()]");
+    expect(globalCss).toBe('@import "tailwindcss";\n');
+    expect(shell).toContain('import "../styles/global.css";');
+    expect(readme).toContain("src/styles/global.css");
+
+    const agents = await readFile(join(targetDir, "AGENTS.md"), "utf-8");
+    expect(agents).toContain("src/styles/global.css");
+  });
+
+  it("scaffolds a tailwind starter with the pages router", async () => {
+    const root = await mkdtemp(join(tmpdir(), "pracht-start-tailwind-pages-"));
+    const targetDir = join(root, "my-tailwind-pages-app");
+
+    await scaffoldProject({
+      adapter: NODE_ADAPTER,
+      packageManager: "pnpm",
+      router: "pages",
+      tailwind: true,
+      targetDir,
+    });
+
+    const viteConfig = await readFile(join(targetDir, "vite.config.ts"), "utf-8");
+    const app = await readFile(join(targetDir, "src/pages/_app.tsx"), "utf-8");
+
+    expect(viteConfig).toContain(
+      'plugins: [pracht({ pagesDir: "/src/pages", adapter: nodeAdapter() }), tailwindcss()]',
+    );
+    expect(app).toContain('import "../styles/global.css";');
+    expect(existsSync(join(targetDir, "src/styles/global.css"))).toBe(true);
+  });
+
+  it("run --dry-run --json lists tailwind and docker files without writing", async () => {
+    const root = await mkdtemp(join(tmpdir(), "pracht-start-dry-run-"));
+    const targetDir = join(root, "my-dry-run-app");
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+    let output;
+    try {
+      await run([
+        targetDir,
+        "--adapter=node",
+        "--router=manifest",
+        "--template=tailwind",
+        "--dry-run",
+        "--json",
+      ]);
+      output = JSON.parse(logSpy.mock.calls.at(-1)[0]);
+    } finally {
+      logSpy.mockRestore();
+    }
+
+    expect(output.dryRun).toBe(true);
+    expect(output.tailwind).toBe(true);
+    expect(output.files).toContain("Dockerfile");
+    expect(output.files).toContain(".dockerignore");
+    expect(output.files).toContain("src/styles/global.css");
+    expect(output.files).toContain(".gitignore");
+    expect(existsSync(targetDir)).toBe(false);
+  });
+
+  it("run --dry-run --json omits tailwind files for the minimal template", async () => {
+    const root = await mkdtemp(join(tmpdir(), "pracht-start-dry-run-minimal-"));
+    const targetDir = join(root, "my-minimal-app");
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+    let output;
+    try {
+      await run([
+        targetDir,
+        "--adapter=vercel",
+        "--router=manifest",
+        "--template=minimal",
+        "--dry-run",
+        "--json",
+      ]);
+      output = JSON.parse(logSpy.mock.calls.at(-1)[0]);
+    } finally {
+      logSpy.mockRestore();
+    }
+
+    expect(output.tailwind).toBe(false);
+    expect(output.files).not.toContain("Dockerfile");
+    expect(output.files).not.toContain("src/styles/global.css");
+    expect(existsSync(targetDir)).toBe(false);
+  });
+
+  it("initializes a git repository with an initial commit", async () => {
+    const root = await mkdtemp(join(tmpdir(), "pracht-start-git-"));
+    const targetDir = join(root, "my-git-app");
+
+    await scaffoldProject({
+      adapter: NODE_ADAPTER,
+      packageManager: "pnpm",
+      targetDir,
+    });
+
+    const result = await initGitRepository(targetDir);
+
+    expect(result.initialized).toBe(true);
+    expect(existsSync(join(targetDir, ".git"))).toBe(true);
+
+    const subject = execFileSync("git", ["-C", targetDir, "log", "-1", "--format=%s"], {
+      encoding: "utf-8",
+    }).trim();
+    expect(subject).toBe("Initial commit from create-pracht");
+
+    const status = execFileSync("git", ["-C", targetDir, "status", "--porcelain"], {
+      encoding: "utf-8",
+    }).trim();
+    expect(status).toBe("");
+  });
+
+  it("skips git init inside an existing repository", async () => {
+    const root = await mkdtemp(join(tmpdir(), "pracht-start-git-skip-"));
+    execFileSync("git", ["-C", root, "init"], { encoding: "utf-8" });
+
+    const targetDir = join(root, "my-nested-app");
+    await scaffoldProject({
+      adapter: NODE_ADAPTER,
+      packageManager: "pnpm",
+      targetDir,
+    });
+
+    const result = await initGitRepository(targetDir);
+
+    expect(result.initialized).toBe(false);
+    expect(result.reason).toBe("existing-repo");
+    expect(existsSync(join(targetDir, ".git"))).toBe(false);
+  });
+
   it("parseArgs handles --yes flag", () => {
     const opts = parseArgs(["my-app", "--yes", "--skip-install"]);
     expect(opts.yes).toBe(true);
@@ -248,6 +435,32 @@ describe("create-pracht", () => {
   it("parseArgs handles --dry-run flag", () => {
     const opts = parseArgs(["my-app", "--dry-run"]);
     expect(opts.dryRun).toBe(true);
+  });
+
+  it("parseArgs handles --tailwind and --no-tailwind flags", () => {
+    expect(parseArgs([]).tailwind).toBeUndefined();
+    expect(parseArgs(["--tailwind"]).tailwind).toBe(true);
+    expect(parseArgs(["--no-tailwind"]).tailwind).toBe(false);
+  });
+
+  it("parseArgs handles --template flag", () => {
+    expect(parseArgs(["--template=minimal"]).tailwind).toBe(false);
+    expect(parseArgs(["--template=tailwind"]).tailwind).toBe(true);
+  });
+
+  it("parseArgs lets an explicit tailwind flag override --template", () => {
+    expect(parseArgs(["--template=tailwind", "--no-tailwind"]).tailwind).toBe(false);
+    expect(parseArgs(["--template=minimal", "--tailwind"]).tailwind).toBe(true);
+  });
+
+  it("parseArgs throws ValidationError for invalid template", () => {
+    expect(() => parseArgs(["--template=invalid"])).toThrow(ValidationError);
+    expect(() => parseArgs(["--template=invalid"])).toThrow(/Invalid template/);
+  });
+
+  it("parseArgs handles --no-git flag", () => {
+    expect(parseArgs([]).git).toBe(true);
+    expect(parseArgs(["--no-git"]).git).toBe(false);
   });
 
   it("parseArgs throws ValidationError for invalid adapter", () => {


### PR DESCRIPTION
## Summary

- Adds a Tailwind CSS option to the starter CLI: an interactive yes/no prompt plus `--tailwind` / `--no-tailwind` flags. When enabled, the scaffold wires `tailwindcss` + `@tailwindcss/vite` into `vite.config.ts`, generates `src/styles/global.css` (`@import "tailwindcss";`, per docs/STYLING.md), imports it from the shell (`src/shells/public.tsx` or `src/pages/_app.tsx`), and adds both packages to the generated `package.json` devDependencies (registry-resolved, with pinned fallbacks for `--dry-run`).
- Adds `--template=minimal|tailwind` as the non-interactive umbrella flag: `minimal` is the existing output, `tailwind` is minimal plus the Tailwind wiring. The prompt flow stays the default when no flags are given; invalid values raise a `ValidationError` like the other flags.
- Initializes a git repository after scaffolding (and after dependency install, so the lockfile lands in the initial commit): if `git` is available and the target directory is not already inside a repository, runs `git init`, stages everything, and creates an "Initial commit from create-pracht" commit. `--no-git` skips it. When no git identity is configured, the commit falls back to a scoped `-c user.name/user.email` so it still succeeds on fresh machines/CI. The existing generated `.gitignore` already covers `node_modules`, `dist`, and `.env*` (with `!.env.example`), so it is reused as-is.
- Generates a multi-stage `Dockerfile` (deps install → build + prod prune → slim `node:22-alpine` runtime running `node dist/server/server.js` on port 3000) and a `.dockerignore` for Node adapter scaffolds. The Dockerfile follows the detected package manager (npm/pnpm/yarn via corepack; bun falls back to npm inside the container), and the generated README documents `docker build` / `docker run`.
- JSON output (`--json`) now includes `tailwind` and, for real runs, `gitInitialized`.
- Docs updated: `packages/start/README.md` (new Options section, generated files) and the root README "Create an app" section. No skills describe scaffolding a new app (grepped for "create pracht" / "create-pracht"), so no skill changes were needed.
- Changeset added: `.changeset/create-pracht-polish.md` (`create-pracht`: minor).

No linked issue.

## Testing

- [x] `pnpm e2e`
- [x] `pnpm format`
- [x] `pnpm lint`
- [x] `pnpm test`

## Checklist

- [x] Docs updated if needed
- [x] Skills updated if needed (none reference scaffolding a new app)
- [x] Changeset added if published packages changed
