### PR TITLE
Dev-server startup banner and rich dev-only 404 page

### DIFF
--- a/.changeset/dev-banner-404.md
+++ b/.changeset/dev-banner-404.md
@@ -1,0 +1,18 @@
+---
+"@pracht/core": minor
+"@pracht/vite-plugin": minor
+"@pracht/cli": minor
+---
+
+Add a dev-server startup banner and a rich dev-only 404 page.
+
+`pracht dev` now prints a route table on startup — every page route with its
+render mode, shell, and middleware, plus API routes with their HTTP methods —
+alongside the local URL. The banner reuses the resolved-app-graph logic shared
+with `pracht inspect` and respects `NO_COLOR`.
+
+In dev mode, document navigations that match no page route and no API route now
+render a styled standalone 404 page (new `@pracht/core/dev-404` entry, same
+self-contained approach as the error overlay) listing all registered routes
+with render modes and links plus the requested path. The module is only loaded
+by the dev middleware; production 404 behavior is unchanged.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -450,6 +450,7 @@ hydration.ts    — Preact options hooks for tracking hydration (no internal dep
 href.ts         — createHref helper layered on buildHref
 forwardRef.ts   — forwardRef helper (no internal deps)
 error-overlay.ts — dev error page HTML (no internal deps)
+dev-404.ts      — dev-only 404 page HTML listing registered routes (no internal deps)
 ```
 
 The published core package also exposes small browser-oriented entries:
@@ -460,6 +461,9 @@ The published core package also exposes small browser-oriented entries:
   transformed route module references to strings.
 - `@pracht/core/server` is used by generated server entries and adapters so
   edge worker builds do not resolve server imports through the browser condition.
+- `@pracht/core/error-overlay` and `@pracht/core/dev-404` are dev-only entries
+  loaded on demand by the Vite dev middleware (via `ssrLoadModule`); no
+  production entry point or generated server entry imports them.
 - The root `@pracht/core` export has a browser condition that points at a
   client-safe public entry for route and shell modules.
 

--- a/docs/ROUTING.md
+++ b/docs/ROUTING.md
@@ -452,3 +452,60 @@ generateRoutesFile("src/pages", "src/routes.ts", {
 
 Then remove `pagesDir` from your pracht config. The generated file includes
 a header comment explaining how to use it directly.
+
+---
+
+## Dev Server
+
+### Startup Banner
+
+`pracht dev` prints a route table when the server starts: the local (and
+network) URL, every page route with its render mode, shell, and middleware,
+plus API routes with their exported HTTP methods.
+
+```
+  pracht dev
+
+  ➜  Local:   http://localhost:3000/
+
+  Routes (5)
+    ROUTE          MODE  SHELL   MIDDLEWARE
+    /              ssg   public  -
+    /pricing       isg   public  -
+    /products/:id  ssr   public  -
+    /dashboard     ssr   app     auth
+    /settings      spa   app     auth
+
+  API (3)
+    ROUTE           METHODS
+    /api/dashboard  GET
+    /api/echo       GET, POST
+    /api/health     GET
+```
+
+The banner reuses the same resolved-app-graph logic as `pracht inspect` (see
+`pracht inspect routes --json` for the machine-readable version). Output
+respects [`NO_COLOR`](https://no-color.org); ANSI colors are only emitted on a
+TTY. API methods are detected with a static export scan at startup — API
+modules are not executed until they receive a request.
+
+### Dev-Only 404 Page
+
+In dev mode, a document navigation (GET/HEAD with an HTML `Accept` header)
+that matches no page route and no API route renders a standalone 404 page
+listing every registered route with its render mode — static paths are
+clickable links. The page is self-contained HTML served by the dev middleware
+(`@pracht/core/dev-404`, same approach as the dev error overlay) and reloads
+automatically when a route is added.
+
+This page exists only in development:
+
+- Route-state (JSON) requests, non-document fetches, and non-GET methods keep
+  their normal 404 behavior.
+- Apps that register a catch-all `route("*", ...)` match every path, so their
+  own not-found page renders instead.
+- Adapters that own the dev server (e.g. Cloudflare) route dev requests
+  through their own worker runtime, so the dev middleware — and this page —
+  does not apply there.
+- Production builds never include the module — production 404 behavior is
+  unchanged.

--- a/e2e/dev-404.test.ts
+++ b/e2e/dev-404.test.ts
@@ -1,0 +1,42 @@
+import { expect, test } from "@playwright/test";
+
+// ---------------------------------------------------------------------------
+// Dev-only 404 page: unmatched document navigations render a standalone HTML
+// page listing every registered route with its render mode. Runs against the
+// pages-router example (node adapter) — the Cloudflare example owns its dev
+// server, so the pracht dev middleware is not active there.
+// ---------------------------------------------------------------------------
+
+test("unmatched navigation renders the dev 404 page with the route table", async ({ page }) => {
+  const response = await page.goto("/this/route/does/not/exist");
+  expect(response?.status()).toBe(404);
+  expect(response?.headers()["content-type"]).toContain("text/html");
+
+  await expect(page.locator(".badge")).toHaveText("404");
+  await expect(page.locator(".message")).toContainText("/this/route/does/not/exist");
+
+  // Every registered page route is listed with its render mode.
+  await expect(page.locator('a.path[href="/about"]')).toHaveText("/about");
+  await expect(page.locator(".path.dynamic")).toContainText("/blog/:slug");
+  await expect(page.locator(".mode-ssg").first()).toBeVisible();
+
+  // API routes are listed too.
+  await expect(page.locator("td", { hasText: "/api/health" })).toBeVisible();
+});
+
+test("dev 404 links navigate to real routes", async ({ page }) => {
+  await page.goto("/missing-page");
+  await page.click('a.path[href="/about"]');
+
+  await expect(page.locator("h1")).toContainText("About");
+});
+
+test("unmatched route-state requests keep their JSON 404 behavior", async ({ request }) => {
+  const response = await request.get("/missing-page?_data=1", {
+    headers: { accept: "*/*" },
+  });
+
+  expect(response.status()).toBe(404);
+  const body = await response.text();
+  expect(body).not.toContain("No route matches");
+});

--- a/packages/cli/src/app-graph.ts
+++ b/packages/cli/src/app-graph.ts
@@ -1,0 +1,116 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+import type { ViteDevServer } from "vite";
+
+import { HTTP_METHODS, type HttpMethod } from "./constants.js";
+
+const METHOD_ORDER: HttpMethod[] = [...HTTP_METHODS];
+
+export interface AppGraphRoute {
+  file: string;
+  id: string;
+  loaderFile: string | null;
+  middleware: string[];
+  path: string;
+  render: string | null;
+  revalidate: unknown;
+  shell: string | null;
+  shellFile: string | null;
+}
+
+export interface AppGraphApiRoute {
+  file: string;
+  methods: string[];
+  path: string;
+}
+
+export interface AppGraph {
+  api: AppGraphApiRoute[];
+  routes: AppGraphRoute[];
+}
+
+interface ResolvedRouteEntry {
+  file: string;
+  id: string;
+  loaderFile?: string;
+  middleware: string[];
+  path: string;
+  render?: string;
+  revalidate?: unknown;
+  shell?: string;
+  shellFile?: string;
+}
+
+interface ApiRouteEntry {
+  file: string;
+  path: string;
+}
+
+/**
+ * Load the resolved app graph (page routes + API routes) from a running Vite
+ * dev server. Shared by `pracht inspect` and the `pracht dev` startup banner.
+ */
+export async function collectAppGraph(
+  server: ViteDevServer,
+  root: string,
+  options: { executeApiModules?: boolean } = {},
+): Promise<AppGraph> {
+  const serverModule = await server.ssrLoadModule("virtual:pracht/server");
+  return {
+    api: await collectApiRoutes(server, root, serverModule.apiRoutes, options),
+    routes: serializeResolvedRoutes(serverModule.resolvedApp.routes),
+  };
+}
+
+export function serializeResolvedRoutes(routes: ResolvedRouteEntry[]): AppGraphRoute[] {
+  return routes.map((route) => ({
+    file: route.file,
+    id: route.id,
+    loaderFile: route.loaderFile ?? null,
+    middleware: route.middleware,
+    path: route.path,
+    render: route.render ?? null,
+    revalidate: route.revalidate ?? null,
+    shell: route.shell ?? null,
+    shellFile: route.shellFile ?? null,
+  }));
+}
+
+export async function collectApiRoutes(
+  server: ViteDevServer,
+  root: string,
+  apiRoutes: ApiRouteEntry[],
+  options: { executeApiModules?: boolean } = {},
+): Promise<AppGraphApiRoute[]> {
+  return Promise.all(
+    apiRoutes.map(async (route) => ({
+      file: route.file,
+      methods: await detectApiMethods(server, root, route.file, options),
+      path: route.path,
+    })),
+  );
+}
+
+async function detectApiMethods(
+  server: ViteDevServer,
+  root: string,
+  file: string,
+  options: { executeApiModules?: boolean },
+): Promise<string[]> {
+  const resolvedFile = resolve(root, `.${file}`);
+  const source = readFileSync(resolvedFile, "utf-8");
+
+  if (options.executeApiModules) {
+    try {
+      const module = await server.ssrLoadModule(file);
+      return METHOD_ORDER.filter((method) => typeof module[method] === "function");
+    } catch {
+      // Fall through to the static scan below.
+    }
+  }
+
+  return METHOD_ORDER.filter((method) =>
+    new RegExp(`export\\s+(?:async\\s+)?(?:function|const|let|var)\\s+${method}\\b`).test(source),
+  );
+}

--- a/packages/cli/src/commands/dev.ts
+++ b/packages/cli/src/commands/dev.ts
@@ -1,6 +1,9 @@
 import { defineCommand } from "citty";
 import { createServer } from "vite";
 
+import { collectAppGraph } from "../app-graph.js";
+import { formatDevBanner, supportsColor } from "../dev-banner.js";
+
 export default defineCommand({
   meta: {
     name: "dev",
@@ -15,13 +18,31 @@ export default defineCommand({
   },
   async run({ args }) {
     const port = parseInt(process.env.PORT || args.port || "3000", 10);
+    const root = process.cwd();
 
     const server = await createServer({
-      root: process.cwd(),
+      root,
       server: { port },
     });
 
     await server.listen();
-    server.printUrls();
+
+    try {
+      const graph = await collectAppGraph(server, root);
+      const urls = server.resolvedUrls ?? { local: [], network: [] };
+      console.log(
+        formatDevBanner({
+          apiRoutes: graph.api,
+          color: supportsColor(),
+          localUrls: urls.local,
+          networkUrls: urls.network,
+          routes: graph.routes,
+        }),
+      );
+    } catch {
+      // Not a resolvable pracht app graph (or it failed to load) — fall back
+      // to Vite's own URL output so the dev server still starts cleanly.
+      server.printUrls();
+    }
   },
 });

--- a/packages/cli/src/commands/inspect.ts
+++ b/packages/cli/src/commands/inspect.ts
@@ -1,16 +1,14 @@
-import { existsSync, readFileSync } from "node:fs";
-import { resolve } from "node:path";
+import { existsSync } from "node:fs";
 
 import { defineCommand } from "citty";
-import { createServer, type ViteDevServer } from "vite";
+import { createServer } from "vite";
 
 import { handleCliError } from "../utils.js";
+import { collectApiRoutes, serializeResolvedRoutes } from "../app-graph.js";
 import { readClientBuildAssets } from "../build-metadata.js";
-import { HTTP_METHODS, type HttpMethod } from "../constants.js";
 import { readProjectConfig, resolveProjectPath } from "../project.js";
 
 const INSPECT_TARGETS = new Set(["routes", "api", "build", "all"]);
-const METHOD_ORDER: HttpMethod[] = [...HTTP_METHODS];
 
 export default defineCommand({
   meta: {
@@ -105,17 +103,13 @@ export async function runInspect(root: string, { target = "all" } = {}): Promise
     };
 
     if (target === "routes" || target === "all") {
-      report.routes = serializeRoutes(serverModule.resolvedApp.routes);
+      report.routes = serializeResolvedRoutes(serverModule.resolvedApp.routes);
     }
 
     if (target === "api" || target === "all") {
-      report.api = await Promise.all(
-        serverModule.apiRoutes.map(async (route: { file: string; path: string }) => ({
-          file: route.file,
-          methods: await detectApiMethods(server, root, route.file),
-          path: route.path,
-        })),
-      );
+      report.api = await collectApiRoutes(server, root, serverModule.apiRoutes, {
+        executeApiModules: true,
+      });
     }
 
     if (target === "build" || target === "all") {
@@ -131,50 +125,6 @@ export async function runInspect(root: string, { target = "all" } = {}): Promise
     return report;
   } finally {
     await server.close();
-  }
-}
-
-interface RouteEntry {
-  file: string;
-  id: string;
-  loaderFile?: string;
-  middleware: string[];
-  path: string;
-  render?: string;
-  revalidate?: unknown;
-  shell?: string;
-  shellFile?: string;
-}
-
-function serializeRoutes(routes: RouteEntry[]) {
-  return routes.map((route) => ({
-    file: route.file,
-    id: route.id,
-    loaderFile: route.loaderFile ?? null,
-    middleware: route.middleware,
-    path: route.path,
-    render: route.render ?? null,
-    revalidate: route.revalidate ?? null,
-    shell: route.shell ?? null,
-    shellFile: route.shellFile ?? null,
-  }));
-}
-
-async function detectApiMethods(
-  server: ViteDevServer,
-  root: string,
-  file: string,
-): Promise<string[]> {
-  const resolvedFile = resolve(root, `.${file}`);
-  const source = readFileSync(resolvedFile, "utf-8");
-
-  try {
-    const module = await server.ssrLoadModule(file);
-    return METHOD_ORDER.filter((method) => typeof module[method] === "function");
-  } catch {
-    return METHOD_ORDER.filter((method) =>
-      new RegExp(`export\\s+(?:async\\s+)?(?:function|const|let|var)\\s+${method}\\b`).test(source),
-    );
   }
 }
 

--- a/packages/cli/src/dev-banner.ts
+++ b/packages/cli/src/dev-banner.ts
@@ -1,0 +1,131 @@
+import type { AppGraphApiRoute, AppGraphRoute } from "./app-graph.js";
+
+export interface DevBannerRoute extends Pick<
+  AppGraphRoute,
+  "middleware" | "path" | "render" | "shell"
+> {}
+
+export interface DevBannerApiRoute extends Pick<AppGraphApiRoute, "methods" | "path"> {}
+
+export interface DevBannerOptions {
+  apiRoutes: DevBannerApiRoute[];
+  color?: boolean;
+  localUrls: string[];
+  networkUrls?: string[];
+  routes: DevBannerRoute[];
+}
+
+const ANSI = {
+  bold: "1",
+  cyan: "36",
+  dim: "2",
+  green: "32",
+  magenta: "35",
+  yellow: "33",
+};
+
+const MODE_COLORS: Record<string, string> = {
+  isg: ANSI.cyan,
+  spa: ANSI.magenta,
+  ssg: ANSI.green,
+  ssr: ANSI.yellow,
+};
+
+/**
+ * Format the `pracht dev` startup banner: local URL(s) plus an aligned table
+ * of page routes (pattern, render mode, shell, middleware) and API routes.
+ */
+export function formatDevBanner(options: DevBannerOptions): string {
+  const { apiRoutes, color = false, localUrls, networkUrls = [], routes } = options;
+  const paint = (text: string, code: string): string =>
+    color ? `\u001b[${code}m${text}\u001b[0m` : text;
+
+  const lines: string[] = [];
+  lines.push("");
+  lines.push(`  ${paint("pracht dev", ANSI.bold)}`);
+  lines.push("");
+
+  for (const url of localUrls) {
+    lines.push(`  ${paint("➜", ANSI.green)}  Local:   ${paint(url, `${ANSI.bold};${ANSI.cyan}`)}`);
+  }
+  for (const url of networkUrls) {
+    lines.push(`  ${paint("➜", ANSI.green)}  Network: ${paint(url, ANSI.cyan)}`);
+  }
+  lines.push("");
+
+  lines.push(`  ${paint(`Routes (${routes.length})`, ANSI.bold)}`);
+  if (routes.length === 0) {
+    lines.push("    (none)");
+  } else {
+    const rows = routes.map((route) => [
+      route.path,
+      route.render ?? "ssr",
+      route.shell ?? "-",
+      route.middleware.length > 0 ? route.middleware.join(", ") : "-",
+    ]);
+    const header = ["ROUTE", "MODE", "SHELL", "MIDDLEWARE"];
+    const widths = columnWidths([header, ...rows]);
+    lines.push(`    ${paint(formatRow(header, widths), ANSI.dim)}`);
+    for (const row of rows) {
+      const [path, mode, shell, middleware] = row;
+      const cells = [
+        path.padEnd(widths[0]),
+        paint(mode.padEnd(widths[1]), MODE_COLORS[mode] ?? ANSI.dim),
+        shell.padEnd(widths[2]),
+        middleware,
+      ];
+      lines.push(`    ${cells.join("  ")}`.trimEnd());
+    }
+  }
+  lines.push("");
+
+  lines.push(`  ${paint(`API (${apiRoutes.length})`, ANSI.bold)}`);
+  if (apiRoutes.length === 0) {
+    lines.push("    (none)");
+  } else {
+    const rows = apiRoutes.map((route) => [
+      route.path,
+      route.methods.length > 0 ? route.methods.join(", ") : "-",
+    ]);
+    const header = ["ROUTE", "METHODS"];
+    const widths = columnWidths([header, ...rows]);
+    lines.push(`    ${paint(formatRow(header, widths), ANSI.dim)}`);
+    for (const row of rows) {
+      lines.push(`    ${formatRow(row, widths)}`);
+    }
+  }
+  lines.push("");
+
+  return lines.join("\n");
+}
+
+/** Respect NO_COLOR (https://no-color.org) and only color TTY output. */
+export function supportsColor(
+  env: Record<string, string | undefined> = process.env,
+  isTTY: boolean = Boolean(process.stdout.isTTY),
+): boolean {
+  if (env.NO_COLOR) {
+    return false;
+  }
+  if (env.FORCE_COLOR) {
+    return true;
+  }
+  return isTTY;
+}
+
+function columnWidths(rows: string[][]): number[] {
+  const widths: number[] = [];
+  for (const row of rows) {
+    row.forEach((cell, index) => {
+      widths[index] = Math.max(widths[index] ?? 0, cell.length);
+    });
+  }
+  return widths;
+}
+
+function formatRow(cells: string[], widths: number[]): string {
+  return cells
+    .map((cell, index) => (index === cells.length - 1 ? cell : cell.padEnd(widths[index])))
+    .join("  ")
+    .trimEnd();
+}

--- a/packages/cli/test/dev-banner.test.ts
+++ b/packages/cli/test/dev-banner.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from "vitest";
+
+import { formatDevBanner, supportsColor } from "../src/dev-banner.ts";
+
+const routes = [
+  { middleware: [], path: "/", render: "ssg", shell: "public" },
+  { middleware: [], path: "/pricing", render: "isg", shell: "public" },
+  { middleware: [], path: "/products/:id", render: "ssr", shell: "public" },
+  { middleware: ["auth"], path: "/dashboard", render: "ssr", shell: "app" },
+  { middleware: ["auth", "audit"], path: "/settings", render: "spa", shell: "app" },
+];
+
+const apiRoutes = [
+  { methods: ["GET"], path: "/api/health" },
+  { methods: ["GET", "POST"], path: "/api/echo" },
+];
+
+describe("formatDevBanner", () => {
+  it("prints the local URL prominently and lists routes with mode, shell, and middleware", () => {
+    const banner = formatDevBanner({
+      apiRoutes,
+      color: false,
+      localUrls: ["http://localhost:3000/"],
+      networkUrls: ["http://192.168.0.10:3000/"],
+      routes,
+    });
+
+    expect(banner).toContain("pracht dev");
+    expect(banner).toContain("Local:   http://localhost:3000/");
+    expect(banner).toContain("Network: http://192.168.0.10:3000/");
+    expect(banner).toContain("Routes (5)");
+    expect(banner).toContain("API (2)");
+    expect(banner).toContain("/products/:id");
+    expect(banner).toContain("auth, audit");
+    expect(banner).toContain("GET, POST");
+  });
+
+  it("aligns route columns", () => {
+    const banner = formatDevBanner({
+      apiRoutes: [],
+      color: false,
+      localUrls: ["http://localhost:3000/"],
+      routes,
+    });
+
+    const lines = banner.split("\n");
+    const home = lines.find((line) => line.trimStart().startsWith("/ "));
+    const settings = lines.find((line) => line.trimStart().startsWith("/settings"));
+    expect(home).toBeDefined();
+    expect(settings).toBeDefined();
+    // Every mode cell starts at the same column.
+    expect(home!.indexOf("ssg")).toBe(settings!.indexOf("spa"));
+    // Every shell cell starts at the same column.
+    expect(home!.indexOf("public")).toBe(settings!.indexOf("app"));
+  });
+
+  it("shows ssr as the effective mode when a route declares none", () => {
+    const banner = formatDevBanner({
+      apiRoutes: [],
+      color: false,
+      localUrls: [],
+      routes: [{ middleware: [], path: "/implicit", render: null, shell: null }],
+    });
+
+    expect(banner).toMatch(/\/implicit\s+ssr/);
+  });
+
+  it("emits no ANSI escapes when color is disabled", () => {
+    const banner = formatDevBanner({
+      apiRoutes,
+      color: false,
+      localUrls: ["http://localhost:3000/"],
+      routes,
+    });
+
+    expect(banner).not.toContain("\u001b[");
+  });
+
+  it("emits ANSI escapes when color is enabled", () => {
+    const banner = formatDevBanner({
+      apiRoutes,
+      color: true,
+      localUrls: ["http://localhost:3000/"],
+      routes,
+    });
+
+    expect(banner).toContain("\u001b[");
+  });
+
+  it("handles empty route and API tables", () => {
+    const banner = formatDevBanner({
+      apiRoutes: [],
+      color: false,
+      localUrls: ["http://localhost:3000/"],
+      routes: [],
+    });
+
+    expect(banner).toContain("Routes (0)");
+    expect(banner).toContain("API (0)");
+    expect(banner).toContain("(none)");
+  });
+});
+
+describe("supportsColor", () => {
+  it("respects NO_COLOR over everything else", () => {
+    expect(supportsColor({ NO_COLOR: "1" }, true)).toBe(false);
+    expect(supportsColor({ FORCE_COLOR: "1", NO_COLOR: "1" }, true)).toBe(false);
+  });
+
+  it("honors FORCE_COLOR even without a TTY", () => {
+    expect(supportsColor({ FORCE_COLOR: "1" }, false)).toBe(true);
+  });
+
+  it("falls back to TTY detection", () => {
+    expect(supportsColor({}, true)).toBe(true);
+    expect(supportsColor({}, false)).toBe(false);
+  });
+});

--- a/packages/framework/package.json
+++ b/packages/framework/package.json
@@ -53,6 +53,10 @@
     "./error-overlay": {
       "types": "./dist/error-overlay.d.mts",
       "default": "./dist/error-overlay.mjs"
+    },
+    "./dev-404": {
+      "types": "./dist/dev-404.d.mts",
+      "default": "./dist/dev-404.mjs"
     }
   },
   "publishConfig": {

--- a/packages/framework/src/dev-404.ts
+++ b/packages/framework/src/dev-404.ts
@@ -1,0 +1,214 @@
+/**
+ * Self-contained 404 page for pracht dev mode.
+ *
+ * Returns a standalone HTML document with inline styles and scripts.
+ * Not a Preact component — rendered by the dev middleware when a request
+ * matches no page route and no API route. Loaded exclusively through the
+ * dev server (`@pracht/core/dev-404`) and never reachable from production
+ * code paths.
+ */
+
+export interface DevNotFoundRoute {
+  path: string;
+  render?: string | null;
+}
+
+export interface DevNotFoundApiRoute {
+  path: string;
+  methods?: string[];
+}
+
+export interface DevNotFoundOptions {
+  requestedPath: string;
+  routes: DevNotFoundRoute[];
+  apiRoutes?: DevNotFoundApiRoute[];
+}
+
+const DYNAMIC_SEGMENT = /[:*]/;
+
+export function buildDevNotFoundHtml(options: DevNotFoundOptions): string {
+  const { requestedPath, routes, apiRoutes = [] } = options;
+
+  const routeRows = routes
+    .map((route) => {
+      const mode = route.render ?? "ssr";
+      const isLinkable = !DYNAMIC_SEGMENT.test(route.path);
+      const pathCell = isLinkable
+        ? `<a class="path" href="${escapeHtml(route.path)}">${escapeHtml(route.path)}</a>`
+        : `<span class="path dynamic">${escapeHtml(route.path)}</span>`;
+      return `<tr><td>${pathCell}</td><td><span class="mode mode-${escapeHtml(mode)}">${escapeHtml(mode)}</span></td></tr>`;
+    })
+    .join("\n      ");
+
+  const routesHtml =
+    routes.length > 0
+      ? `<table class="routes">\n      ${routeRows}\n    </table>`
+      : `<p class="empty">No page routes are registered.</p>`;
+
+  const apiRows = apiRoutes
+    .map((route) => {
+      const methods = route.methods?.length ? route.methods.join(", ") : "";
+      return `<tr><td><span class="path">${escapeHtml(route.path)}</span></td><td><span class="methods">${escapeHtml(methods)}</span></td></tr>`;
+    })
+    .join("\n      ");
+
+  const apiHtml =
+    apiRoutes.length > 0
+      ? `<h2>API routes</h2>\n    <table class="routes">\n      ${apiRows}\n    </table>`
+      : "";
+
+  return `<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>404 — pracht dev</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body {
+      font-family: ui-monospace, "Cascadia Code", "Source Code Pro", Menlo, Consolas, monospace;
+      background: #1a1a2e;
+      color: #e0e0e0;
+      padding: 32px;
+      line-height: 1.5;
+    }
+    .overlay {
+      max-width: 900px;
+      margin: 0 auto;
+    }
+    .header {
+      display: flex;
+      align-items: center;
+      gap: 12px;
+      margin-bottom: 24px;
+      padding-bottom: 16px;
+      border-bottom: 1px solid #333;
+    }
+    .badge {
+      background: #f39c12;
+      color: #1a1a2e;
+      font-size: 11px;
+      font-weight: 700;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+      padding: 4px 10px;
+      border-radius: 4px;
+    }
+    .title {
+      font-size: 14px;
+      color: #888;
+    }
+    .message {
+      font-size: 18px;
+      font-weight: 600;
+      color: #ffd166;
+      margin-bottom: 8px;
+      word-break: break-word;
+    }
+    .requested {
+      color: #a0c4ff;
+    }
+    .sub {
+      font-size: 13px;
+      color: #888;
+      margin-bottom: 28px;
+    }
+    h2 {
+      font-size: 13px;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      color: #888;
+      margin: 28px 0 10px;
+    }
+    .routes {
+      width: 100%;
+      border-collapse: collapse;
+      background: #16162a;
+      border: 1px solid #333;
+      border-radius: 8px;
+      overflow: hidden;
+      font-size: 13px;
+    }
+    .routes td {
+      padding: 8px 16px;
+      border-bottom: 1px solid #262640;
+    }
+    .routes tr:last-child td {
+      border-bottom: none;
+    }
+    .routes td:last-child {
+      text-align: right;
+      width: 1%;
+      white-space: nowrap;
+    }
+    a.path {
+      color: #a0c4ff;
+      text-decoration: none;
+    }
+    a.path:hover {
+      text-decoration: underline;
+    }
+    .path.dynamic {
+      color: #ccc;
+    }
+    .mode {
+      font-size: 11px;
+      font-weight: 700;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+      padding: 2px 8px;
+      border-radius: 4px;
+      background: #262640;
+      color: #a0c4ff;
+    }
+    .mode-ssg { color: #7bd88f; }
+    .mode-isg { color: #5fd7d7; }
+    .mode-ssr { color: #ffd166; }
+    .mode-spa { color: #d7a0ff; }
+    .methods {
+      font-size: 12px;
+      color: #7bd88f;
+    }
+    .empty {
+      font-size: 13px;
+      color: #888;
+    }
+    .hint {
+      margin-top: 24px;
+      font-size: 12px;
+      color: #666;
+    }
+  </style>
+</head>
+<body>
+  <div class="overlay">
+    <div class="header">
+      <span class="badge">404</span>
+      <span class="title">pracht dev</span>
+    </div>
+    <div class="message">No route matches <span class="requested">${escapeHtml(requestedPath)}</span></div>
+    <div class="sub">This page is only shown in development — production serves your app's own 404 response.</div>
+    <h2>Page routes</h2>
+    ${routesHtml}
+    ${apiHtml}
+    <div class="hint">Add the route to your app manifest and save — the page will reload automatically.</div>
+  </div>
+  <script>
+    // Auto-reload when Vite triggers a full reload (e.g. a route was added)
+    if (import.meta.hot) {
+      import.meta.hot.on("vite:beforeFullReload", function () {
+        window.location.reload();
+      });
+    }
+  </script>
+</body>
+</html>`;
+}
+
+function escapeHtml(str: string): string {
+  return str
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}

--- a/packages/framework/test/dev-404.test.ts
+++ b/packages/framework/test/dev-404.test.ts
@@ -1,0 +1,102 @@
+import { existsSync, readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+import { buildDevNotFoundHtml } from "../src/dev-404.ts";
+
+const routes = [
+  { path: "/", render: "ssg" },
+  { path: "/pricing", render: "isg" },
+  { path: "/products/:id", render: "ssr" },
+  { path: "/settings", render: "spa" },
+  { path: "/implicit", render: null },
+];
+
+describe("buildDevNotFoundHtml", () => {
+  it("shows the requested path and lists every route with its render mode", () => {
+    const html = buildDevNotFoundHtml({
+      apiRoutes: [{ path: "/api/health" }],
+      requestedPath: "/nope",
+      routes,
+    });
+
+    expect(html).toContain("No route matches");
+    expect(html).toContain("/nope");
+    expect(html).toContain("/products/:id");
+    expect(html).toContain("mode-ssg");
+    expect(html).toContain("mode-isg");
+    expect(html).toContain("mode-ssr");
+    expect(html).toContain("mode-spa");
+    expect(html).toContain("/api/health");
+  });
+
+  it("links static routes but not dynamic patterns", () => {
+    const html = buildDevNotFoundHtml({ requestedPath: "/nope", routes });
+
+    expect(html).toContain('<a class="path" href="/pricing">/pricing</a>');
+    expect(html).not.toContain('href="/products/:id"');
+    expect(html).toContain('<span class="path dynamic">/products/:id</span>');
+  });
+
+  it("treats an undeclared render mode as ssr", () => {
+    const html = buildDevNotFoundHtml({ requestedPath: "/nope", routes });
+
+    expect(html).toContain('href="/implicit"');
+    expect(html).toMatch(/\/implicit<\/a><\/td><td><span class="mode mode-ssr"/);
+  });
+
+  it("escapes the requested path and route patterns", () => {
+    const html = buildDevNotFoundHtml({
+      requestedPath: '/<script>alert("xss")</script>',
+      routes: [{ path: '/"><img>', render: "ssr" }],
+    });
+
+    expect(html).not.toContain("<script>alert");
+    expect(html).toContain("&lt;script&gt;");
+    expect(html).not.toContain('href="/"><img>"');
+  });
+
+  it("renders an empty state when no routes are registered", () => {
+    const html = buildDevNotFoundHtml({ requestedPath: "/nope", routes: [] });
+
+    expect(html).toContain("No page routes are registered.");
+    expect(html).not.toContain("API routes");
+  });
+});
+
+describe("dev-404 production isolation", () => {
+  const srcDir = resolve(dirname(fileURLToPath(import.meta.url)), "../src");
+  const productionEntries = ["index.ts", "server.ts", "client.ts", "browser.ts", "manifest.ts"];
+
+  it("is not reachable from any production entry point", () => {
+    for (const entry of productionEntries) {
+      const reachable = collectRelativeImports(resolve(srcDir, entry));
+      expect(
+        [...reachable].filter((file) => file.endsWith("dev-404.ts")),
+        `${entry} must not (transitively) import dev-404.ts`,
+      ).toEqual([]);
+    }
+  });
+});
+
+/** Walk static + dynamic relative import specifiers transitively. */
+function collectRelativeImports(entryFile: string, seen = new Set<string>()): Set<string> {
+  if (seen.has(entryFile) || !existsSync(entryFile)) {
+    return seen;
+  }
+  seen.add(entryFile);
+
+  const source = readFileSync(entryFile, "utf-8");
+  const specifiers = [
+    ...source.matchAll(/from\s+["'](\.[^"']+)["']/g),
+    ...source.matchAll(/import\(\s*["'](\.[^"']+)["']\s*\)/g),
+  ].map((match) => match[1]);
+
+  for (const specifier of specifiers) {
+    collectRelativeImports(resolve(dirname(entryFile), specifier), seen);
+  }
+
+  return seen;
+}

--- a/packages/framework/tsdown.config.ts
+++ b/packages/framework/tsdown.config.ts
@@ -9,6 +9,7 @@ export default defineConfig({
     "src/manifest.ts",
     "src/server.ts",
     "src/error-overlay.ts",
+    "src/dev-404.ts",
   ],
   format: "esm",
   dts: true,

--- a/packages/vite-plugin/src/plugin-dev-ssr.ts
+++ b/packages/vite-plugin/src/plugin-dev-ssr.ts
@@ -21,15 +21,19 @@ export function createDevSSRMiddleware(
         server.ssrLoadModule(PRACHT_SERVER_MODULE_ID),
       ]);
 
-      if (
-        shouldBypassDevSSR(requestUrl, req, {
-          app: serverMod.resolvedApp,
-          apiRoutes: serverMod.apiRoutes,
-          matchApiRoute: framework.matchApiRoute,
-          matchAppRoute: framework.matchAppRoute,
-        })
-      ) {
+      const routeMatchers = {
+        app: serverMod.resolvedApp as ResolvedPrachtApp,
+        apiRoutes: serverMod.apiRoutes as ResolvedApiRoute[],
+        matchApiRoute: framework.matchApiRoute,
+        matchAppRoute: framework.matchAppRoute,
+      };
+
+      if (shouldBypassDevSSR(requestUrl, req, routeMatchers)) {
         return next();
+      }
+
+      if (isDevNotFoundRequest(requestUrl, req, routeMatchers)) {
+        return serveDevNotFound(server, res, next, url, requestUrl.pathname, routeMatchers);
       }
 
       let webRequest: Request;
@@ -114,6 +118,68 @@ async function handleDevError(
     res.end(html);
   } catch {
     next(error);
+  }
+}
+
+/**
+ * True when a GET/HEAD document request matches no page route and no API
+ * route — the dev middleware then serves the rich dev-only 404 page instead
+ * of falling through to Vite. Route-state (JSON) requests and non-document
+ * fetches keep their existing 404 behavior.
+ */
+export function isDevNotFoundRequest(
+  requestUrl: URL | string,
+  req: Pick<IncomingMessage, "headers" | "method">,
+  options: {
+    app?: ResolvedPrachtApp;
+    apiRoutes?: ResolvedApiRoute[];
+    matchApiRoute?: (routes: ResolvedApiRoute[], pathname: string) => unknown;
+    matchAppRoute?: (app: ResolvedPrachtApp, pathname: string) => unknown;
+  } = {},
+): boolean {
+  const url = typeof requestUrl === "string" ? new URL(requestUrl, "http://localhost") : requestUrl;
+
+  if (isRouteStateRequest(url, req)) {
+    return false;
+  }
+
+  const method = (req.method ?? "GET").toUpperCase();
+  if (method !== "GET" && method !== "HEAD") {
+    return false;
+  }
+
+  const accept = readRequestHeader(req.headers.accept).toLowerCase();
+  if (!accept.includes("text/html") && !accept.includes("application/xhtml+xml")) {
+    return false;
+  }
+
+  return !matchesResolvedRoute(url.pathname, options);
+}
+
+async function serveDevNotFound(
+  server: ViteDevServer,
+  res: ServerResponse,
+  next: Connect.NextFunction,
+  url: string,
+  pathname: string,
+  options: { app: ResolvedPrachtApp; apiRoutes: ResolvedApiRoute[] },
+): Promise<void> {
+  try {
+    const { buildDevNotFoundHtml } = await server.ssrLoadModule("@pracht/core/dev-404");
+    let html = buildDevNotFoundHtml({
+      apiRoutes: options.apiRoutes.map((route) => ({ path: route.path })),
+      requestedPath: pathname,
+      routes: options.app.routes.map((route) => ({
+        path: route.path,
+        render: route.render ?? null,
+      })),
+    });
+    html = await server.transformIndexHtml(url, html);
+    res.statusCode = 404;
+    res.setHeader("content-type", "text/html; charset=utf-8");
+    res.end(html);
+  } catch {
+    next();
   }
 }
 

--- a/packages/vite-plugin/test/dev-middleware.test.ts
+++ b/packages/vite-plugin/test/dev-middleware.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { shouldBypassDevSSR } from "../src/plugin-dev-ssr.ts";
+import { isDevNotFoundRequest, shouldBypassDevSSR } from "../src/plugin-dev-ssr.ts";
 
 const routeMatchers = {
   app: {} as any,
@@ -110,6 +110,50 @@ describe("shouldBypassDevSSR", () => {
         method: "GET",
       }),
     ).toBe(true);
+  });
+
+  it("serves the dev 404 page for unmatched HTML navigations only", () => {
+    const htmlHeaders = { accept: "text/html,application/xhtml+xml" };
+
+    // Unmatched document navigation → rich dev 404.
+    expect(
+      isDevNotFoundRequest("/nope", { headers: htmlHeaders, method: "GET" }, routeMatchers),
+    ).toBe(true);
+    expect(
+      isDevNotFoundRequest("/api/unknown", { headers: htmlHeaders, method: "GET" }, routeMatchers),
+    ).toBe(true);
+
+    // Matched routes never hit the dev 404.
+    expect(
+      isDevNotFoundRequest("/@alice", { headers: htmlHeaders, method: "GET" }, routeMatchers),
+    ).toBe(false);
+
+    // Route-state (JSON) requests keep their existing 404 behavior.
+    expect(
+      isDevNotFoundRequest(
+        "/nope?_data=1",
+        { headers: { accept: "*/*" }, method: "GET" },
+        routeMatchers,
+      ),
+    ).toBe(false);
+    expect(
+      isDevNotFoundRequest(
+        "/nope",
+        {
+          headers: { accept: "application/json", "x-pracht-route-state-request": "1" },
+          method: "GET",
+        },
+        routeMatchers,
+      ),
+    ).toBe(false);
+
+    // Non-document fetches and mutations keep their existing behavior.
+    expect(
+      isDevNotFoundRequest("/nope", { headers: { accept: "*/*" }, method: "GET" }, routeMatchers),
+    ).toBe(false);
+    expect(
+      isDevNotFoundRequest("/nope", { headers: htmlHeaders, method: "POST" }, routeMatchers),
+    ).toBe(false);
   });
 
   it("still treats unmatched HTML navigations as document requests", () => {

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -16,7 +16,7 @@ export default defineConfig({
     },
     {
       name: "pages-router",
-      testMatch: /pages-router\.test\.ts/,
+      testMatch: /pages-router\.test\.ts|dev-404\.test\.ts/,
       use: {
         baseURL: "http://localhost:3101",
       },

--- a/skills/debug/SKILL.md
+++ b/skills/debug/SKILL.md
@@ -70,7 +70,7 @@ Work through these in order, stopping when you find the root cause:
   - Browser-only APIs used during SSR (`window`, `document`, `localStorage`)
   - Conditional rendering based on client state
 - **Missing shell**: Verify the shell is registered in `defineApp({ shells: { ... } })` and assigned to the route/group.
-- **404 page**: Route not matched — check manifest wiring (step 1).
+- **404 page**: Route not matched — check manifest wiring (step 1). In `pracht dev`, unmatched navigations render a dev-only 404 page listing every registered route with its render mode; compare the requested path against that table. The route table is also printed on dev-server startup and available via `pracht inspect routes`.
 
 ### 5. Middleware issues
 


### PR DESCRIPTION
## Summary

- `pracht dev` now prints a startup banner: the local (and network) URL printed
  prominently, plus an aligned route table showing every page route with its
  render mode (spa/ssr/ssg/isg), shell, and middleware names, and an API route
  table with detected HTTP methods.
- The banner reuses the resolved-app-graph logic from `pracht inspect` — the
  shared serialization/API-method detection now lives in
  `packages/cli/src/app-graph.ts` and is consumed by both commands instead of
  being duplicated. The banner uses a static export scan for API methods (no
  user API modules are executed at startup); `pracht inspect` keeps its
  execute-then-fallback behavior. Output respects `NO_COLOR`/`FORCE_COLOR` and
  only colors TTYs; if the app graph cannot be loaded the command falls back to
  Vite's own URL output.
- In dev mode only, document navigations (GET/HEAD accepting HTML) that match
  no page route and no API route now render a styled, self-contained 404 page
  (new `@pracht/core/dev-404` entry, same standalone-HTML approach as
  `error-overlay.ts` — no Preact dependency) showing the requested path and
  every registered route with its render mode; static paths are clickable
  links, and the page auto-reloads on full-reload HMR events.
- Production 404 behavior is unchanged: the module is only loaded on demand by
  the dev middleware via `ssrLoadModule`, route-state (JSON) requests,
  non-document fetches, and non-GET/HEAD methods keep their existing 404
  behavior, and a unit test asserts no production entry point of
  `@pracht/core` can transitively reach `dev-404.ts`.
- No linked issue.

## Testing

- [x] `pnpm e2e`
- [x] `pnpm format`
- [x] `pnpm lint`
- [x] `pnpm test`

New coverage:

- `packages/cli/test/dev-banner.test.ts` — banner formatting from a manifest
  fixture: column alignment, URL output, empty tables, implicit `ssr` mode,
  ANSI on/off, and `supportsColor` (`NO_COLOR` > `FORCE_COLOR` > TTY).
- `packages/framework/test/dev-404.test.ts` — 404 HTML rendering from a route
  list: requested path, mode badges, static-vs-dynamic links, HTML escaping,
  empty state, plus the production-isolation import-graph test.
- `packages/vite-plugin/test/dev-middleware.test.ts` — `isDevNotFoundRequest`
  matrix (unmatched HTML nav, matched routes, route-state requests,
  non-document fetches, mutations).
- `e2e/dev-404.test.ts` — dev 404 page against the pages-router example (the
  Cloudflare example owns its dev server, so the dev middleware is not active
  there); registered in the `pages-router` Playwright project.

## Checklist

- [x] Docs updated if needed (`docs/ROUTING.md` new Dev Server section,
      `docs/ARCHITECTURE.md` module list and dev-only entry notes)
- [x] Skills updated if needed (`skills/debug/SKILL.md` 404 guidance)
- [x] Changeset added if published packages changed
      (`.changeset/dev-banner-404.md`: minor for `@pracht/core`,
      `@pracht/vite-plugin`, `@pracht/cli`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
