### PR TITLE
feat: opt-in llms.txt emission from the resolved app graph

### DIFF
--- a/.changeset/llms-txt-emission.md
+++ b/.changeset/llms-txt-emission.md
@@ -1,0 +1,8 @@
+---
+"@pracht/core": minor
+"@pracht/vite-plugin": minor
+"@pracht/cli": minor
+"create-pracht": patch
+---
+
+Opt-in llms.txt emission (https://llmstxt.org). Enable via the new `pracht({ llmsTxt })` plugin option: `pracht build` writes `dist/client/llms.txt` generated from the resolved app graph (H1 title + blockquote description with package.json fallbacks, a "## Pages" section listing routes as markdown links — dynamic SSG/ISG routes expanded through `getStaticPaths()`, other dynamic routes skipped — with `Accept: text/markdown` support annotated, and a "## API" section listing endpoints with their detected methods), and the dev server serves `/llms.txt` live from the current graph. Output ordering is deterministic. All three adapters serve the file as a regular static asset; disabled apps are byte-for-byte unchanged. `@pracht/core` gains a `buildLlmsTxt()` export on `@pracht/core/server`, and `create-pracht` templates enable the option by default. See `docs/LLMS_TXT.md`.

--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ Pracht is built to be operated by coding agents as much as by humans:
 
 - **MCP server** — `pracht mcp` starts a stdio [Model Context Protocol](https://modelcontextprotocol.io) server so agents can natively inspect the resolved app graph, run doctor/verify diagnostics, and scaffold routes, shells, middleware, and API handlers. See [docs/MCP.md](docs/MCP.md) for registration and the tool reference.
 - **Claude Code skills** — repo-local skills for scaffolding, auditing, debugging, and deploying pracht apps live in [skills/](skills/README.md).
+- **llms.txt** — the opt-in `llmsTxt` plugin option emits an [llms.txt](https://llmstxt.org) index of your pages and API routes at build time and serves it live in dev. See [docs/LLMS_TXT.md](docs/LLMS_TXT.md).
 
 ## Repo map
 

--- a/docs/LLMS_TXT.md
+++ b/docs/LLMS_TXT.md
@@ -1,0 +1,92 @@
+# llms.txt
+
+Pracht can emit an [llms.txt](https://llmstxt.org) file — a markdown index of
+your site's pages and API endpoints that LLM agents (and audits such as
+Lighthouse's Agentic Browsing check) read to discover what a site offers. The
+file is generated from the resolved app graph, so it always matches the routes
+the app actually serves. The feature is opt-in and has zero cost when disabled.
+
+## Enabling
+
+```ts
+// vite.config.ts
+pracht({
+  adapter: nodeAdapter(),
+  llmsTxt: {
+    title: "My App", // defaults to package.json "name"
+    description: "What the app does.", // defaults to package.json "description"
+    origin: "https://example.com", // emit absolute URLs; relative when omitted
+    include: ["pages", "api"], // sections to emit (default: both)
+  },
+})
+```
+
+`llmsTxt: {}` is enough — the title falls back to the app's package.json
+`name` and the description to its `description` (the blockquote is omitted
+when neither is set).
+
+## What it does
+
+- **Build** — `pracht build` writes `dist/client/llms.txt`. All three adapters
+  serve it as a regular static file: the Node handler and the Vercel Build
+  Output `handle: filesystem` route pick it up directly, and the Cloudflare
+  worker serves it through the `ASSETS` binding.
+- **Dev** — the dev server serves `/llms.txt` live from the current app graph
+  (routes added or removed show up on the next request). With the Cloudflare
+  adapter the Cloudflare vite plugin owns the dev server, so `/llms.txt` is
+  only available in build output there.
+
+## Output format
+
+Per the [llms.txt spec](https://llmstxt.org): an H1 title, an optional
+blockquote summary, and H2 sections containing markdown link lists.
+
+```
+# My App
+
+> What the app does.
+
+## Pages
+
+- [/](/): supports `Accept: text/markdown`
+- [/blog/hello-world](/blog/hello-world)
+- [/pricing](/pricing)
+
+## API
+
+- [/api/echo](/api/echo): POST
+- [/api/health](/api/health): GET
+```
+
+Output is deterministic: entries are sorted by path with a locale-independent
+comparison, so repeated builds produce byte-identical files.
+
+### Pages
+
+- Static routes are always listed, whatever their render mode — they are real
+  URLs an agent can fetch.
+- Dynamic routes (`/blog/:slug`) are listed only when they are SSG/ISG routes
+  with a `getStaticPaths()` export; each prerendered instance becomes its own
+  entry. Dynamic SSR/SPA routes are skipped — there is no concrete URL to
+  link.
+- Routes with a server-only `markdown` export (Markdown-for-Agents content
+  negotiation, see [docs/DATA_LOADING.md](DATA_LOADING.md)) are annotated with
+  `supports \`Accept: text/markdown\``.
+- Link names are the route paths themselves. Page titles are not derivable
+  statically (`head()` needs a request), and paths are unambiguous for agents.
+
+### API
+
+API routes are listed as endpoint patterns (including dynamic params such as
+`/api/users/:id`) with their detected HTTP methods as the note. Handlers
+exported only as `default` produce no method note.
+
+## Notes
+
+- `/llms.txt` is reserved while the option is enabled; an app route at that
+  path is shadowed in dev (a warning is logged) and by the static file in
+  production.
+- If you need curated sections or an `llms-full.txt` with inlined page
+  content, keep using a custom plugin — see
+  [examples/docs/vite-plugin-llms-txt.ts](../examples/docs/vite-plugin-llms-txt.ts)
+  for a frontmatter-driven variant.

--- a/e2e/cloudflare-build.test.ts
+++ b/e2e/cloudflare-build.test.ts
@@ -73,6 +73,15 @@ test("pracht build emits a deployable Cloudflare Worker setup", async () => {
   expect(deploySource).not.toContain("cssManifest");
 
   expect(existsSync(resolve(exampleDir, "dist/client/_pracht/isg.json"))).toBe(true);
+
+  // llms.txt lands in the static assets dir the worker serves via the ASSETS
+  // binding; dynamic SSR routes without static paths are not listed.
+  const llmsTxtPath = resolve(exampleDir, "dist/client/llms.txt");
+  expect(existsSync(llmsTxtPath)).toBe(true);
+  const llmsTxt = readFileSync(llmsTxtPath, "utf-8");
+  expect(llmsTxt.startsWith("# Pracht Cloudflare Example\n")).toBe(true);
+  expect(llmsTxt).toContain("- [/pricing](/pricing)");
+  expect(llmsTxt).not.toContain("/products/:id");
 });
 
 test("prerendered SSG pages include client JS and working framework context", async () => {

--- a/e2e/llms-txt-dev.test.ts
+++ b/e2e/llms-txt-dev.test.ts
@@ -1,0 +1,38 @@
+import { expect, test } from "@playwright/test";
+
+// Runs against the pages-router example dev server, which enables the
+// vite plugin's `llmsTxt` option (see examples/pages-router/vite.config.ts).
+
+test("GET /llms.txt serves the generated llms.txt in dev", async ({ request }) => {
+  const response = await request.get("/llms.txt");
+  expect(response.status()).toBe(200);
+  expect(response.headers()["content-type"]).toContain("text/plain");
+
+  const body = await response.text();
+  expect(body.startsWith("# Pracht Pages Example\n")).toBe(true);
+  expect(body).toContain("## Pages");
+  expect(body).toContain("- [/](/)");
+  expect(body).toContain("- [/about](/about): supports `Accept: text/markdown`");
+
+  // Dynamic SSG routes are expanded through getStaticPaths(); the raw
+  // pattern must not appear.
+  expect(body).toContain("- [/blog/getting-started](/blog/getting-started)");
+  expect(body).toContain("- [/blog/hello-world](/blog/hello-world)");
+  expect(body).not.toContain("/blog/:slug");
+
+  expect(body).toContain("## API");
+  expect(body).toContain("- [/api/health](/api/health): GET");
+  expect(body).toContain("- [/api/me](/api/me): GET");
+});
+
+test("llms.txt page ordering is stable", async ({ request }) => {
+  const body = await (await request.get("/llms.txt")).text();
+  const paths = body.split("\n").flatMap((line) => {
+    const match = line.match(/^- \[([^\]]+)\]/);
+    return match && !match[1].startsWith("/api") ? [match[1]] : [];
+  });
+
+  const sorted = [...paths].sort((left, right) => (left < right ? -1 : left > right ? 1 : 0));
+  expect(paths.length).toBeGreaterThan(3);
+  expect(paths).toEqual(sorted);
+});

--- a/e2e/node-build.test.ts
+++ b/e2e/node-build.test.ts
@@ -75,6 +75,26 @@ test("pracht build emits a deployable Node server entry", async () => {
       expect(productHtml).toContain("Price:");
     }
 
+    // llms.txt is generated from the resolved app graph and served as a
+    // regular static file from dist/client.
+    const llmsTxtPath = resolve(exampleDir, "dist/client/llms.txt");
+    expect(existsSync(llmsTxtPath)).toBe(true);
+    const llmsTxt = readFileSync(llmsTxtPath, "utf-8");
+    expect(llmsTxt.startsWith("# Pracht Example\n")).toBe(true);
+    expect(llmsTxt).toContain("> Example app for the pracht framework.");
+    expect(llmsTxt).toContain("- [/](/): supports `Accept: text/markdown`");
+    // Dynamic SSG instances are listed; the raw pattern is not.
+    expect(llmsTxt).toContain("- [/products/1](/products/1)");
+    expect(llmsTxt).toContain("- [/products/3](/products/3)");
+    expect(llmsTxt).not.toContain("/products/:productId");
+    expect(llmsTxt).toContain("- [/api/echo](/api/echo): POST");
+    expect(llmsTxt).toContain("- [/api/health](/api/health): GET");
+
+    const llmsTxtResponse = await fetch(`http://127.0.0.1:${port}/llms.txt`);
+    expect(llmsTxtResponse.status).toBe(200);
+    expect(llmsTxtResponse.headers.get("content-type")).toContain("text/plain");
+    expect(await llmsTxtResponse.text()).toBe(llmsTxt);
+
     const apiResponse = await fetch(`http://127.0.0.1:${port}/api/health`);
     expect(apiResponse.status).toBe(200);
     await expect(apiResponse.json()).resolves.toEqual({ status: "ok" });
@@ -165,11 +185,12 @@ test("precompileSsrJsx opt-in precompiles server JSX and keeps the app deployabl
   const distDir = resolve(exampleDir, "dist");
 
   const viteConfig = readFileSync(viteConfigPath, "utf-8");
+  expect(viteConfig).toContain("adapter: await resolveAdapter(),");
   writeFileSync(
     viteConfigPath,
     viteConfig.replace(
-      "pracht({ adapter: await resolveAdapter() })",
-      "pracht({ adapter: await resolveAdapter(), precompileSsrJsx: true })",
+      "adapter: await resolveAdapter(),",
+      "adapter: await resolveAdapter(),\n      precompileSsrJsx: true,",
     ),
     "utf-8",
   );

--- a/e2e/vercel-build.test.ts
+++ b/e2e/vercel-build.test.ts
@@ -46,6 +46,12 @@ test("pracht build emits a deployable Vercel Build Output setup", async () => {
   expect(existsSync(resolve(vercelDir, "static/_pracht/isg.json"))).toBe(false);
   expect(existsSync(resolve(exampleDir, "dist/client/_pracht/isg.json"))).toBe(false);
 
+  // llms.txt is copied into the Vercel static output alongside the other
+  // dist/client files and served by the `handle: filesystem` route.
+  const staticLlmsTxtPath = resolve(vercelDir, "static/llms.txt");
+  expect(existsSync(staticLlmsTxtPath)).toBe(true);
+  expect(readFileSync(staticLlmsTxtPath, "utf-8")).toContain("# Pracht Example");
+
   const config = JSON.parse(readFileSync(configPath, "utf-8"));
   expect(config.version).toBe(3);
   expect(config.routes).toEqual(

--- a/examples/basic/src/routes/home.tsx
+++ b/examples/basic/src/routes/home.tsx
@@ -1,5 +1,16 @@
 import type { LoaderArgs, RouteComponentProps } from "@pracht/core";
 
+// Served when a client requests `Accept: text/markdown` (Markdown-for-Agents);
+// llms.txt flags this route as markdown-capable.
+export const markdown = `# Pracht Example
+
+Pracht starts with an explicit app manifest.
+
+- Hybrid route manifest
+- Per-route rendering modes
+- Thin deployment adapters
+`;
+
 export async function loader(_args: LoaderArgs) {
   return {
     highlights: ["Hybrid route manifest", "Per-route rendering modes", "Thin deployment adapters"],

--- a/examples/basic/vite.config.ts
+++ b/examples/basic/vite.config.ts
@@ -17,5 +17,13 @@ async function resolveAdapter() {
 }
 
 export default defineConfig(async () => ({
-  plugins: [pracht({ adapter: await resolveAdapter() })],
+  plugins: [
+    pracht({
+      adapter: await resolveAdapter(),
+      llmsTxt: {
+        title: "Pracht Example",
+        description: "Example app for the pracht framework.",
+      },
+    }),
+  ],
 }));

--- a/examples/cloudflare/vite.config.ts
+++ b/examples/cloudflare/vite.config.ts
@@ -8,6 +8,7 @@ export default defineConfig({
       adapter: cloudflareAdapter({
         workerExportsFrom: "/src/cloudflare.ts",
       }),
+      llmsTxt: { title: "Pracht Cloudflare Example" },
     }),
   ],
 });

--- a/examples/pages-router/src/pages/about.tsx
+++ b/examples/pages-router/src/pages/about.tsx
@@ -2,6 +2,13 @@ import { useLocation } from "@pracht/core";
 
 export const RENDER_MODE = "ssg";
 
+// Served when a client requests `Accept: text/markdown` (Markdown-for-Agents);
+// llms.txt flags this route as markdown-capable.
+export const markdown = `# About
+
+A static page rendered with SSG via the pages router.
+`;
+
 export function Component() {
   const { pathname, search } = useLocation();
 

--- a/examples/pages-router/vite.config.ts
+++ b/examples/pages-router/vite.config.ts
@@ -7,5 +7,11 @@ async function resolveAdapter() {
 }
 
 export default defineConfig(async () => ({
-  plugins: [pracht({ pagesDir: "/src/pages", adapter: await resolveAdapter() })],
+  plugins: [
+    pracht({
+      pagesDir: "/src/pages",
+      adapter: await resolveAdapter(),
+      llmsTxt: { title: "Pracht Pages Example" },
+    }),
+  ],
 }));

--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -174,6 +174,14 @@ export async function runBuild(root: string, options: BuildOptions = {}): Promis
       }
     }
 
+    // The server module only exports generateLlmsTxt when the vite plugin's
+    // `llmsTxt` option is enabled — disabled builds skip this entirely.
+    if (typeof serverMod.generateLlmsTxt === "function") {
+      const llmsTxt: string = await serverMod.generateLlmsTxt();
+      writeFileSync(resolve(clientDir, "llms.txt"), llmsTxt, "utf-8");
+      log("\n  llms.txt → dist/client/llms.txt\n");
+    }
+
     if (Object.keys(headersManifest).length > 0) {
       const headersManifestJson = `${JSON.stringify(headersManifest, null, 2)}\n`;
       writeFileSync(

--- a/packages/framework/src/llms-txt.ts
+++ b/packages/framework/src/llms-txt.ts
@@ -1,0 +1,172 @@
+/**
+ * llms.txt generation (https://llmstxt.org) from the resolved app graph.
+ *
+ * `pracht build` writes the result to `dist/client/llms.txt` and the dev SSR
+ * middleware serves it live at `/llms.txt` when the vite plugin's `llmsTxt`
+ * option is enabled. Output is deterministic: entries are sorted by path and
+ * dynamic SSG/ISG routes are expanded through their `getStaticPaths()`
+ * export. Dynamic routes without enumerable instances (e.g. SSR routes with
+ * params) are skipped — they have no concrete URL an agent could fetch.
+ */
+
+import { buildPathFromSegments } from "./app.ts";
+import { API_METHOD_ORDER } from "./app-graph.ts";
+import { resolveRegistryModule } from "./runtime-manifest.ts";
+import type {
+  ApiRouteModule,
+  ModuleRegistry,
+  ResolvedApiRoute,
+  ResolvedPrachtApp,
+  ResolvedRoute,
+  RouteModule,
+  RouteParams,
+} from "./types.ts";
+
+export type LlmsTxtSection = "pages" | "api";
+
+export interface BuildLlmsTxtOptions {
+  app: ResolvedPrachtApp;
+  apiRoutes?: readonly ResolvedApiRoute[];
+  registry?: ModuleRegistry;
+  /** H1 project title — the only required llms.txt element. */
+  title: string;
+  /** Blockquote summary rendered under the title. Omitted when empty. */
+  description?: string;
+  /**
+   * Origin (e.g. "https://example.com") prepended to every link so the file
+   * contains absolute URLs. Links stay root-relative when omitted.
+   */
+  origin?: string;
+  /** Sections to emit. Defaults to both "pages" and "api". */
+  include?: readonly LlmsTxtSection[];
+}
+
+interface LlmsTxtPageEntry {
+  path: string;
+  /** True when the route module exports a server-only `markdown` string. */
+  markdown: boolean;
+}
+
+interface LlmsTxtApiEntry {
+  path: string;
+  methods: string[];
+}
+
+export async function buildLlmsTxt(options: BuildLlmsTxtOptions): Promise<string> {
+  const include = options.include ?? ["pages", "api"];
+  const origin = options.origin?.replace(/\/$/, "") ?? "";
+
+  const lines: string[] = [`# ${options.title}`];
+  if (options.description) {
+    lines.push("", `> ${options.description}`);
+  }
+
+  if (include.includes("pages")) {
+    const pages = await collectPageEntries(options.app.routes, options.registry);
+    if (pages.length > 0) {
+      lines.push("", "## Pages", "");
+      for (const page of pages) {
+        const note = page.markdown ? ": supports `Accept: text/markdown`" : "";
+        lines.push(`- [${page.path}](${origin}${page.path})${note}`);
+      }
+    }
+  }
+
+  if (include.includes("api")) {
+    const apiEntries = await collectApiEntries(options.apiRoutes ?? [], options.registry);
+    if (apiEntries.length > 0) {
+      lines.push("", "## API", "");
+      for (const entry of apiEntries) {
+        const note = entry.methods.length > 0 ? `: ${entry.methods.join(", ")}` : "";
+        lines.push(`- [${entry.path}](${origin}${entry.path})${note}`);
+      }
+    }
+  }
+
+  return `${lines.join("\n")}\n`;
+}
+
+function isDynamicRoute(route: ResolvedRoute): boolean {
+  return route.segments.some((segment) => segment.type === "param" || segment.type === "catchall");
+}
+
+/** Locale-independent path ordering so output is byte-stable across machines. */
+function comparePaths(left: string, right: string): number {
+  if (left === right) return 0;
+  return left < right ? -1 : 1;
+}
+
+async function loadRouteModule(
+  registry: ModuleRegistry | undefined,
+  file: string,
+): Promise<RouteModule | undefined> {
+  try {
+    return await resolveRegistryModule<RouteModule>(registry?.routeModules, file);
+  } catch {
+    return undefined;
+  }
+}
+
+async function collectPageEntries(
+  routes: readonly ResolvedRoute[],
+  registry: ModuleRegistry | undefined,
+): Promise<LlmsTxtPageEntry[]> {
+  const entries = new Map<string, LlmsTxtPageEntry>();
+
+  for (const route of routes) {
+    const routeModule = await loadRouteModule(registry, route.file);
+    const markdown = typeof routeModule?.markdown === "string";
+
+    if (!isDynamicRoute(route)) {
+      if (!entries.has(route.path)) {
+        entries.set(route.path, { markdown, path: route.path });
+      }
+      continue;
+    }
+
+    // Dynamic routes only have concrete URLs when they are SSG/ISG with a
+    // getStaticPaths() export — list each prerendered instance. Other dynamic
+    // routes (SSR/SPA params) have no enumerable URLs and are skipped.
+    if (route.render !== "ssg" && route.render !== "isg") continue;
+    if (typeof routeModule?.getStaticPaths !== "function") continue;
+
+    let paramSets: RouteParams[];
+    try {
+      paramSets = await routeModule.getStaticPaths();
+    } catch {
+      continue;
+    }
+
+    for (const params of paramSets) {
+      const path = buildPathFromSegments(route.segments, params);
+      if (!entries.has(path)) {
+        entries.set(path, { markdown, path });
+      }
+    }
+  }
+
+  return [...entries.values()].sort((left, right) => comparePaths(left.path, right.path));
+}
+
+async function collectApiEntries(
+  apiRoutes: readonly ResolvedApiRoute[],
+  registry: ModuleRegistry | undefined,
+): Promise<LlmsTxtApiEntry[]> {
+  const entries: LlmsTxtApiEntry[] = [];
+
+  for (const route of apiRoutes) {
+    let apiModule: ApiRouteModule | undefined;
+    try {
+      apiModule = await resolveRegistryModule<ApiRouteModule>(registry?.apiModules, route.file);
+    } catch {
+      apiModule = undefined;
+    }
+
+    const methods = apiModule
+      ? API_METHOD_ORDER.filter((method) => typeof apiModule[method] === "function")
+      : [];
+    entries.push({ methods, path: route.path });
+  }
+
+  return entries.sort((left, right) => comparePaths(left.path, right.path));
+}

--- a/packages/framework/src/server.ts
+++ b/packages/framework/src/server.ts
@@ -30,6 +30,8 @@ export type {
   AppGraphModuleAccess,
   AppGraphRoute,
 } from "./app-graph.ts";
+export { buildLlmsTxt } from "./llms-txt.ts";
+export type { BuildLlmsTxtOptions, LlmsTxtSection } from "./llms-txt.ts";
 export { prerenderApp } from "./prerender.ts";
 export {
   createISGRegenerationRequest,

--- a/packages/framework/test/llms-txt.test.ts
+++ b/packages/framework/test/llms-txt.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it } from "vitest";
+
+import { defineApp, resolveApiRoutes, resolveApp, route } from "../src/app.ts";
+import { buildLlmsTxt } from "../src/llms-txt.ts";
+import type { ModuleRegistry } from "../src/types.ts";
+
+function createResolvedApp() {
+  return resolveApp(
+    defineApp({
+      routes: [
+        route("/", "./routes/home.tsx", { render: "ssg" }),
+        route("/about", "./routes/about.tsx", { render: "ssr" }),
+        route("/blog/:slug", "./routes/blog.tsx", { render: "ssg" }),
+        route("/users/:id", "./routes/user.tsx", { render: "ssr" }),
+        route("/settings", "./routes/settings.tsx", { render: "spa" }),
+      ],
+    }),
+  );
+}
+
+function createRegistry(): ModuleRegistry {
+  return {
+    routeModules: {
+      "/src/routes/home.tsx": async () => ({ markdown: "# Home" }),
+      "/src/routes/about.tsx": async () => ({}),
+      "/src/routes/blog.tsx": async () => ({
+        // Deliberately unsorted to prove output ordering is stable.
+        getStaticPaths: () => [{ slug: "hello-world" }, { slug: "getting-started" }],
+      }),
+      "/src/routes/user.tsx": async () => ({}),
+      "/src/routes/settings.tsx": async () => ({}),
+    },
+    apiModules: {
+      "/src/api/health.ts": async () => ({ GET: () => new Response("ok") }),
+      "/src/api/echo.ts": async () => ({
+        POST: () => new Response("ok"),
+        PUT: () => new Response("ok"),
+      }),
+    },
+  };
+}
+
+const apiRoutes = resolveApiRoutes(["/src/api/health.ts", "/src/api/echo.ts"]);
+
+describe("buildLlmsTxt", () => {
+  it("renders a deterministic llms.txt from the resolved app graph", async () => {
+    const output = await buildLlmsTxt({
+      app: createResolvedApp(),
+      apiRoutes,
+      registry: createRegistry(),
+      title: "Pracht Test App",
+      description: "A test app.",
+    });
+
+    expect(output).toBe(`# Pracht Test App
+
+> A test app.
+
+## Pages
+
+- [/](/): supports \`Accept: text/markdown\`
+- [/about](/about)
+- [/blog/getting-started](/blog/getting-started)
+- [/blog/hello-world](/blog/hello-world)
+- [/settings](/settings)
+
+## API
+
+- [/api/echo](/api/echo): POST, PUT
+- [/api/health](/api/health): GET
+`);
+  });
+
+  it("prefixes links with the configured origin", async () => {
+    const output = await buildLlmsTxt({
+      app: createResolvedApp(),
+      apiRoutes,
+      registry: createRegistry(),
+      title: "Pracht Test App",
+      origin: "https://example.com/",
+    });
+
+    expect(output).toContain("- [/about](https://example.com/about)");
+    expect(output).toContain("- [/api/health](https://example.com/api/health): GET");
+    expect(output).not.toContain("example.com//");
+  });
+
+  it("omits the description blockquote and excluded sections", async () => {
+    const output = await buildLlmsTxt({
+      app: createResolvedApp(),
+      apiRoutes,
+      registry: createRegistry(),
+      title: "Pracht Test App",
+      include: ["pages"],
+    });
+
+    expect(output.startsWith("# Pracht Test App\n\n## Pages\n")).toBe(true);
+    expect(output).not.toContain(">");
+    expect(output).not.toContain("## API");
+  });
+
+  it("skips dynamic routes without enumerable static paths", async () => {
+    const output = await buildLlmsTxt({
+      app: createResolvedApp(),
+      apiRoutes: [],
+      registry: {
+        // No getStaticPaths on the SSG blog route this time — it has no
+        // concrete URLs, so it must not appear.
+        routeModules: {
+          "/src/routes/blog.tsx": async () => ({}),
+        },
+      },
+      title: "Pracht Test App",
+    });
+
+    expect(output).not.toContain("/blog");
+    expect(output).not.toContain("/users");
+    expect(output).toContain("- [/about](/about)");
+  });
+
+  it("renders without a registry (no markdown notes, no dynamic expansion)", async () => {
+    const output = await buildLlmsTxt({
+      app: createResolvedApp(),
+      apiRoutes,
+      title: "Pracht Test App",
+    });
+
+    expect(output).toContain("- [/](/)\n");
+    expect(output).not.toContain("text/markdown");
+    expect(output).toContain("- [/api/health](/api/health)\n");
+  });
+});

--- a/packages/start/src/index.js
+++ b/packages/start/src/index.js
@@ -632,8 +632,8 @@ function createViteConfig(adapter, router, tailwind) {
 
   const prachtOptions =
     router === "pages"
-      ? `{ pagesDir: "/src/pages", adapter: ${info.fn}() }`
-      : `{ adapter: ${info.fn}() }`;
+      ? `{ pagesDir: "/src/pages", adapter: ${info.fn}(), llmsTxt: {} }`
+      : `{ adapter: ${info.fn}(), llmsTxt: {} }`;
 
   const plugins = tailwind
     ? `[pracht(${prachtOptions}), tailwindcss()]`

--- a/packages/start/test/index.test.js
+++ b/packages/start/test/index.test.js
@@ -288,7 +288,9 @@ describe("create-pracht", () => {
     expect(packageJson).toMatch(/"tailwindcss": "\^\d+\.\d+\.\d+"/);
     expect(packageJson).toMatch(/"@tailwindcss\/vite": "\^\d+\.\d+\.\d+"/);
     expect(viteConfig).toContain('import tailwindcss from "@tailwindcss/vite";');
-    expect(viteConfig).toContain("plugins: [pracht({ adapter: nodeAdapter() }), tailwindcss()]");
+    expect(viteConfig).toContain(
+      "plugins: [pracht({ adapter: nodeAdapter(), llmsTxt: {} }), tailwindcss()]",
+    );
     expect(globalCss).toBe('@import "tailwindcss";\n');
     expect(shell).toContain('import "../styles/global.css";');
     expect(readme).toContain("src/styles/global.css");
@@ -313,7 +315,7 @@ describe("create-pracht", () => {
     const app = await readFile(join(targetDir, "src/pages/_app.tsx"), "utf-8");
 
     expect(viteConfig).toContain(
-      'plugins: [pracht({ pagesDir: "/src/pages", adapter: nodeAdapter() }), tailwindcss()]',
+      'plugins: [pracht({ pagesDir: "/src/pages", adapter: nodeAdapter(), llmsTxt: {} }), tailwindcss()]',
     );
     expect(app).toContain('import "../styles/global.css";');
     expect(existsSync(join(targetDir, "src/styles/global.css"))).toBe(true);

--- a/packages/vite-plugin/src/index.ts
+++ b/packages/vite-plugin/src/index.ts
@@ -33,7 +33,11 @@ import {
 
 export type { RenderMode };
 export type { PrachtAdapter } from "./plugin-adapter.ts";
-export type { PrachtPluginOptions } from "./plugin-options.ts";
+export type {
+  LlmsTxtSection,
+  PrachtLlmsTxtOptions,
+  PrachtPluginOptions,
+} from "./plugin-options.ts";
 export {
   createPrachtClientModuleSource,
   createPrachtIslandsClientModuleSource,
@@ -171,7 +175,10 @@ export function pracht(options: PrachtPluginOptions = {}): Plugin[] {
       if (resolved.adapter.ownsDevServer) return;
       return () => {
         server.middlewares.use(
-          createDevSSRMiddleware(server, { maxBodySize: resolved.maxBodySize }),
+          createDevSSRMiddleware(server, {
+            llmsTxt: !!resolved.llmsTxt,
+            maxBodySize: resolved.maxBodySize,
+          }),
         );
       };
     },

--- a/packages/vite-plugin/src/plugin-codegen.ts
+++ b/packages/vite-plugin/src/plugin-codegen.ts
@@ -256,14 +256,18 @@ export function createPrachtServerModuleSource(
     ? readClientBuildAssets(buildOptions.root)
     : { clientEntryUrl: null, islandsEntryUrl: null, cssManifest: {}, jsManifest: {} };
   const adapter = resolved.adapter;
+  const llmsTxtConfig = resolveLlmsTxtConfig(resolved, buildOptions.root);
 
   // The adapter tells us what extra imports it needs (e.g. handlePrachtRequest).
   // Always import prerenderApp so the CLI uses the same bundled copy of
   // @pracht/core/server (and therefore the same Preact context instances) as the
   // route/shell modules — avoids dual-copy issues during SSG prerendering.
-  const prachtImports = adapter?.serverImports
+  let prachtImports = adapter?.serverImports
     ? adapter.serverImports + '\nimport { prerenderApp } from "@pracht/core/server";'
     : 'import { resolveApp, resolveApiRoutes, prerenderApp } from "@pracht/core/server";';
+  if (llmsTxtConfig) {
+    prachtImports += '\nimport { buildLlmsTxt } from "@pracht/core/server";';
+  }
 
   const appImport = isPagesMode
     ? generatePagesAppInlineSource(resolved, buildOptions.root)
@@ -304,6 +308,16 @@ export function createPrachtServerModuleSource(
     `export const prerenderConcurrency = ${JSON.stringify(resolved.prerenderConcurrency)};`,
     `export const budgets = ${JSON.stringify(resolved.budgets)};`,
     "export { prerenderApp };",
+    ...(llmsTxtConfig
+      ? [
+          "// llms.txt (https://llmstxt.org) generated from the resolved app graph.",
+          "// `pracht build` writes it to dist/client/llms.txt; the dev SSR",
+          "// middleware serves it at /llms.txt.",
+          `const llmsTxtConfig = ${JSON.stringify(llmsTxtConfig)};`,
+          "export const generateLlmsTxt = () =>",
+          "  buildLlmsTxt({ ...llmsTxtConfig, apiRoutes, app: resolvedApp, registry });",
+        ]
+      : []),
     "",
   ];
 
@@ -312,6 +326,41 @@ export function createPrachtServerModuleSource(
   }
 
   return source.join("\n");
+}
+
+interface ResolvedLlmsTxtConfig {
+  title: string;
+  description?: string;
+  origin?: string;
+  include?: string[];
+}
+
+/**
+ * Fill llms.txt title/description from the app's package.json when the user
+ * did not set them explicitly. Returns null when the feature is disabled so
+ * the server module codegen stays byte-for-byte unchanged.
+ */
+function resolveLlmsTxtConfig(
+  resolved: ResolvedPrachtPluginOptions,
+  root = process.cwd(),
+): ResolvedLlmsTxtConfig | null {
+  if (!resolved.llmsTxt) return null;
+
+  let pkg: { name?: unknown; description?: unknown } = {};
+  try {
+    pkg = JSON.parse(readFileSync(resolve(root, "package.json"), "utf-8"));
+  } catch {}
+
+  const config: ResolvedLlmsTxtConfig = {
+    title: resolved.llmsTxt.title ?? (typeof pkg.name === "string" && pkg.name ? pkg.name : "App"),
+  };
+  const description =
+    resolved.llmsTxt.description ??
+    (typeof pkg.description === "string" && pkg.description ? pkg.description : undefined);
+  if (description) config.description = description;
+  if (resolved.llmsTxt.origin) config.origin = resolved.llmsTxt.origin;
+  if (resolved.llmsTxt.include) config.include = resolved.llmsTxt.include;
+  return config;
 }
 
 function createApplyRouteLoaderHintsSource(): string[] {

--- a/packages/vite-plugin/src/plugin-dev-ssr.ts
+++ b/packages/vite-plugin/src/plugin-dev-ssr.ts
@@ -14,13 +14,15 @@ const DEFAULT_MAX_BODY_SIZE = 1024 * 1024; // 1 MiB
 
 export const DEVTOOLS_PATH = "/_pracht";
 export const DEVTOOLS_JSON_PATH = "/_pracht.json";
+export const LLMS_TXT_PATH = "/llms.txt";
 
 export function createDevSSRMiddleware(
   server: ViteDevServer,
-  options: { maxBodySize?: number } = {},
+  options: { maxBodySize?: number; llmsTxt?: boolean } = {},
 ): Connect.NextHandleFunction {
   const maxBodySize = options.maxBodySize ?? DEFAULT_MAX_BODY_SIZE;
   let warnedDevtoolsCollision = false;
+  let warnedLlmsTxtCollision = false;
   return async (req: IncomingMessage, res: ServerResponse, next: Connect.NextFunction) => {
     const url = req.url ?? "/";
     const requestUrl = new URL(url, "http://localhost");
@@ -56,6 +58,31 @@ export function createDevSSRMiddleware(
           url,
           wantsJson: requestUrl.pathname === DEVTOOLS_JSON_PATH,
         });
+        return;
+      }
+
+      // `/llms.txt` is served from the live app graph when the plugin's
+      // `llmsTxt` option is enabled — the same content `pracht build` writes
+      // to dist/client/llms.txt.
+      if (
+        options.llmsTxt &&
+        requestUrl.pathname === LLMS_TXT_PATH &&
+        BODYLESS_METHODS.has((req.method ?? "GET").toUpperCase()) &&
+        typeof serverMod.generateLlmsTxt === "function"
+      ) {
+        if (!warnedLlmsTxtCollision && matchesResolvedRoute(LLMS_TXT_PATH, routeMatchers)) {
+          warnedLlmsTxtCollision = true;
+          server.config.logger.warn(
+            `[pracht] An app route matches ${LLMS_TXT_PATH}, which is reserved by the ` +
+              `pracht({ llmsTxt }) option. The generated llms.txt wins; disable the option ` +
+              `to serve the app route instead.`,
+          );
+        }
+
+        const llmsTxt: string = await serverMod.generateLlmsTxt();
+        res.statusCode = 200;
+        res.setHeader("content-type", "text/plain; charset=utf-8");
+        res.end(llmsTxt);
         return;
       }
 

--- a/packages/vite-plugin/src/plugin-options.ts
+++ b/packages/vite-plugin/src/plugin-options.ts
@@ -2,6 +2,25 @@ import type { RenderMode } from "@pracht/core";
 import type { PreactSsrPrecompileOptions } from "@pracht/preact-ssr-precompile";
 import { createDefaultNodeAdapter, type PrachtAdapter } from "./plugin-adapter.ts";
 
+export type LlmsTxtSection = "pages" | "api";
+
+export interface PrachtLlmsTxtOptions {
+  /** H1 title. Defaults to the app's package.json `name`. */
+  title?: string;
+  /**
+   * Blockquote summary under the title. Defaults to the app's package.json
+   * `description`; omitted when neither is set.
+   */
+  description?: string;
+  /**
+   * Origin (e.g. "https://example.com") prepended to every link so llms.txt
+   * contains absolute URLs. Links stay root-relative when omitted.
+   */
+  origin?: string;
+  /** Sections to emit. Defaults to ["pages", "api"]. */
+  include?: LlmsTxtSection[];
+}
+
 export interface PrachtPluginOptions {
   appFile?: string;
   routesDir?: string;
@@ -36,6 +55,12 @@ export interface PrachtPluginOptions {
    * Client bundles keep the normal Preact JSX transform for hydration.
    */
   precompileSsrJsx?: boolean | PreactSsrPrecompileOptions;
+  /**
+   * Opt into emitting an llms.txt file (https://llmstxt.org) generated from
+   * the resolved app graph. `pracht build` writes `dist/client/llms.txt` and
+   * the dev server serves `/llms.txt` live. Disabled by default.
+   */
+  llmsTxt?: false | PrachtLlmsTxtOptions;
 }
 
 export type ResolvedPrachtPluginOptions = Required<PrachtPluginOptions>;
@@ -55,6 +80,7 @@ const DEFAULTS: ResolvedPrachtPluginOptions = {
   maxBodySize: 1024 * 1024,
   budgets: {},
   precompileSsrJsx: false,
+  llmsTxt: false,
 };
 
 export function resolveOptions(options: PrachtPluginOptions): ResolvedPrachtPluginOptions {
@@ -69,7 +95,27 @@ export function resolveOptions(options: PrachtPluginOptions): ResolvedPrachtPlug
     throw new Error("pracht({ maxBodySize }) expects a positive integer number of bytes.");
   }
   validateBudgets(resolved.budgets);
+  validateLlmsTxt(resolved.llmsTxt);
   return resolved;
+}
+
+const LLMS_TXT_SECTIONS = new Set<LlmsTxtSection>(["pages", "api"]);
+
+function validateLlmsTxt(llmsTxt: false | PrachtLlmsTxtOptions): void {
+  if (llmsTxt === false) return;
+  if (typeof llmsTxt !== "object" || llmsTxt === null) {
+    throw new Error("pracht({ llmsTxt }) expects false or an options object.");
+  }
+  if (llmsTxt.include !== undefined) {
+    const isValid =
+      Array.isArray(llmsTxt.include) &&
+      llmsTxt.include.every((section) => LLMS_TXT_SECTIONS.has(section));
+    if (!isValid) {
+      throw new Error(
+        `pracht({ llmsTxt: { include } }) expects an array of "pages" and/or "api", got ${JSON.stringify(llmsTxt.include)}.`,
+      );
+    }
+  }
 }
 
 function validateBudgets(budgets: Record<string, string | number>): void {

--- a/packages/vite-plugin/test/plugin-options.test.ts
+++ b/packages/vite-plugin/test/plugin-options.test.ts
@@ -1,3 +1,4 @@
+import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
 
 import { createPrachtServerModuleSource } from "../src/plugin-codegen.ts";
@@ -24,6 +25,60 @@ describe("resolveOptions budgets", () => {
   it("rejects non-positive or empty values", () => {
     expect(() => resolveOptions({ budgets: { "*": 0 } })).toThrow(/positive number of bytes/);
     expect(() => resolveOptions({ budgets: { "*": "" } })).toThrow(/positive number of bytes/);
+  });
+});
+
+describe("resolveOptions llmsTxt", () => {
+  it("defaults to disabled", () => {
+    expect(resolveOptions({}).llmsTxt).toBe(false);
+  });
+
+  it("accepts an options object", () => {
+    const resolved = resolveOptions({
+      llmsTxt: { title: "My App", origin: "https://example.com", include: ["pages"] },
+    });
+    expect(resolved.llmsTxt).toEqual({
+      title: "My App",
+      origin: "https://example.com",
+      include: ["pages"],
+    });
+  });
+
+  it("rejects non-object values such as true", () => {
+    // @ts-expect-error — llmsTxt is `false | object`, not `true`.
+    expect(() => resolveOptions({ llmsTxt: true })).toThrow(/false or an options object/);
+  });
+
+  it("rejects unknown include sections", () => {
+    // @ts-expect-error — "sitemap" is not a valid section.
+    expect(() => resolveOptions({ llmsTxt: { include: ["sitemap"] } })).toThrow(
+      /"pages" and\/or "api"/,
+    );
+  });
+});
+
+describe("createPrachtServerModuleSource llmsTxt export", () => {
+  it("emits no llms.txt code when disabled", () => {
+    const source = createPrachtServerModuleSource();
+    expect(source).not.toContain("generateLlmsTxt");
+    expect(source).not.toContain("buildLlmsTxt");
+  });
+
+  it("exports generateLlmsTxt with the configured options", () => {
+    const source = createPrachtServerModuleSource({
+      llmsTxt: { title: "My App", description: "Demo.", origin: "https://example.com" },
+    });
+    expect(source).toContain('import { buildLlmsTxt } from "@pracht/core/server";');
+    expect(source).toContain(
+      'const llmsTxtConfig = {"title":"My App","description":"Demo.","origin":"https://example.com"};',
+    );
+    expect(source).toContain("export const generateLlmsTxt = () =>");
+  });
+
+  it("falls back to the app package.json name for the title", () => {
+    const packageRoot = fileURLToPath(new URL("..", import.meta.url));
+    const source = createPrachtServerModuleSource({ llmsTxt: {} }, { root: packageRoot });
+    expect(source).toContain('"title":"@pracht/vite-plugin"');
   });
 });
 

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -16,7 +16,7 @@ export default defineConfig({
     },
     {
       name: "pages-router",
-      testMatch: /pages-router\.test\.ts|dev-404\.test\.ts/,
+      testMatch: /pages-router\.test\.ts|dev-404\.test\.ts|llms-txt-dev\.test\.ts/,
       use: {
         baseURL: "http://localhost:3101",
       },


### PR DESCRIPTION
## Summary

- Adds an opt-in `llmsTxt` option to `pracht()` that emits an [llms.txt](https://llmstxt.org) file generated from the resolved app graph: `pracht build` writes `dist/client/llms.txt`, and the dev SSR middleware serves `/llms.txt` live from the current graph. Zero cost when disabled — the server module codegen and build output are byte-for-byte unchanged.
- Format follows the llms.txt spec: H1 title + blockquote description (with package.json `name`/`description` fallbacks), a `## Pages` link list (dynamic routes are only listed when they are SSG/ISG with `getStaticPaths()` — one entry per prerendered instance; dynamic SSR/SPA routes are skipped since they have no concrete URL), routes with a server-only `markdown` export are annotated with ``supports `Accept: text/markdown` ``, and a `## API` section lists endpoints with their detected methods. Output ordering is deterministic (locale-independent path sort).
- `@pracht/core` gains `buildLlmsTxt()` on `@pracht/core/server`; `@pracht/cli` writes the file during `pracht build`; all three adapters serve it as a regular static asset with no adapter changes (Node static handler, Cloudflare `ASSETS` binding, Vercel Build Output `handle: filesystem`). With the Cloudflare adapter (which owns the dev server) the file is available in build output only; this is documented.
- Enabled in `examples/basic`, `examples/pages-router`, and `examples/cloudflare`, and `create-pracht` templates now scaffold `llmsTxt: {}`.
- New docs page `docs/LLMS_TXT.md` plus a README bullet under AI-assisted development.

## Testing

- [x] `pnpm e2e` (78 passed, incl. new dev-serving tests and llms.txt assertions in the Node/Cloudflare/Vercel build tests)
- [x] `pnpm format`
- [x] `pnpm lint` (`oxlint . --fix`: 0 warnings, 0 errors)
- [x] `pnpm test` (515 passed; also ran `pnpm typecheck` clean)

## Checklist

- [x] Docs updated if needed (`docs/LLMS_TXT.md`, README)
- [x] Skills updated if needed (N/A — no skill references plugin option surfaces)
- [x] Changeset added if published packages changed (`@pracht/core` minor, `@pracht/vite-plugin` minor, `@pracht/cli` minor, `create-pracht` patch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)