### PR TITLE
Apply the vendor manualChunks split to client builds only

### DIFF
--- a/.changeset/manual-chunks-client-only.md
+++ b/.changeset/manual-chunks-client-only.md
@@ -1,0 +1,9 @@
+---
+"@pracht/vite-plugin": patch
+---
+
+Only apply the preact vendor `manualChunks` split to client builds. SSR builds
+that disable code splitting (for example webworker-target server bundles)
+reject `manualChunks` with `"output.manualChunks" cannot be used when
+"output.codeSplitting" is set to false`, and the split never had an effect on
+single-file server output anyway.

--- a/packages/vite-plugin/src/index.ts
+++ b/packages/vite-plugin/src/index.ts
@@ -60,20 +60,27 @@ export function pracht(options: PrachtPluginOptions = {}): Plugin[] {
 
       return {
         appType: "custom" as const,
-        build: {
-          rollupOptions: {
-            output: {
-              manualChunks(id: string) {
-                if (
-                  id.includes("node_modules/preact") ||
-                  id.includes("node_modules/preact-suspense")
-                ) {
-                  return "vendor";
-                }
+        // The vendor split only makes sense for the client bundle; SSR builds
+        // that disable code splitting (e.g. webworker targets) reject
+        // `manualChunks` outright.
+        ...(isSSRBuild
+          ? {}
+          : {
+              build: {
+                rollupOptions: {
+                  output: {
+                    manualChunks(id: string) {
+                      if (
+                        id.includes("node_modules/preact") ||
+                        id.includes("node_modules/preact-suspense")
+                      ) {
+                        return "vendor";
+                      }
+                    },
+                  },
+                },
               },
-            },
-          },
-        },
+            }),
         ...(isEdge && isSSRBuild
           ? {
               ssr: {


### PR DESCRIPTION
## Summary

- The `pracht()` config hook registered the preact vendor `manualChunks` split for every build. SSR builds that disable code splitting — notably webworker-target server bundles — fail with `"output.manualChunks" cannot be used when "output.codeSplitting" is set to false`, and the split has no effect on single-file server output anyway. It is now applied to client builds only.
- Surfaced while building a real Cloudflare app for workerd during the Drydock migration (blocks setting `ssr.target: "webworker"`, follow-up PR); part of a PR series from that migration.
- No issue filed.

## Testing

- [x] `pnpm e2e`
- [x] `pnpm format`
- [x] `pnpm lint`
- [x] `pnpm test`

## Checklist

- [x] Docs updated if needed (N/A — internal build behavior)
- [x] Skills updated if needed (N/A)
- [x] Changeset added if published packages changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)