### PR TITLE
Add `pracht build --analyze` and per-route client JS budgets

### DIFF
--- a/.changeset/build-analyze-budgets.md
+++ b/.changeset/build-analyze-budgets.md
@@ -1,0 +1,10 @@
+---
+"@pracht/cli": minor
+"@pracht/vite-plugin": minor
+---
+
+Add `pracht build --analyze` and per-route client JS budgets.
+
+`pracht build --analyze` prints a per-route report of the client JavaScript each route loads: the transitive chunks (route module + shell) with raw and gzip sizes, a total row per route, and the shared entry chunks broken out. `--json` emits the same data as machine-readable JSON. Output respects `NO_COLOR` and routes are sorted by total gzip size, descending.
+
+The pracht plugin accepts a new `budgets` option (e.g. `budgets: { "*": "120kb", "/dashboard": "200kb" }`) declaring per-route gzip client-JS ceilings; `"*"` applies to every route and explicit route paths override it. `pracht build` evaluates budgets after every build, prints pass/fail per route, writes `dist/server/budget-report.json`, and exits non-zero on exceeded budgets unless `--no-budget-fail` is passed. `pracht verify` and `pracht doctor` surface the last build's budget results when the report file is present.

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Pick SPA, SSR, SSG, or ISG on a route-by-route basis. Ship less JavaScript by de
 - **Per-route render modes** — SPA, SSR, SSG, and ISG in the same app. No global default fighting you.
 - **Explicit over magic** — a typed `defineApp()` manifest wires routes, shells, and middleware. What runs where is never a mystery. Prefer file-based routing? Opt in to the pages router and skip the manifest entirely.
 - **Vite-native** — instant HMR, fast builds, multi-environment output out of the box.
+- **Performance budgets built in** — `pracht build --analyze` reports per-route client JS (gzip + raw), and per-route `budgets` fail the build when a route ships too much.
 - **Deploy anywhere** — one codebase, one build, three production-ready adapters (Node, Cloudflare Workers, Vercel).
 
 ## At a glance
@@ -85,7 +86,7 @@ npm create pracht@latest my-app
 The starter gives you:
 
 - `pracht dev` — local SSR + HMR
-- `pracht build` — client/server output plus SSG/ISG prerendering
+- `pracht build` — client/server output plus SSG/ISG prerendering, with `--analyze` for a per-route client JS report and budget enforcement
 - `pracht inspect [routes|api|build] --json` — resolved app graph metadata
 - `pracht generate route|shell|middleware|api` — framework-native scaffolding
 - `pracht verify` — fast framework-aware checks with `--changed` and `--json`
@@ -97,6 +98,7 @@ The starter gives you:
 - [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) — framework internals
 - [docs/ROUTING.md](docs/ROUTING.md) — manifest and matching model
 - [docs/RENDERING_MODES.md](docs/RENDERING_MODES.md) — SSR, SSG, ISG, SPA behavior
+- [docs/PERFORMANCE.md](docs/PERFORMANCE.md) — bundle analysis and per-route client JS budgets
 - [docs/DATA_LOADING.md](docs/DATA_LOADING.md) — loaders, forms, client hooks
 - [docs/STYLING.md](docs/STYLING.md) — CSS Modules, Tailwind, CSS-in-JS limitations
 - [docs/ADAPTERS.md](docs/ADAPTERS.md) — Node, Cloudflare, Vercel deployment paths

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -1,0 +1,129 @@
+# Performance — Bundle Analysis & Budgets
+
+Pracht's core promise is shipping less JavaScript. Two built-in tools keep that
+promise honest as an app grows: `pracht build --analyze` (visibility) and
+per-route client-JS budgets (enforcement).
+
+## `pracht build --analyze`
+
+After a successful production build, `--analyze` prints a per-route report of
+the client JavaScript each route actually loads:
+
+```bash
+pracht build --analyze
+```
+
+```
+Route / chunk                        Gzip     Raw
+/dashboard (ssr)
+  /assets/dashboard-BCIbC3P5.js      744b   1.3kb
+  /assets/app-CyBulJul.js            257b    447b
+  total (incl. shared)             13.1kb  32.0kb
+/ (ssg)
+  /assets/public-CK2L2x0w.js         242b    385b
+  /assets/home-DYMkGJUW.js           195b    247b
+  total (incl. shared)             12.5kb  30.9kb
+shared entry (all routes)
+  /assets/vendor-Ccfg_lMj.js        5.8kb  14.2kb
+  /assets/client-UTS10mkg.js        3.8kb  10.0kb
+  total                            12.1kb  30.3kb
+```
+
+- Each route lists its **route-specific chunks**: the route module, its shell,
+  and their transitive static imports, resolved from the Vite client manifest —
+  the same chunks the server injects for that page.
+- The **total row** includes the shared entry chunks, because that is what a
+  visitor downloads on a cold load of that route.
+- **Shared entry chunks** (the client runtime and the `vendor` Preact chunk)
+  are broken out separately — every route pays for them once.
+- Sizes are raw bytes and gzip (via `node:zlib` at the default level). Routes
+  are sorted by total gzip size, descending. Colors respect `NO_COLOR`.
+
+### JSON output
+
+For agents and tooling, `--json` emits the same data as machine-readable JSON
+(and silences the human-oriented build logs on stdout):
+
+```bash
+pracht build --json
+```
+
+```jsonc
+{
+  "shared": { "chunks": [...], "bytes": 30994, "gzipBytes": 12382 },
+  "routes": [
+    {
+      "id": "dashboard",
+      "path": "/dashboard",
+      "render": "ssr",
+      "chunks": [{ "url": "/assets/dashboard-....js", "bytes": 1329, "gzipBytes": 744 }],
+      "routeBytes": 1776,
+      "routeGzipBytes": 1001,
+      "totalBytes": 32770,
+      "totalGzipBytes": 13383
+    }
+  ],
+  "budgets": { "results": [...], "unmatched": [], "ok": true } // when budgets are configured
+}
+```
+
+## Per-route client JS budgets
+
+Declare gzip ceilings for total client JS per route in the plugin config:
+
+```ts
+// vite.config.ts
+import { pracht } from "@pracht/vite-plugin";
+
+export default defineConfig({
+  plugins: [
+    pracht({
+      budgets: {
+        "*": "120kb", // default budget applied to every route
+        "/dashboard": "200kb", // explicit routes override the default
+      },
+    }),
+  ],
+});
+```
+
+- Keys are route paths as written in the manifest (e.g. `/products/:productId`)
+  or `"*"` as the default for all routes.
+- Values are byte counts (`200000`) or size strings (`"120kb"`, `"1mb"`);
+  units are 1024-based.
+- The budget applies to a route's **total gzip client JS**: route chunks +
+  shell chunks + shared entry chunks.
+
+When budgets are configured, every `pracht build` evaluates them and prints a
+pass/fail line per route:
+
+```
+Budgets (gzip client JS)
+FAIL  /dashboard            213.1kb > 200.0kb
+PASS  /                      12.5kb <= 120.0kb (*)
+```
+
+An exceeded budget makes `pracht build` exit non-zero. To keep the build output
+while investigating, pass `--no-budget-fail` — the failure downgrades to a
+warning.
+
+### `pracht verify` integration
+
+Builds with budgets write `dist/server/budget-report.json`. When that file is
+present, `pracht verify` (and `pracht doctor`) surface the last build's budget
+results as checks, so CI catches regressions even when it runs `verify`
+separately from the build. The report reflects the most recent build — rerun
+`pracht build` after changing routes or budgets.
+
+## Reducing a route's payload
+
+When a route blows its budget, the usual levers, in order of impact:
+
+1. **Move heavy work server-side** — loaders run on the server; data-crunching
+   dependencies never need to ship to the client.
+2. **Lazy-load below-the-fold or interaction-gated code** with `lazy()` from
+   `preact-suspense`, or a dynamic `import()` inside an event handler.
+3. **Check the shell** — shell chunks are shared by every route using that
+   shell; a heavy dependency imported in a shell taxes every page.
+4. **Audit the vendor chunk** — see the `audit-bundles` skill for a guided
+   deep-dive into fan-in, heavy dependencies, and prefetch tuning.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -18,6 +18,23 @@ Start the local development server with SSR and HMR.
 
 Create a production build with client/server output and SSG/ISG prerendering.
 
+```bash
+pracht build
+pracht build --analyze          # per-route client JS report (gzip + raw)
+pracht build --json             # same report as JSON (agent-friendly)
+pracht build --no-budget-fail   # report exceeded budgets without failing
+```
+
+`--analyze` prints, per route (pattern + render mode), the transitive client
+chunks it loads with raw and gzip sizes, a total row, and the shared entry
+chunks broken out. Output respects `NO_COLOR`.
+
+When the pracht plugin config declares `budgets` (e.g.
+`budgets: { "*": "120kb", "/dashboard": "200kb" }`), every build evaluates the
+per-route gzip client-JS ceilings, writes `dist/server/budget-report.json`, and
+exits non-zero on exceeded budgets unless `--no-budget-fail` is passed. See
+[docs/PERFORMANCE.md](https://github.com/JoviDeCroock/pracht/blob/main/docs/PERFORMANCE.md).
+
 For Node.js targets, run the built server with:
 
 ```bash
@@ -28,7 +45,9 @@ node dist/server/server.js
 
 Run fast framework-aware verification checks without paying for a full build or
 test loop. Use `--changed` to focus on changed manifest-managed files and
-`--json` for machine-readable output.
+`--json` for machine-readable output. When `dist/server/budget-report.json`
+exists (written by `pracht build` when budgets are configured), the last
+build's client JS budget results are surfaced as checks.
 
 ```bash
 pracht verify

--- a/packages/cli/src/build-metadata.ts
+++ b/packages/cli/src/build-metadata.ts
@@ -13,6 +13,8 @@ interface ViteManifestEntry {
 
 export interface ClientBuildAssets {
   clientEntryUrl: string | null;
+  /** Transitive JS chunk urls loaded by the client entry on every page. */
+  clientEntryJs: string[];
   cssManifest: Record<string, string[]>;
   jsManifest: Record<string, string[]>;
 }
@@ -25,6 +27,7 @@ export function readClientBuildAssets(root: string = process.cwd()): ClientBuild
   if (!manifestPath) {
     return {
       clientEntryUrl: null,
+      clientEntryJs: [],
       cssManifest: {},
       jsManifest: {},
     };
@@ -82,6 +85,9 @@ export function readClientBuildAssets(root: string = process.cwd()): ClientBuild
 
   return {
     clientEntryUrl: clientEntry ? `/${clientEntry.file}` : null,
+    clientEntryJs: clientEntry
+      ? collectTransitiveDeps("virtual:pracht/client").js.map((file) => `/${file}`)
+      : [],
     cssManifest,
     jsManifest,
   };

--- a/packages/cli/src/bundle-report.ts
+++ b/packages/cli/src/bundle-report.ts
@@ -1,0 +1,367 @@
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { gzipSync } from "node:zlib";
+
+const SIZE_UNITS: Record<string, number> = {
+  b: 1,
+  kb: 1024,
+  mb: 1024 * 1024,
+  gb: 1024 * 1024 * 1024,
+};
+
+const SIZE_RE = /^(\d+(?:\.\d+)?)\s*(b|kb|mb|gb)?$/;
+
+/**
+ * Parse a size budget value into bytes. Accepts plain numbers (bytes) or
+ * size strings like "120kb" / "1mb" (1kb = 1024 bytes).
+ */
+export function parseSizeToBytes(value: string | number): number {
+  if (typeof value === "number") {
+    if (!Number.isFinite(value) || value <= 0) {
+      throw new Error(
+        `Invalid size ${JSON.stringify(value)}: expected a positive number of bytes.`,
+      );
+    }
+    return Math.floor(value);
+  }
+
+  const match = SIZE_RE.exec(value.trim().toLowerCase());
+  if (!match) {
+    throw new Error(
+      `Invalid size ${JSON.stringify(value)}: expected a byte count or a size string like "120kb" or "1mb".`,
+    );
+  }
+
+  const amount = Number.parseFloat(match[1]);
+  const bytes = Math.round(amount * SIZE_UNITS[match[2] ?? "b"]);
+  if (bytes <= 0) {
+    throw new Error(`Invalid size ${JSON.stringify(value)}: expected a positive size.`);
+  }
+  return bytes;
+}
+
+export function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes}b`;
+  const kb = bytes / 1024;
+  if (kb < 1024) return `${kb.toFixed(1)}kb`;
+  return `${(kb / 1024).toFixed(2)}mb`;
+}
+
+export interface BundleChunk {
+  url: string;
+  bytes: number;
+  gzipBytes: number;
+}
+
+export interface RouteBundle {
+  id?: string;
+  path: string;
+  render: string;
+  /** Route-specific chunks (route module + shell, excluding shared entry chunks). */
+  chunks: BundleChunk[];
+  routeBytes: number;
+  routeGzipBytes: number;
+  /** Route-specific + shared entry chunks. */
+  totalBytes: number;
+  totalGzipBytes: number;
+}
+
+export interface BundleReport {
+  /** Chunks loaded by the client entry on every route. */
+  shared: {
+    chunks: BundleChunk[];
+    bytes: number;
+    gzipBytes: number;
+  };
+  /** Sorted by total gzip size, descending. */
+  routes: RouteBundle[];
+}
+
+export interface BundleReportRoute {
+  id?: string;
+  path: string;
+  render?: string;
+  file: string;
+  shellFile?: string;
+}
+
+export interface CollectBundleReportOptions {
+  routes: BundleReportRoute[];
+  jsManifest: Record<string, string[]>;
+  clientEntryJs: string[];
+  clientDir: string;
+}
+
+/** Strip leading `./` and `/` so module paths share one canonical form. */
+function normalizeModulePath(path: string): string {
+  return path.replace(/^\.?\//, "");
+}
+
+// Mirrors the runtime's suffix matching (@pracht/core runtime-manifest) so the
+// report resolves the same chunks the server injects for each route.
+function buildSuffixIndex(manifest: Record<string, string[]>): Map<string, string> {
+  const index = new Map<string, string>();
+  for (const key of Object.keys(manifest)) {
+    const normalized = normalizeModulePath(key);
+    if (!normalized) continue;
+    if (!index.has(normalized)) index.set(normalized, key);
+    for (let i = normalized.indexOf("/"); i !== -1; i = normalized.indexOf("/", i + 1)) {
+      const suffix = normalized.slice(i + 1);
+      if (suffix && !index.has(suffix)) index.set(suffix, key);
+    }
+  }
+  return index;
+}
+
+function resolveManifestEntries(
+  manifest: Record<string, string[]>,
+  suffixIndex: Map<string, string>,
+  file: string,
+): string[] {
+  if (file in manifest) return manifest[file];
+  const resolved = suffixIndex.get(normalizeModulePath(file));
+  return resolved ? manifest[resolved] : [];
+}
+
+export function collectBundleReport({
+  routes,
+  jsManifest,
+  clientEntryJs,
+  clientDir,
+}: CollectBundleReportOptions): BundleReport {
+  const suffixIndex = buildSuffixIndex(jsManifest);
+  const chunkCache = new Map<string, BundleChunk>();
+
+  function measureChunk(url: string): BundleChunk {
+    const cached = chunkCache.get(url);
+    if (cached) return cached;
+
+    const filePath = join(clientDir, url.replace(/^\//, ""));
+    let bytes = 0;
+    let gzipBytes = 0;
+    if (existsSync(filePath)) {
+      const contents = readFileSync(filePath);
+      bytes = contents.byteLength;
+      gzipBytes = gzipSync(contents).byteLength;
+    }
+
+    const chunk: BundleChunk = { url, bytes, gzipBytes };
+    chunkCache.set(url, chunk);
+    return chunk;
+  }
+
+  const sharedUrls = new Set(clientEntryJs);
+  const sharedChunks = clientEntryJs.map(measureChunk);
+  const sharedBytes = sumBytes(sharedChunks);
+  const sharedGzipBytes = sumGzipBytes(sharedChunks);
+
+  const reportRoutes: RouteBundle[] = routes.map((route) => {
+    const urls = new Set<string>();
+    if (route.shellFile) {
+      for (const url of resolveManifestEntries(jsManifest, suffixIndex, route.shellFile)) {
+        urls.add(url);
+      }
+    }
+    for (const url of resolveManifestEntries(jsManifest, suffixIndex, route.file)) {
+      urls.add(url);
+    }
+
+    const chunks = [...urls]
+      .filter((url) => !sharedUrls.has(url))
+      .map(measureChunk)
+      .sort((left, right) => right.gzipBytes - left.gzipBytes);
+    const routeBytes = sumBytes(chunks);
+    const routeGzipBytes = sumGzipBytes(chunks);
+
+    return {
+      ...(route.id ? { id: route.id } : {}),
+      path: route.path,
+      render: route.render ?? "ssr",
+      chunks,
+      routeBytes,
+      routeGzipBytes,
+      totalBytes: routeBytes + sharedBytes,
+      totalGzipBytes: routeGzipBytes + sharedGzipBytes,
+    };
+  });
+
+  reportRoutes.sort(
+    (left, right) =>
+      right.totalGzipBytes - left.totalGzipBytes || left.path.localeCompare(right.path),
+  );
+
+  return {
+    shared: {
+      chunks: [...sharedChunks].sort((left, right) => right.gzipBytes - left.gzipBytes),
+      bytes: sharedBytes,
+      gzipBytes: sharedGzipBytes,
+    },
+    routes: reportRoutes,
+  };
+}
+
+function sumBytes(chunks: BundleChunk[]): number {
+  return chunks.reduce((total, chunk) => total + chunk.bytes, 0);
+}
+
+function sumGzipBytes(chunks: BundleChunk[]): number {
+  return chunks.reduce((total, chunk) => total + chunk.gzipBytes, 0);
+}
+
+export interface BudgetResult {
+  path: string;
+  render: string;
+  /** The budget value as configured ("120kb", 200000, ...). */
+  budget: string | number;
+  /** Which budget key matched: the route path or "*". */
+  source: string;
+  limitBytes: number;
+  gzipBytes: number;
+  ok: boolean;
+}
+
+export interface BudgetEvaluation {
+  results: BudgetResult[];
+  /** Explicit budget keys that did not match any route. */
+  unmatched: string[];
+  ok: boolean;
+}
+
+export function evaluateBudgets(
+  report: BundleReport,
+  budgets: Record<string, string | number>,
+): BudgetEvaluation {
+  const defaultBudget = budgets["*"];
+  const explicitKeys = Object.keys(budgets).filter((key) => key !== "*");
+  const routePaths = new Set(report.routes.map((route) => route.path));
+  const unmatched = explicitKeys.filter((key) => !routePaths.has(key));
+
+  const results: BudgetResult[] = [];
+  for (const route of report.routes) {
+    const source = route.path in budgets ? route.path : defaultBudget != null ? "*" : null;
+    if (source == null) continue;
+
+    const budget = budgets[source];
+    const limitBytes = parseSizeToBytes(budget);
+    results.push({
+      path: route.path,
+      render: route.render,
+      budget,
+      source,
+      limitBytes,
+      gzipBytes: route.totalGzipBytes,
+      ok: route.totalGzipBytes <= limitBytes,
+    });
+  }
+
+  return {
+    results,
+    unmatched,
+    ok: results.every((result) => result.ok),
+  };
+}
+
+export interface FormatOptions {
+  color?: boolean;
+}
+
+export function shouldUseColor(): boolean {
+  if (process.env.NO_COLOR) return false;
+  return Boolean(process.stdout.isTTY);
+}
+
+function paint(text: string, code: string, color: boolean): string {
+  return color ? `\u001b[${code}m${text}\u001b[0m` : text;
+}
+
+export function formatBundleReport(report: BundleReport, options: FormatOptions = {}): string {
+  const color = options.color ?? false;
+  const rows: { label: string; raw: string; gzip: string; kind: "chunk" | "total" | "header" }[] =
+    [];
+
+  for (const route of report.routes) {
+    rows.push({ label: `${route.path} (${route.render})`, raw: "", gzip: "", kind: "header" });
+    for (const chunk of route.chunks) {
+      rows.push({
+        label: `  ${chunk.url}`,
+        raw: formatBytes(chunk.bytes),
+        gzip: formatBytes(chunk.gzipBytes),
+        kind: "chunk",
+      });
+    }
+    rows.push({
+      label: "  total (incl. shared)",
+      raw: formatBytes(route.totalBytes),
+      gzip: formatBytes(route.totalGzipBytes),
+      kind: "total",
+    });
+  }
+
+  rows.push({ label: "shared entry (all routes)", raw: "", gzip: "", kind: "header" });
+  for (const chunk of report.shared.chunks) {
+    rows.push({
+      label: `  ${chunk.url}`,
+      raw: formatBytes(chunk.bytes),
+      gzip: formatBytes(chunk.gzipBytes),
+      kind: "chunk",
+    });
+  }
+  rows.push({
+    label: "  total",
+    raw: formatBytes(report.shared.bytes),
+    gzip: formatBytes(report.shared.gzipBytes),
+    kind: "total",
+  });
+
+  const labelWidth = Math.max("Route / chunk".length, ...rows.map((row) => row.label.length));
+  const gzipWidth = Math.max("Gzip".length, ...rows.map((row) => row.gzip.length));
+  const rawWidth = Math.max("Raw".length, ...rows.map((row) => row.raw.length));
+
+  const lines: string[] = [];
+  lines.push(
+    paint(
+      `${"Route / chunk".padEnd(labelWidth)}  ${"Gzip".padStart(gzipWidth)}  ${"Raw".padStart(rawWidth)}`,
+      "1",
+      color,
+    ),
+  );
+
+  for (const row of rows) {
+    const line = `${row.label.padEnd(labelWidth)}  ${row.gzip.padStart(gzipWidth)}  ${row.raw.padStart(rawWidth)}`;
+    if (row.kind === "header") {
+      lines.push(paint(line.trimEnd(), "1", color));
+    } else if (row.kind === "total") {
+      lines.push(paint(line, "36", color));
+    } else {
+      lines.push(paint(line, "2", color));
+    }
+  }
+
+  return lines.join("\n");
+}
+
+export function formatBudgetResults(
+  evaluation: BudgetEvaluation,
+  options: FormatOptions = {},
+): string {
+  const color = options.color ?? false;
+  const lines: string[] = [paint("Budgets (gzip client JS)", "1", color)];
+
+  const pathWidth = Math.max(...evaluation.results.map((result) => result.path.length), 0);
+  for (const result of evaluation.results) {
+    const status = result.ok ? paint("PASS", "32", color) : paint("FAIL", "31", color);
+    const comparison = result.ok ? "<=" : ">";
+    const suffix = result.source === "*" ? " (*)" : "";
+    lines.push(
+      `${status}  ${result.path.padEnd(pathWidth)}  ${formatBytes(result.gzipBytes)} ${comparison} ${formatBytes(result.limitBytes)}${suffix}`,
+    );
+  }
+
+  for (const key of evaluation.unmatched) {
+    lines.push(
+      paint(`WARN  budget for ${JSON.stringify(key)} does not match any route.`, "33", color),
+    );
+  }
+
+  return lines.join("\n");
+}

--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -7,18 +7,50 @@ import { build as viteBuild } from "vite";
 
 import { readClientBuildAssets } from "../build-metadata.js";
 import { writeVercelBuildOutput } from "../build-shared.js";
+import {
+  collectBundleReport,
+  evaluateBudgets,
+  formatBudgetResults,
+  formatBundleReport,
+  formatBytes,
+  shouldUseColor,
+  type BundleReportRoute,
+} from "../bundle-report.js";
 
 export default defineCommand({
   meta: {
     name: "build",
     description: "Production build (client + server)",
   },
-  async run() {
+  args: {
+    analyze: {
+      type: "boolean",
+      description: "Print a per-route client JavaScript report after the build",
+    },
+    json: {
+      type: "boolean",
+      description: "Output the analyze report as JSON (implies --analyze)",
+    },
+    "budget-fail": {
+      type: "boolean",
+      default: true,
+      description:
+        "Fail the build when a client JS budget is exceeded (--no-budget-fail to disable)",
+    },
+  },
+  async run({ args }) {
     const root = process.cwd();
+    const analyzeJson = Boolean(args.json);
+    const analyze = Boolean(args.analyze) || analyzeJson;
+    const logLevel = analyzeJson ? ("silent" as const) : undefined;
+    const log = (message: string): void => {
+      if (!analyzeJson) console.log(message);
+    };
 
-    console.log("\n  Building client...\n");
+    log("\n  Building client...\n");
     await viteBuild({
       root,
+      logLevel,
       build: {
         outDir: "dist",
         manifest: true,
@@ -28,9 +60,10 @@ export default defineCommand({
       },
     });
 
-    console.log("\n  Building server...\n");
+    log("\n  Building server...\n");
     await viteBuild({
       root,
+      logLevel,
       build: {
         outDir: "dist/server",
         rollupOptions: {
@@ -65,7 +98,8 @@ export default defineCommand({
     if (existsSync(serverEntry)) {
       const serverMod = await import(pathToFileURL(serverEntry).href);
       const { prerenderApp } = serverMod;
-      const { clientEntryUrl, cssManifest, jsManifest } = readClientBuildAssets(root);
+      const { clientEntryUrl, clientEntryJs, cssManifest, jsManifest } =
+        readClientBuildAssets(root);
 
       const { pages, isgManifest } = await prerenderApp({
         app: serverMod.resolvedApp,
@@ -84,13 +118,13 @@ export default defineCommand({
       );
 
       if (pages.length > 0) {
-        console.log(`\n  Prerendering ${pages.length} SSG/ISG route(s)...\n`);
+        log(`\n  Prerendering ${pages.length} SSG/ISG route(s)...\n`);
         for (const page of pages) {
           const filePath = resolvePrerenderOutputPath(clientDir, page.path);
 
           mkdirSync(dirname(filePath), { recursive: true });
           writeFileSync(filePath, page.html, "utf-8");
-          console.log(`    ${page.path} → ${filePath.replace(root + "/", "")}`);
+          log(`    ${page.path} → ${filePath.replace(root + "/", "")}`);
         }
       }
 
@@ -108,7 +142,7 @@ export default defineCommand({
       if (Object.keys(isgManifest).length > 0) {
         const isgManifestPath = resolve(root, "dist/server/isg-manifest.json");
         writeFileSync(isgManifestPath, JSON.stringify(isgManifest, null, 2), "utf-8");
-        console.log(
+        log(
           `\n  ISG manifest → dist/server/isg-manifest.json (${Object.keys(isgManifest).length} route(s))\n`,
         );
       }
@@ -119,8 +153,8 @@ export default defineCommand({
             "\n  Warning: Cloudflare adapter currently serves prerendered ISG HTML as static assets and does not perform runtime revalidation. Use SSR/SSG on Cloudflare, or deploy ISG routes to Node until Cloudflare ISG support is added.\n",
           );
         }
-        console.log("\n  Cloudflare worker → dist/server/server.js\n");
-        console.log("  Deploy with: wrangler deploy\n");
+        log("\n  Cloudflare worker → dist/server/server.js\n");
+        log("  Deploy with: wrangler deploy\n");
       }
 
       if (serverMod.buildTarget === "vercel") {
@@ -135,13 +169,93 @@ export default defineCommand({
             .filter((path: string) => !(path in isgManifest)),
         });
 
-        console.log(`\n  Vercel build output → ${outputPath}\n`);
+        log(`\n  Vercel build output → ${outputPath}\n`);
+      }
+
+      const budgets = (serverMod.budgets ?? {}) as Record<string, string | number>;
+      const hasBudgets = Object.keys(budgets).length > 0;
+
+      if (analyze || hasBudgets) {
+        const routes = (serverMod.resolvedApp?.routes ?? []) as BundleReportRoute[];
+        const report = collectBundleReport({
+          routes,
+          jsManifest,
+          clientEntryJs,
+          clientDir,
+        });
+        const evaluation = hasBudgets ? evaluateBudgets(report, budgets) : null;
+        const color = shouldUseColor();
+
+        if (analyzeJson) {
+          console.log(
+            JSON.stringify(
+              {
+                shared: report.shared,
+                routes: report.routes,
+                ...(evaluation ? { budgets: evaluation } : {}),
+              },
+              null,
+              2,
+            ),
+          );
+        } else if (analyze) {
+          console.log(`\n${indentBlock(formatBundleReport(report, { color }))}\n`);
+        }
+
+        if (evaluation) {
+          writeFileSync(
+            resolve(root, "dist/server/budget-report.json"),
+            `${JSON.stringify(
+              {
+                generatedAt: new Date().toISOString(),
+                budgets,
+                results: evaluation.results,
+                unmatched: evaluation.unmatched,
+                ok: evaluation.ok,
+              },
+              null,
+              2,
+            )}\n`,
+            "utf-8",
+          );
+
+          if (!analyzeJson) {
+            console.log(`\n${indentBlock(formatBudgetResults(evaluation, { color }))}\n`);
+          }
+
+          if (!evaluation.ok) {
+            const failed = evaluation.results.filter((result) => !result.ok);
+            const summary = failed
+              .map(
+                (result) =>
+                  `${result.path} (${formatBytes(result.gzipBytes)} gzip > ${formatBytes(result.limitBytes)})`,
+              )
+              .join(", ");
+            if (args["budget-fail"]) {
+              console.error(`\n  Build failed: client JS budget exceeded for ${summary}.\n`);
+              process.exitCode = 1;
+              return;
+            }
+            if (!analyzeJson) {
+              console.warn(
+                `\n  Warning: client JS budget exceeded for ${summary} (--no-budget-fail).\n`,
+              );
+            }
+          }
+        }
       }
     }
 
-    console.log("\n  Build complete.\n");
+    log("\n  Build complete.\n");
   },
 });
+
+function indentBlock(block: string): string {
+  return block
+    .split("\n")
+    .map((line) => (line ? `  ${line}` : line))
+    .join("\n");
+}
 
 export function resolvePrerenderOutputPath(clientDir: string, routePath: string): string {
   if (routePath.includes("\0")) {

--- a/packages/cli/src/verification-checks.ts
+++ b/packages/cli/src/verification-checks.ts
@@ -1,6 +1,7 @@
 import { dirname, resolve } from "node:path";
 import { existsSync, readFileSync } from "node:fs";
 
+import { formatBytes } from "./bundle-report.js";
 import { extractRegistryEntries, extractRelativeModulePaths } from "./manifest.js";
 import {
   displayPath,
@@ -371,6 +372,53 @@ export function collectApiVerification(
       createCheck(
         "ok",
         `Changed API route ${JSON.stringify(display)} resolves to ${JSON.stringify(resolveApiRoutePath(apiDir, file))}.`,
+      ),
+    );
+  }
+}
+
+interface BudgetReportFile {
+  results?: {
+    path: string;
+    gzipBytes: number;
+    limitBytes: number;
+    ok: boolean;
+  }[];
+}
+
+export function collectBudgetChecks(project: ProjectConfig, checks: Check[]): void {
+  const reportPath = resolve(project.root, "dist/server/budget-report.json");
+  if (!existsSync(reportPath)) return;
+
+  let report: BudgetReportFile;
+  try {
+    report = JSON.parse(readFileSync(reportPath, "utf-8"));
+  } catch {
+    checks.push(
+      createCheck("warning", "dist/server/budget-report.json exists but could not be parsed."),
+    );
+    return;
+  }
+
+  const results = report.results ?? [];
+  if (results.length === 0) return;
+
+  const failed = results.filter((result) => !result.ok);
+  if (failed.length === 0) {
+    checks.push(
+      createCheck(
+        "ok",
+        `All ${results.length} route client JS budget${results.length === 1 ? "" : "s"} pass (from the last \`pracht build\`).`,
+      ),
+    );
+    return;
+  }
+
+  for (const result of failed) {
+    checks.push(
+      createCheck(
+        "error",
+        `Route ${JSON.stringify(result.path)} exceeds its client JS budget: ${formatBytes(result.gzipBytes)} gzip > ${formatBytes(result.limitBytes)} (from the last \`pracht build\`).`,
       ),
     );
   }

--- a/packages/cli/src/verification.ts
+++ b/packages/cli/src/verification.ts
@@ -3,6 +3,7 @@ import { resolve } from "node:path";
 import { displayPath, readProjectConfig } from "./project.js";
 import {
   collectApiVerification,
+  collectBudgetChecks,
   collectConfigChecks,
   collectManifestVerification,
   collectPackageChecks,
@@ -88,6 +89,7 @@ export function runVerification(
 
   collectApiVerification(project, checks, { changedFiles: frameworkFiles, scope });
   collectPackageChecks(project, checks, packageJsonPath);
+  collectBudgetChecks(project, checks);
 
   if (options.changed && frameworkFiles.length === 0 && !changedInfo.warning) {
     checks.push(

--- a/packages/cli/test/bundle-report.test.ts
+++ b/packages/cli/test/bundle-report.test.ts
@@ -1,0 +1,238 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { gzipSync } from "node:zlib";
+
+import { afterAll, describe, expect, it } from "vitest";
+
+import {
+  collectBundleReport,
+  evaluateBudgets,
+  formatBudgetResults,
+  formatBundleReport,
+  formatBytes,
+  parseSizeToBytes,
+  type BundleReport,
+} from "../src/bundle-report.ts";
+
+describe("parseSizeToBytes", () => {
+  it("treats plain numbers as bytes", () => {
+    expect(parseSizeToBytes(2048)).toBe(2048);
+    expect(parseSizeToBytes(1.9)).toBe(1);
+  });
+
+  it("parses numeric strings as bytes", () => {
+    expect(parseSizeToBytes("2048")).toBe(2048);
+    expect(parseSizeToBytes("512b")).toBe(512);
+  });
+
+  it("parses kb/mb/gb size strings using 1024-based units", () => {
+    expect(parseSizeToBytes("120kb")).toBe(120 * 1024);
+    expect(parseSizeToBytes("1mb")).toBe(1024 * 1024);
+    expect(parseSizeToBytes("1.5KB")).toBe(1536);
+    expect(parseSizeToBytes(" 2 GB ")).toBe(2 * 1024 * 1024 * 1024);
+  });
+
+  it("rejects invalid values", () => {
+    expect(() => parseSizeToBytes("")).toThrow(/Invalid size/);
+    expect(() => parseSizeToBytes("12 kilobytes")).toThrow(/Invalid size/);
+    expect(() => parseSizeToBytes("-1kb")).toThrow(/Invalid size/);
+    expect(() => parseSizeToBytes(0)).toThrow(/Invalid size/);
+    expect(() => parseSizeToBytes(Number.NaN)).toThrow(/Invalid size/);
+  });
+});
+
+describe("formatBytes", () => {
+  it("formats bytes, kilobytes, and megabytes", () => {
+    expect(formatBytes(512)).toBe("512b");
+    expect(formatBytes(1536)).toBe("1.5kb");
+    expect(formatBytes(2 * 1024 * 1024)).toBe("2.00mb");
+  });
+});
+
+const tempDirs: string[] = [];
+
+afterAll(() => {
+  for (const dir of tempDirs) {
+    rmSync(dir, { force: true, recursive: true });
+  }
+});
+
+function createClientDirFixture(files: Record<string, string>): string {
+  const dir = mkdtempSync(join(tmpdir(), "pracht-bundle-report-"));
+  tempDirs.push(dir);
+  mkdirSync(join(dir, "assets"), { recursive: true });
+  for (const [name, contents] of Object.entries(files)) {
+    writeFileSync(join(dir, name), contents, "utf-8");
+  }
+  return dir;
+}
+
+function gzipSize(contents: string): number {
+  return gzipSync(Buffer.from(contents)).byteLength;
+}
+
+const ENTRY_JS = "console.log('entry');".repeat(20);
+const VENDOR_JS = "export const preact = 'preact';".repeat(40);
+const HOME_JS = "console.log('home');".repeat(10);
+const DASHBOARD_JS = "console.log('dashboard');".repeat(100);
+const CHART_JS = "export const chart = () => 'chart';".repeat(200);
+const SHELL_JS = "console.log('shell');".repeat(5);
+
+function createFixtureReport(): BundleReport {
+  const clientDir = createClientDirFixture({
+    "assets/entry.js": ENTRY_JS,
+    "assets/vendor.js": VENDOR_JS,
+    "assets/home.js": HOME_JS,
+    "assets/dashboard.js": DASHBOARD_JS,
+    "assets/chart.js": CHART_JS,
+    "assets/shell.js": SHELL_JS,
+  });
+
+  return collectBundleReport({
+    clientDir,
+    clientEntryJs: ["/assets/entry.js", "/assets/vendor.js"],
+    jsManifest: {
+      "src/routes/home.tsx": ["/assets/home.js", "/assets/vendor.js"],
+      "src/routes/dashboard.tsx": ["/assets/dashboard.js", "/assets/chart.js"],
+      "src/shells/app.tsx": ["/assets/shell.js"],
+    },
+    routes: [
+      { id: "home", path: "/", render: "ssg", file: "./routes/home.tsx" },
+      {
+        id: "dashboard",
+        path: "/dashboard",
+        render: "spa",
+        file: "./routes/dashboard.tsx",
+        shellFile: "./shells/app.tsx",
+      },
+    ],
+  });
+}
+
+describe("collectBundleReport", () => {
+  it("computes per-route transitive chunks with raw and gzip sizes", () => {
+    const report = createFixtureReport();
+
+    expect(report.shared.chunks.map((chunk) => chunk.url).sort()).toEqual([
+      "/assets/entry.js",
+      "/assets/vendor.js",
+    ]);
+    expect(report.shared.bytes).toBe(ENTRY_JS.length + VENDOR_JS.length);
+    expect(report.shared.gzipBytes).toBe(gzipSize(ENTRY_JS) + gzipSize(VENDOR_JS));
+
+    // Sorted by total gzip size descending: dashboard ships more JS than home.
+    expect(report.routes.map((route) => route.path)).toEqual(["/dashboard", "/"]);
+
+    const dashboard = report.routes[0];
+    expect(dashboard.render).toBe("spa");
+    // Shell + route chunks, shared chunks excluded from the route-specific list.
+    expect(dashboard.chunks.map((chunk) => chunk.url).sort()).toEqual([
+      "/assets/chart.js",
+      "/assets/dashboard.js",
+      "/assets/shell.js",
+    ]);
+    expect(dashboard.routeGzipBytes).toBe(
+      gzipSize(DASHBOARD_JS) + gzipSize(CHART_JS) + gzipSize(SHELL_JS),
+    );
+    expect(dashboard.totalGzipBytes).toBe(dashboard.routeGzipBytes + report.shared.gzipBytes);
+    expect(dashboard.totalBytes).toBe(
+      DASHBOARD_JS.length + CHART_JS.length + SHELL_JS.length + report.shared.bytes,
+    );
+
+    const home = report.routes[1];
+    // vendor.js is shared, so home only ships its own chunk on top of the entry.
+    expect(home.chunks.map((chunk) => chunk.url)).toEqual(["/assets/home.js"]);
+    expect(home.totalGzipBytes).toBe(gzipSize(HOME_JS) + report.shared.gzipBytes);
+  });
+
+  it("resolves route files through suffix matching like the runtime manifest", () => {
+    const report = createFixtureReport();
+    // Route files were "./routes/home.tsx" while manifest keys are
+    // "src/routes/home.tsx" — suffix matching must bridge the difference.
+    expect(report.routes.every((route) => route.chunks.length > 0)).toBe(true);
+  });
+});
+
+describe("evaluateBudgets", () => {
+  it("applies the default budget to all routes and lets explicit keys override", () => {
+    const report = createFixtureReport();
+    const evaluation = evaluateBudgets(report, { "*": 50, "/dashboard": "1mb" });
+
+    const home = evaluation.results.find((result) => result.path === "/");
+    const dashboard = evaluation.results.find((result) => result.path === "/dashboard");
+
+    expect(home?.source).toBe("*");
+    expect(home?.limitBytes).toBe(50);
+    expect(home?.ok).toBe(false);
+
+    expect(dashboard?.source).toBe("/dashboard");
+    expect(dashboard?.limitBytes).toBe(1024 * 1024);
+    expect(dashboard?.ok).toBe(true);
+
+    expect(evaluation.ok).toBe(false);
+    expect(evaluation.unmatched).toEqual([]);
+  });
+
+  it("only evaluates routes with explicit budgets when no default is set", () => {
+    const report = createFixtureReport();
+    const evaluation = evaluateBudgets(report, { "/dashboard": "1mb" });
+
+    expect(evaluation.results.map((result) => result.path)).toEqual(["/dashboard"]);
+    expect(evaluation.ok).toBe(true);
+  });
+
+  it("reports budget keys that do not match any route", () => {
+    const report = createFixtureReport();
+    const evaluation = evaluateBudgets(report, { "/missing": "1kb" });
+
+    expect(evaluation.results).toEqual([]);
+    expect(evaluation.unmatched).toEqual(["/missing"]);
+    expect(evaluation.ok).toBe(true);
+  });
+});
+
+describe("formatBundleReport", () => {
+  it("renders an aligned plain-text table without ANSI codes by default", () => {
+    const report = createFixtureReport();
+    const output = formatBundleReport(report);
+    const lines = output.split("\n");
+
+    expect(output).not.toContain("\u001b[");
+    expect(lines[0]).toMatch(/^Route \/ chunk\s+Gzip\s+Raw$/);
+    expect(output).toContain("/dashboard (spa)");
+    expect(output).toContain("/ (ssg)");
+    expect(output).toContain("shared entry (all routes)");
+    expect(output).toContain("total (incl. shared)");
+
+    // Routes sorted by total gzip descending.
+    expect(output.indexOf("/dashboard (spa)")).toBeLessThan(output.indexOf("/ (ssg)"));
+
+    // Columns are aligned: every row has the same width.
+    const widths = new Set(lines.map((line) => line.trimEnd().length === line.length));
+    expect(widths.size).toBe(1);
+  });
+
+  it("emits ANSI codes when color is enabled", () => {
+    const report = createFixtureReport();
+    expect(formatBundleReport(report, { color: true })).toContain("\u001b[1m");
+  });
+});
+
+describe("formatBudgetResults", () => {
+  it("prints pass/fail per route with the matched budget", () => {
+    const report = createFixtureReport();
+    const evaluation = evaluateBudgets(report, { "*": 50, "/dashboard": "1mb" });
+    const output = formatBudgetResults(evaluation);
+
+    expect(output).not.toContain("\u001b[");
+    expect(output).toMatch(/FAIL\s+\/\s+.* > 50b \(\*\)/);
+    expect(output).toMatch(/PASS\s+\/dashboard\s+.* <= 1\.00mb/);
+  });
+
+  it("warns about unmatched budget keys", () => {
+    const report = createFixtureReport();
+    const evaluation = evaluateBudgets(report, { "/missing": "1kb" });
+    expect(formatBudgetResults(evaluation)).toContain('budget for "/missing" does not match');
+  });
+});

--- a/packages/vite-plugin/src/plugin-codegen.ts
+++ b/packages/vite-plugin/src/plugin-codegen.ts
@@ -142,6 +142,7 @@ export function createPrachtServerModuleSource(
     `export const cssManifest = ${JSON.stringify(clientBuild.cssManifest)};`,
     `export const jsManifest = ${JSON.stringify(clientBuild.jsManifest)};`,
     `export const prerenderConcurrency = ${JSON.stringify(resolved.prerenderConcurrency)};`,
+    `export const budgets = ${JSON.stringify(resolved.budgets)};`,
     "export { prerenderApp };",
     "",
   ];

--- a/packages/vite-plugin/src/plugin-options.ts
+++ b/packages/vite-plugin/src/plugin-options.ts
@@ -19,6 +19,14 @@ export interface PrachtPluginOptions {
   /** Maximum request body size (bytes) accepted by the dev SSR middleware. Defaults to 1 MiB. */
   maxBodySize?: number;
   /**
+   * Per-route gzip client-JS budgets evaluated by `pracht build`, e.g.
+   * `{ "*": "120kb", "/dashboard": "200kb" }`. `"*"` applies to every route;
+   * explicit route paths override it. Values are byte counts or size strings
+   * ("120kb", "1mb"). Exceeded budgets fail the build unless
+   * `pracht build --no-budget-fail` is used.
+   */
+  budgets?: Record<string, string | number>;
+  /**
    * Opt into precompiling safe Preact JSX DOM subtrees for SSR/SSG server bundles.
    * Client bundles keep the normal Preact JSX transform for hydration.
    */
@@ -39,6 +47,7 @@ const DEFAULTS: ResolvedPrachtPluginOptions = {
   pagesDefaultRender: "ssr",
   prerenderConcurrency: 10,
   maxBodySize: 1024 * 1024,
+  budgets: {},
   precompileSsrJsx: false,
 };
 
@@ -53,5 +62,23 @@ export function resolveOptions(options: PrachtPluginOptions): ResolvedPrachtPlug
   if (!Number.isInteger(resolved.maxBodySize) || resolved.maxBodySize <= 0) {
     throw new Error("pracht({ maxBodySize }) expects a positive integer number of bytes.");
   }
+  validateBudgets(resolved.budgets);
   return resolved;
+}
+
+function validateBudgets(budgets: Record<string, string | number>): void {
+  for (const [key, value] of Object.entries(budgets)) {
+    if (key !== "*" && !key.startsWith("/")) {
+      throw new Error(
+        `pracht({ budgets }) keys must be "*" or a route path starting with "/", got ${JSON.stringify(key)}.`,
+      );
+    }
+    const isValidNumber = typeof value === "number" && Number.isFinite(value) && value > 0;
+    const isValidString = typeof value === "string" && value.trim().length > 0;
+    if (!isValidNumber && !isValidString) {
+      throw new Error(
+        `pracht({ budgets }) values must be a positive number of bytes or a size string like "120kb", got ${JSON.stringify(value)} for ${JSON.stringify(key)}.`,
+      );
+    }
+  }
 }

--- a/packages/vite-plugin/test/plugin-options.test.ts
+++ b/packages/vite-plugin/test/plugin-options.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+
+import { createPrachtServerModuleSource } from "../src/plugin-codegen.ts";
+import { resolveOptions } from "../src/plugin-options.ts";
+
+describe("resolveOptions budgets", () => {
+  it("defaults to no budgets", () => {
+    expect(resolveOptions({}).budgets).toEqual({});
+  });
+
+  it("accepts size strings and byte counts keyed by route path or *", () => {
+    const resolved = resolveOptions({
+      budgets: { "*": "120kb", "/dashboard": "200kb", "/": 50000 },
+    });
+    expect(resolved.budgets).toEqual({ "*": "120kb", "/dashboard": "200kb", "/": 50000 });
+  });
+
+  it("rejects keys that are not * or a route path", () => {
+    expect(() => resolveOptions({ budgets: { dashboard: "200kb" } })).toThrow(
+      /keys must be "\*" or a route path/,
+    );
+  });
+
+  it("rejects non-positive or empty values", () => {
+    expect(() => resolveOptions({ budgets: { "*": 0 } })).toThrow(/positive number of bytes/);
+    expect(() => resolveOptions({ budgets: { "*": "" } })).toThrow(/positive number of bytes/);
+  });
+});
+
+describe("createPrachtServerModuleSource budgets export", () => {
+  it("embeds the configured budgets in the server module", () => {
+    const source = createPrachtServerModuleSource({
+      budgets: { "*": "120kb", "/dashboard": "200kb" },
+    });
+    expect(source).toContain('export const budgets = {"*":"120kb","/dashboard":"200kb"};');
+  });
+
+  it("embeds an empty budgets object by default", () => {
+    const source = createPrachtServerModuleSource();
+    expect(source).toContain("export const budgets = {};");
+  });
+});

--- a/skills/audit-bundles/SKILL.md
+++ b/skills/audit-bundles/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: audit-bundles
-version: 1.0.0
+version: 1.1.0
 description: |
   Analyze a pracht production build. Report client bundle size per route,
   flag fat vendor chunks, find route components that ship large dependencies,
@@ -21,15 +21,22 @@ Pracht performs route-level code splitting via the Vite plugin and emits a
 manifest. This skill reads that manifest, sizes each route's client payload,
 and surfaces the worst offenders.
 
-## Step 1: Build
+## Step 1: Build with analysis
 
 ```bash
-pracht build
+pracht build --analyze --json
 ```
 
-A stale `dist/` produces misleading numbers. Confirm the build succeeded.
+This is the native per-route payload report: for every route (pattern + render
+mode) it emits the transitive client JS chunks with raw and gzip sizes
+(`routes[].chunks`), route-specific and total sums (`routeGzipBytes`,
+`totalGzipBytes`), and the shared entry chunks broken out (`shared`), sorted by
+total gzip descending. A stale `dist/` produces misleading numbers — rebuild,
+don't reuse.
 
-## Step 2: Pull the build graph
+For a human-readable table, use `pracht build --analyze` instead.
+
+## Step 2: Pull supporting metadata
 
 ```bash
 pracht inspect build --json
@@ -37,27 +44,26 @@ pracht inspect build --json
 
 Captures the resolved adapter, client entry URL, and CSS/JS manifest. Cross
 reference with `dist/client/.vite/manifest.json` for chunk metadata
-(file, imports, dynamicImports, css, isEntry).
+(file, imports, dynamicImports, css, isEntry) — needed for vendor fan-in
+analysis (Step 4) and CSS sizing, which the analyze report does not cover.
 
-## Step 3: Compute per-route payload
+## Step 3: Interpret per-route payload
 
-For each route, the client payload is:
+From the Step 1 JSON, report:
 
-1. The route module's chunk (via the manifest).
-2. Its `imports[]` (transitive synchronous imports — recurse).
-3. Plus the client entry chunk and its imports (shared by every route).
-4. Plus the route's CSS chunks.
+| Route | Route JS (gz) | Shared (gz) | Total (gz) | CSS (gz) | LCP-class? |
+| ----- | ------------- | ----------- | ---------- | -------- | ---------- |
 
-Report:
-
-| Route | Route chunk (gz) | Shared (gz) | Total (gz) | CSS (gz) | LCP-class? |
-| ----- | ---------------- | ----------- | ---------- | -------- | ---------- |
-
-`gz` = gzip size. Use Node's `zlib.gzipSync` on the raw file content if a CLI
-tool is not available.
+`gz` = gzip size, taken directly from `routeGzipBytes` / `shared.gzipBytes` /
+`totalGzipBytes`. Size CSS chunks (from `cssManifest`) with `zlib.gzipSync`.
 
 `LCP-class?` is `yes` when total gz exceeds 200 KB — that's the order of
 magnitude where mid-tier mobile starts losing LCP budget.
+
+If the app declares `budgets` in the pracht plugin config, the Step 1 JSON also
+contains a `budgets` section with per-route pass/fail — lead the report with any
+failures. If no budgets are configured, suggest adding them (see
+docs/PERFORMANCE.md), starting from the current sizes plus ~10% headroom.
 
 ## Step 4: Vendor chunk health
 
@@ -110,7 +116,8 @@ inside `Component`: -180 KB gz off `/dashboard/analytics`."
 
 ## Rules
 
-1. Always run `pracht build` first. A stale build is a source of bad advice.
+1. Always run `pracht build --analyze --json` first. A stale build is a source
+   of bad advice.
 2. Use the Vite manifest as the source of truth — chunk names rotate per
    build.
 3. Report gzip size, not raw — the wire size is what users pay.


### PR DESCRIPTION
## Summary

- Adds `pracht build --analyze`: after a successful build, prints a per-route report of client JavaScript — for each route (pattern + render mode) the transitive client chunks it loads (route module + shell, resolved from the Vite client manifest via the same suffix matching the runtime uses), with raw and gzip sizes (`node:zlib` `gzipSync` at the default level), a total row per route, and the shared entry chunks broken out. Routes are sorted by total gzip descending, columns are aligned, and colors respect `NO_COLOR`.
- Adds `pracht build --json`: the same data as machine-readable JSON (implies `--analyze`, silences human-oriented build logs on stdout), consistent with `pracht inspect --json` conventions.
- Adds a `budgets` option to the `pracht()` plugin config, e.g. `budgets: { "*": "120kb", "/dashboard": "200kb" }` — per-route gzip client-JS ceilings where `"*"` is the default for all routes and explicit route paths override it. After every build with budgets configured, `pracht build` prints pass/fail per route, writes `dist/server/budget-report.json`, and exits non-zero on exceeded budgets unless `--no-budget-fail` is passed.
- Surfaces the last build's budget results in `pracht verify` / `pracht doctor` when `dist/server/budget-report.json` is present (verify itself never runs a build, so it reads the persisted report written by `pracht build`).
- New `packages/cli/src/bundle-report.ts` with `parseSizeToBytes` ("120kb", "1mb", plain number = bytes; 1024-based units), report collection, budget evaluation, and formatting helpers — all unit tested against a manifest fixture.
- Docs: new `docs/PERFORMANCE.md`, README feature bullets and repo map, `packages/cli` README, and `skills/audit-bundles/SKILL.md` realigned to the native `pracht build --analyze --json` command.
- Drive-by: `pnpm run format` normalized a regex escape in `.github/scripts/stage-packages.mjs`.

No linked issue.

## Testing

- [x] `pnpm e2e`
- [x] `pnpm format`
- [x] `pnpm lint`
- [x] `pnpm test`

## Checklist

- [x] Docs updated if needed
- [x] Skills updated if needed
- [x] Changeset added if published packages changed
