### PR TITLE
Dev error overlay: open-in-editor stack frames + "did you mean" wiring errors

### DIFF
--- a/.changeset/overlay-open-in-editor.md
+++ b/.changeset/overlay-open-in-editor.md
@@ -1,0 +1,8 @@
+---
+"@pracht/core": minor
+"@pracht/vite-plugin": minor
+---
+
+Dev error overlay: stack frames and the reported file path are now clickable and open the file at the exact line/column in your editor via Vite's built-in `/__open-in-editor` endpoint. App-code frames are parsed from the stack (handling `file://` URLs, `/@fs/` prefixes, Vite transform queries, and root-relative dev-server URLs), while `node_modules` and Node-internal frames are de-emphasized and never linked.
+
+Manifest wiring mistakes now fail loudly with "did you mean" hints: referencing an unknown shell or middleware name (including `api.middleware`) throws during `resolveApp()`, and unknown route ids throw from `href()`/`buildHref()`, each listing the closest match and all registered names, e.g. `Unknown shell "pubic" for route "/". Did you mean "public"? Registered shells: public, app.` These errors surface in the dev error overlay as soon as the dev server loads the manifest.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -432,6 +432,8 @@ The internal module graph within the framework package is acyclic:
 ```
 types.ts        — pure types, no internal deps
     ↑
+name-suggestions.ts — edit-distance "did you mean" helpers for wiring errors
+    ↑
 app.ts          — route manifest, matching, SSG path building
     ↑
 runtime-context.ts — hydration state reader and Preact runtime provider
@@ -449,7 +451,7 @@ router.ts       — client router, hydration bootstrap (imports runtime-context 
 hydration.ts    — Preact options hooks for tracking hydration (no internal deps)
 href.ts         — createHref helper layered on buildHref
 forwardRef.ts   — forwardRef helper (no internal deps)
-error-overlay.ts — dev error page HTML (no internal deps)
+error-overlay.ts — dev error page HTML + stack-frame parsing (no internal deps)
 dev-404.ts      — dev-only 404 page HTML listing registered routes (no internal deps)
 ```
 
@@ -604,3 +606,34 @@ visible banner:
 
 The banner is only installed when `import.meta.env.DEV` is true, so the
 overhead — and the wrappers themselves — never ship to production builds.
+
+### Dev error overlay (`error-overlay.ts`)
+
+When an uncaught error escapes the dev SSR middleware, the vite-plugin
+renders a standalone HTML error page via `buildErrorOverlayHtml()` (exposed
+as `@pracht/core/error-overlay`). The overlay is deliberately not a Preact
+component — it must render even when Preact itself fails — and it is only
+served by the dev middleware, never in production builds.
+
+Two ergonomics features are built in:
+
+- **Open-in-editor links.** `parseStackFrames()` parses V8-style stack
+  traces into frames with `file:line:column` locations. App-code frames
+  become clickable links that hit Vite's built-in
+  `/__open-in-editor?file=<path>:<line>:<column>` endpoint (launch-editor
+  middleware) via `fetch`. Frames from `node_modules`, `node:` internals,
+  and Vite-internal/virtual modules are visually de-emphasized and never
+  linked. Path normalization handles `file://` URLs, `/@fs/` prefixes,
+  Vite transform queries (`?t=…`, `?pracht-client`), and root-relative
+  dev-server URLs (`/src/routes/home.tsx`), which are joined onto the
+  project root the dev middleware passes in (`server.config.root`).
+- **"Did you mean" wiring errors.** `resolveApp()` fails loudly when a
+  route or group references an unknown shell or middleware name (including
+  `api.middleware`), and `buildHref()` does the same for unknown route ids.
+  The messages include a closest-match suggestion (small internal
+  edit-distance helper in `name-suggestions.ts`, no dependency) and the
+  full list of registered names, e.g.
+  `Unknown shell "pubic" for route "/". Did you mean "public"? Registered shells: public, app.`
+  Because the virtual server module calls `resolveApp()` at load time,
+  these errors surface in the overlay as soon as the dev server evaluates
+  the manifest.

--- a/docs/DATA_LOADING.md
+++ b/docs/DATA_LOADING.md
@@ -160,6 +160,27 @@ production, serialized route and API failures also include `error.diagnostics`
 with framework metadata such as `phase`, `routeId`, `routePath`, `routeFile`,
 `loaderFile`, `shellFile`, `middlewareFiles`, and `status`.
 
+#### Dev error overlay
+
+In dev, uncaught server errors render pracht's full-page error overlay
+instead of a bare 500. Stack frames from your app code (and the reported
+file path) are clickable — they open the file at the exact line and column
+in your editor through Vite's built-in `/__open-in-editor` endpoint. Frames
+from `node_modules` and Node internals are de-emphasized.
+
+Manifest wiring mistakes fail loudly with a "did you mean" hint. Referencing
+an unregistered shell or middleware name (including `api.middleware`) throws
+during `resolveApp()`, and unknown route ids throw from `href()`/`<Link route>`:
+
+```
+Unknown shell "pubic" for route "/". Did you mean "public"? Registered shells: public, app.
+Unknown middleware "auht" for route "/admin". Did you mean "auth"? Registered middleware: auth, logging.
+Unknown pracht route id "prduct". Did you mean "product"? Registered route ids: home, product, docs.
+```
+
+These messages flow into the dev error overlay as soon as the dev server
+loads the manifest.
+
 ---
 
 ## Head Metadata

--- a/packages/framework/src/app.ts
+++ b/packages/framework/src/app.ts
@@ -22,6 +22,7 @@ import type {
   PrachtApp,
   PrachtAppConfig,
 } from "./types.ts";
+import { formatUnknownNameError } from "./name-suggestions.ts";
 
 interface InheritedRouteConfig {
   pathPrefix: string;
@@ -117,6 +118,20 @@ export function resolveApp(app: PrachtApp): ResolvedPrachtApp {
     middleware: [],
   };
 
+  for (const name of app.api?.middleware ?? []) {
+    if (!hasOwnEntry(app.middleware, name)) {
+      throw new Error(
+        formatUnknownNameError({
+          kind: "middleware",
+          kindPlural: "middleware",
+          name,
+          registered: Object.keys(app.middleware),
+          context: "api routes",
+        }),
+      );
+    }
+  }
+
   for (const node of app.routes) {
     flattenRouteNode(app, node, inherited, routes);
   }
@@ -177,6 +192,17 @@ function flattenRouteNode(
   const shell = node.shell ?? inherited.shell;
   const middleware = [...inherited.middleware, ...(node.middleware ?? [])];
 
+  if (shell !== undefined && !hasOwnEntry(app.shells, shell)) {
+    throw new Error(
+      formatUnknownNameError({
+        kind: "shell",
+        name: shell,
+        registered: Object.keys(app.shells),
+        context: `route "${fullPath}"`,
+      }),
+    );
+  }
+
   routes.push({
     id: node.id ?? createRouteId(fullPath),
     path: fullPath,
@@ -184,16 +210,31 @@ function flattenRouteNode(
     loaderFile: node.loaderFile,
     hasLoader: node.loaderFile ? true : node.hasLoader,
     shell,
-    shellFile: shell ? app.shells[shell] : undefined,
+    shellFile: shell !== undefined ? app.shells[shell] : undefined,
     render: node.render ?? inherited.render,
     middleware,
-    middlewareFiles: middleware.flatMap((name) => {
-      const middlewareFile = app.middleware[name];
-      return middlewareFile ? [middlewareFile] : [];
+    middlewareFiles: middleware.map((name) => {
+      if (!hasOwnEntry(app.middleware, name)) {
+        throw new Error(
+          formatUnknownNameError({
+            kind: "middleware",
+            kindPlural: "middleware",
+            name,
+            registered: Object.keys(app.middleware),
+            context: `route "${fullPath}"`,
+          }),
+        );
+      }
+      return app.middleware[name];
     }),
     revalidate: node.revalidate,
     segments: parseRouteSegments(fullPath),
   });
+}
+
+/** `in` would also match `Object.prototype` keys such as `constructor`. */
+function hasOwnEntry(record: Record<string, string>, name: string): boolean {
+  return Object.prototype.hasOwnProperty.call(record, name);
 }
 
 function isResolvedApp(app: PrachtApp | ResolvedPrachtApp): app is ResolvedPrachtApp {
@@ -356,7 +397,14 @@ function buildHrefUntyped(
 ): string {
   const route = routes.find((candidate) => candidate.id === routeId);
   if (!route) {
-    throw new Error(`Unknown pracht route id: ${routeId}.`);
+    throw new Error(
+      formatUnknownNameError({
+        kind: "pracht route id",
+        kindPlural: "route ids",
+        name: routeId,
+        registered: routes.flatMap((candidate) => (candidate.id ? [candidate.id] : [])),
+      }),
+    );
   }
 
   const segments = route.segments ?? parseRouteSegments(route.path);

--- a/packages/framework/src/error-overlay.ts
+++ b/packages/framework/src/error-overlay.ts
@@ -3,6 +3,10 @@
  *
  * Returns a standalone HTML document with inline styles and scripts.
  * Not a Preact component — must render even when Preact itself fails.
+ *
+ * Dev-only: the overlay is served exclusively by the vite-plugin dev SSR
+ * middleware, so it can rely on Vite's built-in `/__open-in-editor`
+ * endpoint (launch-editor middleware) to make stack frames clickable.
  */
 
 export interface ErrorOverlayOptions {
@@ -10,19 +14,143 @@ export interface ErrorOverlayOptions {
   stack?: string;
   routeId?: string;
   file?: string;
+  /**
+   * Project root (Vite's `server.config.root`). Used to resolve
+   * dev-server URL paths such as `/src/routes/home.tsx` to filesystem
+   * paths for the open-in-editor links.
+   */
+  root?: string;
+}
+
+export interface StackFrame {
+  /** The original stack line, unmodified. */
+  raw: string;
+  /** The exact `file:line:column` substring inside `raw`, when present. */
+  locationText?: string;
+  /** Normalized filesystem path suitable for `/__open-in-editor`. */
+  file?: string;
+  line?: number;
+  column?: number;
+  /** False for node_modules, `node:` internals, and Vite-internal frames. */
+  isApp: boolean;
+}
+
+const FRAME_PARENS = /^\s*at\s+(?:async\s+)?.*?\((.*)\)\s*$/;
+const FRAME_BARE = /^\s*at\s+(?:async\s+)?(.*?)\s*$/;
+const LOCATION = /^(.*?):(\d+):(\d+)$/;
+const WINDOWS_DRIVE_PATH = /^\/?[A-Za-z]:[\\/]/;
+
+/**
+ * Parse a V8-style stack trace into frames. Non-frame lines (the message
+ * line, empty lines) are preserved as non-app frames without a location.
+ */
+export function parseStackFrames(stack: string, options: { root?: string } = {}): StackFrame[] {
+  return stack.split("\n").map((line) => parseStackFrameLine(line, options.root));
+}
+
+function parseStackFrameLine(raw: string, root: string | undefined): StackFrame {
+  const locationText = FRAME_PARENS.exec(raw)?.[1] ?? FRAME_BARE.exec(raw)?.[1];
+  if (!locationText) {
+    return { raw, isApp: false };
+  }
+
+  const location = LOCATION.exec(locationText);
+  if (!location) {
+    return { raw, locationText, isApp: !isInternalStackPath(locationText) };
+  }
+
+  const [, rawPath, line, column] = location;
+  if (isInternalStackPath(rawPath)) {
+    return { raw, locationText, isApp: false };
+  }
+
+  const file = normalizeStackFile(rawPath, root);
+  return {
+    raw,
+    locationText,
+    file,
+    line: Number(line),
+    column: Number(column),
+    isApp: true,
+  };
+}
+
+function isInternalStackPath(path: string): boolean {
+  return (
+    path === "native" ||
+    path === "<anonymous>" ||
+    // Nested eval locations like `eval at foo (file:1:2), <anonymous>` are
+    // not openable file paths.
+    path.includes("(") ||
+    path.startsWith("node:") ||
+    path.startsWith("internal/") ||
+    path.startsWith("virtual:") ||
+    path.includes("\0") ||
+    path.includes("/node_modules/") ||
+    path.includes("\\node_modules\\") ||
+    path.includes("/@vite/")
+  );
+}
+
+/**
+ * Normalize a stack-frame path to a filesystem path that Vite's
+ * `/__open-in-editor` endpoint can open. Handles `file://` URLs,
+ * `http://` dev-server URLs, `/@fs/` prefixes, Vite query suffixes
+ * (`?t=123`, `?pracht-client`), and root-relative dev URLs like
+ * `/src/routes/home.tsx` (joined onto `root` when provided).
+ */
+export function normalizeStackFile(rawPath: string, root?: string): string | undefined {
+  let path = rawPath;
+
+  if (path.startsWith("http://") || path.startsWith("https://") || path.startsWith("file://")) {
+    try {
+      const url = new URL(path);
+      path = decodeURIComponent(url.pathname);
+    } catch {
+      return undefined;
+    }
+  }
+
+  // Strip Vite transform queries and hashes (`/src/a.tsx?t=123`).
+  path = path.split("?")[0].split("#")[0];
+
+  if (path.startsWith("/@fs/")) {
+    path = path.slice("/@fs".length);
+  }
+
+  // `file://C:/...` and `/@fs/C:/...` leave a spurious leading slash on Windows.
+  if (WINDOWS_DRIVE_PATH.test(path) && path.startsWith("/")) {
+    path = path.slice(1);
+  }
+
+  if (!path) return undefined;
+
+  // Root-relative dev-server URL (e.g. `/src/routes/home.tsx`): join onto
+  // the project root so launch-editor resolves the real file. Paths already
+  // under the root (or Windows drive paths) are absolute filesystem paths.
+  if (root && path.startsWith("/") && !WINDOWS_DRIVE_PATH.test(path)) {
+    const normalizedRoot = root.endsWith("/") ? root.slice(0, -1) : root;
+    if (path !== normalizedRoot && !path.startsWith(`${normalizedRoot}/`)) {
+      return `${normalizedRoot}${path}`;
+    }
+  }
+
+  return path;
 }
 
 export function buildErrorOverlayHtml(options: ErrorOverlayOptions): string {
-  const { message, stack, routeId, file } = options;
+  const { message, stack, routeId, file, root } = options;
 
-  const stackHtml = stack ? `<pre class="stack">${escapeHtml(stack)}</pre>` : "";
+  const stackHtml = stack
+    ? `<pre class="stack">${renderStackFrames(parseStackFrames(stack, { root }))}</pre>`
+    : "";
 
   const routeHtml = routeId
     ? `<div class="meta"><span class="label">Route</span> <span class="value">${escapeHtml(routeId)}</span></div>`
     : "";
 
   const fileHtml = file
-    ? `<div class="meta"><span class="label">File</span> <span class="value">${escapeHtml(file)}</span></div>`
+    ? `<div class="meta"><span class="label">File</span> ${renderFileValue(file, root)}</div>`
     : "";
 
   return `<!DOCTYPE html>
@@ -96,6 +224,20 @@ export function buildErrorOverlayHtml(options: ErrorOverlayOptions): string {
       word-break: break-word;
       color: #ccc;
     }
+    .frame-internal {
+      opacity: 0.45;
+    }
+    .editor-link {
+      color: #a0c4ff;
+      text-decoration: underline;
+      text-decoration-style: dotted;
+      text-underline-offset: 3px;
+      cursor: pointer;
+    }
+    .editor-link:hover {
+      color: #d0e2ff;
+      text-decoration-style: solid;
+    }
     .hint {
       margin-top: 24px;
       font-size: 12px;
@@ -113,8 +255,19 @@ export function buildErrorOverlayHtml(options: ErrorOverlayOptions): string {
     ${routeHtml}
     ${fileHtml}
     ${stackHtml}
-    <div class="hint">Fix the error and save — the page will reload automatically.</div>
+    <div class="hint">Click a stack frame to open it in your editor. Fix the error and save — the page will reload automatically.</div>
   </div>
+  <script>
+    // Open clicked stack frames in the editor via Vite's built-in
+    // /__open-in-editor endpoint (dev server only).
+    document.addEventListener("click", function (event) {
+      var target = event.target;
+      var link = target && target.closest ? target.closest("[data-editor-file]") : null;
+      if (!link) return;
+      event.preventDefault();
+      fetch("/__open-in-editor?file=" + encodeURIComponent(link.getAttribute("data-editor-file")));
+    });
+  </script>
   <script>
     // Auto-reload when Vite triggers a full reload (e.g. file saved after fix)
     if (import.meta.hot) {
@@ -125,6 +278,79 @@ export function buildErrorOverlayHtml(options: ErrorOverlayOptions): string {
   </script>
 </body>
 </html>`;
+}
+
+function renderStackFrames(frames: StackFrame[]): string {
+  return frames.map(renderStackFrame).join("\n");
+}
+
+function renderStackFrame(frame: StackFrame): string {
+  if (!frame.isApp) {
+    // Message line vs de-emphasized internal frame.
+    return frame.locationText
+      ? `<span class="frame-internal">${escapeHtml(frame.raw)}</span>`
+      : escapeHtml(frame.raw);
+  }
+
+  if (!frame.file || !frame.locationText) {
+    return escapeHtml(frame.raw);
+  }
+
+  const locationIndex = frame.raw.indexOf(frame.locationText);
+  if (locationIndex === -1) {
+    return escapeHtml(frame.raw);
+  }
+
+  const prefix = frame.raw.slice(0, locationIndex);
+  const suffix = frame.raw.slice(locationIndex + frame.locationText.length);
+  const link = renderEditorLink(frame.file, frame.line, frame.column, frame.locationText);
+  return `${escapeHtml(prefix)}${link}${escapeHtml(suffix)}`;
+}
+
+function renderEditorLink(
+  file: string,
+  line: number | undefined,
+  column: number | undefined,
+  label: string,
+): string {
+  let target = file;
+  if (line !== undefined) {
+    target += `:${line}`;
+    if (column !== undefined) {
+      target += `:${column}`;
+    }
+  }
+
+  return `<a class="editor-link" href="#" data-editor-file="${escapeHtml(target)}">${escapeHtml(label)}</a>`;
+}
+
+function renderFileValue(file: string, root: string | undefined): string {
+  const resolved = resolveEditorFilePath(file, root);
+  if (!resolved) {
+    return `<span class="value">${escapeHtml(file)}</span>`;
+  }
+
+  return `<a class="value editor-link" href="#" data-editor-file="${escapeHtml(resolved)}">${escapeHtml(file)}</a>`;
+}
+
+/**
+ * Resolve the `file` metadata option (typically a manifest-relative path
+ * such as `./routes/home.tsx`) to a filesystem path for open-in-editor.
+ */
+function resolveEditorFilePath(file: string, root: string | undefined): string | undefined {
+  if (file.startsWith("./")) {
+    if (!root) return undefined;
+    const normalizedRoot = root.endsWith("/") ? root.slice(0, -1) : root;
+    // Manifest-relative paths are rooted at the src directory by convention.
+    return `${normalizedRoot}/src/${file.slice(2)}`;
+  }
+
+  if (file.startsWith("../")) {
+    // Cannot resolve reliably without knowing the manifest location.
+    return undefined;
+  }
+
+  return normalizeStackFile(file, root);
 }
 
 function escapeHtml(str: string): string {

--- a/packages/framework/src/name-suggestions.ts
+++ b/packages/framework/src/name-suggestions.ts
@@ -1,0 +1,86 @@
+/**
+ * "Did you mean" helpers for manifest wiring errors.
+ *
+ * When a route references an unknown shell, middleware, or route id, the
+ * error message includes the closest registered name plus the full list of
+ * registered names. A tiny internal edit-distance implementation keeps this
+ * dependency-free.
+ */
+
+/** Classic Levenshtein edit distance using two rolling rows. */
+export function levenshteinDistance(a: string, b: string): number {
+  if (a === b) return 0;
+  if (a.length === 0) return b.length;
+  if (b.length === 0) return a.length;
+
+  let previous = Array.from({ length: b.length + 1 }, (_, index) => index);
+  let current = Array.from<number>({ length: b.length + 1 });
+
+  for (let i = 1; i <= a.length; i += 1) {
+    current[0] = i;
+    for (let j = 1; j <= b.length; j += 1) {
+      const substitution = previous[j - 1] + (a[i - 1] === b[j - 1] ? 0 : 1);
+      current[j] = Math.min(previous[j] + 1, current[j - 1] + 1, substitution);
+    }
+    [previous, current] = [current, previous];
+  }
+
+  return previous[b.length];
+}
+
+/**
+ * Return the candidate closest to `input`, or `undefined` when nothing is
+ * close enough to be a plausible typo. The threshold scales with the input
+ * length (roughly a third of it, minimum 2 edits).
+ */
+export function closestName(input: string, candidates: readonly string[]): string | undefined {
+  let best: string | undefined;
+  let bestDistance = Infinity;
+
+  for (const candidate of candidates) {
+    const distance = levenshteinDistance(input.toLowerCase(), candidate.toLowerCase());
+    if (distance < bestDistance) {
+      bestDistance = distance;
+      best = candidate;
+    }
+  }
+
+  const threshold = Math.max(2, Math.floor(input.length / 3));
+  return bestDistance <= threshold ? best : undefined;
+}
+
+export interface UnknownNameErrorOptions {
+  /** Singular label, e.g. `shell`. */
+  kind: string;
+  /** Plural label for the registered list. Defaults to `${kind}s`. */
+  kindPlural?: string;
+  /** The unknown name that was referenced. */
+  name: string;
+  /** All registered names of this kind. */
+  registered: readonly string[];
+  /** Where the bad reference lives, e.g. `route "/"`. */
+  context?: string;
+}
+
+/**
+ * Format an enriched wiring error, e.g.
+ * `Unknown shell "pubic" for route "/". Did you mean "public"? Registered shells: public, app.`
+ */
+export function formatUnknownNameError(options: UnknownNameErrorOptions): string {
+  const { kind, name, registered, context } = options;
+  const kindPlural = options.kindPlural ?? `${kind}s`;
+
+  let message = `Unknown ${kind} "${name}"${context ? ` for ${context}` : ""}.`;
+
+  const suggestion = closestName(name, registered);
+  if (suggestion) {
+    message += ` Did you mean "${suggestion}"?`;
+  }
+
+  message +=
+    registered.length > 0
+      ? ` Registered ${kindPlural}: ${registered.join(", ")}.`
+      : ` No ${kindPlural} are registered in defineApp().`;
+
+  return message;
+}

--- a/packages/framework/test/error-overlay.test.ts
+++ b/packages/framework/test/error-overlay.test.ts
@@ -1,0 +1,196 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildErrorOverlayHtml,
+  normalizeStackFile,
+  parseStackFrames,
+} from "../src/error-overlay.ts";
+
+const STACK_FIXTURE = [
+  "Error: loader exploded",
+  "    at loader (/Users/dev/my-app/src/routes/home.tsx:12:9)",
+  "    at async handlePrachtRequest (/Users/dev/my-app/node_modules/@pracht/core/dist/index.mjs:100:5)",
+  "    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)",
+].join("\n");
+
+describe("parseStackFrames", () => {
+  it("extracts file, line, and column from app frames", () => {
+    const frames = parseStackFrames(STACK_FIXTURE);
+
+    expect(frames).toHaveLength(4);
+    expect(frames[1]).toMatchObject({
+      file: "/Users/dev/my-app/src/routes/home.tsx",
+      line: 12,
+      column: 9,
+      isApp: true,
+    });
+  });
+
+  it("keeps the message line as a non-frame entry", () => {
+    const frames = parseStackFrames(STACK_FIXTURE);
+
+    expect(frames[0]).toMatchObject({ raw: "Error: loader exploded", isApp: false });
+    expect(frames[0].file).toBeUndefined();
+  });
+
+  it("marks node_modules and node: internals as non-app frames", () => {
+    const frames = parseStackFrames(STACK_FIXTURE);
+
+    expect(frames[2].isApp).toBe(false);
+    expect(frames[3].isApp).toBe(false);
+  });
+
+  it("parses bare frames without a function name", () => {
+    const [frame] = parseStackFrames("    at /Users/dev/my-app/src/api/health.ts:3:1");
+
+    expect(frame).toMatchObject({
+      file: "/Users/dev/my-app/src/api/health.ts",
+      line: 3,
+      column: 1,
+      isApp: true,
+    });
+  });
+
+  it("parses async frames", () => {
+    const [frame] = parseStackFrames(
+      "    at async loader (/Users/dev/my-app/src/server/data.ts:8:3)",
+    );
+
+    expect(frame).toMatchObject({ file: "/Users/dev/my-app/src/server/data.ts", line: 8 });
+  });
+
+  it("resolves file:// URLs to filesystem paths", () => {
+    const [frame] = parseStackFrames(
+      "    at loader (file:///Users/dev/my%20app/src/routes/home.tsx:4:11)",
+    );
+
+    expect(frame).toMatchObject({
+      file: "/Users/dev/my app/src/routes/home.tsx",
+      line: 4,
+      column: 11,
+    });
+  });
+
+  it("strips Vite transform queries and /@fs/ prefixes", () => {
+    const [frame] = parseStackFrames(
+      "    at loader (/@fs/Users/dev/my-app/src/routes/home.tsx?t=1699999999:7:2)",
+    );
+
+    expect(frame).toMatchObject({ file: "/Users/dev/my-app/src/routes/home.tsx", line: 7 });
+  });
+
+  it("joins root-relative dev-server URLs onto the project root", () => {
+    const [frame] = parseStackFrames("    at loader (/src/routes/home.tsx:5:3)", {
+      root: "/Users/dev/my-app",
+    });
+
+    expect(frame).toMatchObject({ file: "/Users/dev/my-app/src/routes/home.tsx", line: 5 });
+  });
+
+  it("leaves absolute paths under the root untouched", () => {
+    const [frame] = parseStackFrames("    at loader (/Users/dev/my-app/src/routes/home.tsx:5:3)", {
+      root: "/Users/dev/my-app",
+    });
+
+    expect(frame.file).toBe("/Users/dev/my-app/src/routes/home.tsx");
+  });
+
+  it("does not link virtual modules or eval frames", () => {
+    const frames = parseStackFrames(
+      [
+        "    at loader (virtual:pracht/server:1:1)",
+        "    at eval (eval at run (/Users/dev/app.ts:1:1), <anonymous>:1:1)",
+        "    at native",
+      ].join("\n"),
+    );
+
+    for (const frame of frames) {
+      expect(frame.isApp).toBe(false);
+      expect(frame.file).toBeUndefined();
+    }
+  });
+});
+
+describe("normalizeStackFile", () => {
+  it("strips queries and hashes", () => {
+    expect(normalizeStackFile("/a/b.tsx?pracht-client#L1")).toBe("/a/b.tsx");
+  });
+
+  it("converts http dev-server URLs using the root", () => {
+    expect(normalizeStackFile("http://localhost:3100/src/routes/home.tsx?t=1", "/proj")).toBe(
+      "/proj/src/routes/home.tsx",
+    );
+  });
+
+  it("handles Windows drive paths behind /@fs/", () => {
+    expect(normalizeStackFile("/@fs/C:/proj/src/a.tsx")).toBe("C:/proj/src/a.tsx");
+  });
+
+  it("tolerates a trailing slash on the root", () => {
+    expect(normalizeStackFile("/src/a.tsx", "/proj/")).toBe("/proj/src/a.tsx");
+  });
+});
+
+describe("buildErrorOverlayHtml", () => {
+  it("renders open-in-editor links for app stack frames", () => {
+    const html = buildErrorOverlayHtml({
+      message: "loader exploded",
+      stack: STACK_FIXTURE,
+      root: "/Users/dev/my-app",
+    });
+
+    expect(html).toContain('data-editor-file="/Users/dev/my-app/src/routes/home.tsx:12:9"');
+    expect(html).toContain("/__open-in-editor?file=");
+    expect(html).toContain('class="editor-link"');
+  });
+
+  it("de-emphasizes node_modules and internal frames without linking them", () => {
+    const html = buildErrorOverlayHtml({
+      message: "loader exploded",
+      stack: STACK_FIXTURE,
+      root: "/Users/dev/my-app",
+    });
+
+    expect(html).toContain('class="frame-internal"');
+    expect(html).not.toContain('data-editor-file="/Users/dev/my-app/node_modules');
+    expect(html).not.toContain('data-editor-file="node:');
+  });
+
+  it("links the file metadata to the editor", () => {
+    const html = buildErrorOverlayHtml({
+      message: "boom",
+      file: "./routes/home.tsx",
+      root: "/Users/dev/my-app",
+    });
+
+    expect(html).toContain('data-editor-file="/Users/dev/my-app/src/routes/home.tsx"');
+  });
+
+  it("falls back to plain text for the file metadata without a root", () => {
+    const html = buildErrorOverlayHtml({
+      message: "boom",
+      file: "./routes/home.tsx",
+    });
+
+    expect(html).toContain('<span class="value">./routes/home.tsx</span>');
+  });
+
+  it("escapes HTML in messages and stack frames", () => {
+    const html = buildErrorOverlayHtml({
+      message: '<script>alert("xss")</script>',
+      stack: 'Error: <img src=x onerror=alert(1)>\n    at loader (/app/src/"quote".tsx:1:1)',
+    });
+
+    expect(html).not.toContain('<script>alert("xss")</script>');
+    expect(html).not.toContain("<img src=x");
+    expect(html).toContain("&lt;script&gt;");
+    expect(html).toContain('data-editor-file="/app/src/&quot;quote&quot;.tsx:1:1"');
+  });
+
+  it("renders without a stack", () => {
+    const html = buildErrorOverlayHtml({ message: "boom" });
+
+    expect(html).toContain("boom");
+    expect(html).not.toContain('class="stack"');
+  });
+});

--- a/packages/framework/test/name-suggestions.test.ts
+++ b/packages/framework/test/name-suggestions.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  closestName,
+  formatUnknownNameError,
+  levenshteinDistance,
+} from "../src/name-suggestions.ts";
+
+describe("levenshteinDistance", () => {
+  it("returns 0 for identical strings", () => {
+    expect(levenshteinDistance("public", "public")).toBe(0);
+    expect(levenshteinDistance("", "")).toBe(0);
+  });
+
+  it("returns the other string's length when one side is empty", () => {
+    expect(levenshteinDistance("", "auth")).toBe(4);
+    expect(levenshteinDistance("auth", "")).toBe(4);
+  });
+
+  it("counts substitutions, insertions, and deletions", () => {
+    expect(levenshteinDistance("kitten", "sitting")).toBe(3);
+    expect(levenshteinDistance("pubic", "public")).toBe(1);
+    expect(levenshteinDistance("auht", "auth")).toBe(2);
+    expect(levenshteinDistance("flaw", "lawn")).toBe(2);
+  });
+
+  it("is symmetric", () => {
+    expect(levenshteinDistance("shell", "shells")).toBe(levenshteinDistance("shells", "shell"));
+  });
+});
+
+describe("closestName", () => {
+  it("suggests the closest registered name", () => {
+    expect(closestName("pubic", ["public", "app"])).toBe("public");
+    expect(closestName("auht", ["auth", "logging"])).toBe("auth");
+  });
+
+  it("matches case-insensitively but returns the registered casing", () => {
+    expect(closestName("PUBLIC", ["public", "app"])).toBe("public");
+  });
+
+  it("returns undefined when nothing is a plausible typo", () => {
+    expect(closestName("dashboard", ["auth", "log"])).toBeUndefined();
+  });
+
+  it("returns undefined for an empty candidate list", () => {
+    expect(closestName("public", [])).toBeUndefined();
+  });
+});
+
+describe("formatUnknownNameError", () => {
+  it("includes the suggestion, context, and registered names", () => {
+    expect(
+      formatUnknownNameError({
+        kind: "shell",
+        name: "pubic",
+        registered: ["public", "app"],
+        context: 'route "/"',
+      }),
+    ).toBe(
+      'Unknown shell "pubic" for route "/". Did you mean "public"? Registered shells: public, app.',
+    );
+  });
+
+  it("omits the suggestion when nothing is close", () => {
+    expect(
+      formatUnknownNameError({
+        kind: "shell",
+        name: "dashboard",
+        registered: ["auth"],
+        context: 'route "/x"',
+      }),
+    ).toBe('Unknown shell "dashboard" for route "/x". Registered shells: auth.');
+  });
+
+  it("supports an explicit plural label", () => {
+    expect(
+      formatUnknownNameError({
+        kind: "middleware",
+        kindPlural: "middleware",
+        name: "athu",
+        registered: ["auth"],
+        context: "api routes",
+      }),
+    ).toBe(
+      'Unknown middleware "athu" for api routes. Did you mean "auth"? Registered middleware: auth.',
+    );
+  });
+
+  it("says when nothing is registered at all", () => {
+    expect(
+      formatUnknownNameError({
+        kind: "shell",
+        name: "public",
+        registered: [],
+      }),
+    ).toBe('Unknown shell "public". No shells are registered in defineApp().');
+  });
+});

--- a/packages/framework/test/router.test.ts
+++ b/packages/framework/test/router.test.ts
@@ -44,6 +44,69 @@ describe("resolveApp", () => {
   });
 });
 
+describe("resolveApp wiring errors", () => {
+  it("throws with a did-you-mean hint for unknown shell names", () => {
+    const app = defineApp({
+      shells: {
+        public: "./shells/public.tsx",
+        app: "./shells/app.tsx",
+      },
+      routes: [group({ shell: "pubic" }, [route("/", "./routes/home.tsx")])],
+    });
+
+    expect(() => resolveApp(app)).toThrow(
+      'Unknown shell "pubic" for route "/". Did you mean "public"? Registered shells: public, app.',
+    );
+  });
+
+  it("throws without a suggestion when no shell name is close", () => {
+    const app = defineApp({
+      shells: { public: "./shells/public.tsx" },
+      routes: [route("/", "./routes/home.tsx", { shell: "dashboard" })],
+    });
+
+    expect(() => resolveApp(app)).toThrow(
+      'Unknown shell "dashboard" for route "/". Registered shells: public.',
+    );
+  });
+
+  it("reports when no shells are registered at all", () => {
+    const app = defineApp({
+      routes: [route("/", "./routes/home.tsx", { shell: "public" })],
+    });
+
+    expect(() => resolveApp(app)).toThrow(
+      'Unknown shell "public" for route "/". No shells are registered in defineApp().',
+    );
+  });
+
+  it("throws with a did-you-mean hint for unknown middleware names", () => {
+    const app = defineApp({
+      middleware: {
+        auth: "./middleware/auth.ts",
+        logging: "./middleware/logging.ts",
+      },
+      routes: [route("/admin", "./routes/admin.tsx", { middleware: ["auht"] })],
+    });
+
+    expect(() => resolveApp(app)).toThrow(
+      'Unknown middleware "auht" for route "/admin". Did you mean "auth"? Registered middleware: auth, logging.',
+    );
+  });
+
+  it("validates api middleware names", () => {
+    const app = defineApp({
+      middleware: { auth: "./middleware/auth.ts" },
+      api: { middleware: ["athu"] },
+      routes: [],
+    });
+
+    expect(() => resolveApp(app)).toThrow(
+      'Unknown middleware "athu" for api routes. Did you mean "auth"? Registered middleware: auth.',
+    );
+  });
+});
+
 describe("route() with RouteConfig object", () => {
   it("accepts an object config with component and loader", () => {
     const app = defineApp({
@@ -119,6 +182,9 @@ describe("typed route href helpers", () => {
 
   it("throws for unknown, missing, and extra params", () => {
     expect(() => buildHref(app.routes, "missing")).toThrow(/Unknown pracht route id/);
+    expect(() => buildHref(app.routes, "prduct")).toThrow(
+      'Unknown pracht route id "prduct". Did you mean "product"? Registered route ids: home, product, docs.',
+    );
     expect(() => buildHref(app.routes, "product")).toThrow(/Missing route param: id/);
     expect(() => buildHref(app.routes, "product", { params: { id: "1", extra: "x" } })).toThrow(
       /Unexpected route param: extra/,

--- a/packages/vite-plugin/src/plugin-dev-ssr.ts
+++ b/packages/vite-plugin/src/plugin-dev-ssr.ts
@@ -111,6 +111,7 @@ async function handleDevError(
     let html = buildErrorOverlayHtml({
       message: error instanceof Error ? error.message : String(error),
       stack: error instanceof Error ? error.stack : undefined,
+      root: server.config.root,
     });
     html = await server.transformIndexHtml(url, html);
     res.statusCode = 500;

--- a/skills/debug/SKILL.md
+++ b/skills/debug/SKILL.md
@@ -51,7 +51,7 @@ Work through these in order, stopping when you find the root cause:
 - If `<Link route="...">`, `href("...")`, or route-object `useNavigate()` fails to typecheck, run `pracht typegen --check` to detect stale generated files.
 - Run `pracht inspect routes --json` and confirm the route id exists. If it is a fallback id, remember path changes can rename it.
 - Check generated `src/pracht-routes.d.ts` for inferred params. `:id`, `*`, and `:path*` params are required; extra params should fail at typecheck time.
-- If runtime navigation throws `Unknown pracht route id`, ensure `pracht typegen` was run and the component is rendered inside the pracht route tree.
+- If runtime navigation throws `Unknown pracht route id "..."`, the error includes a `Did you mean "..."?` suggestion and the list of registered route ids — check for a typo first, then ensure `pracht typegen` was run and the component is rendered inside the pracht route tree.
 - For unexpected URLs, reproduce with `href(routeId, options)` and compare against the route's resolved path and params.
 
 ### 3. Loader / API route errors
@@ -69,12 +69,14 @@ Work through these in order, stopping when you find the root cause:
   - Date/time rendering differences
   - Browser-only APIs used during SSR (`window`, `document`, `localStorage`)
   - Conditional rendering based on client state
-- **Missing shell**: Verify the shell is registered in `defineApp({ shells: { ... } })` and assigned to the route/group.
+- **Missing shell**: Referencing an unregistered shell name throws at manifest resolution — `Unknown shell "..." for route "...". Did you mean "..."? Registered shells: ...` — and shows up in the dev error overlay as soon as the server loads the manifest. Verify the shell is registered in `defineApp({ shells: { ... } })` and assigned to the route/group.
 - **404 page**: Route not matched — check manifest wiring (step 1). In `pracht dev`, unmatched navigations render a dev-only 404 page listing every registered route with its render mode; compare the requested path against that table. The route table is also printed on dev-server startup and available via `pracht inspect routes`.
 
 ### 5. Middleware issues
 
-- Verify middleware is registered in `defineApp({ middleware: { ... } })`.
+- Verify middleware is registered in `defineApp({ middleware: { ... } })`. An
+  unregistered name (on a route, group, or `api.middleware`) throws at manifest
+  resolution — `Unknown middleware "..." for route "...". Did you mean "..."? Registered middleware: ...`
 - Verify middleware is applied to the route/group: `middleware: ["name"]`.
 - Middleware is wrap-around: it must always return a `Response`, either by
   calling `await next()` (to continue down the chain) or short-circuiting.


### PR DESCRIPTION
## Summary

- **Open-in-editor links (Part A).** The dev error overlay now parses V8-style stack traces (`parseStackFrames()` in `@pracht/core/error-overlay`) and renders app-code frames as clickable links that open the file at the exact `file:line:column` in your editor via Vite's built-in `/__open-in-editor` endpoint (launch-editor middleware), triggered with a `fetch` from an inline click handler. Frames from `node_modules`, `node:` internals, eval sites, and Vite-internal/virtual modules are visually de-emphasized (`.frame-internal`) and never linked. Path normalization handles `file://` URLs, `/@fs/` prefixes (including Windows drive paths), Vite transform queries (`?t=…`, `?pracht-client`), and root-relative dev-server URLs (`/src/routes/home.tsx`), which are joined onto the project root — the dev SSR middleware now passes `server.config.root` into `buildErrorOverlayHtml()`. The `File` metadata line is clickable too. The overlay remains dev-only: it is served exclusively by the vite-plugin dev SSR middleware.
- **"Did you mean" wiring errors (Part B).** Unknown shell and middleware names previously resolved silently to `undefined`/dropped entries. `resolveApp()` now throws with an enriched message for unknown shell names on routes/groups, unknown middleware names on routes/groups, and unknown `api.middleware` names; `buildHref()`'s `Unknown pracht route id` error is enriched the same way. Messages include a closest-match suggestion (small internal Levenshtein helper in `name-suggestions.ts`, ~20 lines, no new dependency) and the list of registered names, e.g. `Unknown shell "pubic" for route "/". Did you mean "public"? Registered shells: public, app.` Because the virtual server module calls `resolveApp()` at load time, these messages flow straight into the dev error overlay.
- Added vitest coverage: stack-frame parsing (V8 formats, `file://`, `/@fs/`, query stripping, root joining, internal-frame classification), `normalizeStackFile`, edit-distance/suggestion/threshold behavior, enriched message formatting, resolveApp/buildHref wiring errors, and overlay HTML containing editor links for a stack fixture (plus escaping).
- Docs updated (`docs/ARCHITECTURE.md` dev error overlay section + module graph, `docs/DATA_LOADING.md` dev error overlay subsection) and `skills/debug/SKILL.md` references to the affected error messages.
- No linked issue.

## Testing

- [x] `pnpm e2e`
- [x] `pnpm format`
- [x] `pnpm lint`
- [x] `pnpm test`

## Checklist

- [x] Docs updated if needed
- [x] Skills updated if needed
- [x] Changeset added if published packages changed
