### PR TITLE
Document importing the app manifest without the Vite plugin

### DIFF
--- a/.github/scripts/stage-packages.mjs
+++ b/.github/scripts/stage-packages.mjs
@@ -20,7 +20,7 @@ function packageJsonPathsFromPnpmWorkspace() {
   for (const rawLine of readFileSync(workspace, "utf8").split(/\r?\n/)) {
     const line = rawLine.trim();
     if (!line.startsWith("- ")) continue;
-    const pattern = line.slice(2).replace(/^['\"]|['\"]$/g, "");
+    const pattern = line.slice(2).replace(/^['"]|['"]$/g, "");
     if (!pattern || pattern.startsWith("!")) continue;
     patterns.push(pattern);
   }

--- a/docs/ROUTING.md
+++ b/docs/ROUTING.md
@@ -43,6 +43,38 @@ Module references accept two forms — both are fully supported:
 
 The Vite plugin transforms import functions to strings at build/dev time, so both produce identical behavior when the app runs through `@pracht/vite-plugin`. Direct framework-only tests/scripts should use string refs or run the same transform.
 
+### Importing the manifest without the Vite plugin
+
+Anything that imports the app manifest outside the plugin — a vitest `node`
+project asserting on the route table, a script feeding `matchAppRoute()`, a
+custom lint rule — never sees the transform. With function refs, `route()`
+throws at import time:
+
+```text
+Error: Invalid ModuleRef: expected a string path, but received a function at
+runtime. Use a plain string path (e.g. "./routes/home.tsx"), or ensure the
+Vite plugin rewrites inline `() => import("./file")` refs in the app manifest.
+```
+
+If the manifest needs to work in both worlds, prefer string refs:
+
+```typescript
+// src/routes.ts — loads under vitest, tsx, plain node, and the Vite plugin
+export const app = defineApp({
+  shells: { root: "./shells/root.tsx" },
+  routes: [route("/", "./routes/home.tsx", { render: "ssg" })],
+});
+```
+
+```typescript
+// test/routes.test.ts — no Vite plugin involved
+import { matchAppRoute, resolveApp } from "@pracht/core";
+import { app } from "../src/routes.ts";
+
+const resolved = resolveApp(app);
+expect(matchAppRoute(resolved, "/products/42")?.params).toEqual({ id: "42" });
+```
+
 ### `defineApp(config)`
 
 Top-level configuration:


### PR DESCRIPTION
## Summary

- Expands the module-ref section of `docs/ROUTING.md` with a dedicated "Importing the manifest without the Vite plugin" subsection: the exact `Invalid ModuleRef` error people will search for, why it happens (the `() => import()` rewrite only runs inside `@pracht/vite-plugin`), the string-ref manifest shape that loads everywhere, and a `resolveApp`/`matchAppRoute` vitest example.
- Hit in practice when a vitest `node` project imported `src/routes.ts` to assert on the route table during the Drydock migration; the existing one-line note was easy to miss. Docs only.

## Testing

- [x] `pnpm e2e`
- [x] `pnpm format`
- [x] `pnpm lint`
- [x] `pnpm test`

## Checklist

- [x] Docs updated if needed
- [x] Skills updated if needed (N/A)
- [x] Changeset added if published packages changed (N/A — docs only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)