### PR TITLE
Mark the document with data-pracht-hydrated when the router is ready

### DIFF
--- a/.changeset/hydration-marker.md
+++ b/.changeset/hydration-marker.md
@@ -1,0 +1,10 @@
+---
+"@pracht/core": minor
+---
+
+The client router now sets `data-pracht-hydrated="true"` on `<html>` once it
+finishes initializing. Server-rendered pages look interactive before
+hydration, so end-to-end tests that drive prerendered forms too early trigger
+native form submits instead of the framework handlers — wait for
+`html[data-pracht-hydrated]` before interacting. Documented in
+`docs/ROUTING.md` under "Testing Hydration".

--- a/docs/ROUTING.md
+++ b/docs/ROUTING.md
@@ -509,3 +509,27 @@ This page exists only in development:
   does not apply there.
 - Production builds never include the module — production 404 behavior is
   unchanged.
+
+## Testing Hydration
+
+Server-rendered pages (SSR/SSG, and the shell of SPA routes) contain fully
+formed markup before the client router hydrates, so a form can *look*
+interactive while its JS handlers are not attached yet. Driving it too early —
+as end-to-end tools like Playwright will happily do — triggers a native form
+submit (full page load) instead of the framework handler.
+
+When the client router finishes initializing, pracht:
+
+- sets `data-pracht-hydrated="true"` on `<html>` — the supported marker for
+  test tooling and CSS;
+- sets `window.__PRACHT_ROUTER_READY__ = true` and exposes
+  `window.__PRACHT_NAVIGATE__` for programmatic navigation.
+
+Wait for the attribute before interacting with prerendered markup:
+
+```typescript
+// Playwright
+await page.goto("/register");
+await page.locator("html[data-pracht-hydrated]").waitFor();
+await page.getByLabel("Email").fill("user@example.com");
+```

--- a/e2e/basic.test.ts
+++ b/e2e/basic.test.ts
@@ -68,6 +68,14 @@ test("dashboard redirects to / without session cookie", async ({ page }) => {
   expect(response?.status()).toBe(200);
 });
 
+test("hydration marks the document with data-pracht-hydrated", async ({ page }) => {
+  await page.goto("/");
+  await page.locator("html[data-pracht-hydrated]").waitFor();
+
+  const marker = await page.getAttribute("html", "data-pracht-hydrated");
+  expect(marker).toBe("true");
+});
+
 test("client navigation to a protected route no-ops when middleware redirects back to the current page", async ({
   page,
 }) => {

--- a/packages/framework/src/router.ts
+++ b/packages/framework/src/router.ts
@@ -497,6 +497,11 @@ export async function initClientRouter(options: InitClientRouterOptions): Promis
 
   window.__PRACHT_NAVIGATE__ = navigate;
   window.__PRACHT_ROUTER_READY__ = true;
+  // Public hydration marker for test tooling: server-rendered pages look
+  // interactive before the client router takes over, so tests (Playwright,
+  // etc.) should wait for `html[data-pracht-hydrated]` before driving forms —
+  // interacting earlier triggers native form submits instead of JS handlers.
+  document.documentElement.setAttribute("data-pracht-hydrated", "true");
 
   const warmModules: ModuleWarmFn = (match) => {
     startRouteImport(match);


### PR DESCRIPTION
## Summary

- The client router now sets `data-pracht-hydrated="true"` on `<html>` once initialization completes, as a documented, supported hydration marker (alongside the existing internal `__PRACHT_ROUTER_READY__`).
- Motivation: server-rendered pages look interactive before hydration; Playwright suites in the Drydock migration deterministically filled and submitted a prerendered register form before handlers attached, triggering a native form submit that wiped the fields. Tests need an official signal to wait on.
- Adds a "Testing Hydration" section to `docs/ROUTING.md` with the Playwright pattern, and an e2e asserting the marker appears.
- Part of the Drydock-migration PR series.

## Testing

- [x] `pnpm e2e`
- [x] `pnpm format`
- [x] `pnpm lint`
- [x] `pnpm test`

## Checklist

- [x] Docs updated if needed
- [x] Skills updated if needed (N/A)
- [x] Changeset added if published packages changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)