### PR TITLE
[codex] add deno adapter

### DIFF
--- a/.changeset/deno-adapter.md
+++ b/.changeset/deno-adapter.md
@@ -1,0 +1,11 @@
+---
+"@pracht/adapter-deno": minor
+"@pracht/cli": patch
+---
+
+Add a Deno adapter that generates a native `Deno.serve` production entry, serves
+static assets from `dist/client`, and delegates SSR, route-state, loaders,
+middleware, and API routes to Pracht's Web Request/Response runtime.
+
+`pracht preview` now detects Deno targets and runs the built server through
+`deno run` with the required read, net, and env permissions.

--- a/VISION_MVP.md
+++ b/VISION_MVP.md
@@ -104,6 +104,7 @@ Platform adapters export a request handler shaped for their runtime:
 | `adapter-node`       | Node.js `http`    | Static file serving, ISG mtime check |
 | `adapter-cloudflare` | Workers `fetch`   | `env.ASSETS`, bindings, no runtime ISG yet |
 | `adapter-vercel`     | Serverless / Edge | Build Output API v3 + edge handler   |
+| `adapter-deno`       | Deno `Deno.serve` | Native Web Request/Response handler, no runtime ISG yet |
 
 Each adapter:
 
@@ -186,6 +187,7 @@ pracht/
     adapter-node/     # Node.js server adapter
     adapter-cloudflare/  # Cloudflare Workers adapter
     adapter-vercel/      # Vercel Edge adapter
+    adapter-deno/        # Deno server adapter
     cli/              # Dev/build/generate/inspect/verify/doctor commands
     create-pracht/     # (Phase 2) Starter scaffolding
   example/            # Working example app

--- a/docs/ADAPTERS.md
+++ b/docs/ADAPTERS.md
@@ -369,6 +369,92 @@ export default {
 
 ---
 
+## Deno Adapter
+
+### `createDenoRequestHandler(options)`
+
+| Option          | Type                                | Description                                                     |
+| --------------- | ----------------------------------- | --------------------------------------------------------------- |
+| `app`           | `PrachtApp`                         | The resolved app from `defineApp()`                             |
+| `registry`      | `ModuleRegistry`                    | Lazy module importers                                           |
+| `staticDir`     | `string \| URL`                     | File URL or path for `dist/client/`                             |
+| `createContext` | `(args) => TContext`                | App-level context factory                                       |
+| `apiRoutes`     | `ResolvedApiRoute[]`                | Resolved API route metadata                                     |
+| `clientEntryUrl` | `string`                           | Client entry script URL                                         |
+| `cssManifest`   | `Record<string, string[]>`          | Route/shell CSS asset manifest                                  |
+| `jsManifest`    | `Record<string, string[]>`          | Route/shell JS asset manifest                                   |
+| `headersManifest` | `Record<string, Record<string, string>>` | Prerendered document headers                            |
+
+### Features
+
+- **Native Deno server**: generated entries call `Deno.serve()` and pass Web
+  `Request` objects directly to pracht. No Node request/response bridge is
+  involved.
+- **Static file serving**: reads from `dist/client/` with proper content-type
+  headers. Hashed assets under `/assets/` get `Cache-Control: public,
+  max-age=31536000, immutable`; HTML and other files get `public, max-age=0,
+  must-revalidate`. Clean URLs resolve to `index.html` files. Static responses
+  apply the same baseline security headers as dynamic responses, and
+  prerendered HTML receives route and shell document headers from
+  `dist/server/headers-manifest.json`.
+- **Route-state bypass**: route-state requests (`x-pracht-route-state-request:
+  1` or `?_data=1`) and Markdown negotiation requests bypass static files and
+  reach `handlePrachtRequest()`.
+- **ISG caveat**: runtime ISG revalidation is not implemented for Deno yet. ISG
+  routes are prerendered at build time and served as static files. `pracht
+  build` warns when a Deno build contains ISG routes.
+- **Local preview**: `pracht preview` runs `pracht build` and then executes the
+  built server with `deno run --allow-net --allow-read=dist --allow-env=PORT`.
+
+### Generated entry options
+
+When using `denoAdapter()` in `vite.config.ts`, generated entries can import a context factory:
+
+```typescript
+denoAdapter({
+  createContextFrom: "/src/server/context.ts",
+  port: 8787,
+});
+```
+
+The context module must export `createContext(args)`. Deno passes `{ request }`.
+
+### Entry module
+
+```javascript
+// virtual:pracht/server (generated in deno mode)
+import { createDenoRequestHandler } from "@pracht/adapter-deno";
+
+const staticDir = new URL("../client/", import.meta.url);
+const denoHandler = createDenoRequestHandler({
+  app: resolvedApp,
+  registry,
+  staticDir,
+  apiRoutes,
+  clientEntryUrl,
+  cssManifest,
+  jsManifest,
+});
+
+export async function handler(request) {
+  return denoHandler(request);
+}
+
+if (import.meta.main) {
+  const port = Number(Deno.env.get("PORT") ?? 3000);
+  Deno.serve({ port }, handler);
+}
+```
+
+Running `pracht build` for a Deno target emits `dist/server/server.js`, which is
+the executable production server entry. Run it manually with:
+
+```bash
+deno run --allow-net --allow-read=dist --allow-env=PORT dist/server/server.js
+```
+
+---
+
 ## Vercel Adapter (Phase 2)
 
 ### `createVercelEdgeHandler(options)`

--- a/docs/RENDERING_MODES.md
+++ b/docs/RENDERING_MODES.md
@@ -113,6 +113,11 @@ stale, it serves the stale HTML immediately and triggers regeneration.
 > prerenders ISG routes at build time and routes ISG paths through the Edge
 > Function rather than relying on process-local cache state. Use SSG for static
 > output or SSR for per-request freshness on Vercel.
+>
+> **Deno note:** The Deno adapter currently does not implement runtime ISG
+> revalidation. ISG routes are prerendered at build time and served as static
+> files. Use SSG/SSR on Deno, or deploy ISG routes to Node until a persistent
+> Deno cache/storage design lands.
 
 ### Webhook-based revalidation
 

--- a/docs/WORKSPACE.md
+++ b/docs/WORKSPACE.md
@@ -13,6 +13,7 @@ described in `VISION_MVP.md`.
 | `packages/adapter-node`       | `@pracht/adapter-node`       | Node `IncomingMessage`/`ServerResponse` bridge, ISG stale-while-revalidate                                   |
 | `packages/adapter-cloudflare` | `@pracht/adapter-cloudflare` | Cloudflare Workers fetch handler, generated worker entry source, and static asset handoff (no runtime ISG revalidation yet) |
 | `packages/adapter-vercel`     | `@pracht/adapter-vercel`     | Vercel Edge handler and Build Output API entry source                                                        |
+| `packages/adapter-deno`       | `@pracht/adapter-deno`       | Deno `Deno.serve` handler, generated server entry source, and static asset handoff (no runtime ISG revalidation yet) |
 | `packages/preact-worker-facets` | `@pracht/preact-worker-facets` | Experimental Cloudflare Dynamic Worker + Durable Object facets runtime for inert, stateful Preact components |
 | `packages/cli`                | `@pracht/cli`                | `pracht dev`, `build`, `verify`, the `generate` subcommands, and `doctor`                                    |
 | `examples/cloudflare`         | `@pracht/example-cloudflare` | Cloudflare-targeted example app with SSG, ISG, SSR, SPA routes, auth middleware, and API routes              |
@@ -67,11 +68,12 @@ described in `VISION_MVP.md`.
   `hydrate()` from Preact.
 - **CLI** — `pracht dev` starts a Vite dev server with SSR, `pracht build` runs
   client + server builds (with Vite manifest generation, SSG/ISG prerendering,
-  ISG manifest output, executable Node server output in `dist/server/server.js`,
-  and Vercel `.vercel/output/` generation when the app targets those adapters),
-  `pracht preview` builds and serves the production output locally (Node runs
-  `dist/server/server.js`, Cloudflare delegates to `wrangler dev`, and Vercel
-  points at `vercel build`/`vercel dev`),
+  ISG manifest output, executable Node/Deno server output in
+  `dist/server/server.js`, and Vercel `.vercel/output/` generation when the app
+  targets those adapters), `pracht preview` builds and serves the production
+  output locally (Node runs `dist/server/server.js`, Deno runs it through
+  `deno run`, Cloudflare delegates to `wrangler dev`, and Vercel points at
+  `vercel build`/`vercel dev`),
   `pracht verify` runs fast framework-aware checks with optional `--changed`
   and `--json` output, `pracht inspect [routes|api|build] --json` emits the
   resolved route graph, API handlers, and build metadata for agents/tools,
@@ -81,8 +83,9 @@ described in `VISION_MVP.md`.
   files, and `pracht doctor` validates app wiring across the whole project.
 - **Package builds** — `tsdown` compiles `pracht`, `@pracht/vite-plugin`,
   `@pracht/preact-ssr-precompile`, `@pracht/adapter-node`,
-  `@pracht/adapter-cloudflare`, and `@pracht/adapter-vercel` from TypeScript to
-  ESM (`dist/index.mjs` + `.d.mts`). `@pracht/core` also publishes browser,
+  `@pracht/adapter-cloudflare`, `@pracht/adapter-vercel`, and
+  `@pracht/adapter-deno` from TypeScript to ESM (`dist/index.mjs` + `.d.mts`).
+  `@pracht/core` also publishes browser,
   client, manifest, and server subpath entries so the Vite plugin can keep
   server-only runtime code and route-only browser helpers out of the critical
   client bootstrap graph while generated server modules avoid the browser export
@@ -99,6 +102,11 @@ described in `VISION_MVP.md`.
   `.vercel/output/static` and `.vercel/output/functions/render.func`, rewrites
   clean SSG URLs to static HTML, and routes ISG plus dynamic requests to the
   generated edge function.
+- **Deno adapter** — Emits a native `Deno.serve` entry that accepts Web
+  `Request` objects directly, serves static files from `dist/client`, and falls
+  back to `handlePrachtRequest()` for SSR, SPA route-state requests, loaders,
+  middleware, and API routes. Runtime ISG revalidation is intentionally not
+  implemented yet; Deno builds warn when ISG routes are present.
 - **Preact Worker facets prototype** — `@pracht/preact-worker-facets` provides
   experimental helpers for running Preact-style component modules inside
   Cloudflare Dynamic Workers. A supervisor Durable Object owns auth, source

--- a/e2e/deno-build.test.ts
+++ b/e2e/deno-build.test.ts
@@ -1,0 +1,48 @@
+import { spawnSync } from "node:child_process";
+import { existsSync, readFileSync, rmSync } from "node:fs";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { expect, test } from "@playwright/test";
+
+test("pracht build emits a Deno server entry", async () => {
+  test.setTimeout(120_000);
+
+  const repoRoot = resolve(fileURLToPath(new URL("..", import.meta.url)));
+  const exampleDir = resolve(repoRoot, "examples/basic");
+  const distDir = resolve(exampleDir, "dist");
+  const serverEntryPath = resolve(exampleDir, "dist/server/server.js");
+  const staticIndexPath = resolve(exampleDir, "dist/client/index.html");
+  const headersManifestPath = resolve(exampleDir, "dist/server/headers-manifest.json");
+
+  rmSync(distDir, { force: true, recursive: true });
+
+  const result = spawnSync(process.execPath, ["../../packages/cli/bin/pracht.js", "build"], {
+    cwd: exampleDir,
+    encoding: "utf-8",
+    env: {
+      ...process.env,
+      NODE_OPTIONS: "--experimental-strip-types",
+      PRACHT_ADAPTER: "deno",
+    },
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+
+  if (result.status !== 0) {
+    throw new Error(result.stderr || result.stdout || "Deno example build failed");
+  }
+
+  expect(existsSync(serverEntryPath)).toBe(true);
+  expect(existsSync(staticIndexPath)).toBe(true);
+  expect(existsSync(headersManifestPath)).toBe(true);
+
+  const output = `${result.stdout}${result.stderr}`;
+  expect(output).toContain("Deno adapter currently serves prerendered ISG HTML");
+
+  const serverSource = readFileSync(serverEntryPath, "utf-8");
+  expect(serverSource).toContain('buildTarget = "deno"');
+  expect(serverSource).toContain("createDenoRequestHandler");
+  expect(serverSource).toContain('new URL("../client/", import.meta.url)');
+  expect(serverSource).toContain("Deno.serve({ port }, handler)");
+  expect(serverSource).toContain("Deno.readTextFile");
+});

--- a/examples/basic/package.json
+++ b/examples/basic/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "type": "module",
   "dependencies": {
+    "@pracht/adapter-deno": "workspace:*",
     "@pracht/adapter-node": "workspace:*",
     "@pracht/adapter-vercel": "workspace:*",
     "@pracht/core": "workspace:*"

--- a/examples/basic/vite.config.ts
+++ b/examples/basic/vite.config.ts
@@ -12,6 +12,11 @@ async function resolveAdapter() {
     return cloudflareAdapter();
   }
 
+  if (process.env.PRACHT_ADAPTER === "deno") {
+    const { denoAdapter } = await import("@pracht/adapter-deno");
+    return denoAdapter();
+  }
+
   const { nodeAdapter } = await import("@pracht/adapter-node");
   return nodeAdapter();
 }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "type": "module",
   "scripts": {
-    "build": "pnpm -r --filter @pracht/core --filter @pracht/vite-plugin --filter @pracht/preact-ssr-precompile --filter @pracht/adapter-node --filter @pracht/adapter-cloudflare --filter @pracht/adapter-vercel --filter @pracht/cli --filter create-pracht run build",
+    "build": "pnpm -r --filter @pracht/core --filter @pracht/vite-plugin --filter @pracht/preact-ssr-precompile --filter @pracht/adapter-node --filter @pracht/adapter-cloudflare --filter @pracht/adapter-vercel --filter @pracht/adapter-deno --filter @pracht/cli --filter create-pracht run build",
     "check": "pnpm build && pnpm typecheck && pnpm test",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",

--- a/packages/adapter-deno/LICENSE
+++ b/packages/adapter-deno/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Pracht contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/adapter-deno/README.md
+++ b/packages/adapter-deno/README.md
@@ -1,0 +1,21 @@
+# @pracht/adapter-deno
+
+Deno adapter for Pracht apps.
+
+```ts
+import { denoAdapter } from "@pracht/adapter-deno";
+import { pracht } from "@pracht/vite-plugin";
+
+export default {
+  plugins: [pracht({ adapter: denoAdapter() })],
+};
+```
+
+Build and run with Deno:
+
+```sh
+pnpm pracht build
+deno run --allow-net --allow-read=dist --allow-env=PORT dist/server/server.js
+```
+
+`pracht preview` runs the same server entry with the required Deno permissions.

--- a/packages/adapter-deno/package.json
+++ b/packages/adapter-deno/package.json
@@ -1,0 +1,46 @@
+{
+  "name": "@pracht/adapter-deno",
+  "version": "0.1.0",
+  "description": "Deno adapter for serving Pracht apps with Deno.serve, static assets, loaders, and API routes.",
+  "keywords": [
+    "pracht",
+    "preact",
+    "deno",
+    "adapter",
+    "server",
+    "ssr",
+    "ssg",
+    "api-routes",
+    "vite"
+  ],
+  "license": "MIT",
+  "homepage": "https://github.com/JoviDeCroock/pracht/tree/main/packages/adapter-deno",
+  "bugs": {
+    "url": "https://github.com/JoviDeCroock/pracht/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/JoviDeCroock/pracht",
+    "directory": "packages/adapter-deno"
+  },
+  "files": [
+    "dist"
+  ],
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.mts",
+      "default": "./dist/index.mjs"
+    }
+  },
+  "publishConfig": {
+    "provenance": true
+  },
+  "scripts": {
+    "build": "tsdown",
+    "prepublishOnly": "npm run build"
+  },
+  "dependencies": {
+    "@pracht/core": "workspace:*"
+  }
+}

--- a/packages/adapter-deno/src/index.ts
+++ b/packages/adapter-deno/src/index.ts
@@ -1,0 +1,394 @@
+import type { PrachtAdapter } from "@pracht/vite-plugin";
+import {
+  applyDefaultSecurityHeaders,
+  handlePrachtRequest,
+  type HandlePrachtRequestOptions,
+  type ModuleRegistry,
+  type ResolvedApiRoute,
+  type PrachtApp,
+} from "@pracht/core/server";
+
+type HeadersManifest = Record<string, Record<string, string>>;
+
+interface DenoFileInfo {
+  isFile: boolean;
+  isSymlink: boolean;
+  mtime: Date | null;
+  size: number;
+}
+
+interface DenoRuntime {
+  cwd(): string;
+  env: {
+    get(name: string): string | undefined;
+  };
+  errors: {
+    NotFound: new (...args: unknown[]) => Error;
+  };
+  lstat(path: string | URL): Promise<DenoFileInfo>;
+  readFile(path: string | URL): Promise<Uint8Array>;
+  realPath(path: string | URL): Promise<string>;
+  serve(
+    options: { port?: number },
+    handler: (request: Request) => Response | Promise<Response>,
+  ): unknown;
+}
+
+declare const Deno: DenoRuntime | undefined;
+
+const ROUTE_STATE_REQUEST_HEADER = "x-pracht-route-state-request";
+
+const MIME_TYPES: Record<string, string> = {
+  ".html": "text/html; charset=utf-8",
+  ".js": "application/javascript",
+  ".css": "text/css",
+  ".json": "application/json",
+  ".png": "image/png",
+  ".jpg": "image/jpeg",
+  ".jpeg": "image/jpeg",
+  ".gif": "image/gif",
+  ".webp": "image/webp",
+  ".svg": "image/svg+xml",
+  ".ico": "image/x-icon",
+  ".woff": "font/woff",
+  ".woff2": "font/woff2",
+  ".ttf": "font/ttf",
+  ".otf": "font/otf",
+  ".txt": "text/plain",
+  ".xml": "application/xml",
+  ".webmanifest": "application/manifest+json",
+};
+
+export interface DenoAdapterContextArgs {
+  request: Request;
+}
+
+export interface DenoAdapterOptions<TContext = unknown> {
+  app: PrachtApp;
+  registry?: ModuleRegistry;
+  staticDir?: string | URL;
+  apiRoutes?: ResolvedApiRoute[];
+  clientEntryUrl?: string;
+  cssManifest?: Record<string, string[]>;
+  jsManifest?: Record<string, string[]>;
+  headersManifest?: HeadersManifest;
+  createContext?: (args: DenoAdapterContextArgs) => TContext | Promise<TContext>;
+}
+
+export interface DenoServerEntryModuleOptions {
+  port?: number;
+  /** Vite-resolvable module path exporting `createContext(args)`. */
+  createContextFrom?: string;
+}
+
+export function createDenoRequestHandler<TContext = unknown>(
+  options: DenoAdapterOptions<TContext>,
+): (request: Request) => Promise<Response> {
+  const headersManifest = options.headersManifest ?? {};
+  const staticDir = options.staticDir;
+
+  return async (request: Request): Promise<Response> => {
+    if (staticDir && isStaticAssetRequest(request)) {
+      const staticResponse = await maybeServeStaticFile(request, staticDir, headersManifest);
+      if (staticResponse) {
+        return staticResponse;
+      }
+    }
+
+    const context = options.createContext ? await options.createContext({ request }) : undefined;
+
+    return handlePrachtRequest({
+      app: options.app,
+      context,
+      registry: options.registry,
+      request,
+      apiRoutes: options.apiRoutes,
+      clientEntryUrl: options.clientEntryUrl,
+      cssManifest: options.cssManifest,
+      jsManifest: options.jsManifest,
+    } satisfies HandlePrachtRequestOptions<TContext>);
+  };
+}
+
+export function createDenoServerEntryModule(options: DenoServerEntryModuleOptions = {}): string {
+  const port = options.port ?? 3000;
+  const contextImport = options.createContextFrom
+    ? `import { createContext as createPrachtContext } from ${JSON.stringify(options.createContextFrom)};`
+    : "const createPrachtContext = undefined;";
+
+  return [
+    'import { createDenoRequestHandler } from "@pracht/adapter-deno";',
+    contextImport,
+    "",
+    'const staticDir = new URL("../client/", import.meta.url);',
+    "let headersManifestPromise;",
+    "async function readHeadersManifest() {",
+    "  if (!headersManifestPromise) {",
+    "    headersManifestPromise = Deno.readTextFile(new URL('./headers-manifest.json', import.meta.url))",
+    "      .then((text) => JSON.parse(text))",
+    "      .catch(() => ({}));",
+    "  }",
+    "  return headersManifestPromise;",
+    "}",
+    "",
+    "let denoHandlerPromise;",
+    "function getDenoHandler() {",
+    "  if (!denoHandlerPromise) {",
+    "    denoHandlerPromise = readHeadersManifest().then((headersManifest) => createDenoRequestHandler({",
+    "      app: resolvedApp,",
+    "      registry,",
+    "      staticDir,",
+    "      headersManifest,",
+    "      apiRoutes,",
+    "      clientEntryUrl: clientEntryUrl ?? undefined,",
+    "      cssManifest,",
+    "      jsManifest,",
+    "      createContext: createPrachtContext,",
+    "    }));",
+    "  }",
+    "  return denoHandlerPromise;",
+    "}",
+    "",
+    "export async function handler(request) {",
+    "  return (await getDenoHandler())(request);",
+    "}",
+    "",
+    "if (import.meta.main) {",
+    `  const port = Number(Deno.env.get("PORT") ?? ${port});`,
+    "  Deno.serve({ port }, handler);",
+    "}",
+    "",
+  ].join("\n");
+}
+
+/**
+ * Create a pracht adapter for Deno.
+ *
+ * ```ts
+ * import { denoAdapter } from "@pracht/adapter-deno";
+ * pracht({ adapter: denoAdapter() })
+ * ```
+ */
+export function denoAdapter(options: DenoServerEntryModuleOptions = {}): PrachtAdapter {
+  return {
+    id: "deno",
+    edge: true,
+    serverImports:
+      'import { handlePrachtRequest, resolveApp, resolveApiRoutes } from "@pracht/core/server";',
+    createServerEntryModule() {
+      return createDenoServerEntryModule(options);
+    },
+  };
+}
+
+function isStaticAssetRequest(request: Request): boolean {
+  if (request.method !== "GET" && request.method !== "HEAD") {
+    return false;
+  }
+
+  const url = new URL(request.url);
+  if (
+    request.headers.get(ROUTE_STATE_REQUEST_HEADER) === "1" ||
+    url.searchParams.get("_data") === "1"
+  ) {
+    return false;
+  }
+
+  return !(request.headers.get("accept") ?? "").includes("text/markdown");
+}
+
+async function maybeServeStaticFile(
+  request: Request,
+  staticDir: string | URL,
+  headersManifest: HeadersManifest,
+): Promise<Response | null> {
+  if (typeof Deno === "undefined") {
+    return null;
+  }
+
+  const url = new URL(request.url);
+  const resolved = await resolveStaticFile(staticDir, url.pathname);
+  if (!resolved) {
+    return null;
+  }
+
+  const headers = applyDefaultSecurityHeaders(
+    new Headers({
+      "content-type": resolved.contentType,
+      "cache-control": resolved.cacheControl,
+      etag: createWeakEtag(resolved.info),
+      "last-modified": (resolved.info.mtime ?? new Date(0)).toUTCString(),
+      vary: ROUTE_STATE_REQUEST_HEADER,
+    }),
+  );
+
+  if (resolved.contentType.includes("text/html")) {
+    applyHeadersManifest(headers, headersManifest, url.pathname);
+  }
+
+  if (isNotModified(request, headers)) {
+    return new Response(null, { status: 304, headers });
+  }
+
+  if (request.method === "HEAD") {
+    return new Response(null, { status: 200, headers });
+  }
+
+  const bytes = await Deno.readFile(resolved.fileUrl);
+  const body = new Uint8Array(bytes);
+  return new Response(body, { status: 200, headers });
+}
+
+async function resolveStaticFile(
+  staticDir: string | URL,
+  pathname: string,
+): Promise<{
+  fileUrl: URL;
+  info: DenoFileInfo;
+  contentType: string;
+  cacheControl: string;
+} | null> {
+  const rootUrl = normalizeStaticRoot(staticDir);
+  if (!rootUrl || pathname.includes("\0") || pathname.includes("\\")) {
+    return null;
+  }
+
+  const exactUrl = resolveUrlPath(rootUrl, pathname);
+  if (!exactUrl) return null;
+
+  const exactInfo = await lstatFileInside(rootUrl, exactUrl);
+  if (exactInfo) {
+    return {
+      fileUrl: exactUrl,
+      info: exactInfo,
+      contentType: MIME_TYPES[getExtension(exactUrl.pathname)] || "application/octet-stream",
+      cacheControl: getCacheControl(pathname),
+    };
+  }
+
+  const indexUrl =
+    pathname === "/"
+      ? new URL("index.html", rootUrl)
+      : resolveUrlPath(rootUrl, `${pathname.replace(/\/$/, "")}/index.html`);
+  if (!indexUrl) return null;
+
+  const indexInfo = await lstatFileInside(rootUrl, indexUrl);
+  if (!indexInfo) return null;
+
+  return {
+    fileUrl: indexUrl,
+    info: indexInfo,
+    contentType: "text/html; charset=utf-8",
+    cacheControl: "public, max-age=0, must-revalidate",
+  };
+}
+
+function normalizeStaticRoot(staticDir: string | URL): URL | null {
+  const url = staticDir instanceof URL ? new URL(staticDir.href) : stringPathToFileUrl(staticDir);
+  if (url.protocol !== "file:") return null;
+  if (!url.pathname.endsWith("/")) {
+    url.pathname += "/";
+  }
+  return url;
+}
+
+function stringPathToFileUrl(path: string): URL {
+  try {
+    return new URL(path);
+  } catch {
+    const normalized = path.replace(/\\/g, "/");
+    if (normalized.startsWith("/")) {
+      return new URL(`file://${normalized}`);
+    }
+    if (/^[A-Za-z]:\//.test(normalized)) {
+      return new URL(`file:///${normalized}`);
+    }
+
+    const cwd =
+      typeof Deno === "undefined" ? "/" : Deno.cwd().replace(/\\/g, "/").replace(/\/$/, "");
+    return stringPathToFileUrl(`${cwd}/${normalized}`);
+  }
+}
+
+function resolveUrlPath(rootUrl: URL, pathname: string): URL | null {
+  const candidate = new URL(`.${pathname}`, rootUrl);
+  return urlIsInside(rootUrl, candidate) ? candidate : null;
+}
+
+async function lstatFileInside(rootUrl: URL, fileUrl: URL): Promise<DenoFileInfo | null> {
+  if (typeof Deno === "undefined") return null;
+
+  const info = await Deno.lstat(fileUrl).catch((error: unknown) => {
+    if (error instanceof Deno.errors.NotFound) return null;
+    throw error;
+  });
+  if (!info?.isFile || info.isSymlink) return null;
+
+  const [rootReal, fileReal] = await Promise.all([
+    Deno.realPath(rootUrl).catch(() => rootUrl.pathname),
+    Deno.realPath(fileUrl).catch(() => null),
+  ]);
+  if (!fileReal) return null;
+
+  return pathIsInside(rootReal, fileReal) ? info : null;
+}
+
+function applyHeadersManifest(
+  headers: Headers,
+  headersManifest: HeadersManifest,
+  pathname: string,
+): void {
+  const withoutIndex = pathname.replace(/\/index\.html$/, "") || "/";
+  const withoutSlash = pathname.replace(/\/$/, "") || "/";
+  const routeHeaders =
+    headersManifest[pathname] ?? headersManifest[withoutSlash] ?? headersManifest[withoutIndex];
+
+  if (!routeHeaders) return;
+
+  for (const [key, value] of Object.entries(routeHeaders)) {
+    headers.set(key, value);
+  }
+}
+
+function getCacheControl(urlPath: string): string {
+  return /\/assets\//.test(urlPath)
+    ? "public, max-age=31536000, immutable"
+    : "public, max-age=0, must-revalidate";
+}
+
+function getExtension(pathname: string): string {
+  const basename = pathname.slice(pathname.lastIndexOf("/") + 1);
+  const index = basename.lastIndexOf(".");
+  return index === -1 ? "" : basename.slice(index).toLowerCase();
+}
+
+function createWeakEtag(info: DenoFileInfo): string {
+  const mtimeMs = info.mtime?.getTime() ?? 0;
+  return `W/"${info.size}-${Math.floor(mtimeMs)}"`;
+}
+
+function isNotModified(request: Request, headers: Headers): boolean {
+  const ifNoneMatch = request.headers.get("if-none-match");
+  if (ifNoneMatch && ifNoneMatch === headers.get("etag")) {
+    return true;
+  }
+
+  const ifModifiedSince = request.headers.get("if-modified-since");
+  const lastModified = headers.get("last-modified");
+  if (ifModifiedSince && lastModified) {
+    const since = Date.parse(ifModifiedSince);
+    const modified = Date.parse(lastModified);
+    return Number.isFinite(since) && Number.isFinite(modified) && modified <= since;
+  }
+
+  return false;
+}
+
+function urlIsInside(rootUrl: URL, candidate: URL): boolean {
+  return candidate.href === rootUrl.href || candidate.href.startsWith(rootUrl.href);
+}
+
+function pathIsInside(root: string, candidate: string): boolean {
+  const normalizedRoot = root.endsWith("/") ? root : `${root}/`;
+  return candidate === root || candidate.startsWith(normalizedRoot);
+}

--- a/packages/adapter-deno/test/index.test.ts
+++ b/packages/adapter-deno/test/index.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { defineApp, resolveApiRoutes, route } from "../../framework/src/index.ts";
+
+import {
+  createDenoRequestHandler,
+  createDenoServerEntryModule,
+  denoAdapter,
+} from "../src/index.ts";
+
+describe("createDenoServerEntryModule", () => {
+  it("imports an app createContext module when configured", () => {
+    const source = createDenoServerEntryModule({
+      createContextFrom: "/src/server/context.ts",
+    });
+
+    expect(source).toContain(
+      'import { createContext as createPrachtContext } from "/src/server/context.ts";',
+    );
+    expect(source).toContain("createContext: createPrachtContext");
+  });
+
+  it("starts with Deno.serve only when run directly", () => {
+    const source = createDenoServerEntryModule({ port: 8787 });
+
+    expect(source).toContain("if (import.meta.main)");
+    expect(source).toContain('Number(Deno.env.get("PORT") ?? 8787)');
+    expect(source).toContain("Deno.serve({ port }, handler)");
+  });
+});
+
+describe("denoAdapter", () => {
+  it("declares a Deno build target and edge-style bundling", () => {
+    const adapter = denoAdapter();
+
+    expect(adapter.id).toBe("deno");
+    expect(adapter.edge).toBe(true);
+    expect(adapter.serverImports).toContain("resolveApp");
+    expect(adapter.createServerEntryModule()).toContain("createDenoRequestHandler");
+  });
+});
+
+describe("createDenoRequestHandler", () => {
+  it("passes Web requests directly to API routes", async () => {
+    const handler = createDenoRequestHandler({
+      apiRoutes: resolveApiRoutes(["/src/api/hello.ts"]),
+      app: defineApp({ routes: [] }),
+      registry: {
+        apiModules: {
+          "/src/api/hello.ts": async () => ({
+            GET: ({ request }) =>
+              new Response(`hello ${new URL(request.url).searchParams.get("name")}`),
+          }),
+        },
+      },
+    });
+
+    const response = await handler(new Request("https://example.com/api/hello?name=deno"));
+
+    expect(response.status).toBe(200);
+    await expect(response.text()).resolves.toBe("hello deno");
+  });
+
+  it("uses createContext for loader requests", async () => {
+    const createContext = vi.fn(({ request }) => ({
+      runtime: request.headers.get("x-runtime"),
+    }));
+    const handler = createDenoRequestHandler({
+      app: defineApp({
+        routes: [route("/runtime", "./routes/runtime.tsx", { render: "ssr" })],
+      }),
+      createContext,
+      registry: {
+        routeModules: {
+          "./routes/runtime.tsx": async () => ({
+            Component: ({ data }) => `<main>${(data as { runtime: string }).runtime}</main>`,
+            loader: ({ context }) => ({
+              runtime: (context as { runtime: string }).runtime,
+            }),
+          }),
+        },
+      },
+    });
+
+    const response = await handler(
+      new Request("https://example.com/runtime", {
+        headers: { "x-runtime": "deno" },
+      }),
+    );
+
+    expect(createContext).toHaveBeenCalledOnce();
+    expect(response.status).toBe(200);
+    await expect(response.text()).resolves.toContain("deno");
+  });
+});

--- a/packages/adapter-deno/tsdown.config.ts
+++ b/packages/adapter-deno/tsdown.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "tsdown";
+
+export default defineConfig({
+  clean: true,
+  entry: ["src/index.ts"],
+  format: "esm",
+  dts: true,
+  external: [/^@pracht\/core(\/.*)?$/, "@pracht/vite-plugin"],
+});

--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -220,6 +220,12 @@ export async function runBuild(root: string, options: BuildOptions = {}): Promis
       log("  Deploy with: wrangler deploy\n");
     }
 
+    if (serverMod.buildTarget === "deno" && Object.keys(isgManifest).length > 0) {
+      console.warn(
+        "\n  Warning: Deno adapter currently serves prerendered ISG HTML as static assets and does not perform runtime revalidation. Use SSR/SSG on Deno, or deploy ISG routes to Node until Deno ISG support is added.\n",
+      );
+    }
+
     if (serverMod.buildTarget === "vercel") {
       const outputPath = writeVercelBuildOutput({
         functionName: serverMod.vercelFunctionName,

--- a/packages/cli/src/commands/preview.ts
+++ b/packages/cli/src/commands/preview.ts
@@ -11,9 +11,9 @@ import { runBuild } from "./build.js";
 
 const SERVER_ENTRY = "dist/server/server.js";
 const WRANGLER_CONFIG_FILES = ["wrangler.jsonc", "wrangler.json", "wrangler.toml"];
-const ADAPTER_TARGETS = new Set(["cloudflare", "node", "vercel"]);
+const ADAPTER_TARGETS = new Set(["cloudflare", "deno", "node", "vercel"]);
 
-export type AdapterTarget = "cloudflare" | "node" | "vercel";
+export type AdapterTarget = "cloudflare" | "deno" | "node" | "vercel";
 
 export default defineCommand({
   meta: {
@@ -102,6 +102,29 @@ export default defineCommand({
       return;
     }
 
+    if (target === "deno") {
+      const denoBin = resolveDenoBin(root);
+      if (!denoBin) {
+        throw new Error(
+          [
+            "`pracht preview` needs deno to serve Deno builds, but it was not found on your PATH.",
+            "Install Deno from https://deno.com/ and re-run `pracht preview`.",
+          ].join("\n"),
+        );
+      }
+
+      console.log(`\n  Previewing Deno build → http://localhost:${port}\n`);
+      spawnPreviewProcess(
+        denoBin,
+        ["run", "--allow-net", "--allow-read=dist", "--allow-env=PORT", serverEntry],
+        {
+          cwd: root,
+          env: { ...process.env, PORT: String(port) },
+        },
+      );
+      return;
+    }
+
     console.log(`\n  Previewing production build → http://localhost:${port}\n`);
     spawnPreviewProcess(process.execPath, [serverEntry], {
       cwd: root,
@@ -121,6 +144,10 @@ export function detectAdapterTarget(project: Pick<ProjectConfig, "rawConfig">): 
     return "vercel";
   }
 
+  if (/\bdenoAdapter\s*\(/.test(source) || source.includes("@pracht/adapter-deno")) {
+    return "deno";
+  }
+
   return "node";
 }
 
@@ -134,6 +161,23 @@ export function resolveWranglerBin(
 ): string | null {
   const binNames =
     process.platform === "win32" ? ["wrangler.cmd", "wrangler.exe", "wrangler"] : ["wrangler"];
+  const searchDirs = [
+    resolve(root, "node_modules/.bin"),
+    ...(env.PATH ?? "").split(delimiter).filter(Boolean),
+  ];
+
+  for (const dir of searchDirs) {
+    for (const name of binNames) {
+      const candidate = join(dir, name);
+      if (existsSync(candidate)) return candidate;
+    }
+  }
+
+  return null;
+}
+
+export function resolveDenoBin(root: string, env: NodeJS.ProcessEnv = process.env): string | null {
+  const binNames = process.platform === "win32" ? ["deno.cmd", "deno.exe", "deno"] : ["deno"];
   const searchDirs = [
     resolve(root, "node_modules/.bin"),
     ...(env.PATH ?? "").split(delimiter).filter(Boolean),

--- a/packages/cli/test/preview.test.ts
+++ b/packages/cli/test/preview.test.ts
@@ -7,6 +7,7 @@ import { afterEach, describe, expect, it } from "vitest";
 import {
   detectAdapterTarget,
   normalizeAdapterTarget,
+  resolveDenoBin,
   resolveWranglerBin,
 } from "../src/commands/preview.ts";
 
@@ -52,6 +53,23 @@ describe("detectAdapterTarget", () => {
     ).toBe("node");
   });
 
+  it("detects the deno adapter from the factory call", () => {
+    expect(
+      detectAdapterTarget({
+        rawConfig:
+          'import { denoAdapter } from "@pracht/adapter-deno";\nexport default { plugins: [pracht({ adapter: denoAdapter() })] };',
+      }),
+    ).toBe("deno");
+  });
+
+  it("detects the deno adapter from the package import", () => {
+    expect(
+      detectAdapterTarget({
+        rawConfig: 'import { denoAdapter as adapter } from "@pracht/adapter-deno";',
+      }),
+    ).toBe("deno");
+  });
+
   it("defaults to node when no adapter is configured", () => {
     expect(detectAdapterTarget({ rawConfig: "export default { plugins: [pracht()] };" })).toBe(
       "node",
@@ -63,6 +81,7 @@ describe("normalizeAdapterTarget", () => {
   it("accepts the built-in adapter targets", () => {
     expect(normalizeAdapterTarget("node")).toBe("node");
     expect(normalizeAdapterTarget("cloudflare")).toBe("cloudflare");
+    expect(normalizeAdapterTarget("deno")).toBe("deno");
     expect(normalizeAdapterTarget("vercel")).toBe("vercel");
   });
 
@@ -70,6 +89,47 @@ describe("normalizeAdapterTarget", () => {
     expect(normalizeAdapterTarget("my-platform")).toBe(null);
     expect(normalizeAdapterTarget(undefined)).toBe(null);
     expect(normalizeAdapterTarget(42)).toBe(null);
+  });
+});
+
+describe("resolveDenoBin", () => {
+  const tempDirs: string[] = [];
+
+  function makeTempDir(prefix: string): string {
+    const dir = mkdtempSync(join(tmpdir(), prefix));
+    tempDirs.push(dir);
+    return dir;
+  }
+
+  afterEach(() => {
+    while (tempDirs.length > 0) {
+      rmSync(tempDirs.pop()!, { force: true, recursive: true });
+    }
+  });
+
+  it("prefers the project-local deno binary", () => {
+    const root = makeTempDir("pracht-preview-local-");
+    const binDir = join(root, "node_modules/.bin");
+    mkdirSync(binDir, { recursive: true });
+    writeFileSync(join(binDir, "deno"), "#!/bin/sh\n", { mode: 0o755 });
+
+    const pathDir = makeTempDir("pracht-preview-path-");
+    writeFileSync(join(pathDir, "deno"), "#!/bin/sh\n", { mode: 0o755 });
+
+    expect(resolveDenoBin(root, { PATH: pathDir })).toBe(join(binDir, "deno"));
+  });
+
+  it("falls back to deno on PATH", () => {
+    const root = makeTempDir("pracht-preview-root-");
+    const pathDir = makeTempDir("pracht-preview-path-");
+    writeFileSync(join(pathDir, "deno"), "#!/bin/sh\n", { mode: 0o755 });
+
+    expect(resolveDenoBin(root, { PATH: pathDir })).toBe(join(pathDir, "deno"));
+  });
+
+  it("returns null when deno is not installed anywhere", () => {
+    const root = makeTempDir("pracht-preview-missing-");
+    expect(resolveDenoBin(root, { PATH: makeTempDir("pracht-preview-empty-") })).toBe(null);
   });
 });
 

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -9,7 +9,7 @@ export default defineConfig({
     {
       name: "basic",
       testMatch:
-        /basic\.test\.ts|navigation\.test\.ts|node-build\.test\.ts|cloudflare-build\.test\.ts|vercel-build\.test\.ts|client-bundle-strip\.test\.ts|tsrx-build\.test\.ts/,
+        /basic\.test\.ts|navigation\.test\.ts|node-build\.test\.ts|cloudflare-build\.test\.ts|vercel-build\.test\.ts|deno-build\.test\.ts|client-bundle-strip\.test\.ts|tsrx-build\.test\.ts/,
       use: {
         baseURL: "http://localhost:3100",
       },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -53,6 +53,9 @@ importers:
 
   examples/basic:
     dependencies:
+      '@pracht/adapter-deno':
+        specifier: workspace:*
+        version: link:../../packages/adapter-deno
       '@pracht/adapter-node':
         specifier: workspace:*
         version: link:../../packages/adapter-node
@@ -233,6 +236,12 @@ importers:
       wrangler:
         specifier: ^4.81.0
         version: 4.81.0
+
+  packages/adapter-deno:
+    dependencies:
+      '@pracht/core':
+        specifier: workspace:*
+        version: link:../framework
 
   packages/adapter-node:
     dependencies:

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -23,7 +23,8 @@
       "@pracht/preact-ssr-precompile": ["./packages/preact-ssr-precompile/src/index.ts"],
       "@pracht/adapter-node": ["./packages/adapter-node/src/index.ts"],
       "@pracht/adapter-cloudflare": ["./packages/adapter-cloudflare/src/index.ts"],
-      "@pracht/adapter-vercel": ["./packages/adapter-vercel/src/index.ts"]
+      "@pracht/adapter-vercel": ["./packages/adapter-vercel/src/index.ts"],
+      "@pracht/adapter-deno": ["./packages/adapter-deno/src/index.ts"]
     }
   },
   "include": [

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,6 +1,13 @@
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({
+  resolve: {
+    alias: {
+      "@pracht/core/server": new URL("./packages/framework/src/server.ts", import.meta.url)
+        .pathname,
+      "@pracht/core": new URL("./packages/framework/src/index.ts", import.meta.url).pathname,
+    },
+  },
   test: {
     exclude: ["**/node_modules/**", "e2e/**"],
   },


### PR DESCRIPTION
## Summary

- Add `@pracht/adapter-deno` with a native `Deno.serve` generated entry, Web `Request`/`Response` request handling, static asset serving, document header manifest support, and Deno context hooks.
- Wire Deno into `pracht build`/`pracht preview`, including Deno target detection, `deno run` preview permissions, and an ISG runtime-revalidation warning.
- Update adapter docs, workspace/vision docs, render-mode caveats, the basic example, and add a Deno build-output e2e test.

## Testing

- [x] `pnpm run build`
- [x] `pnpm run e2e`
- [x] `pnpm run format`
- [x] `pnpm run lint`
- [x] `pnpm run test`
- [x] `pnpm run typecheck`

## Checklist

- [x] Docs updated if needed
- [x] Skills updated if needed (N/A)
- [x] Changeset added if published packages changed
