### PR TITLE
fix(ci): repair release publish job (git identity + drop redundant build)

### DIFF
--- a/.changeset/cli-prepublish-build.md
+++ b/.changeset/cli-prepublish-build.md
@@ -1,0 +1,5 @@
+---
+"@pracht/cli": patch
+---
+
+Add a `prepublishOnly` build hook so `@pracht/cli` is rebuilt when published. The release workflow no longer runs a separate top-level build before publishing; each package is now built by its own `prepublishOnly` during staged publish.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -94,6 +94,14 @@ jobs:
       - name: Build
         run: pnpm build
 
+      # changesets/action skips `git config user.*` in github-api commit mode,
+      # and checkout uses persist-credentials: false, so no identity is set.
+      # stage-packages.mjs creates annotated tags (`git tag -m`), which require one.
+      - name: Configure git identity
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
       - name: Publish packages
         uses: changesets/action@a45c4d594aa4e2c509dc14a9f2b3b67ba3780d0d # v1.9.0
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -91,8 +91,9 @@ jobs:
       - name: Install npm
         run: npm install -g npm@11.15.0
 
-      - name: Build
-        run: pnpm build
+      # No separate build step: stage-packages.mjs stages each package with
+      # `pnpm publish`, whose prepublishOnly hook builds it. Package types resolve
+      # from source via tsconfig `paths`, so per-package builds need no ordering.
 
       # changesets/action skips `git config user.*` in github-api commit mode,
       # and checkout uses persist-credentials: false, so no identity is set.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -38,7 +38,8 @@
     "provenance": true
   },
   "scripts": {
-    "build": "tsdown"
+    "build": "tsdown",
+    "prepublishOnly": "npm run build"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.29.0",


### PR DESCRIPTION
## Summary

- Fixes the Release workflow's `publish` job failing at stage 1 with exit code 128 (`fatal: empty ident name`): in `commitMode: github-api` the changesets action's `setupUser()` is a no-op and checkout uses `persist-credentials: false`, so no git identity exists — but `stage-packages.mjs` creates annotated tags (`git tag -m`), which require one. Adds a "Configure git identity" step to the publish job.
- Removes the redundant top-level `pnpm build` from the publish job: `pnpm stage publish` already rebuilds each package via its `prepublishOnly` hook, so the packages were being built twice. Package types resolve from source via tsconfig `paths` (runtime deps are external), so per-package builds are self-contained and need no topological ordering — verified by building dependents in isolation with no dependency dist present.
- Adds the missing `prepublishOnly` build hook to `@pracht/cli`, the only published package that lacked one (patch changeset included).

## Testing

- [ ] `pnpm e2e`
- [x] `pnpm format`
- [x] `pnpm lint`
- [ ] `pnpm test`

CI-config + publish-hook change; the app e2e/test suites can't be affected by it. `format` and `lint` (oxlint) pass. Build ordering was validated by wiping all `dist/` and building `adapter-node`, `vite-plugin`, and `cli` in isolation — each succeeds and emits valid types with no dependency dist present.

## Checklist

- [x] Docs updated if needed (N/A — no doc-facing changes)
- [x] Skills updated if needed (N/A)
- [x] Changeset added if published packages changed (`@pracht/cli` patch)
