### PR TITLE
Target webworker for edge SSR builds and externalize cloudflare: modules

### DIFF
--- a/.changeset/cli-prerender-cloudflare-stubs.md
+++ b/.changeset/cli-prerender-cloudflare-stubs.md
@@ -1,0 +1,10 @@
+---
+"@pracht/cli": patch
+---
+
+`pracht build` now stubs `cloudflare:*` platform modules (via Node module
+hooks) while importing the built server bundle for SSG prerendering. Edge
+server bundles keep these imports external because they only exist inside
+workerd, so any app whose worker graph imports `cloudflare:workers` or
+`cloudflare:email` previously failed the prerender pass with
+`ERR_UNSUPPORTED_ESM_URL_SCHEME`.

--- a/.changeset/edge-ssr-webworker-target.md
+++ b/.changeset/edge-ssr-webworker-target.md
@@ -1,0 +1,10 @@
+---
+"@pracht/vite-plugin": patch
+---
+
+Edge adapters now build the server bundle with `ssr.target: "webworker"` and
+externalize `cloudflare:*` platform modules. Without the webworker target, SSR
+builds of apps with CommonJS dependencies emit Node-flavored interop
+(`createRequire(import.meta.url)`) that workerd rejects at startup, and
+`cloudflare:workers`/`cloudflare:email` imports failed to resolve at build
+time instead of remaining runtime imports.

--- a/examples/cloudflare/src/workers/cloudflare-workers.d.ts
+++ b/examples/cloudflare/src/workers/cloudflare-workers.d.ts
@@ -1,0 +1,10 @@
+// Minimal ambient types for the `cloudflare:workers` runtime module so the
+// example typechecks without pulling in @cloudflare/workers-types. The real
+// module only exists inside workerd; `pracht build` stubs it during SSG
+// prerendering.
+declare module "cloudflare:workers" {
+  export class WorkerEntrypoint {
+    fetch?(request: Request): Response | Promise<Response>;
+  }
+  export class DurableObject {}
+}

--- a/examples/cloudflare/src/workers/counter.ts
+++ b/examples/cloudflare/src/workers/counter.ts
@@ -1,7 +1,12 @@
-export class Counter {
+import { WorkerEntrypoint } from "cloudflare:workers";
+
+// Extending a `cloudflare:workers` base class exercises the real-world shape
+// of worker entrypoints: the import stays external in the server bundle and is
+// stubbed by the CLI while prerendering SSG routes in Node.
+export class Counter extends WorkerEntrypoint {
   private value = 0;
 
-  async fetch(): Promise<Response> {
+  override async fetch(): Promise<Response> {
     return Response.json({ value: ++this.value });
   }
 }

--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -1,4 +1,5 @@
 import { cpSync, existsSync, mkdirSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import { register } from "node:module";
 import { dirname, isAbsolute, join, relative, resolve, sep } from "node:path";
 import { pathToFileURL } from "node:url";
 
@@ -16,6 +17,20 @@ import {
   shouldUseColor,
   type BundleReportRoute,
 } from "../bundle-report.js";
+
+let prerenderHooksRegistered = false;
+
+function registerPrerenderModuleHooks(): void {
+  if (prerenderHooksRegistered) return;
+  prerenderHooksRegistered = true;
+  try {
+    // Published layout: the hooks file is a sibling tsdown entry in dist/.
+    register("./prerender-module-hooks.mjs", import.meta.url);
+  } catch {
+    // Source layout (running the CLI with type stripping from src/).
+    register("../prerender-module-hooks.ts", import.meta.url);
+  }
+}
 
 export default defineCommand({
   meta: {
@@ -96,6 +111,9 @@ export default defineCommand({
     }
 
     if (existsSync(serverEntry)) {
+      // Edge server bundles keep `cloudflare:*` imports external; stub them so
+      // the bundle can be imported in Node for the prerender pass below.
+      registerPrerenderModuleHooks();
       const serverMod = await import(pathToFileURL(serverEntry).href);
       const { prerenderApp } = serverMod;
       const { clientEntryUrl, clientEntryJs, cssManifest, jsManifest } =

--- a/packages/cli/src/prerender-module-hooks.ts
+++ b/packages/cli/src/prerender-module-hooks.ts
@@ -1,0 +1,73 @@
+/**
+ * Node module hooks that stub `cloudflare:*` platform modules while
+ * `pracht build` imports the built server bundle for SSG prerendering.
+ *
+ * Edge server bundles keep platform-scheme imports external (they only exist
+ * inside workerd), so importing the bundle in Node would otherwise fail
+ * before the prerender pass can run. Nothing that touches these classes runs
+ * during prerendering — SSG only reads the resolved route manifest and
+ * renders page components.
+ *
+ * Registered from the build command via `module.register()`.
+ */
+const STUB_PREFIX = "pracht-cloudflare-stub:";
+
+const STUB_SOURCES: Record<string, string> = {
+  "cloudflare:workers": [
+    "export class WorkerEntrypoint {}",
+    "export class DurableObject {}",
+    "export class WorkflowEntrypoint {}",
+    "export class RpcTarget {}",
+    "export const env = {};",
+    "",
+  ].join("\n"),
+  "cloudflare:email": "export class EmailMessage {}\n",
+  "cloudflare:sockets":
+    'export function connect() { throw new Error("cloudflare:sockets is not available during prerendering"); }\n',
+};
+
+interface ResolveResult {
+  url: string;
+  shortCircuit: boolean;
+}
+
+interface LoadResult {
+  format: string;
+  source: string;
+  shortCircuit: boolean;
+}
+
+export function resolve(
+  specifier: string,
+  context: unknown,
+  nextResolve: (specifier: string, context: unknown) => unknown,
+): unknown {
+  if (specifier.startsWith("cloudflare:")) {
+    if (!(specifier in STUB_SOURCES)) {
+      throw new Error(
+        `pracht build has no prerender stub for "${specifier}". ` +
+          "SSG prerendering imports the server bundle in Node, where Cloudflare " +
+          "platform modules do not exist. Please report this so the stub list " +
+          "can be extended.",
+      );
+    }
+    return { url: `${STUB_PREFIX}${specifier}`, shortCircuit: true } satisfies ResolveResult;
+  }
+  return nextResolve(specifier, context);
+}
+
+export function load(
+  url: string,
+  context: unknown,
+  nextLoad: (url: string, context: unknown) => unknown,
+): unknown {
+  if (url.startsWith(STUB_PREFIX)) {
+    const specifier = url.slice(STUB_PREFIX.length);
+    return {
+      format: "module",
+      source: STUB_SOURCES[specifier] ?? "",
+      shortCircuit: true,
+    } satisfies LoadResult;
+  }
+  return nextLoad(url, context);
+}

--- a/packages/cli/test/prerender-module-hooks.test.ts
+++ b/packages/cli/test/prerender-module-hooks.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+
+import { load, resolve } from "../src/prerender-module-hooks.ts";
+
+const nextResolve = (specifier: string) => ({ url: `resolved:${specifier}` });
+const nextLoad = (url: string) => ({ format: "module", source: `loaded:${url}` });
+
+describe("prerender module hooks", () => {
+  it("short-circuits known cloudflare modules to stub URLs", () => {
+    const result = resolve("cloudflare:workers", {}, nextResolve) as {
+      url: string;
+      shortCircuit: boolean;
+    };
+    expect(result.url).toBe("pracht-cloudflare-stub:cloudflare:workers");
+    expect(result.shortCircuit).toBe(true);
+  });
+
+  it("serves stub sources with the platform base classes", () => {
+    const result = load("pracht-cloudflare-stub:cloudflare:workers", {}, nextLoad) as {
+      format: string;
+      source: string;
+    };
+    expect(result.format).toBe("module");
+    expect(result.source).toContain("export class WorkerEntrypoint {}");
+    expect(result.source).toContain("export class DurableObject {}");
+  });
+
+  it("throws a descriptive error for unknown cloudflare modules", () => {
+    expect(() => resolve("cloudflare:unknown-thing", {}, nextResolve)).toThrow(
+      /no prerender stub for "cloudflare:unknown-thing"/,
+    );
+  });
+
+  it("delegates non-cloudflare specifiers to the next resolver", () => {
+    expect(resolve("node:fs", {}, nextResolve)).toEqual({ url: "resolved:node:fs" });
+    expect(load("file:///app.js", {}, nextLoad)).toEqual({
+      format: "module",
+      source: "loaded:file:///app.js",
+    });
+  });
+});

--- a/packages/cli/tsdown.config.ts
+++ b/packages/cli/tsdown.config.ts
@@ -2,7 +2,9 @@ import { defineConfig } from "tsdown";
 
 export default defineConfig({
   clean: true,
-  entry: ["src/index.ts"],
+  // prerender-module-hooks is a separate entry so the build command can pass
+  // it to `module.register()` as a standalone file.
+  entry: ["src/index.ts", "src/prerender-module-hooks.ts"],
   format: "esm",
   external: [/^@pracht\//, /^@modelcontextprotocol\//, /^node:/, "vite", "citty", "zod"],
 });

--- a/packages/vite-plugin/src/index.ts
+++ b/packages/vite-plugin/src/index.ts
@@ -86,6 +86,18 @@ export function pracht(options: PrachtPluginOptions = {}): Plugin[] {
           ? {
               ssr: {
                 noExternal: true,
+                // Edge server bundles run outside Node; without this the SSR
+                // build emits Node-flavored CJS interop
+                // (`createRequire(import.meta.url)`) that workerd rejects at
+                // startup.
+                target: "webworker" as const,
+              },
+              build: {
+                rollupOptions: {
+                  // Platform-scheme modules only exist inside the target
+                  // runtime and must stay runtime imports.
+                  external: [/^cloudflare:/],
+                },
               },
             }
           : {}),

--- a/packages/vite-plugin/test/plugin-build-config.test.ts
+++ b/packages/vite-plugin/test/plugin-build-config.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+
+import { pracht, type PrachtAdapter } from "../src/index.ts";
+
+const edgeAdapter: PrachtAdapter = {
+  id: "cloudflare",
+  edge: true,
+  serverImports: "",
+  createServerEntryModule: () => "export default {};",
+};
+
+interface BuildConfig {
+  ssr?: { noExternal?: boolean; target?: string };
+  build?: {
+    rollupOptions?: {
+      external?: unknown[];
+      output?: { manualChunks?: unknown };
+    };
+  };
+}
+
+function runConfigHook(adapter: PrachtAdapter, isSsrBuild: boolean): BuildConfig {
+  const plugin = pracht({ adapter }).find((candidate) => candidate.name === "pracht");
+  if (!plugin) throw new Error("pracht plugin not found");
+  const hook = plugin.config as (
+    config: Record<string, unknown>,
+    env: { command: string; mode: string; isSsrBuild: boolean },
+  ) => BuildConfig;
+  return hook.call(plugin as never, {}, { command: "build", mode: "production", isSsrBuild });
+}
+
+describe("pracht plugin build config", () => {
+  it("targets webworker and externalizes platform-scheme modules for edge SSR builds", () => {
+    const config = runConfigHook(edgeAdapter, true);
+
+    expect(config.ssr?.noExternal).toBe(true);
+    expect(config.ssr?.target).toBe("webworker");
+    const external = config.build?.rollupOptions?.external ?? [];
+    expect(
+      external.some((entry) => entry instanceof RegExp && entry.test("cloudflare:workers")),
+    ).toBe(true);
+  });
+
+  it("keeps the vendor manualChunks split on client builds only", () => {
+    const clientConfig = runConfigHook(edgeAdapter, false);
+    const ssrConfig = runConfigHook(edgeAdapter, true);
+
+    expect(typeof clientConfig.build?.rollupOptions?.output?.manualChunks).toBe("function");
+    expect(ssrConfig.build?.rollupOptions?.output?.manualChunks).toBeUndefined();
+  });
+
+  it("does not force edge SSR options on non-edge adapters", () => {
+    const nodeLikeAdapter: PrachtAdapter = { ...edgeAdapter, id: "node", edge: false };
+    const config = runConfigHook(nodeLikeAdapter, true);
+
+    expect(config.ssr).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

- Edge adapters now build the server bundle with `ssr.target: "webworker"` and mark `cloudflare:*` platform modules external.
- Without the webworker target, SSR builds of apps with CommonJS dependencies emit Node-flavored interop (`createRequire(import.meta.url)`) that workerd rejects at boot (`The argument 'path' ... Received 'undefined'`); `cloudflare:workers`/`cloudflare:email` imports also failed at build time (`Rolldown failed to resolve import "cloudflare:workers"`) instead of staying runtime imports.
- Adds unit coverage for the plugin's build-config hook (webworker target, externals, and the client-only manualChunks split).
- **Stacked on #184** (webworker targets disable code splitting, which rejects `manualChunks`); the base will retarget to `main` when #184 merges.
- Found booting a real app (Drydock, which pulls CJS deps via better-auth/zod) in workerd; part of a PR series from that migration.

## Testing

- [x] `pnpm e2e`
- [x] `pnpm format`
- [x] `pnpm lint`
- [x] `pnpm test`

## Checklist

- [x] Docs updated if needed (N/A — internal build behavior)
- [x] Skills updated if needed (N/A)
- [x] Changeset added if published packages changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)