### PR TITLE
fix: exclude non-hydrated routes from client bundle

### DIFF
--- a/.changeset/quiet-nonhydrated-routes.md
+++ b/.changeset/quiet-nonhydrated-routes.md
@@ -1,0 +1,5 @@
+---
+"@pracht/vite-plugin": patch
+---
+
+Exclude `hydration: "islands"` and `hydration: "none"` route modules from the generated full client runtime entry so server-only code in non-hydrated routes is not emitted into public client assets.

--- a/docs/ISLANDS.md
+++ b/docs/ISLANDS.md
@@ -170,6 +170,10 @@ outer island.)
   a small bootstrap that scans the DOM for markers, dynamically imports only
   the islands present on the page (each island is its own code-split chunk),
   and hydrates each one in place with its serialized props.
+- Routes configured with `hydration: "islands"` or `hydration: "none"` are
+  also excluded from the generated full client-router entry, so server-only
+  helpers imported by those page modules are not emitted into public client
+  chunks.
 - If an islands route renders zero islands, no script tag is emitted at all —
   the output is as static as `hydration: "none"`.
 

--- a/packages/vite-plugin/src/plugin-codegen.ts
+++ b/packages/vite-plugin/src/plugin-codegen.ts
@@ -1,4 +1,5 @@
-import { dirname, resolve } from "node:path";
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { dirname, extname, join, resolve } from "node:path";
 import { PRACHT_CLIENT_MODULE_QUERY } from "./client-module-query.ts";
 import { generatePagesManifestSource, scanPagesDirectory } from "./pages-router.ts";
 import {
@@ -12,6 +13,120 @@ import {
   type ResolvedPrachtPluginOptions,
 } from "./plugin-options.ts";
 import { createRouteLoaderHints } from "./route-loader-hints.ts";
+
+const ROUTE_MODULE_EXTENSIONS = new Set([".ts", ".tsx", ".js", ".jsx", ".md", ".mdx", ".tsrx"]);
+const NON_FULL_HYDRATION_RE = /hydration\s*:\s*["'](?:islands|none)["']/;
+const FULL_HYDRATION_RE = /hydration\s*:\s*["']full["']/;
+const PAGES_NON_FULL_HYDRATION_RE = /export\s+const\s+HYDRATION\s*=\s*["'](?:islands|none)["']/;
+
+function toPosixPath(path: string): string {
+  return path.replace(/\\/g, "/");
+}
+
+function findMatching(source: string, start: number, open: string, close: string): number {
+  let depth = 0;
+  for (let i = start; i < source.length; i++) {
+    const ch = source[i];
+    if (ch === open) depth++;
+    if (ch === close) {
+      depth--;
+      if (depth === 0) return i;
+    }
+  }
+  return -1;
+}
+
+function scanFiles(dir: string, files: string[]): void {
+  let entries: string[];
+  try {
+    entries = readdirSync(dir);
+  } catch {
+    return;
+  }
+
+  for (const entry of entries) {
+    const abs = join(dir, entry);
+    let stat;
+    try {
+      stat = statSync(abs);
+    } catch {
+      continue;
+    }
+    if (stat.isDirectory()) {
+      scanFiles(abs, files);
+    } else if (ROUTE_MODULE_EXTENSIONS.has(extname(entry))) {
+      files.push(abs);
+    }
+  }
+}
+
+function createNonFullHydrationExcludes(
+  resolved: ResolvedPrachtPluginOptions,
+  root: string = process.cwd(),
+): string[] {
+  const excludes = new Set<string>();
+
+  if (resolved.pagesDir) {
+    const files: string[] = [];
+    scanFiles(resolve(root, resolved.pagesDir.replace(/^\//, "")), files);
+    for (const file of files) {
+      try {
+        if (PAGES_NON_FULL_HYDRATION_RE.test(readFileSync(file, "utf-8"))) {
+          excludes.add(
+            `!/${toPosixPath(file).replace(toPosixPath(root).replace(/\/$/, "") + "/", "")}`,
+          );
+        }
+      } catch {}
+    }
+    return [...excludes];
+  }
+
+  const appFile = resolve(root, resolved.appFile.replace(/^\//, ""));
+  let source: string;
+  try {
+    source = readFileSync(appFile, "utf-8");
+  } catch {
+    return [];
+  }
+  const groups: Array<{ start: number; end: number; nonFull: boolean }> = [];
+  for (const match of source.matchAll(/\bgroup\s*\(/g)) {
+    const parenStart = match.index! + match[0].lastIndexOf("(");
+    const parenEnd = findMatching(source, parenStart, "(", ")");
+    if (parenEnd === -1) continue;
+    const args = source.slice(parenStart + 1, parenEnd);
+    const arrayStart = source.indexOf("[", parenStart);
+    if (arrayStart === -1 || arrayStart > parenEnd) continue;
+    const arrayEnd = findMatching(source, arrayStart, "[", "]");
+    if (arrayEnd === -1) continue;
+    groups.push({
+      start: arrayStart,
+      end: arrayEnd,
+      nonFull: NON_FULL_HYDRATION_RE.test(args.split("[")[0] ?? ""),
+    });
+  }
+
+  const appDir = dirname(appFile);
+  const routeRe =
+    /\broute\s*\(\s*[^,]+,\s*(?:(?:\(\s*\)\s*=>\s*import\s*\(\s*)?["']([^"']+)["']\s*\)?|["']([^"']+)["'])/g;
+  for (const match of source.matchAll(routeRe)) {
+    const fileRef = match[1] ?? match[2];
+    const callStart = match.index!;
+    const parenStart = source.indexOf("(", callStart);
+    const parenEnd = findMatching(source, parenStart, "(", ")");
+    if (parenEnd === -1) continue;
+    const callSource = source.slice(parenStart, parenEnd);
+    const ownNonFull = NON_FULL_HYDRATION_RE.test(callSource);
+    const ownFull = FULL_HYDRATION_RE.test(callSource);
+    const inheritedNonFull = groups
+      .filter((group) => group.start < callStart && callStart < group.end)
+      .sort((a, b) => b.start - a.start)[0]?.nonFull;
+    if (ownFull || (!ownNonFull && inheritedNonFull !== true)) continue;
+    const abs = resolve(appDir, fileRef);
+    excludes.add(`!/${toPosixPath(abs).replace(toPosixPath(root).replace(/\/$/, "") + "/", "")}`);
+  }
+
+  return [...excludes];
+}
 
 export function createPrachtClientModuleSource(
   options: PrachtPluginOptions = {},
@@ -33,6 +148,10 @@ export function createPrachtClientModuleSource(
   const dirPrefix = isPagesMode ? resolved.pagesDir : resolved.routesDir;
   const routeGlob = `${dirPrefix}/**/*.{ts,tsx,js,jsx,md,mdx}`;
   const routeTsrxGlob = `${dirPrefix}/**/*.tsrx`;
+  const routeExcludes = createNonFullHydrationExcludes(resolved, buildOptions.root);
+  const routeGlobPattern = routeExcludes.length > 0 ? [routeGlob, ...routeExcludes] : routeGlob;
+  const routeTsrxGlobPattern =
+    routeExcludes.length > 0 ? [routeTsrxGlob, ...routeExcludes] : routeTsrxGlob;
 
   const shellGlob = isPagesMode
     ? `${resolved.pagesDir}/**/_app.{ts,tsx,js,jsx}`
@@ -47,8 +166,8 @@ export function createPrachtClientModuleSource(
     "",
     `const routeLoaderHints = ${JSON.stringify(routeLoaderHints)};`,
     `const routeModules = {`,
-    `  ...import.meta.glob(${JSON.stringify(routeGlob)}, { query: ${JSON.stringify(PRACHT_CLIENT_MODULE_QUERY)} }),`,
-    `  ...import.meta.glob(${JSON.stringify(routeTsrxGlob)}),`,
+    `  ...import.meta.glob(${JSON.stringify(routeGlobPattern)}, { query: ${JSON.stringify(PRACHT_CLIENT_MODULE_QUERY)} }),`,
+    `  ...import.meta.glob(${JSON.stringify(routeTsrxGlobPattern)}),`,
     `};`,
     `const shellModules = {`,
     `  ...import.meta.glob(${JSON.stringify(shellGlob)}, { query: ${JSON.stringify(PRACHT_CLIENT_MODULE_QUERY)} }),`,

--- a/packages/vite-plugin/test/client-module-transform.test.ts
+++ b/packages/vite-plugin/test/client-module-transform.test.ts
@@ -437,6 +437,40 @@ describe("client route module build", () => {
     expect(transformed).toContain('route("/", "./routes/home.tsx"');
   });
 
+  it("excludes non-full hydration manifest routes from the generated client entry", () => {
+    const root = makeTempProject();
+    mkdirSync(join(root, "src", "routes"), { recursive: true });
+
+    writeFileSync(
+      join(root, "src", "routes.ts"),
+      [
+        'import { defineApp, group, route } from "@pracht/core";',
+        "export const app = defineApp({",
+        "  routes: [",
+        '    group({ hydration: "islands" }, [',
+        '      route("/", () => import("./routes/home.tsx"), { render: "ssg" }),',
+        '      route("/full", () => import("./routes/full.tsx"), { render: "ssg", hydration: "full" }),',
+        "    ]),",
+        '    route("/static", "./routes/static.tsx", { render: "ssg", hydration: "none" }),',
+        "  ],",
+        "});",
+        "",
+      ].join("\n"),
+    );
+
+    const clientSource = createPrachtClientModuleSource(
+      {
+        appFile: "/src/routes.ts",
+        routesDir: "/src/routes",
+      },
+      { root },
+    );
+
+    expect(clientSource).toContain('"!/src/routes/home.tsx"');
+    expect(clientSource).toContain('"!/src/routes/static.tsx"');
+    expect(clientSource).not.toContain('"!/src/routes/full.tsx"');
+  });
+
   it("embeds route loader hints for manifest routes", () => {
     const root = makeTempProject();
     mkdirSync(join(root, "src", "routes"), { recursive: true });


### PR DESCRIPTION
### Motivation

- Prevent route modules marked `hydration: "islands"` or `hydration: "none"` from being pulled into the full client runtime bundle and thereby exposing server-only code or secrets in public JS assets.

### Description

- Add detection of non-full-hydration routes for both manifest and pages-router apps via `createNonFullHydrationExcludes(...)` and use that to build exclusion patterns for the generated client `import.meta.glob` registry in `packages/vite-plugin/src/plugin-codegen.ts`.
- Apply the computed excludes to the route globs so the generated `virtual:pracht/client` entry no longer imports route modules whose hydration is `"islands"` or `"none"` (while preserving explicit `hydration: "full"` overrides).
- Add a unit/regression test that asserts inherited `hydration: "islands"` and explicit `hydration: "none"` manifest routes are excluded and that `hydration: "full"` remains included in `packages/vite-plugin/test/client-module-transform.test.ts`.
- Update `docs/ISLANDS.md` to document the client-bundle boundary and add a patch changeset for `@pracht/vite-plugin` describing the fix.

### Testing

- Ran `pnpm run build` which completed successfully for the workspace packages that were built. (success)
- Ran typecheck via `pnpm exec tsc --noEmit --pretty false` which completed without errors. (success)
- Ran the targeted vite-plugin tests via `pnpm exec vitest run packages/vite-plugin/test/client-module-transform.test.ts` and the new regression case passed. (success)
- Built the example app with `cd examples/islands && node ../../packages/cli/bin/pracht.js build` and verified the `static` route produced no client chunk (no `static-page` asset in `dist/client/assets`). (success)
- Attempted the full E2E suite with `pnpm run e2e` but it failed in this environment because Playwright/Chromium cannot launch due to a missing system library (`libatk-1.0.so.0`), so E2E failures are environmental and unrelated to the change. (blocked by environment)
- Ran `pnpm run format` and `pnpm run lint` which completed cleanly; `pnpm run test` ran but some unrelated scaffold/timeouting tests in `packages/start` timed out in this CI-like environment; targeted tests for this fix passed. (partial success)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4f3f997468832f88dc09576b726c46)