### PR TITLE
Add workerHandlersFrom option to cloudflareAdapter

### DIFF
--- a/.changeset/worker-handlers-from.md
+++ b/.changeset/worker-handlers-from.md
@@ -1,0 +1,10 @@
+---
+"@pracht/adapter-cloudflare": minor
+---
+
+Add a `workerHandlersFrom` option to `cloudflareAdapter()`. It points at a
+Vite-resolvable module whose named exports (`queue`, `scheduled`, `email`,
+`tail`, ...) are merged into the generated worker's default export next to
+pracht's `fetch` handler, so apps can consume Queues, Cron Triggers, and Email
+Routing without replacing the adapter. `fetch` always remains pracht's
+handler.

--- a/docs/ADAPTERS.md
+++ b/docs/ADAPTERS.md
@@ -260,6 +260,35 @@ explicit. Pair this with the corresponding `wrangler.jsonc` bindings:
 }
 ```
 
+### Handling queue, cron, and email events (`workerHandlersFrom`)
+
+Queues consumers, Cron Triggers, and Email Routing deliver events to handlers
+on the worker's **default export** (`queue`, `scheduled`, `email`, ...), which
+the generated entry normally reserves for pracht's `fetch`. Point
+`workerHandlersFrom` at a module whose named exports should ride along:
+
+```typescript
+cloudflareAdapter({
+  workerHandlersFrom: "/src/worker-handlers.ts",
+});
+```
+
+```typescript
+// src/worker-handlers.ts
+export async function queue(batch, env, ctx) {
+  for (const message of batch.messages) await processJob(message, env);
+}
+
+export async function scheduled(event, env, ctx) {
+  await runCronSweep(env, ctx);
+}
+```
+
+The generated entry becomes
+`export default { ...handlers, fetch }` — every named export of the module is
+merged in, but `fetch` always stays pracht's handler; export request handling
+belongs in API routes or middleware instead.
+
 ### Using Cloudflare bindings in dev
 
 The adapter handles everything — just declare bindings in `wrangler.jsonc`:

--- a/packages/adapter-cloudflare/src/index.ts
+++ b/packages/adapter-cloudflare/src/index.ts
@@ -50,6 +50,14 @@ export interface CloudflareServerEntryModuleOptions {
   workerExportsFrom?: string;
   /** Vite-resolvable module path exporting `createContext(args)`. */
   createContextFrom?: string;
+  /**
+   * Vite-resolvable module path whose named exports (`queue`, `scheduled`,
+   * `email`, `tail`, ...) are merged into the generated worker's default
+   * export next to pracht's `fetch` handler, so apps can consume Queues, Cron
+   * Triggers, and Email Routing without replacing the adapter. `fetch` always
+   * remains pracht's handler; a `fetch` export in this module is ignored.
+   */
+  workerHandlersFrom?: string;
 }
 
 export function createCloudflareFetchHandler<
@@ -103,9 +111,13 @@ export function createCloudflareServerEntryModule(
   const contextImport = options.createContextFrom
     ? `import { createContext as createPrachtContext } from ${JSON.stringify(options.createContextFrom)};`
     : "const createPrachtContext = undefined;";
+  const handlersImport = options.workerHandlersFrom
+    ? `import * as prachtWorkerHandlers from ${JSON.stringify(options.workerHandlersFrom)};`
+    : "const prachtWorkerHandlers = {};";
 
   return [
     contextImport,
+    handlersImport,
     `export const cloudflareAssetsBinding = ${JSON.stringify(assetsBinding)};`,
     "",
     "let headersManifestPromise;",
@@ -186,7 +198,7 @@ export function createCloudflareServerEntryModule(
     "  });",
     "}",
     "",
-    "export default { fetch };",
+    "export default { ...prachtWorkerHandlers, fetch };",
     "",
     ...workerExports,
     "",

--- a/packages/adapter-cloudflare/test/index.test.ts
+++ b/packages/adapter-cloudflare/test/index.test.ts
@@ -29,6 +29,22 @@ describe("createCloudflareServerEntryModule", () => {
     expect(source).not.toContain("export * from");
   });
 
+  it("merges worker handlers from a dedicated module into the default export", () => {
+    const source = createCloudflareServerEntryModule({
+      workerHandlersFrom: "/src/worker-handlers.ts",
+    });
+
+    expect(source).toContain('import * as prachtWorkerHandlers from "/src/worker-handlers.ts";');
+    expect(source).toContain("export default { ...prachtWorkerHandlers, fetch };");
+  });
+
+  it("keeps the default export shape stable when no handlers module is configured", () => {
+    const source = createCloudflareServerEntryModule();
+
+    expect(source).toContain("const prachtWorkerHandlers = {};");
+    expect(source).toContain("export default { ...prachtWorkerHandlers, fetch };");
+  });
+
   it("bypasses static assets for the _data route-state transport", () => {
     const source = createCloudflareServerEntryModule();
 


### PR DESCRIPTION
## Summary

- Adds a `workerHandlersFrom` option to `cloudflareAdapter()` / `createCloudflareServerEntryModule()`: a Vite-resolvable module whose named exports (`queue`, `scheduled`, `email`, `tail`, ...) are merged into the generated worker's default export next to pracht's `fetch` (`export default { ...prachtWorkerHandlers, fetch }`). `fetch` always remains pracht's handler.
- Documents the option in `docs/ADAPTERS.md` alongside `workerExportsFrom`.
- Found while migrating Drydock (production Hono + Preact worker with a Queues consumer and a Cron Trigger) onto pracht — previously the only escape hatch was string-patching the generated entry from a custom adapter.
- No issue filed; part of a PR series from that migration.

## Testing

- [x] `pnpm e2e`
- [x] `pnpm format`
- [x] `pnpm lint`
- [x] `pnpm test`

## Checklist

- [x] Docs updated if needed
- [x] Skills updated if needed (N/A — no skill references adapter options)
- [x] Changeset added if published packages changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)