### PR TITLE
Add dev-only /_pracht devtools page and Server-Timing phase headers

### DIFF
--- a/.changeset/devtools-route.md
+++ b/.changeset/devtools-route.md
@@ -1,0 +1,11 @@
+---
+"@pracht/core": minor
+"@pracht/vite-plugin": minor
+"@pracht/cli": patch
+---
+
+Add a dev-only `/_pracht` devtools page and `Server-Timing` phase headers.
+
+- The dev server now serves a self-contained devtools page at `/_pracht` listing every page route (pattern, render mode, shell, middleware chain, source file) and API route (path, methods, source file), with the same data available as JSON at `/_pracht.json`. The path is reserved in dev only — a colliding user route logs a warning in dev and still wins in production.
+- Dev SSR responses now carry a standards-compliant `Server-Timing` header (e.g. `mw;dur=1.2, loader;dur=14.8, render;dur=3.1`) so middleware/loader/render phase durations show up in the browser Network panel. The runtime only records timings when the new `HandlePrachtRequestOptions.timings` collector is passed; production requests skip all timing work.
+- `@pracht/core` gains a shared app-graph module (`buildAppGraph`, `serializeAppRoutes`, `serializeApiRoutes`, `detectApiMethods`, and a new `@pracht/core/devtools` entry) that both `pracht inspect` and the devtools page use, so the CLI and the page report the same graph.

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ The prompts cover the target directory, hosting adapter (Node.js, Cloudflare Wor
 
 The starter gives you:
 
-- `pracht dev` — local SSR + HMR
+- `pracht dev` — local SSR + HMR, a `/_pracht` devtools page with the resolved route/API graph (JSON at `/_pracht.json`), and `Server-Timing` middleware/loader/render phase timings on every dev SSR response
 - `pracht build` — client/server output plus SSG/ISG prerendering, with `--analyze` for a per-route client JS report and budget enforcement
 - `pracht inspect [routes|api|build] --json` — resolved app graph metadata
 - `pracht generate route|shell|middleware|api` — framework-native scaffolding

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -306,6 +306,43 @@ Secrets in loader code stay server-side. The client only receives serialized dat
 
 ---
 
+## Dev Server Debugging
+
+The Vite dev SSR middleware (`packages/vite-plugin/src/plugin-dev-ssr.ts`) adds two
+dev-only debugging surfaces. Neither exists in production builds, and adapters that
+own the dev server (`ownsDevServer: true`, e.g. Cloudflare's workerd-based dev) bypass
+this middleware and therefore don't expose them.
+
+### `/_pracht` devtools page
+
+- `GET /_pracht` serves a self-contained HTML page (no Preact — same approach as the
+  error overlay in `packages/framework/src/error-overlay.ts`) listing every page route
+  (pattern, render mode, shell, middleware chain, source file) and API route
+  (path, methods, source file), with links to navigable routes.
+- `GET /_pracht.json` serves the same data as JSON.
+- Both are built from the shared app-graph helpers in
+  `packages/framework/src/app-graph.ts` (`@pracht/core/devtools`) — the same
+  serialization `pracht inspect --json` uses, so the CLI and the page never drift.
+- The path is reserved in dev only: a user route at `/_pracht` still wins in
+  production, while in dev the middleware logs a collision warning and serves the
+  devtools page.
+
+### `Server-Timing` header
+
+In dev, every SSR page response carries a standards-compliant `Server-Timing` header,
+e.g. `mw;dur=1.2, loader;dur=14.8, render;dur=3.1`, visible in the browser devtools
+Network panel:
+
+- `mw` — time spent in the middleware chain (excluding loader/render)
+- `loader` — time awaiting the route loader (omitted when the route has none)
+- `render` — module resolution + component rendering + HTML assembly
+
+The runtime only records timings when the dev middleware passes a collector via
+`HandlePrachtRequestOptions.timings`; production adapters never pass one, so
+production requests skip all timing work.
+
+---
+
 ## Build Pipeline
 
 Pracht uses Vite's multi-environment build:

--- a/e2e/pages-router.test.ts
+++ b/e2e/pages-router.test.ts
@@ -261,3 +261,46 @@ test("unmatched route returns 404", async ({ request }) => {
   const response = await request.get("/nonexistent-page");
   expect(response.status()).toBe(404);
 });
+
+// ---------------------------------------------------------------------------
+// Dev devtools: /_pracht + Server-Timing
+// ---------------------------------------------------------------------------
+
+test("/_pracht serves the devtools page in dev", async ({ request }) => {
+  const response = await request.get("/_pracht");
+  expect(response.status()).toBe(200);
+  expect(response.headers()["content-type"]).toContain("text/html");
+
+  const html = await response.text();
+  expect(html).toContain("pracht");
+  expect(html).toContain("/about");
+  expect(html).toContain("/blog/:slug");
+  expect(html).toContain("/api/health");
+  expect(html).toContain("/_pracht.json");
+});
+
+test("/_pracht.json serves the resolved app graph as JSON", async ({ request }) => {
+  const response = await request.get("/_pracht.json");
+  expect(response.status()).toBe(200);
+  expect(response.headers()["content-type"]).toContain("application/json");
+
+  const graph = await response.json();
+  const routePaths = graph.routes.map((route: { path: string }) => route.path);
+  expect(routePaths).toContain("/");
+  expect(routePaths).toContain("/about");
+  expect(routePaths).toContain("/blog/:slug");
+
+  const health = graph.api.find((route: { path: string }) => route.path === "/api/health");
+  expect(health.methods).toContain("GET");
+  expect(health.file).toContain("health");
+});
+
+test("dev SSR responses carry a Server-Timing header with phase durations", async ({ request }) => {
+  const response = await request.get("/");
+  expect(response.status()).toBe(200);
+
+  const serverTiming = response.headers()["server-timing"];
+  expect(serverTiming).toMatch(/mw;dur=\d+(\.\d+)?/);
+  expect(serverTiming).toMatch(/loader;dur=\d+(\.\d+)?/);
+  expect(serverTiming).toMatch(/render;dur=\d+(\.\d+)?/);
+});

--- a/packages/cli/src/commands/inspect.ts
+++ b/packages/cli/src/commands/inspect.ts
@@ -1,10 +1,12 @@
-import { existsSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
+import { resolve } from "node:path";
 
+import { serializeApiRoutes, serializeAppRoutes } from "@pracht/core";
+import type { AppGraphApiRoute, AppGraphRoute } from "@pracht/core";
 import { defineCommand } from "citty";
 import { createServer } from "vite";
 
 import { handleCliError } from "../utils.js";
-import { collectApiRoutes, serializeResolvedRoutes } from "../app-graph.js";
 import { readClientBuildAssets } from "../build-metadata.js";
 import { readProjectConfig, resolveProjectPath } from "../project.js";
 
@@ -47,7 +49,7 @@ export default defineCommand({
 });
 
 export interface InspectReport {
-  api?: { file: string; methods: string[]; path: string }[];
+  api?: AppGraphApiRoute[];
   build?: {
     adapterTarget: string;
     clientEntryUrl: string | null;
@@ -55,17 +57,7 @@ export interface InspectReport {
     jsManifest: Record<string, string[]>;
   };
   mode: string;
-  routes?: {
-    file: string;
-    id: string;
-    loaderFile: string | null;
-    middleware: string[];
-    path: string;
-    render: string | null;
-    revalidate: unknown;
-    shell: string | null;
-    shellFile: string | null;
-  }[];
+  routes?: AppGraphRoute[];
 }
 
 export async function runInspect(root: string, { target = "all" } = {}): Promise<InspectReport> {
@@ -103,12 +95,13 @@ export async function runInspect(root: string, { target = "all" } = {}): Promise
     };
 
     if (target === "routes" || target === "all") {
-      report.routes = serializeResolvedRoutes(serverModule.resolvedApp.routes);
+      report.routes = serializeAppRoutes(serverModule.resolvedApp.routes);
     }
 
     if (target === "api" || target === "all") {
-      report.api = await collectApiRoutes(server, root, serverModule.apiRoutes, {
-        executeApiModules: true,
+      report.api = await serializeApiRoutes(serverModule.apiRoutes, {
+        loadModule: (file) => server.ssrLoadModule(file),
+        readSource: (file) => readFileSync(resolve(root, `.${file}`), "utf-8"),
       });
     }
 

--- a/packages/framework/package.json
+++ b/packages/framework/package.json
@@ -57,6 +57,10 @@
     "./dev-404": {
       "types": "./dist/dev-404.d.mts",
       "default": "./dist/dev-404.mjs"
+    },
+    "./devtools": {
+      "types": "./dist/devtools.d.mts",
+      "default": "./dist/devtools.mjs"
     }
   },
   "publishConfig": {

--- a/packages/framework/src/app-graph.ts
+++ b/packages/framework/src/app-graph.ts
@@ -1,0 +1,110 @@
+/**
+ * Shared resolved-app-graph serialization.
+ *
+ * Both `pracht inspect` (CLI) and the dev-only `/_pracht` devtools endpoint
+ * (vite plugin) consume this module so they always report the same graph.
+ * Module loading and file reading are injected by the caller to keep this
+ * module platform-neutral.
+ */
+
+import type { HttpMethod, ResolvedApiRoute, ResolvedPrachtApp, ResolvedRoute } from "./types.ts";
+
+export const API_METHOD_ORDER: readonly HttpMethod[] = [
+  "GET",
+  "POST",
+  "PUT",
+  "PATCH",
+  "DELETE",
+  "HEAD",
+  "OPTIONS",
+];
+
+export interface AppGraphRoute {
+  file: string;
+  id: string;
+  loaderFile: string | null;
+  middleware: string[];
+  path: string;
+  render: string | null;
+  revalidate: unknown;
+  shell: string | null;
+  shellFile: string | null;
+}
+
+export interface AppGraphApiRoute {
+  file: string;
+  methods: string[];
+  path: string;
+}
+
+export interface AppGraph {
+  api: AppGraphApiRoute[];
+  routes: AppGraphRoute[];
+}
+
+export interface AppGraphModuleAccess {
+  /** Import an app module by its app-relative file path (e.g. Vite's `ssrLoadModule`). */
+  loadModule: (file: string) => Promise<Record<string, unknown>>;
+  /** Read an app module's source text — fallback method detection when importing fails. */
+  readSource: (file: string) => string;
+}
+
+export function serializeAppRoutes(routes: readonly ResolvedRoute[]): AppGraphRoute[] {
+  return routes.map((route) => ({
+    file: route.file,
+    id: route.id ?? "",
+    loaderFile: route.loaderFile ?? null,
+    middleware: route.middleware,
+    path: route.path,
+    render: route.render ?? null,
+    revalidate: route.revalidate ?? null,
+    shell: route.shell ?? null,
+    shellFile: route.shellFile ?? null,
+  }));
+}
+
+export function serializeApiRoutes(
+  apiRoutes: readonly ResolvedApiRoute[],
+  access: AppGraphModuleAccess,
+): Promise<AppGraphApiRoute[]> {
+  return Promise.all(
+    apiRoutes.map(async (route) => ({
+      file: route.file,
+      methods: await detectApiMethods(route.file, access),
+      path: route.path,
+    })),
+  );
+}
+
+export async function buildAppGraph(
+  options: {
+    apiRoutes?: readonly ResolvedApiRoute[];
+    app: ResolvedPrachtApp;
+  } & AppGraphModuleAccess,
+): Promise<AppGraph> {
+  return {
+    api: await serializeApiRoutes(options.apiRoutes ?? [], options),
+    routes: serializeAppRoutes(options.app.routes),
+  };
+}
+
+export async function detectApiMethods(
+  file: string,
+  access: AppGraphModuleAccess,
+): Promise<HttpMethod[]> {
+  try {
+    const module = await access.loadModule(file);
+    return API_METHOD_ORDER.filter((method) => typeof module[method] === "function");
+  } catch {
+    let source: string;
+    try {
+      source = access.readSource(file);
+    } catch {
+      return [];
+    }
+
+    return API_METHOD_ORDER.filter((method) =>
+      new RegExp(`export\\s+(?:async\\s+)?(?:function|const|let|var)\\s+${method}\\b`).test(source),
+    );
+  }
+}

--- a/packages/framework/src/devtools.ts
+++ b/packages/framework/src/devtools.ts
@@ -1,0 +1,205 @@
+/**
+ * Self-contained devtools page for pracht dev mode, served at `/_pracht`.
+ *
+ * Returns a standalone HTML document with inline styles.
+ * Not a Preact component — the page must render even when the app's own
+ * module graph is broken, so it never imports Preact or app code.
+ */
+
+import type { AppGraph, AppGraphApiRoute, AppGraphRoute } from "./app-graph.ts";
+
+export {
+  buildAppGraph,
+  detectApiMethods,
+  serializeApiRoutes,
+  serializeAppRoutes,
+} from "./app-graph.ts";
+export type {
+  AppGraph,
+  AppGraphApiRoute,
+  AppGraphModuleAccess,
+  AppGraphRoute,
+} from "./app-graph.ts";
+
+export const DEVTOOLS_PATH = "/_pracht";
+export const DEVTOOLS_JSON_PATH = "/_pracht.json";
+
+export function buildDevtoolsHtml(graph: AppGraph): string {
+  const routeRows = graph.routes
+    .map(
+      (route) => `<tr>
+        <td>${routeLinkHtml(route)}</td>
+        <td>${escapeHtml(route.render ?? "ssr")}</td>
+        <td>${escapeHtml(route.shell ?? "—")}</td>
+        <td>${escapeHtml(route.middleware.length > 0 ? route.middleware.join(" → ") : "—")}</td>
+        <td class="file">${escapeHtml(route.file)}</td>
+      </tr>`,
+    )
+    .join("\n");
+
+  const apiRows = graph.api
+    .map(
+      (route) => `<tr>
+        <td>${apiLinkHtml(route)}</td>
+        <td>${escapeHtml(route.methods.length > 0 ? route.methods.join(", ") : "—")}</td>
+        <td class="file">${escapeHtml(route.file)}</td>
+      </tr>`,
+    )
+    .join("\n");
+
+  const apiSection =
+    graph.api.length > 0
+      ? `<h2>API routes</h2>
+    <table>
+      <thead><tr><th>Path</th><th>Methods</th><th>Source</th></tr></thead>
+      <tbody>
+${apiRows}
+      </tbody>
+    </table>`
+      : `<h2>API routes</h2>
+    <p class="empty">No API routes found.</p>`;
+
+  return `<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="robots" content="noindex">
+  <title>pracht devtools</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body {
+      font-family: ui-monospace, "Cascadia Code", "Source Code Pro", Menlo, Consolas, monospace;
+      background: #1a1a2e;
+      color: #e0e0e0;
+      padding: 32px;
+      line-height: 1.5;
+    }
+    .devtools {
+      max-width: 1100px;
+      margin: 0 auto;
+    }
+    .header {
+      display: flex;
+      align-items: center;
+      gap: 12px;
+      margin-bottom: 24px;
+      padding-bottom: 16px;
+      border-bottom: 1px solid #333;
+    }
+    .badge {
+      background: #4c6ef5;
+      color: #fff;
+      font-size: 11px;
+      font-weight: 700;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+      padding: 4px 10px;
+      border-radius: 4px;
+    }
+    .title {
+      font-size: 14px;
+      color: #888;
+    }
+    .title a {
+      color: #a0c4ff;
+    }
+    h2 {
+      font-size: 14px;
+      font-weight: 600;
+      color: #a0c4ff;
+      margin: 24px 0 10px;
+    }
+    table {
+      width: 100%;
+      border-collapse: collapse;
+      font-size: 13px;
+    }
+    th {
+      text-align: left;
+      color: #888;
+      font-weight: 600;
+      padding: 6px 12px 6px 0;
+      border-bottom: 1px solid #333;
+    }
+    td {
+      padding: 6px 12px 6px 0;
+      border-bottom: 1px solid #26263e;
+      vertical-align: top;
+      word-break: break-word;
+    }
+    td a {
+      color: #74c0fc;
+    }
+    .file {
+      color: #888;
+    }
+    .empty {
+      font-size: 13px;
+      color: #888;
+    }
+    .hint {
+      margin-top: 24px;
+      font-size: 12px;
+      color: #666;
+    }
+    .hint a {
+      color: #a0c4ff;
+    }
+  </style>
+</head>
+<body>
+  <div class="devtools">
+    <div class="header">
+      <span class="badge">pracht</span>
+      <span class="title">devtools — resolved app graph (dev only)</span>
+    </div>
+    <h2>Page routes</h2>
+    <table>
+      <thead><tr><th>Route</th><th>Render</th><th>Shell</th><th>Middleware</th><th>Source</th></tr></thead>
+      <tbody>
+${routeRows}
+      </tbody>
+    </table>
+    ${apiSection}
+    <div class="hint">
+      Raw JSON at <a href="${DEVTOOLS_JSON_PATH}">${DEVTOOLS_JSON_PATH}</a> ·
+      same data as <code>pracht inspect --json</code> ·
+      per-request middleware/loader/render timings are on the <code>Server-Timing</code>
+      response header in the browser Network panel.
+    </div>
+  </div>
+</body>
+</html>`;
+}
+
+function routeLinkHtml(route: AppGraphRoute): string {
+  const label = escapeHtml(route.path);
+  if (!isLinkablePath(route.path)) {
+    return label;
+  }
+
+  return `<a href="${escapeHtml(route.path)}">${label}</a>`;
+}
+
+function apiLinkHtml(route: AppGraphApiRoute): string {
+  const label = escapeHtml(route.path);
+  if (!isLinkablePath(route.path) || !route.methods.includes("GET")) {
+    return label;
+  }
+
+  return `<a href="${escapeHtml(route.path)}">${label}</a>`;
+}
+
+/** Dynamic patterns (`:id`, `*`) are not navigable as-is — render them as text. */
+function isLinkablePath(path: string): boolean {
+  return !path.includes(":") && !path.includes("*");
+}
+
+function escapeHtml(str: string): string {
+  return str
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}

--- a/packages/framework/src/index.ts
+++ b/packages/framework/src/index.ts
@@ -11,12 +11,25 @@ export {
   timeRevalidate,
 } from "./app.ts";
 export { createHref } from "./href.ts";
+export {
+  buildAppGraph,
+  detectApiMethods,
+  serializeApiRoutes,
+  serializeAppRoutes,
+} from "./app-graph.ts";
+export type {
+  AppGraph,
+  AppGraphApiRoute,
+  AppGraphModuleAccess,
+  AppGraphRoute,
+} from "./app-graph.ts";
 export { forwardRef } from "./forwardRef.ts";
 export { useIsHydrated } from "./hydration.ts";
 export { Suspense, lazy } from "preact-suspense";
 export {
   applyDefaultSecurityHeaders,
   Form,
+  formatServerTimingHeader,
   Link,
   handlePrachtRequest,
   readHydrationState,
@@ -98,6 +111,7 @@ export type {
   HandlePrachtRequestOptions,
   LinkProps,
   Location,
+  PrachtPhaseTimings,
   PrachtRuntimeDiagnosticPhase,
   PrachtRuntimeDiagnostics,
   RouteStateResult,

--- a/packages/framework/src/runtime-timing.ts
+++ b/packages/framework/src/runtime-timing.ts
@@ -1,0 +1,39 @@
+/**
+ * Per-request phase timing for dev tooling.
+ *
+ * The runtime only records durations when a collector object is passed via
+ * `HandlePrachtRequestOptions.timings` — the dev server passes one, production
+ * adapters never do, so production requests skip all timing work.
+ */
+
+export interface PrachtPhaseTimings {
+  /** Milliseconds spent in the middleware chain, excluding loader and render. */
+  mw?: number;
+  /** Milliseconds spent awaiting the route loader. */
+  loader?: number;
+  /** Milliseconds spent resolving modules and rendering the response, excluding the loader. */
+  render?: number;
+}
+
+const PHASE_ORDER = ["mw", "loader", "render"] as const;
+
+/**
+ * Format collected phase timings as a standards-compliant `Server-Timing`
+ * header value, e.g. `mw;dur=1.2, loader;dur=14.8, render;dur=3.1`.
+ * Returns an empty string when nothing was recorded.
+ */
+export function formatServerTimingHeader(timings: PrachtPhaseTimings): string {
+  const entries: string[] = [];
+  for (const phase of PHASE_ORDER) {
+    const duration = timings[phase];
+    if (typeof duration === "number" && Number.isFinite(duration)) {
+      entries.push(`${phase};dur=${formatDuration(duration)}`);
+    }
+  }
+
+  return entries.join(", ");
+}
+
+function formatDuration(duration: number): string {
+  return String(Math.max(0, Math.round(duration * 10) / 10));
+}

--- a/packages/framework/src/runtime.ts
+++ b/packages/framework/src/runtime.ts
@@ -33,6 +33,7 @@ import {
 } from "./runtime-response.ts";
 import { withRouteResponseHeaders } from "./runtime-headers.ts";
 import { markdownResponse, prefersMarkdown } from "./runtime-negotiation.ts";
+import type { PrachtPhaseTimings } from "./runtime-timing.ts";
 import type {
   ApiRouteArgs,
   ApiRouteModule,
@@ -153,6 +154,12 @@ export interface HandlePrachtRequestOptions<TContext = unknown> {
   /** Per-source-file JS chunk map produced by the vite plugin for modulepreload hints. */
   jsManifest?: Record<string, string[]>;
   apiRoutes?: ResolvedApiRoute[];
+  /**
+   * Dev-only phase-timing collector. When provided, the runtime records
+   * middleware/loader/render durations (ms) onto it so callers can emit a
+   * `Server-Timing` header. Leave unset in production — no timing work runs.
+   */
+  timings?: PrachtPhaseTimings;
 }
 
 export async function handlePrachtRequest<TContext>(
@@ -331,6 +338,7 @@ export async function handlePrachtRequest<TContext>(
   let shellModule: ShellModule | undefined;
   let loaderFile: string | undefined;
   let currentPhase: PrachtRuntimeDiagnosticPhase = "middleware";
+  const timings = options.timings;
 
   try {
     // Kick off every piece of the pipeline that doesn't depend on the
@@ -375,7 +383,14 @@ export async function handlePrachtRequest<TContext>(
       const { loader, loaderFile: resolvedLoaderFile } = await dataFunctionsPromise;
       loaderFile = resolvedLoaderFile;
 
-      const loaderResult = loader ? await loader(routeArgs) : undefined;
+      let loaderResult: unknown;
+      if (loader) {
+        const loaderStart = timings ? performance.now() : 0;
+        loaderResult = await loader(routeArgs);
+        if (timings) {
+          timings.loader = performance.now() - loaderStart;
+        }
+      }
 
       // Allow loaders to return a Response directly (e.g. for redirects)
       if (loaderResult instanceof Response) {
@@ -518,6 +533,24 @@ export async function handlePrachtRequest<TContext>(
       );
     };
 
+    // Dev-only instrumentation: wrap the terminal so middleware time can be
+    // derived as "chain total minus terminal", and terminal time minus the
+    // loader becomes the render phase. Production passes no collector and
+    // uses the un-wrapped terminal.
+    let terminal = pageTerminal;
+    let chainStart = 0;
+    if (timings) {
+      terminal = async () => {
+        const terminalStart = performance.now();
+        try {
+          return await pageTerminal();
+        } finally {
+          timings.render = performance.now() - terminalStart - (timings.loader ?? 0);
+        }
+      };
+      chainStart = performance.now();
+    }
+
     const response = await runMiddlewareChain({
       context: pageContext,
       middlewareFiles: match.route.middlewareFiles,
@@ -527,8 +560,11 @@ export async function handlePrachtRequest<TContext>(
       route: match.route,
       signal: requestSignal,
       url,
-      terminal: pageTerminal,
+      terminal,
     });
+    if (timings) {
+      timings.mw = performance.now() - chainStart - (timings.render ?? 0) - (timings.loader ?? 0);
+    }
     return normalizePageResponse(response, { isRouteStateRequest });
   } catch (error: unknown) {
     return renderRouteErrorResponse({
@@ -574,6 +610,7 @@ function isHrefRouteDefinition(value: unknown): value is HrefRouteDefinition {
 // Public runtime surface — re-exported so `./runtime.ts` remains the
 // single import entry for the framework's runtime API.
 export { applyDefaultSecurityHeaders } from "./runtime-headers.ts";
+export { formatServerTimingHeader, type PrachtPhaseTimings } from "./runtime-timing.ts";
 export {
   deserializeRouteError,
   type PrachtRuntimeDiagnosticPhase,

--- a/packages/framework/src/server.ts
+++ b/packages/framework/src/server.ts
@@ -13,9 +13,22 @@ export {
 export { createHref } from "./href.ts";
 export {
   applyDefaultSecurityHeaders,
+  formatServerTimingHeader,
   handlePrachtRequest,
   PrachtRuntimeProvider,
 } from "./runtime.ts";
+export {
+  buildAppGraph,
+  detectApiMethods,
+  serializeApiRoutes,
+  serializeAppRoutes,
+} from "./app-graph.ts";
+export type {
+  AppGraph,
+  AppGraphApiRoute,
+  AppGraphModuleAccess,
+  AppGraphRoute,
+} from "./app-graph.ts";
 export { prerenderApp } from "./prerender.ts";
 export { redirect, type RedirectOptions } from "./runtime-middleware.ts";
 export { PrachtHttpError } from "./types.ts";
@@ -84,6 +97,7 @@ export type {
 } from "./types.ts";
 export type {
   HandlePrachtRequestOptions,
+  PrachtPhaseTimings,
   PrachtRuntimeDiagnosticPhase,
   PrachtRuntimeDiagnostics,
   SerializedRouteError,

--- a/packages/framework/test/devtools.test.ts
+++ b/packages/framework/test/devtools.test.ts
@@ -1,0 +1,229 @@
+import { describe, expect, it } from "vitest";
+
+import type { AppGraph } from "../src/app-graph.ts";
+import { buildAppGraph, detectApiMethods, serializeAppRoutes } from "../src/app-graph.ts";
+import { defineApp, resolveApiRoutes, resolveApp, route } from "../src/app.ts";
+import { buildDevtoolsHtml, DEVTOOLS_JSON_PATH } from "../src/devtools.ts";
+
+const graphFixture: AppGraph = {
+  api: [
+    {
+      file: "/src/api/health.ts",
+      methods: ["GET"],
+      path: "/api/health",
+    },
+    {
+      file: "/src/api/users/[id].ts",
+      methods: ["GET", "POST"],
+      path: "/api/users/:id",
+    },
+  ],
+  routes: [
+    {
+      file: "./routes/home.tsx",
+      id: "home",
+      loaderFile: null,
+      middleware: [],
+      path: "/",
+      render: "ssr",
+      revalidate: null,
+      shell: "public",
+      shellFile: "./shells/public.tsx",
+    },
+    {
+      file: "./routes/user.tsx",
+      id: "user",
+      loaderFile: "./routes/user.data.ts",
+      middleware: ["auth", "logger"],
+      path: "/users/:id",
+      render: "spa",
+      revalidate: null,
+      shell: null,
+      shellFile: null,
+    },
+  ],
+};
+
+describe("buildDevtoolsHtml", () => {
+  it("renders a self-contained page with the route table", () => {
+    const html = buildDevtoolsHtml(graphFixture);
+
+    expect(html).toContain("<!DOCTYPE html>");
+    expect(html).toContain("pracht");
+    // Page route columns: pattern, render mode, shell, middleware chain, source file.
+    expect(html).toContain("/users/:id");
+    expect(html).toContain("spa");
+    expect(html).toContain("public");
+    expect(html).toContain("auth → logger");
+    expect(html).toContain("./routes/user.tsx");
+    // No Preact — the page must be standalone markup.
+    expect(html).not.toContain("preact");
+  });
+
+  it("renders the API table and links to the JSON endpoint", () => {
+    const html = buildDevtoolsHtml(graphFixture);
+
+    expect(html).toContain("/api/health");
+    expect(html).toContain("GET, POST");
+    expect(html).toContain("/src/api/users/[id].ts");
+    expect(html).toContain(`href="${DEVTOOLS_JSON_PATH}"`);
+  });
+
+  it("links static routes but not dynamic patterns", () => {
+    const html = buildDevtoolsHtml(graphFixture);
+
+    expect(html).toContain('<a href="/">/</a>');
+    expect(html).toContain('<a href="/api/health">/api/health</a>');
+    expect(html).not.toContain('href="/users/:id"');
+    expect(html).not.toContain('href="/api/users/:id"');
+  });
+
+  it("escapes HTML in graph values", () => {
+    const html = buildDevtoolsHtml({
+      api: [],
+      routes: [
+        {
+          file: "./routes/<script>alert(1)</script>.tsx",
+          id: "xss",
+          loaderFile: null,
+          middleware: [],
+          path: "/xss",
+          render: null,
+          revalidate: null,
+          shell: null,
+          shellFile: null,
+        },
+      ],
+    });
+
+    expect(html).not.toContain("<script>alert(1)</script>");
+    expect(html).toContain("&lt;script&gt;alert(1)&lt;/script&gt;");
+  });
+
+  it("renders an empty state when there are no API routes", () => {
+    const html = buildDevtoolsHtml({ api: [], routes: graphFixture.routes });
+
+    expect(html).toContain("No API routes found.");
+  });
+});
+
+describe("buildAppGraph", () => {
+  it("produces the same payload shape as pracht inspect", async () => {
+    const app = resolveApp(
+      defineApp({
+        middleware: { auth: "./middleware/auth.ts" },
+        routes: [
+          route("/", "./routes/home.tsx", { id: "home", render: "ssg", shell: "public" }),
+          route("/users/:id", "./routes/user.tsx", { middleware: ["auth"] }),
+        ],
+        shells: { public: "./shells/public.tsx" },
+      }),
+    );
+
+    const graph = await buildAppGraph({
+      apiRoutes: resolveApiRoutes(["/src/api/health.ts"]),
+      app,
+      loadModule: async () => ({ GET() {}, POST() {}, helper: 1 }),
+      readSource: () => "",
+    });
+
+    expect(graph).toEqual({
+      api: [
+        {
+          file: "/src/api/health.ts",
+          methods: ["GET", "POST"],
+          path: "/api/health",
+        },
+      ],
+      routes: [
+        {
+          file: "./routes/home.tsx",
+          id: "home",
+          loaderFile: null,
+          middleware: [],
+          path: "/",
+          render: "ssg",
+          revalidate: null,
+          shell: "public",
+          shellFile: "./shells/public.tsx",
+        },
+        {
+          file: "./routes/user.tsx",
+          id: expect.any(String),
+          loaderFile: null,
+          middleware: ["auth"],
+          path: "/users/:id",
+          render: null,
+          revalidate: null,
+          shell: null,
+          shellFile: null,
+        },
+      ],
+    });
+  });
+
+  it("defaults to an empty API list when no API routes are passed", async () => {
+    const app = resolveApp(defineApp({ routes: [route("/", "./routes/home.tsx")] }));
+
+    const graph = await buildAppGraph({
+      app,
+      loadModule: async () => ({}),
+      readSource: () => "",
+    });
+
+    expect(graph.api).toEqual([]);
+    expect(graph.routes).toHaveLength(1);
+  });
+});
+
+describe("detectApiMethods", () => {
+  it("falls back to source scanning when the module fails to load", async () => {
+    const methods = await detectApiMethods("/src/api/broken.ts", {
+      loadModule: async () => {
+        throw new Error("boom");
+      },
+      readSource: () => "export async function GET() {}\nexport const DELETE = () => {};",
+    });
+
+    expect(methods).toEqual(["GET", "DELETE"]);
+  });
+
+  it("returns no methods when the module and source are both unavailable", async () => {
+    const methods = await detectApiMethods("/src/api/missing.ts", {
+      loadModule: async () => {
+        throw new Error("boom");
+      },
+      readSource: () => {
+        throw new Error("missing");
+      },
+    });
+
+    expect(methods).toEqual([]);
+  });
+});
+
+describe("serializeAppRoutes", () => {
+  it("normalizes optional fields to null", () => {
+    const [serialized] = serializeAppRoutes([
+      {
+        file: "./routes/home.tsx",
+        middleware: [],
+        middlewareFiles: [],
+        path: "/",
+        segments: [],
+      },
+    ]);
+
+    expect(serialized).toEqual({
+      file: "./routes/home.tsx",
+      id: "",
+      loaderFile: null,
+      middleware: [],
+      path: "/",
+      render: null,
+      revalidate: null,
+      shell: null,
+      shellFile: null,
+    });
+  });
+});

--- a/packages/framework/test/runtime-timing.test.ts
+++ b/packages/framework/test/runtime-timing.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from "vitest";
+
+import { defineApp, handlePrachtRequest, route } from "../src/index.ts";
+import { formatServerTimingHeader, type PrachtPhaseTimings } from "../src/runtime-timing.ts";
+
+describe("formatServerTimingHeader", () => {
+  it("formats all phases in stable order", () => {
+    expect(formatServerTimingHeader({ loader: 14.84, mw: 1.23, render: 3.06 })).toBe(
+      "mw;dur=1.2, loader;dur=14.8, render;dur=3.1",
+    );
+  });
+
+  it("omits phases that were not recorded", () => {
+    expect(formatServerTimingHeader({ mw: 0.5, render: 2 })).toBe("mw;dur=0.5, render;dur=2");
+  });
+
+  it("returns an empty string when nothing was recorded", () => {
+    expect(formatServerTimingHeader({})).toBe("");
+  });
+
+  it("clamps negative durations to zero", () => {
+    expect(formatServerTimingHeader({ mw: -0.04 })).toBe("mw;dur=0");
+  });
+
+  it("skips non-finite durations", () => {
+    expect(formatServerTimingHeader({ loader: Number.NaN, mw: 1 })).toBe("mw;dur=1");
+  });
+});
+
+describe("handlePrachtRequest timings option", () => {
+  const app = defineApp({
+    middleware: { logger: "./middleware/logger.ts" },
+    routes: [route("/", "./routes/home.tsx", { middleware: ["logger"] })],
+  });
+
+  const registry = {
+    middlewareModules: {
+      "./middleware/logger.ts": async () => ({
+        middleware: async (_args: unknown, next: () => Promise<Response>) => next(),
+      }),
+    },
+    routeModules: {
+      "./routes/home.tsx": async () => ({
+        Component: () => null,
+        loader: async () => ({ ok: true }),
+      }),
+    },
+  };
+
+  it("records middleware, loader, and render durations when a collector is passed", async () => {
+    const timings: PrachtPhaseTimings = {};
+    const response = await handlePrachtRequest({
+      app,
+      registry,
+      request: new Request("http://localhost/"),
+      timings,
+    });
+
+    expect(response.status).toBe(200);
+    expect(timings.mw).toBeTypeOf("number");
+    expect(timings.loader).toBeTypeOf("number");
+    expect(timings.render).toBeTypeOf("number");
+    expect(formatServerTimingHeader(timings)).toMatch(
+      /^mw;dur=\d+(\.\d+)?, loader;dur=\d+(\.\d+)?, render;dur=\d+(\.\d+)?$/,
+    );
+  });
+
+  it("skips the loader phase when the route has no loader", async () => {
+    const timings: PrachtPhaseTimings = {};
+    const response = await handlePrachtRequest({
+      app: defineApp({ routes: [route("/", "./routes/plain.tsx")] }),
+      registry: {
+        routeModules: {
+          "./routes/plain.tsx": async () => ({ Component: () => null }),
+        },
+      },
+      request: new Request("http://localhost/"),
+      timings,
+    });
+
+    expect(response.status).toBe(200);
+    expect(timings.loader).toBeUndefined();
+    expect(timings.mw).toBeTypeOf("number");
+    expect(timings.render).toBeTypeOf("number");
+  });
+});

--- a/packages/framework/tsdown.config.ts
+++ b/packages/framework/tsdown.config.ts
@@ -10,6 +10,7 @@ export default defineConfig({
     "src/server.ts",
     "src/error-overlay.ts",
     "src/dev-404.ts",
+    "src/devtools.ts",
   ],
   format: "esm",
   dts: true,

--- a/packages/vite-plugin/src/plugin-dev-ssr.ts
+++ b/packages/vite-plugin/src/plugin-dev-ssr.ts
@@ -1,16 +1,22 @@
+import { readFileSync } from "node:fs";
 import type { IncomingMessage, ServerResponse } from "node:http";
+import { resolve } from "node:path";
 import type { Connect, ViteDevServer } from "vite";
-import type { ResolvedApiRoute, ResolvedPrachtApp } from "@pracht/core";
+import type { PrachtPhaseTimings, ResolvedApiRoute, ResolvedPrachtApp } from "@pracht/core";
 import { CLIENT_BROWSER_PATH, PRACHT_SERVER_MODULE_ID } from "./plugin-assets.ts";
 
 const BODYLESS_METHODS = new Set(["GET", "HEAD"]);
 const DEFAULT_MAX_BODY_SIZE = 1024 * 1024; // 1 MiB
+
+export const DEVTOOLS_PATH = "/_pracht";
+export const DEVTOOLS_JSON_PATH = "/_pracht.json";
 
 export function createDevSSRMiddleware(
   server: ViteDevServer,
   options: { maxBodySize?: number } = {},
 ): Connect.NextHandleFunction {
   const maxBodySize = options.maxBodySize ?? DEFAULT_MAX_BODY_SIZE;
+  let warnedDevtoolsCollision = false;
   return async (req: IncomingMessage, res: ServerResponse, next: Connect.NextFunction) => {
     const url = req.url ?? "/";
     const requestUrl = new URL(url, "http://localhost");
@@ -27,6 +33,27 @@ export function createDevSSRMiddleware(
         matchApiRoute: framework.matchApiRoute,
         matchAppRoute: framework.matchAppRoute,
       };
+
+      // `/_pracht` is reserved in dev only. Production builds never see this
+      // branch, so a user route at that path keeps working in production.
+      if (requestUrl.pathname === DEVTOOLS_PATH || requestUrl.pathname === DEVTOOLS_JSON_PATH) {
+        if (!warnedDevtoolsCollision && matchesResolvedRoute(requestUrl.pathname, routeMatchers)) {
+          warnedDevtoolsCollision = true;
+          server.config.logger.warn(
+            `[pracht] An app route matches ${requestUrl.pathname}, which is reserved for the ` +
+              `pracht devtools page in dev. The devtools page wins during development; the app ` +
+              `route is only served in production builds.`,
+          );
+        }
+
+        await serveDevtools(server, res, {
+          apiRoutes: serverMod.apiRoutes ?? [],
+          app: serverMod.resolvedApp,
+          url,
+          wantsJson: requestUrl.pathname === DEVTOOLS_JSON_PATH,
+        });
+        return;
+      }
 
       if (shouldBypassDevSSR(requestUrl, req, routeMatchers)) {
         return next();
@@ -47,6 +74,9 @@ export function createDevSSRMiddleware(
         }
         throw err;
       }
+      // Dev-only: collect middleware/loader/render phase durations so the
+      // browser Network panel shows them via the Server-Timing header.
+      const timings: PrachtPhaseTimings = {};
       const response = await framework.handlePrachtRequest({
         app: serverMod.resolvedApp,
         registry: serverMod.registry,
@@ -54,6 +84,7 @@ export function createDevSSRMiddleware(
         debugErrors: true,
         clientEntryUrl: CLIENT_BROWSER_PATH,
         apiRoutes: serverMod.apiRoutes,
+        timings,
       });
 
       if (response.status === 404) {
@@ -71,11 +102,51 @@ export function createDevSSRMiddleware(
       response.headers.forEach((value: string, key: string) => {
         res.setHeader(key, value);
       });
+      const serverTiming = framework.formatServerTimingHeader(timings);
+      if (serverTiming) {
+        res.setHeader("Server-Timing", serverTiming);
+      }
       res.end(body);
     } catch (error: unknown) {
       await handleDevError(server, req, res, next, url, error);
     }
   };
+}
+
+/**
+ * Serve the dev-only `/_pracht` devtools page (or `/_pracht.json`) built from
+ * the same resolved app graph that `pracht inspect` reports.
+ */
+async function serveDevtools(
+  server: ViteDevServer,
+  res: ServerResponse,
+  options: {
+    apiRoutes: ResolvedApiRoute[];
+    app: ResolvedPrachtApp;
+    url: string;
+    wantsJson: boolean;
+  },
+): Promise<void> {
+  const devtools = await server.ssrLoadModule("@pracht/core/devtools");
+  const graph = await devtools.buildAppGraph({
+    apiRoutes: options.apiRoutes,
+    app: options.app,
+    loadModule: (file: string) => server.ssrLoadModule(file),
+    readSource: (file: string) => readFileSync(resolve(server.config.root, `.${file}`), "utf-8"),
+  });
+
+  if (options.wantsJson) {
+    res.statusCode = 200;
+    res.setHeader("content-type", "application/json; charset=utf-8");
+    res.end(JSON.stringify(graph, null, 2));
+    return;
+  }
+
+  let html = devtools.buildDevtoolsHtml(graph);
+  html = await server.transformIndexHtml(options.url, html);
+  res.statusCode = 200;
+  res.setHeader("content-type", "text/html; charset=utf-8");
+  res.end(html);
 }
 
 async function handleDevError(

--- a/packages/vite-plugin/test/devtools-route.test.ts
+++ b/packages/vite-plugin/test/devtools-route.test.ts
@@ -1,0 +1,196 @@
+import type { IncomingMessage, ServerResponse } from "node:http";
+import type { ViteDevServer } from "vite";
+import { describe, expect, it, vi } from "vitest";
+
+import * as devtoolsModule from "../../framework/src/devtools.ts";
+import * as frameworkServer from "../../framework/src/server.ts";
+import { defineApp, resolveApiRoutes, resolveApp, route } from "../../framework/src/app.ts";
+import { PRACHT_SERVER_MODULE_ID } from "../src/plugin-assets.ts";
+import {
+  createDevSSRMiddleware,
+  DEVTOOLS_JSON_PATH,
+  DEVTOOLS_PATH,
+} from "../src/plugin-dev-ssr.ts";
+
+function createServerMod(overrides: { routes?: ReturnType<typeof route>[] } = {}) {
+  const app = defineApp({
+    middleware: { auth: "./middleware/auth.ts" },
+    routes: overrides.routes ?? [
+      route("/", "./routes/home.tsx", { id: "home", render: "ssr", shell: "public" }),
+      route("/users/:id", "./routes/user.tsx", { middleware: ["auth"] }),
+    ],
+    shells: { public: "./shells/public.tsx" },
+  });
+
+  return {
+    apiRoutes: resolveApiRoutes(["/src/api/health.ts"]),
+    registry: {
+      middlewareModules: {
+        "./middleware/auth.ts": async () => ({
+          middleware: async (_args: unknown, next: () => Promise<Response>) => next(),
+        }),
+      },
+      routeModules: {
+        "./routes/home.tsx": async () => ({
+          Component: () => null,
+          loader: async () => ({ ok: true }),
+        }),
+      },
+      shellModules: {
+        "./shells/public.tsx": async () => ({}),
+      },
+    },
+    resolvedApp: resolveApp(app),
+  };
+}
+
+function createStubServer(serverMod: ReturnType<typeof createServerMod>) {
+  const warn = vi.fn();
+  const server = {
+    config: { logger: { warn }, root: "/tmp/pracht-devtools-test" },
+    ssrFixStacktrace: () => {},
+    ssrLoadModule: async (id: string) => {
+      if (id === "@pracht/core/server") return frameworkServer;
+      if (id === "@pracht/core/devtools") return devtoolsModule;
+      if (id === PRACHT_SERVER_MODULE_ID) return serverMod;
+      if (id === "/src/api/health.ts") return { GET: async () => Response.json({ ok: true }) };
+      throw new Error(`Unexpected ssrLoadModule id: ${id}`);
+    },
+    transformIndexHtml: async (_url: string, html: string) => html,
+  } as unknown as ViteDevServer;
+
+  return { server, warn };
+}
+
+function createRequest(url: string): IncomingMessage {
+  return {
+    headers: { accept: "text/html,application/xhtml+xml", host: "localhost" },
+    method: "GET",
+    url,
+  } as unknown as IncomingMessage;
+}
+
+function createResponse() {
+  const headers: Record<string, string> = {};
+  const state = { body: "", ended: false, statusCode: 0 };
+  const res = {
+    end(body?: unknown) {
+      state.body = String(body ?? "");
+      state.ended = true;
+      state.statusCode = res.statusCode;
+    },
+    setHeader(name: string, value: unknown) {
+      headers[name.toLowerCase()] = String(value);
+    },
+    statusCode: 200,
+  };
+
+  return { headers, res: res as unknown as ServerResponse, state };
+}
+
+async function runMiddleware(server: ViteDevServer, url: string) {
+  const middleware = createDevSSRMiddleware(server);
+  const req = createRequest(url);
+  const { headers, res, state } = createResponse();
+  const next = vi.fn();
+  await middleware(req, res, next);
+  return { headers, next, state };
+}
+
+describe("dev middleware /_pracht devtools route", () => {
+  it("serves the self-contained devtools HTML page", async () => {
+    const serverMod = createServerMod();
+    const { server, warn } = createStubServer(serverMod);
+
+    const { headers, next, state } = await runMiddleware(server, DEVTOOLS_PATH);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(state.statusCode).toBe(200);
+    expect(headers["content-type"]).toContain("text/html");
+    expect(state.body).toContain("<!DOCTYPE html>");
+    expect(state.body).toContain("pracht");
+    expect(state.body).toContain("/users/:id");
+    expect(state.body).toContain("auth");
+    expect(state.body).toContain("./routes/user.tsx");
+    expect(state.body).toContain("/api/health");
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it("serves the app graph as JSON at /_pracht.json", async () => {
+    const serverMod = createServerMod();
+    const { server } = createStubServer(serverMod);
+
+    const { headers, state } = await runMiddleware(server, DEVTOOLS_JSON_PATH);
+
+    expect(state.statusCode).toBe(200);
+    expect(headers["content-type"]).toContain("application/json");
+
+    const graph = JSON.parse(state.body) as devtoolsModule.AppGraph;
+    expect(graph.routes).toEqual([
+      {
+        file: "./routes/home.tsx",
+        id: "home",
+        loaderFile: null,
+        middleware: [],
+        path: "/",
+        render: "ssr",
+        revalidate: null,
+        shell: "public",
+        shellFile: "./shells/public.tsx",
+      },
+      {
+        file: "./routes/user.tsx",
+        id: expect.any(String),
+        loaderFile: null,
+        middleware: ["auth"],
+        path: "/users/:id",
+        render: null,
+        revalidate: null,
+        shell: null,
+        shellFile: null,
+      },
+    ]);
+    expect(graph.api).toEqual([
+      {
+        file: "/src/api/health.ts",
+        methods: ["GET"],
+        path: "/api/health",
+      },
+    ]);
+  });
+
+  it("warns once and lets devtools win when an app route collides in dev", async () => {
+    const serverMod = createServerMod({
+      routes: [route("/_pracht", "./routes/collide.tsx", { id: "collide" })],
+    });
+    const { server, warn } = createStubServer(serverMod);
+    const middleware = createDevSSRMiddleware(server);
+
+    const first = createResponse();
+    await middleware(createRequest(DEVTOOLS_PATH), first.res, vi.fn());
+    expect(first.state.body).toContain("<!DOCTYPE html>");
+    expect(first.state.body).toContain("devtools");
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn.mock.calls[0][0]).toContain(DEVTOOLS_PATH);
+
+    const second = createResponse();
+    await middleware(createRequest(DEVTOOLS_PATH), second.res, vi.fn());
+    expect(second.state.body).toContain("devtools");
+    expect(warn).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("dev middleware Server-Timing header", () => {
+  it("emits phase durations on SSR page responses", async () => {
+    const serverMod = createServerMod();
+    const { server } = createStubServer(serverMod);
+
+    const { headers, state } = await runMiddleware(server, "/");
+
+    expect(state.statusCode).toBe(200);
+    expect(headers["content-type"]).toContain("text/html");
+    expect(headers["server-timing"]).toMatch(
+      /^mw;dur=\d+(\.\d+)?, loader;dur=\d+(\.\d+)?, render;dur=\d+(\.\d+)?$/,
+    );
+  });
+});

--- a/skills/debug/SKILL.md
+++ b/skills/debug/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: debug
-version: 1.1.0
+version: 1.2.0
 description: |
   Pracht framework-aware debugging. Systematically investigates route matching,
   loader/API route errors, rendering issues, middleware, API routes, HMR, and build
@@ -27,6 +27,7 @@ The user will describe a symptom (error, unexpected behavior, blank page, etc.).
 
 Before deep manual inspection, prefer running `pracht verify` for a fast agent loop or `pracht doctor` when the problem could be caused by broader broken app wiring or missing files.
 When another agent/tool needs the framework's resolved graph, prefer `pracht inspect routes --json`, `pracht inspect api --json`, or `pracht inspect build --json` over reconstructing it from source files.
+While the dev server is running, `GET /_pracht` serves a devtools page with the same resolved route/API graph (raw JSON at `/_pracht.json`) — useful when you have a browser or `curl` handy but no CLI access. Dev SSR responses also carry a `Server-Timing` header (`mw`, `loader`, `render` durations in ms) — check it in the browser Network panel or with `curl -sI` to see which phase makes a route slow.
 
 ## Iron Law
 
@@ -40,7 +41,7 @@ Work through these in order, stopping when you find the root cause:
 
 - Run `pracht verify` first if you want a cheap changed-file confidence check.
 - Run `pracht doctor` if the route might be missing, miswired, or pointing at a missing module across the project.
-- For machine-readable route wiring, run `pracht inspect routes --json`.
+- For machine-readable route wiring, run `pracht inspect routes --json`. With a running dev server, `curl http://localhost:5173/_pracht.json` returns the same graph.
 - Read `src/routes.ts` — is the route defined? Is the path correct?
 - Check for typos in file paths (the manifest uses relative paths like `"./routes/home.tsx"`).
 - For dynamic segments, verify bracket syntax: `route("/users/:id", ...)` in manifest, `[id].ts` in filenames.
@@ -56,6 +57,7 @@ Work through these in order, stopping when you find the root cause:
 
 ### 3. Loader / API route errors
 
+- For slow pages, read the dev `Server-Timing` response header (`mw`/`loader`/`render` in ms) to see which phase dominates before reading code.
 - Read the route module's `loader` function or the matching API route handler.
 - Check that `loader` returns serializable data (no functions, no circular refs).
 - Check that API route handlers return `Response` objects and branch on `request.method` when using a default export.


### PR DESCRIPTION
## Summary

- Adds a dev-only devtools page at `/_pracht` served by the Vite dev SSR middleware: a self-contained HTML document (no Preact, same approach as the error overlay) with a table of page routes (pattern, render mode, shell, middleware chain, source file) and API routes (path, methods, source file), plus the same data as JSON at `/_pracht.json`.
- The graph is built from new shared helpers in `@pracht/core` (`packages/framework/src/app-graph.ts`, also exposed via a new `@pracht/core/devtools` entry) that `pracht inspect` now uses too, so the CLI and the devtools page can never drift.
- The `/_pracht` path is reserved in dev only: production behavior is untouched (a user route at that path wins in production); in dev a collision logs a warning once and the devtools page wins.
- Dev SSR responses now carry a standards-compliant `Server-Timing` header (e.g. `mw;dur=1.2, loader;dur=14.8, render;dur=3.1`) so middleware/loader/render phase durations show up in the browser devtools Network panel. The runtime only records timings when the dev middleware passes the new optional `HandlePrachtRequestOptions.timings` collector — production adapters never pass one, so production requests skip all timing work (single wrap when a collector is present, no per-phase work otherwise).
- Docs: new "Dev Server Debugging" section in `docs/ARCHITECTURE.md`, README dev bullet, and `skills/debug/SKILL.md` now point at `/_pracht`, `/_pracht.json`, and `Server-Timing` as debugging tools.
- Tests: unit tests for devtools HTML generation from a graph fixture, app-graph/JSON payload shape, Server-Timing header formatting, runtime timing collection, and the dev middleware routes (HTML, JSON, collision warning, Server-Timing); e2e coverage added to `e2e/pages-router.test.ts` (the Node-adapter dev server — the Cloudflare example owns its dev server and bypasses this middleware).

No linked issue.

## Testing

- [x] `pnpm e2e`
- [x] `pnpm format`
- [x] `pnpm lint`
- [x] `pnpm test`

## Checklist

- [x] Docs updated if needed
- [x] Skills updated if needed
- [x] Changeset added if published packages changed
