### PR TITLE
Emit a clean Cloudflare deploy entry (dist/server/worker.js)

### DIFF
--- a/.changeset/cf-deploy-entry.md
+++ b/.changeset/cf-deploy-entry.md
@@ -1,0 +1,15 @@
+---
+"@pracht/cli": minor
+"@pracht/adapter-cloudflare": patch
+---
+
+`pracht build` for the Cloudflare target now writes a thin deploy entry at
+`dist/server/worker.js` that re-exports only the default handler and the
+`workerExportsFrom` entrypoint classes. workerd validates every named export
+of the deployed entry module and rejects the build metadata (`buildTarget`,
+asset manifests, `resolvedApp`, ...) that `dist/server/server.js` exports for
+the SSG prerender pass, so pointing `wrangler.jsonc`'s `main` at `server.js`
+failed to boot with `Incorrect type for map entry 'buildTarget'`. Point `main`
+at `dist/server/worker.js` instead. The generated server entry now also
+exports `cloudflareWorkerEntrypointNames` so the CLI knows which classes to
+re-export.

--- a/docs/ADAPTERS.md
+++ b/docs/ADAPTERS.md
@@ -218,9 +218,13 @@ the executable production server entry.
   executionContext }` to pracht so loaders, API routes, and middleware can
   access bindings without extra wiring.
 - **Build output**: `pracht({ adapter: cloudflareAdapter() })` makes `pracht build`
-  emit a Worker bundle in `dist/server/server.js`. You own a `wrangler.jsonc`
-  in your project root that points at the output — this lets you add KV, D1,
-  R2, cron, and any other Cloudflare bindings without losing them on rebuild.
+  emit a Worker bundle in `dist/server/server.js` plus a thin deploy entry in
+  `dist/server/worker.js` that re-exports only the default handler and your
+  Cloudflare entrypoint classes (workerd rejects the build metadata that
+  `server.js` also exports for the prerender pass). Point `wrangler.jsonc`'s
+  `main` at `dist/server/worker.js` — you own that file, which lets you add
+  KV, D1, R2, cron, and any other Cloudflare bindings without losing them on
+  rebuild.
 - **KV/D1/R2 support**: custom context factories and the default build entry both
   surface the Cloudflare `env` object.
 - **`@cloudflare/vite-plugin` integration**: the adapter automatically includes
@@ -266,13 +270,13 @@ The adapter handles everything — just declare bindings in `wrangler.jsonc`:
 
 ```jsonc
 {
-  "main": "dist/server/server.js",
+  "main": "dist/server/worker.js",
   "kv_namespaces": [{ "binding": "MY_KV", "id": "..." }],
   "d1_databases": [{ "binding": "DB", "database_name": "my-db", "database_id": "..." }],
 }
 ```
 
-The `main` field stays pointed at `dist/server/server.js` for production
+The `main` field stays pointed at `dist/server/worker.js` for production
 deploys. During dev, the adapter automatically overrides the entry to
 pracht's virtual server module via `@cloudflare/vite-plugin` — no extra
 files needed.

--- a/e2e/cloudflare-build.test.ts
+++ b/e2e/cloudflare-build.test.ts
@@ -32,16 +32,18 @@ test("pracht build emits a deployable Cloudflare Worker setup", async () => {
 
   const wranglerPath = resolve(exampleDir, "wrangler.jsonc");
   const serverEntryPath = resolve(exampleDir, "dist/server/server.js");
+  const deployEntryPath = resolve(exampleDir, "dist/server/worker.js");
 
   const output = buildCloudflareExample();
 
   // wrangler.jsonc is user-owned (checked into the project), not generated
   expect(existsSync(wranglerPath)).toBe(true);
   expect(existsSync(serverEntryPath)).toBe(true);
+  expect(existsSync(deployEntryPath)).toBe(true);
 
   const wranglerConfig = parseJsonc(readFileSync(wranglerPath, "utf-8"));
   expect(wranglerConfig).toMatchObject({
-    main: "dist/server/server.js",
+    main: "dist/server/worker.js",
     assets: {
       directory: "dist/client",
       binding: "ASSETS",
@@ -58,6 +60,15 @@ test("pracht build emits a deployable Cloudflare Worker setup", async () => {
 
   // Cloudflare primitives configured via `workerExportsFrom` must be re-exported
   expect(workerSource).toContain("Counter");
+
+  // The deploy entry re-exports only the default handler and entrypoint
+  // classes: workerd rejects non-handler named exports (buildTarget,
+  // manifests, ...) on the deployed entry module.
+  const deploySource = readFileSync(deployEntryPath, "utf-8");
+  expect(deploySource).toContain('export { Counter } from "./server.js";');
+  expect(deploySource).toContain('export { default } from "./server.js";');
+  expect(deploySource).not.toContain("buildTarget");
+  expect(deploySource).not.toContain("cssManifest");
 });
 
 test("prerendered SSG pages include client JS and working framework context", async () => {

--- a/examples/cloudflare/README.md
+++ b/examples/cloudflare/README.md
@@ -7,7 +7,8 @@ This example is wired to Pracht's Cloudflare build target.
 - `pnpm pracht dev` starts the app with the regular Pracht/Vite development server.
 - `pnpm pracht build` creates:
   - `dist/client/` for static assets and prerendered HTML
-  - `dist/server/server.js` as the Worker bundle
+  - `dist/server/server.js` as the Worker bundle and `dist/server/worker.js` as
+    the deploy entry (`main` in `wrangler.jsonc`)
 
 ## Deploy
 

--- a/examples/cloudflare/wrangler.jsonc
+++ b/examples/cloudflare/wrangler.jsonc
@@ -1,7 +1,7 @@
 {
   "$schema": "node_modules/wrangler/config-schema.json",
   "name": "pracht-example-cloudflare",
-  "main": "dist/server/server.js",
+  "main": "dist/server/worker.js",
   "compatibility_date": "2026-04-06",
   "assets": {
     "binding": "ASSETS",

--- a/packages/adapter-cloudflare/src/index.ts
+++ b/packages/adapter-cloudflare/src/index.ts
@@ -97,9 +97,18 @@ export function createCloudflareServerEntryModule(
   options: CloudflareServerEntryModuleOptions = {},
 ): string {
   const assetsBinding = options.assetsBinding ?? "ASSETS";
+  // The entrypoint-name list lets `pracht build` write a clean deploy entry
+  // (dist/server/worker.js) that re-exports only the default handler and these
+  // classes: workerd validates every named export of the deployed entry module
+  // and rejects the build metadata (buildTarget, manifests, ...) this module
+  // also exports for the CLI's prerender pass.
   const workerExports = options.workerExportsFrom
-    ? [`export * from ${JSON.stringify(options.workerExportsFrom)};`]
-    : [];
+    ? [
+        `export * from ${JSON.stringify(options.workerExportsFrom)};`,
+        `import * as prachtWorkerEntrypoints from ${JSON.stringify(options.workerExportsFrom)};`,
+        "export const cloudflareWorkerEntrypointNames = Object.keys(prachtWorkerEntrypoints);",
+      ]
+    : ["export const cloudflareWorkerEntrypointNames = [];"];
   const contextImport = options.createContextFrom
     ? `import { createContext as createPrachtContext } from ${JSON.stringify(options.createContextFrom)};`
     : "const createPrachtContext = undefined;";

--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -153,7 +153,25 @@ export default defineCommand({
             "\n  Warning: Cloudflare adapter currently serves prerendered ISG HTML as static assets and does not perform runtime revalidation. Use SSR/SSG on Cloudflare, or deploy ISG routes to Node until Cloudflare ISG support is added.\n",
           );
         }
-        log("\n  Cloudflare worker → dist/server/server.js\n");
+
+        // workerd validates every named export of the deployed entry module as
+        // an entrypoint and rejects the build metadata (buildTarget, manifests,
+        // resolvedApp, ...) that server.js exports for the prerender pass
+        // above. Deploy a thin wrapper that re-exports only the default
+        // handler and the Cloudflare entrypoint classes.
+        const entrypointNames: string[] = Array.isArray(serverMod.cloudflareWorkerEntrypointNames)
+          ? serverMod.cloudflareWorkerEntrypointNames
+          : [];
+        const deployEntryLines = [
+          ...(entrypointNames.length > 0
+            ? [`export { ${entrypointNames.join(", ")} } from "./server.js";`]
+            : []),
+          'export { default } from "./server.js";',
+          "",
+        ];
+        writeFileSync(resolve(root, "dist/server/worker.js"), deployEntryLines.join("\n"), "utf-8");
+
+        log("\n  Cloudflare worker → dist/server/worker.js\n");
         log("  Deploy with: wrangler deploy\n");
       }
 

--- a/skills/deploy/SKILL.md
+++ b/skills/deploy/SKILL.md
@@ -106,7 +106,7 @@ npx wrangler deploy
 ```json
 {
   "name": "my-pracht-app",
-  "main": "dist/server/server.js",
+  "main": "dist/server/worker.js",
   "compatibility_date": "2024-01-01",
   "assets": { "directory": "dist/client" }
 }


### PR DESCRIPTION
## Summary

- `pracht build` for the Cloudflare target now writes `dist/server/worker.js`, a thin deploy entry re-exporting only the default handler and the `workerExportsFrom` entrypoint classes. workerd validates every named export of the deployed entry module and rejects the build metadata (`buildTarget`, manifests, `resolvedApp`, ...) that `server.js` must export for the SSG prerender pass — booting `server.js` directly fails with `Incorrect type for map entry 'buildTarget'`.
- The generated server entry additionally exports `cloudflareWorkerEntrypointNames` so the CLI knows which classes to re-export.
- Example `wrangler.jsonc`, `docs/ADAPTERS.md`, the example README, and the deploy skill now point `main` at `dist/server/worker.js`; the cloudflare-build e2e asserts the deploy entry's contents.
- Found by booting a real app's build in local workerd during the Drydock migration; part of a PR series from that migration.

## Testing

- [x] `pnpm e2e`
- [x] `pnpm format`
- [x] `pnpm lint`
- [x] `pnpm test`

## Checklist

- [x] Docs updated if needed
- [x] Skills updated if needed
- [x] Changeset added if published packages changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)