### PR TITLE
Add `pracht preview` to serve the production build locally

### DIFF
--- a/.changeset/preview-command.md
+++ b/.changeset/preview-command.md
@@ -1,0 +1,6 @@
+---
+"@pracht/cli": minor
+"create-pracht": minor
+---
+
+Add `pracht preview` to serve the production build locally with one command. It runs `pracht build` first (skippable with `--skip-build`) and then serves the output for the configured adapter: Node targets run `dist/server/server.js` as a child process (`--port <n>`, `$PORT`, default 3000), Cloudflare targets delegate to `wrangler dev` against the built worker (with an actionable error when wrangler or its config is missing), and Vercel targets print guidance towards `vercel build`/`vercel dev` since there is no faithful local production runtime. Scaffolded Node and Cloudflare starters now include a `preview` script.

--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ The starter gives you:
 
 - `pracht dev` — local SSR + HMR
 - `pracht build` — client/server output plus SSG/ISG prerendering, with `--analyze` for a per-route client JS report and budget enforcement
+- `pracht preview` — build and serve the production build locally
 - `pracht inspect [routes|api|build] --json` — resolved app graph metadata
 - `pracht generate route|shell|middleware|api` — framework-native scaffolding
 - `pracht verify` — fast framework-aware checks with `--changed` and `--json`

--- a/docs/ADAPTERS.md
+++ b/docs/ADAPTERS.md
@@ -190,7 +190,9 @@ export const handler = createNodeRequestHandler({
 ```
 
 Running `pracht build` for a Node target emits `dist/server/server.js`, which is
-the executable production server entry.
+the executable production server entry. `pracht preview` builds and runs it in
+one step (`--port`/`$PORT` select the port, `--skip-build` reuses the existing
+build).
 
 ---
 
@@ -225,6 +227,10 @@ the executable production server entry.
   `main` at `dist/server/worker.js` — you own that file, which lets you add
   KV, D1, R2, cron, and any other Cloudflare bindings without losing them on
   rebuild.
+- **Local preview**: `pracht preview` runs `pracht build` and then delegates to
+  `wrangler dev --port <port>` against the built worker. It requires wrangler
+  (in `node_modules` or on PATH) and a wrangler config; it errors with install
+  instructions otherwise.
 - **KV/D1/R2 support**: custom context factories and the default build entry both
   surface the Cloudflare `env` object.
 - **`@cloudflare/vite-plugin` integration**: the adapter automatically includes
@@ -380,6 +386,9 @@ export default {
 - **Build Output API v3**: `pracht({ adapter: vercelAdapter() })` makes `pracht build`
   emit `.vercel/output/config.json`, `.vercel/output/static/`, and
   `.vercel/output/functions/render.func/`.
+- **Local preview**: there is no faithful local Vercel production runtime, so
+  `pracht preview` does not emulate one — it points at `vercel build` /
+  `vercel dev` instead.
 - **Clean URL routing**: prerendered SSG pages are copied into
   `.vercel/output/static` and exposed through `config.json` rewrites so `/about`
   resolves to `/about/index.html`.

--- a/docs/WORKSPACE.md
+++ b/docs/WORKSPACE.md
@@ -69,6 +69,9 @@ described in `VISION_MVP.md`.
   client + server builds (with Vite manifest generation, SSG/ISG prerendering,
   ISG manifest output, executable Node server output in `dist/server/server.js`,
   and Vercel `.vercel/output/` generation when the app targets those adapters),
+  `pracht preview` builds and serves the production output locally (Node runs
+  `dist/server/server.js`, Cloudflare delegates to `wrangler dev`, and Vercel
+  points at `vercel build`/`vercel dev`),
   `pracht verify` runs fast framework-aware checks with optional `--changed`
   and `--json` output, `pracht inspect [routes|api|build] --json` emits the
   resolved route graph, API handlers, and build metadata for agents/tools,

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -41,6 +41,23 @@ For Node.js targets, run the built server with:
 node dist/server/server.js
 ```
 
+### `pracht preview`
+
+Serve the production build locally. Runs `pracht build` first (skip with
+`--skip-build`), then serves the output for the configured adapter:
+
+- **Node**: runs `dist/server/server.js` on `--port` (or `$PORT`, default 3000).
+- **Cloudflare**: delegates to `wrangler dev` against the built worker; requires
+  wrangler in `node_modules` or on your PATH plus a wrangler config.
+- **Vercel**: there is no faithful local production runtime — the command points
+  you at `vercel build` / `vercel dev` instead.
+
+```bash
+pracht preview
+pracht preview --port 4000
+pracht preview --skip-build
+```
+
 ### `pracht verify`
 
 Run fast framework-aware verification checks without paying for a full build or

--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -54,235 +54,11 @@ export default defineCommand({
     },
   },
   async run({ args }) {
-    const root = process.cwd();
-    const analyzeJson = Boolean(args.json);
-    const analyze = Boolean(args.analyze) || analyzeJson;
-    const logLevel = analyzeJson ? ("silent" as const) : undefined;
-    const log = (message: string): void => {
-      if (!analyzeJson) console.log(message);
-    };
-
-    log("\n  Building client...\n");
-    await viteBuild({
-      root,
-      logLevel,
-      build: {
-        outDir: "dist",
-        manifest: true,
-        rollupOptions: {
-          input: "virtual:pracht/client",
-        },
-      },
+    await runBuild(process.cwd(), {
+      analyze: Boolean(args.analyze),
+      analyzeJson: Boolean(args.json),
+      budgetFail: Boolean(args["budget-fail"]),
     });
-
-    log("\n  Building server...\n");
-    await viteBuild({
-      root,
-      logLevel,
-      build: {
-        outDir: "dist/server",
-        rollupOptions: {
-          input: "virtual:pracht/server",
-        },
-        ssr: true,
-      },
-    });
-
-    const serverEntry = resolve(root, "dist/server/server.js");
-    let clientDir: string;
-    if (existsSync(resolve(root, "dist/client/.vite/manifest.json"))) {
-      clientDir = resolve(root, "dist/client");
-    } else {
-      clientDir = resolve(root, "dist/client");
-      const distRoot = resolve(root, "dist");
-      mkdirSync(clientDir, { recursive: true });
-      for (const entry of readdirSync(distRoot)) {
-        if (entry === "server" || entry === "client") continue;
-        const sourcePath = join(distRoot, entry);
-        const destinationPath = join(clientDir, entry);
-        cpSync(sourcePath, destinationPath, { recursive: true });
-        rmSync(sourcePath, { force: true, recursive: true });
-      }
-    }
-
-    const publicDir = resolve(root, "public");
-    if (existsSync(publicDir)) {
-      cpSync(publicDir, clientDir, { recursive: true });
-    }
-
-    if (existsSync(serverEntry)) {
-      // Edge server bundles keep `cloudflare:*` imports external; stub them so
-      // the bundle can be imported in Node for the prerender pass below.
-      registerPrerenderModuleHooks();
-      const serverMod = await import(pathToFileURL(serverEntry).href);
-      const { prerenderApp } = serverMod;
-      const { clientEntryUrl, clientEntryJs, cssManifest, jsManifest } =
-        readClientBuildAssets(root);
-
-      const { pages, isgManifest } = await prerenderApp({
-        app: serverMod.resolvedApp,
-        clientEntryUrl: clientEntryUrl ?? undefined,
-        cssManifest,
-        jsManifest,
-        registry: serverMod.registry,
-        withISGManifest: true,
-        concurrency: serverMod.prerenderConcurrency,
-      });
-      const headersManifest: Record<string, Record<string, string>> = Object.fromEntries(
-        pages.map((page: { path: string; headers?: Record<string, string> }) => [
-          page.path,
-          page.headers ?? {},
-        ]),
-      );
-
-      if (pages.length > 0) {
-        log(`\n  Prerendering ${pages.length} SSG/ISG route(s)...\n`);
-        for (const page of pages) {
-          const filePath = resolvePrerenderOutputPath(clientDir, page.path);
-
-          mkdirSync(dirname(filePath), { recursive: true });
-          writeFileSync(filePath, page.html, "utf-8");
-          log(`    ${page.path} → ${filePath.replace(root + "/", "")}`);
-        }
-      }
-
-      if (Object.keys(headersManifest).length > 0) {
-        const headersManifestJson = `${JSON.stringify(headersManifest, null, 2)}\n`;
-        writeFileSync(
-          resolve(root, "dist/server/headers-manifest.json"),
-          headersManifestJson,
-          "utf-8",
-        );
-        mkdirSync(resolve(clientDir, "_pracht"), { recursive: true });
-        writeFileSync(resolve(clientDir, "_pracht/headers.json"), headersManifestJson, "utf-8");
-      }
-
-      if (Object.keys(isgManifest).length > 0) {
-        const isgManifestPath = resolve(root, "dist/server/isg-manifest.json");
-        writeFileSync(isgManifestPath, JSON.stringify(isgManifest, null, 2), "utf-8");
-        log(
-          `\n  ISG manifest → dist/server/isg-manifest.json (${Object.keys(isgManifest).length} route(s))\n`,
-        );
-      }
-
-      if (serverMod.buildTarget === "cloudflare") {
-        if (Object.keys(isgManifest).length > 0) {
-          console.warn(
-            "\n  Warning: Cloudflare adapter currently serves prerendered ISG HTML as static assets and does not perform runtime revalidation. Use SSR/SSG on Cloudflare, or deploy ISG routes to Node until Cloudflare ISG support is added.\n",
-          );
-        }
-
-        // workerd validates every named export of the deployed entry module as
-        // an entrypoint and rejects the build metadata (buildTarget, manifests,
-        // resolvedApp, ...) that server.js exports for the prerender pass
-        // above. Deploy a thin wrapper that re-exports only the default
-        // handler and the Cloudflare entrypoint classes.
-        const entrypointNames: string[] = Array.isArray(serverMod.cloudflareWorkerEntrypointNames)
-          ? serverMod.cloudflareWorkerEntrypointNames
-          : [];
-        const deployEntryLines = [
-          ...(entrypointNames.length > 0
-            ? [`export { ${entrypointNames.join(", ")} } from "./server.js";`]
-            : []),
-          'export { default } from "./server.js";',
-          "",
-        ];
-        writeFileSync(resolve(root, "dist/server/worker.js"), deployEntryLines.join("\n"), "utf-8");
-
-        log("\n  Cloudflare worker → dist/server/worker.js\n");
-        log("  Deploy with: wrangler deploy\n");
-      }
-
-      if (serverMod.buildTarget === "vercel") {
-        const outputPath = writeVercelBuildOutput({
-          functionName: serverMod.vercelFunctionName,
-          isgRoutes: Object.keys(isgManifest),
-          headersManifest,
-          regions: serverMod.vercelRegions,
-          root,
-          staticRoutes: pages
-            .map((page: { path: string }) => page.path)
-            .filter((path: string) => !(path in isgManifest)),
-        });
-
-        log(`\n  Vercel build output → ${outputPath}\n`);
-      }
-
-      const budgets = (serverMod.budgets ?? {}) as Record<string, string | number>;
-      const hasBudgets = Object.keys(budgets).length > 0;
-
-      if (analyze || hasBudgets) {
-        const routes = (serverMod.resolvedApp?.routes ?? []) as BundleReportRoute[];
-        const report = collectBundleReport({
-          routes,
-          jsManifest,
-          clientEntryJs,
-          clientDir,
-        });
-        const evaluation = hasBudgets ? evaluateBudgets(report, budgets) : null;
-        const color = shouldUseColor();
-
-        if (analyzeJson) {
-          console.log(
-            JSON.stringify(
-              {
-                shared: report.shared,
-                routes: report.routes,
-                ...(evaluation ? { budgets: evaluation } : {}),
-              },
-              null,
-              2,
-            ),
-          );
-        } else if (analyze) {
-          console.log(`\n${indentBlock(formatBundleReport(report, { color }))}\n`);
-        }
-
-        if (evaluation) {
-          writeFileSync(
-            resolve(root, "dist/server/budget-report.json"),
-            `${JSON.stringify(
-              {
-                generatedAt: new Date().toISOString(),
-                budgets,
-                results: evaluation.results,
-                unmatched: evaluation.unmatched,
-                ok: evaluation.ok,
-              },
-              null,
-              2,
-            )}\n`,
-            "utf-8",
-          );
-
-          if (!analyzeJson) {
-            console.log(`\n${indentBlock(formatBudgetResults(evaluation, { color }))}\n`);
-          }
-
-          if (!evaluation.ok) {
-            const failed = evaluation.results.filter((result) => !result.ok);
-            const summary = failed
-              .map(
-                (result) =>
-                  `${result.path} (${formatBytes(result.gzipBytes)} gzip > ${formatBytes(result.limitBytes)})`,
-              )
-              .join(", ");
-            if (args["budget-fail"]) {
-              console.error(`\n  Build failed: client JS budget exceeded for ${summary}.\n`);
-              process.exitCode = 1;
-              return;
-            }
-            if (!analyzeJson) {
-              console.warn(
-                `\n  Warning: client JS budget exceeded for ${summary} (--no-budget-fail).\n`,
-              );
-            }
-          }
-        }
-      }
-    }
-
-    log("\n  Build complete.\n");
   },
 });
 
@@ -291,6 +67,250 @@ function indentBlock(block: string): string {
     .split("\n")
     .map((line) => (line ? `  ${line}` : line))
     .join("\n");
+}
+
+export interface BuildResult {
+  buildTarget: string | null;
+}
+
+interface BuildOptions {
+  analyze?: boolean;
+  analyzeJson?: boolean;
+  budgetFail?: boolean;
+}
+
+export async function runBuild(root: string, options: BuildOptions = {}): Promise<BuildResult> {
+  const analyzeJson = Boolean(options.analyzeJson);
+  const analyze = Boolean(options.analyze) || analyzeJson;
+  const budgetFail = options.budgetFail ?? true;
+  const logLevel = analyzeJson ? ("silent" as const) : undefined;
+  const log = (message: string): void => {
+    if (!analyzeJson) console.log(message);
+  };
+
+  log("\n  Building client...\n");
+  await viteBuild({
+    root,
+    logLevel,
+    build: {
+      outDir: "dist",
+      manifest: true,
+      rollupOptions: {
+        input: "virtual:pracht/client",
+      },
+    },
+  });
+
+  log("\n  Building server...\n");
+  await viteBuild({
+    root,
+    logLevel,
+    build: {
+      outDir: "dist/server",
+      rollupOptions: {
+        input: "virtual:pracht/server",
+      },
+      ssr: true,
+    },
+  });
+
+  const serverEntry = resolve(root, "dist/server/server.js");
+  let clientDir: string;
+  if (existsSync(resolve(root, "dist/client/.vite/manifest.json"))) {
+    clientDir = resolve(root, "dist/client");
+  } else {
+    clientDir = resolve(root, "dist/client");
+    const distRoot = resolve(root, "dist");
+    mkdirSync(clientDir, { recursive: true });
+    for (const entry of readdirSync(distRoot)) {
+      if (entry === "server" || entry === "client") continue;
+      const sourcePath = join(distRoot, entry);
+      const destinationPath = join(clientDir, entry);
+      cpSync(sourcePath, destinationPath, { recursive: true });
+      rmSync(sourcePath, { force: true, recursive: true });
+    }
+  }
+
+  const publicDir = resolve(root, "public");
+  if (existsSync(publicDir)) {
+    cpSync(publicDir, clientDir, { recursive: true });
+  }
+
+  let buildTarget: string | null = null;
+  if (existsSync(serverEntry)) {
+    // Edge server bundles keep `cloudflare:*` imports external; stub them so
+    // the bundle can be imported in Node for the prerender pass below.
+    registerPrerenderModuleHooks();
+    const serverMod = await import(pathToFileURL(serverEntry).href);
+    buildTarget = typeof serverMod.buildTarget === "string" ? serverMod.buildTarget : null;
+    const { prerenderApp } = serverMod;
+    const { clientEntryUrl, clientEntryJs, cssManifest, jsManifest } = readClientBuildAssets(root);
+
+    const { pages, isgManifest } = await prerenderApp({
+      app: serverMod.resolvedApp,
+      clientEntryUrl: clientEntryUrl ?? undefined,
+      cssManifest,
+      jsManifest,
+      registry: serverMod.registry,
+      withISGManifest: true,
+      concurrency: serverMod.prerenderConcurrency,
+    });
+    const headersManifest: Record<string, Record<string, string>> = Object.fromEntries(
+      pages.map((page: { path: string; headers?: Record<string, string> }) => [
+        page.path,
+        page.headers ?? {},
+      ]),
+    );
+
+    if (pages.length > 0) {
+      log(`\n  Prerendering ${pages.length} SSG/ISG route(s)...\n`);
+      for (const page of pages) {
+        const filePath = resolvePrerenderOutputPath(clientDir, page.path);
+
+        mkdirSync(dirname(filePath), { recursive: true });
+        writeFileSync(filePath, page.html, "utf-8");
+        log(`    ${page.path} → ${filePath.replace(root + "/", "")}`);
+      }
+    }
+
+    if (Object.keys(headersManifest).length > 0) {
+      const headersManifestJson = `${JSON.stringify(headersManifest, null, 2)}\n`;
+      writeFileSync(
+        resolve(root, "dist/server/headers-manifest.json"),
+        headersManifestJson,
+        "utf-8",
+      );
+      mkdirSync(resolve(clientDir, "_pracht"), { recursive: true });
+      writeFileSync(resolve(clientDir, "_pracht/headers.json"), headersManifestJson, "utf-8");
+    }
+
+    if (Object.keys(isgManifest).length > 0) {
+      const isgManifestPath = resolve(root, "dist/server/isg-manifest.json");
+      writeFileSync(isgManifestPath, JSON.stringify(isgManifest, null, 2), "utf-8");
+      log(
+        `\n  ISG manifest → dist/server/isg-manifest.json (${Object.keys(isgManifest).length} route(s))\n`,
+      );
+    }
+
+    if (serverMod.buildTarget === "cloudflare") {
+      if (Object.keys(isgManifest).length > 0) {
+        console.warn(
+          "\n  Warning: Cloudflare adapter currently serves prerendered ISG HTML as static assets and does not perform runtime revalidation. Use SSR/SSG on Cloudflare, or deploy ISG routes to Node until Cloudflare ISG support is added.\n",
+        );
+      }
+
+      // workerd validates every named export of the deployed entry module as
+      // an entrypoint and rejects the build metadata (buildTarget, manifests,
+      // resolvedApp, ...) that server.js exports for the prerender pass
+      // above. Deploy a thin wrapper that re-exports only the default
+      // handler and the Cloudflare entrypoint classes.
+      const entrypointNames: string[] = Array.isArray(serverMod.cloudflareWorkerEntrypointNames)
+        ? serverMod.cloudflareWorkerEntrypointNames
+        : [];
+      const deployEntryLines = [
+        ...(entrypointNames.length > 0
+          ? [`export { ${entrypointNames.join(", ")} } from "./server.js";`]
+          : []),
+        'export { default } from "./server.js";',
+        "",
+      ];
+      writeFileSync(resolve(root, "dist/server/worker.js"), deployEntryLines.join("\n"), "utf-8");
+
+      log("\n  Cloudflare worker → dist/server/worker.js\n");
+      log("  Deploy with: wrangler deploy\n");
+    }
+
+    if (serverMod.buildTarget === "vercel") {
+      const outputPath = writeVercelBuildOutput({
+        functionName: serverMod.vercelFunctionName,
+        isgRoutes: Object.keys(isgManifest),
+        headersManifest,
+        regions: serverMod.vercelRegions,
+        root,
+        staticRoutes: pages
+          .map((page: { path: string }) => page.path)
+          .filter((path: string) => !(path in isgManifest)),
+      });
+
+      log(`\n  Vercel build output → ${outputPath}\n`);
+    }
+
+    const budgets = (serverMod.budgets ?? {}) as Record<string, string | number>;
+    const hasBudgets = Object.keys(budgets).length > 0;
+
+    if (analyze || hasBudgets) {
+      const routes = (serverMod.resolvedApp?.routes ?? []) as BundleReportRoute[];
+      const report = collectBundleReport({
+        routes,
+        jsManifest,
+        clientEntryJs,
+        clientDir,
+      });
+      const evaluation = hasBudgets ? evaluateBudgets(report, budgets) : null;
+      const color = shouldUseColor();
+
+      if (analyzeJson) {
+        console.log(
+          JSON.stringify(
+            {
+              shared: report.shared,
+              routes: report.routes,
+              ...(evaluation ? { budgets: evaluation } : {}),
+            },
+            null,
+            2,
+          ),
+        );
+      } else if (analyze) {
+        console.log(`\n${indentBlock(formatBundleReport(report, { color }))}\n`);
+      }
+
+      if (evaluation) {
+        writeFileSync(
+          resolve(root, "dist/server/budget-report.json"),
+          `${JSON.stringify(
+            {
+              generatedAt: new Date().toISOString(),
+              budgets,
+              results: evaluation.results,
+              unmatched: evaluation.unmatched,
+              ok: evaluation.ok,
+            },
+            null,
+            2,
+          )}\n`,
+          "utf-8",
+        );
+
+        if (!analyzeJson) {
+          console.log(`\n${indentBlock(formatBudgetResults(evaluation, { color }))}\n`);
+        }
+
+        if (!evaluation.ok) {
+          const failed = evaluation.results.filter((result) => !result.ok);
+          const summary = failed
+            .map(
+              (result) =>
+                `${result.path} (${formatBytes(result.gzipBytes)} gzip > ${formatBytes(result.limitBytes)})`,
+            )
+            .join(", ");
+          if (budgetFail) {
+            console.error(`\n  Build failed: client JS budget exceeded for ${summary}.\n`);
+            process.exitCode = 1;
+            return { buildTarget };
+          }
+          if (!analyzeJson) {
+            console.warn(
+              `\n  Warning: client JS budget exceeded for ${summary} (--no-budget-fail).\n`,
+            );
+          }
+        }
+      }
+    }
+  }
+
+  log("\n  Build complete.\n");
+  return { buildTarget };
 }
 
 export function resolvePrerenderOutputPath(clientDir: string, routePath: string): string {

--- a/packages/cli/src/commands/preview.ts
+++ b/packages/cli/src/commands/preview.ts
@@ -1,0 +1,208 @@
+import { spawn } from "node:child_process";
+import { existsSync } from "node:fs";
+import { delimiter, join, resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+
+import { defineCommand } from "citty";
+
+import { requirePositiveInteger } from "../utils.js";
+import { readProjectConfig, type ProjectConfig } from "../project.js";
+import { runBuild } from "./build.js";
+
+const SERVER_ENTRY = "dist/server/server.js";
+const WRANGLER_CONFIG_FILES = ["wrangler.jsonc", "wrangler.json", "wrangler.toml"];
+const ADAPTER_TARGETS = new Set(["cloudflare", "node", "vercel"]);
+
+export type AdapterTarget = "cloudflare" | "node" | "vercel";
+
+export default defineCommand({
+  meta: {
+    name: "preview",
+    description: "Build and serve the production build locally",
+  },
+  args: {
+    port: {
+      type: "string",
+      description: "Port number (defaults to $PORT or 3000)",
+    },
+    "skip-build": {
+      type: "boolean",
+      description: "Serve the existing build output without rebuilding",
+    },
+  },
+  async run({ args }) {
+    const root = process.cwd();
+    const project = readProjectConfig(root);
+
+    if (!project.configFile) {
+      throw new Error(
+        "Missing vite config. `pracht preview` requires a project with pracht configured.",
+      );
+    }
+
+    if (!project.hasPrachtPlugin) {
+      throw new Error("vite.config does not appear to register the pracht plugin.");
+    }
+
+    const skipBuild = Boolean(args["skip-build"]);
+
+    // The `buildTarget` export of an existing build is authoritative; the vite
+    // config is a static fallback for projects that have not been built yet.
+    let target: AdapterTarget | null = skipBuild ? await readBuildTarget(root) : null;
+    target ??= detectAdapterTarget(project);
+
+    if (target === "vercel") {
+      printVercelGuidance();
+      process.exitCode = 1;
+      return;
+    }
+
+    const port = requirePositiveInteger(args.port ?? process.env.PORT, "port", 3000);
+
+    if (!skipBuild) {
+      const { buildTarget } = await runBuild(root);
+      target = normalizeAdapterTarget(buildTarget) ?? target;
+
+      if (target === "vercel") {
+        printVercelGuidance();
+        process.exitCode = 1;
+        return;
+      }
+    }
+
+    const serverEntry = resolve(root, SERVER_ENTRY);
+    if (!existsSync(serverEntry)) {
+      throw new Error(
+        `Missing ${SERVER_ENTRY}. Run \`pracht build\` first, or drop --skip-build to build automatically.`,
+      );
+    }
+
+    if (target === "cloudflare") {
+      const wranglerBin = resolveWranglerBin(root);
+      if (!wranglerBin) {
+        throw new Error(
+          [
+            "`pracht preview` needs wrangler to serve Cloudflare builds, but it was not found in node_modules or on your PATH.",
+            "Install it with `npm install --save-dev wrangler` (or `pnpm add -D wrangler`) and re-run `pracht preview`.",
+          ].join("\n"),
+        );
+      }
+
+      if (!findWranglerConfig(root)) {
+        throw new Error(
+          [
+            "`pracht preview` needs a wrangler config (wrangler.jsonc, wrangler.json, or wrangler.toml) pointing at the built worker.",
+            'Create one with `"main": "dist/server/worker.js"` — see docs/ADAPTERS.md for a full example.',
+          ].join("\n"),
+        );
+      }
+
+      console.log(`\n  Previewing Cloudflare build with wrangler dev on port ${port}...\n`);
+      spawnPreviewProcess(wranglerBin, ["dev", "--port", String(port)], { cwd: root });
+      return;
+    }
+
+    console.log(`\n  Previewing production build → http://localhost:${port}\n`);
+    spawnPreviewProcess(process.execPath, [serverEntry], {
+      cwd: root,
+      env: { ...process.env, PORT: String(port) },
+    });
+  },
+});
+
+export function detectAdapterTarget(project: Pick<ProjectConfig, "rawConfig">): AdapterTarget {
+  const source = project.rawConfig;
+
+  if (/\bcloudflareAdapter\s*\(/.test(source) || source.includes("@pracht/adapter-cloudflare")) {
+    return "cloudflare";
+  }
+
+  if (/\bvercelAdapter\s*\(/.test(source) || source.includes("@pracht/adapter-vercel")) {
+    return "vercel";
+  }
+
+  return "node";
+}
+
+export function normalizeAdapterTarget(value: unknown): AdapterTarget | null {
+  return typeof value === "string" && ADAPTER_TARGETS.has(value) ? (value as AdapterTarget) : null;
+}
+
+export function resolveWranglerBin(
+  root: string,
+  env: NodeJS.ProcessEnv = process.env,
+): string | null {
+  const binNames =
+    process.platform === "win32" ? ["wrangler.cmd", "wrangler.exe", "wrangler"] : ["wrangler"];
+  const searchDirs = [
+    resolve(root, "node_modules/.bin"),
+    ...(env.PATH ?? "").split(delimiter).filter(Boolean),
+  ];
+
+  for (const dir of searchDirs) {
+    for (const name of binNames) {
+      const candidate = join(dir, name);
+      if (existsSync(candidate)) return candidate;
+    }
+  }
+
+  return null;
+}
+
+async function readBuildTarget(root: string): Promise<AdapterTarget | null> {
+  const serverEntry = resolve(root, SERVER_ENTRY);
+  if (!existsSync(serverEntry)) return null;
+
+  try {
+    const serverMod = await import(pathToFileURL(serverEntry).href);
+    return normalizeAdapterTarget(serverMod.buildTarget);
+  } catch {
+    return null;
+  }
+}
+
+function findWranglerConfig(root: string): string | null {
+  for (const name of WRANGLER_CONFIG_FILES) {
+    const candidate = resolve(root, name);
+    if (existsSync(candidate)) return candidate;
+  }
+  return null;
+}
+
+function printVercelGuidance(): void {
+  console.log(
+    [
+      "",
+      "  The Vercel adapter has no faithful local production runtime, so `pracht preview` does not emulate it.",
+      "",
+      "  To exercise the Vercel build output locally, use Vercel's own tooling:",
+      "",
+      "    vercel build   # reproduce the production build (.vercel/output) with your project settings",
+      "    vercel dev     # run a local Vercel development environment",
+      "",
+      "  To ship the output of `pracht build`, run: vercel deploy --prebuilt",
+      "",
+    ].join("\n"),
+  );
+}
+
+function spawnPreviewProcess(
+  command: string,
+  commandArgs: string[],
+  options: { cwd: string; env?: NodeJS.ProcessEnv },
+): void {
+  const child = spawn(command, commandArgs, {
+    cwd: options.cwd,
+    env: options.env ?? process.env,
+    stdio: "inherit",
+  });
+
+  child.on("close", (code) => {
+    process.exitCode = code ?? 0;
+  });
+
+  child.on("error", (error) => {
+    console.error(`Failed to start preview process: ${error.message}`);
+    process.exitCode = 1;
+  });
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -20,6 +20,7 @@ const main = defineCommand({
     generate: () => import("./commands/generate.js").then((m) => m.default),
     inspect: () => import("./commands/inspect.js").then((m) => m.default),
     mcp: () => import("./commands/mcp.js").then((m) => m.default),
+    preview: () => import("./commands/preview.js").then((m) => m.default),
     typegen: () => import("./commands/typegen.js").then((m) => m.default),
     verify: () => import("./commands/verify.js").then((m) => m.default),
   },

--- a/packages/cli/test/preview.test.ts
+++ b/packages/cli/test/preview.test.ts
@@ -1,0 +1,115 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  detectAdapterTarget,
+  normalizeAdapterTarget,
+  resolveWranglerBin,
+} from "../src/commands/preview.ts";
+
+describe("detectAdapterTarget", () => {
+  it("detects the cloudflare adapter from the factory call", () => {
+    expect(
+      detectAdapterTarget({
+        rawConfig: "export default { plugins: [pracht({ adapter: cloudflareAdapter() })] };",
+      }),
+    ).toBe("cloudflare");
+  });
+
+  it("detects the cloudflare adapter from the package import", () => {
+    expect(
+      detectAdapterTarget({
+        rawConfig: 'import { cloudflareAdapter as adapter } from "@pracht/adapter-cloudflare";',
+      }),
+    ).toBe("cloudflare");
+  });
+
+  it("detects the vercel adapter from the factory call", () => {
+    expect(
+      detectAdapterTarget({
+        rawConfig: "export default { plugins: [pracht({ adapter: vercelAdapter() })] };",
+      }),
+    ).toBe("vercel");
+  });
+
+  it("detects the vercel adapter from the package import", () => {
+    expect(
+      detectAdapterTarget({
+        rawConfig: 'import { vercelAdapter as adapter } from "@pracht/adapter-vercel";',
+      }),
+    ).toBe("vercel");
+  });
+
+  it("detects the node adapter from the factory call", () => {
+    expect(
+      detectAdapterTarget({
+        rawConfig:
+          'import { nodeAdapter } from "@pracht/adapter-node";\nexport default { plugins: [pracht({ adapter: nodeAdapter() })] };',
+      }),
+    ).toBe("node");
+  });
+
+  it("defaults to node when no adapter is configured", () => {
+    expect(detectAdapterTarget({ rawConfig: "export default { plugins: [pracht()] };" })).toBe(
+      "node",
+    );
+  });
+});
+
+describe("normalizeAdapterTarget", () => {
+  it("accepts the built-in adapter targets", () => {
+    expect(normalizeAdapterTarget("node")).toBe("node");
+    expect(normalizeAdapterTarget("cloudflare")).toBe("cloudflare");
+    expect(normalizeAdapterTarget("vercel")).toBe("vercel");
+  });
+
+  it("returns null for custom or missing targets", () => {
+    expect(normalizeAdapterTarget("my-platform")).toBe(null);
+    expect(normalizeAdapterTarget(undefined)).toBe(null);
+    expect(normalizeAdapterTarget(42)).toBe(null);
+  });
+});
+
+describe("resolveWranglerBin", () => {
+  const tempDirs: string[] = [];
+
+  function makeTempDir(prefix: string): string {
+    const dir = mkdtempSync(join(tmpdir(), prefix));
+    tempDirs.push(dir);
+    return dir;
+  }
+
+  afterEach(() => {
+    while (tempDirs.length > 0) {
+      rmSync(tempDirs.pop()!, { force: true, recursive: true });
+    }
+  });
+
+  it("prefers the project-local wrangler binary", () => {
+    const root = makeTempDir("pracht-preview-local-");
+    const binDir = join(root, "node_modules/.bin");
+    mkdirSync(binDir, { recursive: true });
+    writeFileSync(join(binDir, "wrangler"), "#!/bin/sh\n", { mode: 0o755 });
+
+    const pathDir = makeTempDir("pracht-preview-path-");
+    writeFileSync(join(pathDir, "wrangler"), "#!/bin/sh\n", { mode: 0o755 });
+
+    expect(resolveWranglerBin(root, { PATH: pathDir })).toBe(join(binDir, "wrangler"));
+  });
+
+  it("falls back to wrangler on PATH", () => {
+    const root = makeTempDir("pracht-preview-root-");
+    const pathDir = makeTempDir("pracht-preview-path-");
+    writeFileSync(join(pathDir, "wrangler"), "#!/bin/sh\n", { mode: 0o755 });
+
+    expect(resolveWranglerBin(root, { PATH: pathDir })).toBe(join(pathDir, "wrangler"));
+  });
+
+  it("returns null when wrangler is not installed anywhere", () => {
+    const root = makeTempDir("pracht-preview-missing-");
+    expect(resolveWranglerBin(root, { PATH: makeTempDir("pracht-preview-empty-") })).toBe(null);
+  });
+});

--- a/packages/start/README.md
+++ b/packages/start/README.md
@@ -73,10 +73,12 @@ Cloudflare scaffolds also include:
 
 Node starters also include:
 
+- `preview` -> `pracht preview`
 - `start` -> `node dist/server/server.js`
 
 Cloudflare starters also include:
 
+- `preview` -> `pracht preview`
 - `deploy` -> `pracht build && wrangler deploy`
 
 Vercel starters also include:

--- a/packages/start/src/index.js
+++ b/packages/start/src/index.js
@@ -575,6 +575,7 @@ function createPackageJson({ adapter, projectName, tailwind, versions }) {
   };
 
   if (adapter.id === "node") {
+    scripts.preview = "pracht preview";
     scripts.start = "node dist/server/server.js";
   }
 
@@ -588,6 +589,7 @@ function createPackageJson({ adapter, projectName, tailwind, versions }) {
 
   if (adapter.id === "cloudflare") {
     scripts.deploy = "pracht build && wrangler deploy";
+    scripts.preview = "pracht preview";
     devDependencies.wrangler = "^4.81.0";
   }
 
@@ -930,6 +932,10 @@ function createAgentInstructions({ adapter, packageManager, router, tailwind }) 
     `- \`${runCmd} build\` — production build`,
   ];
 
+  if (adapter.id === "node" || adapter.id === "cloudflare") {
+    lines.push(`- \`${runCmd} preview\` — build and serve the production build locally`);
+  }
+
   if (adapter.id === "node") {
     lines.push(`- \`${runCmd} start\` — run the built server`);
   }
@@ -990,6 +996,7 @@ function createAgentInstructions({ adapter, packageManager, router, tailwind }) 
 function createReadme({ adapter, packageManager, projectName, router, tailwind }) {
   const installCommand = packageManager === "npm" ? "npm install" : `${packageManager} install`;
   const devCommand = packageManager === "npm" ? "npm run dev" : `${packageManager} dev`;
+  const previewCommand = packageManager === "npm" ? "npm run preview" : `${packageManager} preview`;
   const startCommand = packageManager === "npm" ? "npm run start" : `${packageManager} start`;
   const deployCommand = packageManager === "npm" ? "npm run deploy" : `${packageManager} deploy`;
 
@@ -1005,10 +1012,12 @@ function createReadme({ adapter, packageManager, projectName, router, tailwind }
   ];
 
   if (adapter.id === "node") {
+    lines.push(`- \`${previewCommand}\``);
     lines.push(`- \`${startCommand}\``);
   }
 
   if (adapter.id === "cloudflare") {
+    lines.push(`- \`${previewCommand}\``);
     lines.push(`- \`${deployCommand}\``);
     lines.push("");
     lines.push(

--- a/packages/start/test/index.test.js
+++ b/packages/start/test/index.test.js
@@ -53,6 +53,7 @@ describe("create-pracht", () => {
 
     expect(packageJson).toMatch(/"@pracht\/cli": "\^\d+\.\d+\.\d+"/);
     expect(packageJson).toMatch(/"@pracht\/adapter-node": "\^\d+\.\d+\.\d+"/);
+    expect(packageJson).toContain('"preview": "pracht preview"');
     expect(packageJson).toContain('"start": "node dist/server/server.js"');
     expect(packageJson).not.toContain("wrangler");
     expect(gitignore).toContain(".env*");
@@ -136,6 +137,7 @@ describe("create-pracht", () => {
     expect(packageJson).toMatch(/"@pracht\/cli": "\^\d+\.\d+\.\d+"/);
     expect(packageJson).toMatch(/"@pracht\/adapter-cloudflare": "\^\d+\.\d+\.\d+"/);
 
+    expect(packageJson).toContain('"preview": "pracht preview"');
     expect(packageJson).toContain('"wrangler": "^4.81.0"');
     expect(packageJson).not.toContain('"@cloudflare/vite-plugin"');
     expect(wranglerConfig).toContain('"main": "dist/server/server.js"');
@@ -201,6 +203,7 @@ describe("create-pracht", () => {
     expect(packageJson).toMatch(/"vercel": "\^\d+\.\d+\.\d+"/);
 
     expect(packageJson).toContain('"deploy": "pracht build && vercel deploy --prebuilt"');
+    expect(packageJson).not.toContain('"preview"');
     expect(readme).toContain("configured for Vercel");
     expect(readme).toContain("pnpm deploy");
     expect(existsSync(join(targetDir, "wrangler.jsonc"))).toBe(false);

--- a/skills/audit-a11y/SKILL.md
+++ b/skills/audit-a11y/SKILL.md
@@ -26,11 +26,11 @@ runs axe-core against the result.
 
 ## Step 1: Boot the app
 
-Prefer the production build/runtime (`node dist/server/server.js` for Node targets, or the target platform's local preview) — production HTML is what users
+Prefer the production build/runtime (`pracht preview` builds and serves it for Node and Cloudflare targets) — production HTML is what users
 actually receive. Fall back to `pracht dev` only if the user can't build.
 
 ```bash
-pracht build && node dist/server/server.js &
+pracht preview &
 ```
 
 Or, if `BASE_URL` is set, target the deployed app.

--- a/skills/debug/SKILL.md
+++ b/skills/debug/SKILL.md
@@ -107,6 +107,7 @@ Work through these in order, stopping when you find the root cause:
 ### 8. Build / deployment issues
 
 - `pracht build` runs client + server builds, then prerenders SSG/ISG routes.
+- `pracht preview` builds and serves the production output locally (Node runs `dist/server/server.js`, Cloudflare delegates to `wrangler dev`).
 - `pracht inspect build --json` reports the resolved adapter target plus client/CSS/JS manifests from the latest build output.
 - Check `dist/client/` for client assets and `dist/server/` for server bundle.
 - ISG manifest: `dist/client/pracht-isg-manifest.json`.

--- a/skills/deploy/SKILL.md
+++ b/skills/deploy/SKILL.md
@@ -67,7 +67,7 @@ Produces:
 node dist/server/server.js
 ```
 
-Port 3000 by default. For production: reverse proxy (nginx, Caddy), process manager (PM2, systemd), `NODE_ENV=production`.
+Port 3000 by default. For a local production smoke test, `pracht preview` builds and runs the server in one step (`--port <n>`, `--skip-build` to reuse an existing build). For production: reverse proxy (nginx, Caddy), process manager (PM2, systemd), `NODE_ENV=production`.
 
 ### Docker
 
@@ -100,6 +100,8 @@ CMD ["node", "dist/server/server.js"]
 pracht build
 npx wrangler deploy
 ```
+
+To smoke-test the built worker locally first, run `pracht preview` — it builds and then delegates to `wrangler dev` against `dist/server/server.js`.
 
 ### Wrangler Configuration
 
@@ -158,14 +160,14 @@ Produces: `.vercel/output/config.json`, `.vercel/output/static/`, `.vercel/outpu
 2. **Environment variables**: Ensure secrets/config needed by loaders are available at runtime.
 3. **Static assets**: Verify `dist/client/` contains prerendered HTML for SSG/ISG routes.
 4. **ISG routes**: Confirm the ISG manifest exists if using incremental static generation.
-5. **API routes**: Test API endpoints work in the production runtime. For Node.js, run `node dist/server/server.js`.
+5. **API routes**: Test API endpoints work in the production runtime. For Node.js, run `pracht preview` (or `node dist/server/server.js`).
 6. **Middleware**: Verify auth/redirect middleware behaves correctly in production.
 
 ## Rules
 
 1. Read `vite.config.ts` and `package.json` before giving advice.
 2. Run `pracht build` to verify the build succeeds before deploying.
-3. Smoke-test the production runtime before pushing to production. For Node.js, run `node dist/server/server.js`.
+3. Smoke-test the production runtime before pushing to production. For Node.js and Cloudflare, run `pracht preview`.
 4. If the user needs an adapter that isn't installed, help them add it (`pnpm add @pracht/adapter-*`).
 5. Don't push to production without the user's explicit confirmation.
 

--- a/skills/migrate-nextjs/SKILL.md
+++ b/skills/migrate-nextjs/SKILL.md
@@ -111,7 +111,7 @@ For pages router projects, you can **skip manual manifest wiring entirely** (Pha
 3. Update `package.json`:
    - Replace `react`, `react-dom` → `preact`
    - Replace `next` → `pracht`, `@pracht/vite-plugin`, `@pracht/adapter-node` (or target adapter)
-   - Update scripts: `dev` → `pracht dev`, `build` → `pracht build`, `start` → `node dist/server/server.js` (Node.js) or a platform-specific deploy command
+   - Update scripts: `dev` → `pracht dev`, `build` → `pracht build`, `start` → `node dist/server/server.js` (Node.js) or a platform-specific deploy command; add `preview` → `pracht preview` to serve the production build locally
 4. Remove Next.js config files: `next.config.*`, `next-env.d.ts`, `.next/`
 5. If `tsconfig.json` has `"jsx": "preserve"`, change to `"jsx": "react-jsx"` and add `"jsxImportSource": "preact"`.
 

--- a/skills/pre-deploy/SKILL.md
+++ b/skills/pre-deploy/SKILL.md
@@ -61,7 +61,7 @@ These catch app-graph wiring problems independent of the adapter. Resolve all
 - `dist/server/server.js` exists.
 - `dist/client/.vite/manifest.json` exists.
 - `dist/server/isg-manifest.json` exists if any route has `render: "isg"`.
-- Smoke test: `node dist/server/server.js` boots and `curl localhost:3000` returns 200.
+- Smoke test: `pracht preview --skip-build` (or `node dist/server/server.js`) boots and `curl localhost:3000` returns 200.
 - Required env vars (grep `process.env.*` across `src/`) are set in the
   deployment environment. List them for the user.
 - Reverse-proxy / TLS termination configured (out of scope for this skill —


### PR DESCRIPTION
## Summary

- Adds a new `pracht preview` CLI command that serves the production build locally with one command. It runs `pracht build` first (skippable via `--skip-build`) and then serves the built output for the configured adapter:
  - **Node**: starts `dist/server/server.js` as a child process, with `--port <n>` support (falls back to `$PORT`, default 3000).
  - **Cloudflare**: delegates to `wrangler dev --port <n>` against the built worker. Exits with clear, actionable errors when wrangler (node_modules/.bin or PATH) or a wrangler config is missing.
  - **Vercel**: prints guidance towards `vercel build` / `vercel dev` / `vercel deploy --prebuilt` instead of faking a local runtime, and exits non-zero.
- Adapter detection reuses `readProjectConfig()` from `packages/cli/src/project.ts` to statically detect the adapter from the vite config, and treats the `buildTarget` export of the built server bundle as authoritative (used directly with `--skip-build`, and re-checked after a fresh build so dynamic/conditional vite configs resolve correctly).
- Refactors `pracht build` into an exported `runBuild(root)` (now returning `{ buildTarget }`) so preview reuses the exact build pipeline; the `build` command behavior is unchanged.
- `create-pracht` now generates a `preview` script (`pracht preview`) for Node and Cloudflare starters, and mentions it in the generated README/AGENTS instructions. Vercel starters intentionally get no preview script since there is no faithful local runtime.
- Docs updated: root README "Create an app" list, `packages/cli/README.md`, `docs/ADAPTERS.md`, `docs/WORKSPACE.md`, `packages/start/README.md`, and the skills that enumerate CLI commands (`deploy`, `pre-deploy`, `debug`, `audit-a11y`, `migrate-nextjs`).
- Adds vitest coverage for `detectAdapterTarget`, `normalizeAdapterTarget`, and `resolveWranglerBin`, plus starter-script assertions in `packages/start/test`.
- Changeset added (`@pracht/cli`: minor, `create-pracht`: minor).

No linked issue.

## Testing

- [x] `pnpm e2e`
- [x] `pnpm format`
- [x] `pnpm lint`
- [x] `pnpm test`

Additionally smoke-tested manually: `pracht preview --port 3987` and `pracht preview --skip-build --port 3987` against `examples/basic` (200 on `/` and `/api/health`), the Vercel guidance path (exit 1 with message), and the missing-vite-config error path.

## Checklist

- [x] Docs updated if needed
- [x] Skills updated if needed
- [x] Changeset added if published packages changed
