### PR TITLE
Pre-bundle pracht core entries in the dev dependency optimizer

### DIFF
--- a/.changeset/optimize-virtual-client-deps.md
+++ b/.changeset/optimize-virtual-client-deps.md
@@ -1,0 +1,13 @@
+---
+"@pracht/vite-plugin": patch
+---
+
+Pre-bundle `@pracht/core` (index, `/client`, and `/manifest` entries) in the
+dev dependency optimizer when the package is installed from npm. The virtual
+client entry and the plugin's own transforms import these after Vite's scanner
+has run, so the first browser hit triggered a re-optimize plus full reload
+that aborted in-flight module requests mid-hydration (breaking, for example,
+Playwright runs against a freshly started dev server). Workspace-linked
+setups (like this monorepo's examples) are left untouched — Vite treats
+linked packages as source, and force-including them would split the runtime
+into two copies.

--- a/.github/scripts/stage-packages.mjs
+++ b/.github/scripts/stage-packages.mjs
@@ -20,7 +20,7 @@ function packageJsonPathsFromPnpmWorkspace() {
   for (const rawLine of readFileSync(workspace, "utf8").split(/\r?\n/)) {
     const line = rawLine.trim();
     if (!line.startsWith("- ")) continue;
-    const pattern = line.slice(2).replace(/^['\"]|['\"]$/g, "");
+    const pattern = line.slice(2).replace(/^['"]|['"]$/g, "");
     if (!pattern || pattern.startsWith("!")) continue;
     patterns.push(pattern);
   }

--- a/packages/vite-plugin/src/index.ts
+++ b/packages/vite-plugin/src/index.ts
@@ -1,6 +1,7 @@
 import { preactSsrPrecompile } from "@pracht/preact-ssr-precompile";
 import preact from "@preact/preset-vite";
-import { resolve } from "node:path";
+import { createRequire } from "node:module";
+import { join, resolve } from "node:path";
 import type { Plugin, UserConfig } from "vite";
 import {
   isPrachtClientModuleId,
@@ -193,7 +194,11 @@ export function pracht(options: PrachtPluginOptions = {}): Plugin[] {
     enforce: "post",
 
     config(config) {
-      return withPrachtOptimizeDepsEntries(config, createPrachtOptimizeDepsEntries(resolved));
+      return withPrachtOptimizeDepsEntries(
+        config,
+        createPrachtOptimizeDepsEntries(resolved),
+        createPrachtOptimizeDepsInclude(config.root ?? process.cwd()),
+      );
     },
   };
 
@@ -243,7 +248,41 @@ function rewriteManifestCoreImports(code: string): string {
   );
 }
 
-function withPrachtOptimizeDepsEntries(config: UserConfig, prachtEntries: string[]): UserConfig {
+// Client-side dependencies the scanner can never discover on its own: the
+// virtual client entry imports `@pracht/core/client`, and the plugin's
+// transforms inject `@pracht/core/manifest` imports after scanning. Without
+// pre-bundling them, the first browser hit triggers a re-optimize + full
+// reload that aborts in-flight module requests mid-hydration. `@pracht/core`
+// is included alongside them so user imports share the same optimized chunk
+// graph (a source copy next to a pre-bundled client copy splits the runtime
+// context in two).
+const PRACHT_OPTIMIZE_DEPS_INCLUDE = [
+  "@pracht/core",
+  "@pracht/core/client",
+  "@pracht/core/manifest",
+];
+
+function createPrachtOptimizeDepsInclude(root: string): string[] {
+  // Vite deliberately leaves workspace-linked packages un-optimized (they are
+  // treated as source). Force-including only some `@pracht/core` entries in
+  // that setup would create a pre-bundled copy of the runtime next to the
+  // linked source copy and split the router context in two — so the includes
+  // only apply when the app resolves `@pracht/core` from node_modules.
+  try {
+    const require = createRequire(join(root, "package.json"));
+    const corePackagePath = toPosixPath(require.resolve("@pracht/core/package.json"));
+    if (!corePackagePath.includes("/node_modules/")) return [];
+    return PRACHT_OPTIMIZE_DEPS_INCLUDE;
+  } catch {
+    return [];
+  }
+}
+
+function withPrachtOptimizeDepsEntries(
+  config: UserConfig,
+  prachtEntries: string[],
+  prachtInclude: string[],
+): UserConfig {
   const environments = Object.fromEntries(
     Object.entries(config.environments ?? {}).map(([name, environment]) => [
       name,
@@ -258,6 +297,9 @@ function withPrachtOptimizeDepsEntries(config: UserConfig, prachtEntries: string
   return {
     optimizeDeps: {
       entries: mergeOptimizeDepsEntries(config.optimizeDeps?.entries, prachtEntries),
+      ...(prachtInclude.length > 0
+        ? { include: mergeOptimizeDepsEntries(config.optimizeDeps?.include, prachtInclude) }
+        : {}),
     },
     ...(Object.keys(environments).length > 0 ? { environments } : {}),
   };

--- a/packages/vite-plugin/test/fixtures/npm-app/.gitignore
+++ b/packages/vite-plugin/test/fixtures/npm-app/.gitignore
@@ -1,0 +1,3 @@
+# The fixture models an app that installed @pracht/core from npm, so its
+# node_modules layout is intentional test data, not an install artifact.
+!node_modules/

--- a/packages/vite-plugin/test/fixtures/npm-app/node_modules/@pracht/core/package.json
+++ b/packages/vite-plugin/test/fixtures/npm-app/node_modules/@pracht/core/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "@pracht/core",
+  "version": "0.0.0"
+}

--- a/packages/vite-plugin/test/fixtures/npm-app/package.json
+++ b/packages/vite-plugin/test/fixtures/npm-app/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "npm-app",
+  "private": true
+}

--- a/packages/vite-plugin/test/plugin-optimize-deps.test.ts
+++ b/packages/vite-plugin/test/plugin-optimize-deps.test.ts
@@ -1,0 +1,59 @@
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+import { pracht } from "../src/index.ts";
+
+interface OptimizeDepsConfig {
+  root?: string;
+  optimizeDeps?: { entries?: string[]; include?: string[] };
+  environments?: Record<string, { optimizeDeps?: { entries?: string[]; include?: string[] } }>;
+}
+
+// An app layout where @pracht/core is installed from npm (resolves through
+// node_modules), unlike this monorepo where the package is workspace-linked.
+const npmAppRoot = fileURLToPath(new URL("./fixtures/npm-app", import.meta.url));
+
+function runOptimizeDepsHook(userConfig: OptimizeDepsConfig): OptimizeDepsConfig {
+  const plugin = pracht().find((candidate) => candidate.name === "pracht:optimize-deps-entries");
+  if (!plugin) throw new Error("optimize-deps plugin not found");
+  const hook = plugin.config as (config: OptimizeDepsConfig) => OptimizeDepsConfig;
+  return hook.call(plugin as never, userConfig);
+}
+
+describe("pracht optimizeDeps config", () => {
+  it("pre-bundles the virtual client entry dependencies for npm-installed apps", () => {
+    const config = runOptimizeDepsHook({ root: npmAppRoot });
+
+    expect(config.optimizeDeps?.include).toContain("@pracht/core");
+    expect(config.optimizeDeps?.include).toContain("@pracht/core/client");
+    expect(config.optimizeDeps?.include).toContain("@pracht/core/manifest");
+  });
+
+  it("preserves user-configured includes without duplicating entries", () => {
+    const config = runOptimizeDepsHook({
+      root: npmAppRoot,
+      optimizeDeps: { include: ["preact", "@pracht/core/client"] },
+    });
+
+    expect(config.optimizeDeps?.include).toContain("preact");
+    const clientEntries = config.optimizeDeps?.include?.filter(
+      (entry) => entry === "@pracht/core/client",
+    );
+    expect(clientEntries).toHaveLength(1);
+  });
+
+  it("skips the includes when @pracht/core is workspace-linked", () => {
+    // In this monorepo the package resolves to packages/framework, not
+    // node_modules; Vite treats linked packages as source, and force-including
+    // only some entries would split the runtime into two copies.
+    const config = runOptimizeDepsHook({});
+
+    expect(config.optimizeDeps?.include).toBeUndefined();
+  });
+
+  it("still contributes scan entries for route and shell files", () => {
+    const config = runOptimizeDepsHook({ root: npmAppRoot });
+
+    expect(config.optimizeDeps?.entries?.some((entry) => entry.includes("src/routes"))).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `@pracht/core`, `@pracht/core/client`, and `@pracht/core/manifest` to `optimizeDeps.include` for apps that install pracht from npm. The virtual client entry and the plugin's transforms import these after the dependency scanner has run, so a fresh dev server re-optimizes + full-reloads on the first browser hit, aborting in-flight module requests mid-hydration (this deterministically broke Playwright suites in the Drydock migration: forms were filled pre-reload and wiped).
- Workspace-linked setups (this monorepo's examples) are deliberately skipped: Vite treats linked packages as source, and force-including only pre-bundles part of the graph, splitting the router runtime into two copies — the first version of this change broke the `basic`/`pages-router` navigation e2es exactly that way.
- Unit coverage via an npm-style fixture (`test/fixtures/npm-app`) plus a linked-workspace regression test.
- Part of the Drydock-migration PR series.

## Testing

- [x] `pnpm e2e`
- [x] `pnpm format`
- [x] `pnpm lint`
- [x] `pnpm test`

## Checklist

- [x] Docs updated if needed (N/A — transparent dev-server behavior)
- [x] Skills updated if needed (N/A)
- [x] Changeset added if published packages changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)