### PR TITLE
fix(adapter-cloudflare): honor ISG cache-safety before stamping Workers Caching headers

### DIFF
--- a/.changeset/cloudflare-workers-cache-vary-safety.md
+++ b/.changeset/cloudflare-workers-cache-vary-safety.md
@@ -1,0 +1,5 @@
+---
+"@pracht/adapter-cloudflare": patch
+---
+
+Prevent Cloudflare Workers Caching from stamping public edge-cache headers on ISG responses that vary by cookie, authorization, or all request headers.

--- a/docs/ADAPTERS.md
+++ b/docs/ADAPTERS.md
@@ -310,7 +310,10 @@ With the option on:
 - A route/shell `headers()` export that sets `Cache-Control` (or
   `cloudflare-cdn-cache-control`) takes full precedence — pracht adds
   nothing, so individual routes can opt out or tune their own policy.
-  Responses with `Set-Cookie` are never cached.
+  Pracht also reuses the shared ISG cache-safety policy before stamping edge
+  headers: responses with `Set-Cookie`, `Cache-Control: private` /
+  `no-store`, or `Vary: Cookie`, `Vary: Authorization`, or `Vary: *` are
+  never stored in the shared edge cache.
 - Route-state JSON (client navigations) stays `no-store` and always reaches
   the Worker.
 - Everything pracht did **not** deliberately mark cacheable gets

--- a/docs/RENDERING_MODES.md
+++ b/docs/RENDERING_MODES.md
@@ -118,8 +118,11 @@ with `expiration` set from the time policy.
 > stale pages are served instantly while the Worker re-renders in the
 > background — a true edge-tier cache rather than the per-colo Cache API.
 > Cached pages can be purged early with `purgeCache()` from
-> `@pracht/adapter-cloudflare/cache`. See
-> [ADAPTERS.md](ADAPTERS.md#isg-via-workers-caching-cache).
+> `@pracht/adapter-cloudflare/cache`. Pracht only stamps Workers Caching
+> headers on ISG responses that pass the shared ISG cache-safety policy, so
+> responses with `Set-Cookie`, `Cache-Control: private` / `no-store`, or
+> `Vary: Cookie`, `Vary: Authorization`, or `Vary: *` stay out of the shared
+> edge cache. See [ADAPTERS.md](ADAPTERS.md#isg-via-workers-caching-cache).
 
 ### Webhook-based revalidation
 

--- a/packages/adapter-cloudflare/src/cache.ts
+++ b/packages/adapter-cloudflare/src/cache.ts
@@ -13,7 +13,11 @@
  * Everything in this module must stay safe to bundle into the worker —
  * no `vite` or Node imports.
  */
-import { getTimeRevalidateSeconds, matchAppRoute } from "@pracht/core/server";
+import {
+  getTimeRevalidateSeconds,
+  isCacheableISGResponse,
+  matchAppRoute,
+} from "@pracht/core/server";
 import type { PrachtApp, ResolvedPrachtApp, ResolvedRoute } from "@pracht/core/server";
 
 export interface CloudflareWorkersCacheOptions {
@@ -125,8 +129,9 @@ export function findCacheableIsgRoute(
  * A user-set `Cache-Control` or `cloudflare-cdn-cache-control` (via a
  * route/shell `headers()` export or middleware) takes full precedence:
  * pracht adds nothing, so routes can opt out or tune their own policy.
- * Responses that are not a cacheable page (non-200, `Set-Cookie`) pass
- * through untouched.
+ * Responses that are not a cacheable page (non-200, `Set-Cookie`,
+ * `Cache-Control: private` / `no-store`, or `Vary: Cookie` /
+ * `Authorization` / `*`) pass through untouched.
  */
 export function applyWorkersCacheHeaders(
   response: Response,
@@ -136,7 +141,7 @@ export function applyWorkersCacheHeaders(
   if (response.status !== 200) return response;
   if (response.headers.has("cache-control")) return response;
   if (response.headers.has("cloudflare-cdn-cache-control")) return response;
-  if (response.headers.has("set-cookie")) return response;
+  if (!isCacheableISGResponse(response)) return response;
 
   const seconds = getTimeRevalidateSeconds(route.revalidate) ?? 0;
   if (seconds <= 0) return response;

--- a/packages/adapter-cloudflare/test/cache.test.ts
+++ b/packages/adapter-cloudflare/test/cache.test.ts
@@ -174,6 +174,21 @@ describe("applyWorkersCacheHeaders", () => {
 
     expect(response.headers.has("cache-control")).toBe(false);
   });
+
+  it("does not edge-cache responses that vary by cookie, authorization, or everything", () => {
+    for (const vary of ["Cookie", "Accept, Authorization", "*"]) {
+      const response = applyWorkersCacheHeaders(
+        new Response("<html></html>", { headers: { vary } }),
+        isgRoute(),
+        cacheOptions,
+      );
+
+      expect(response.headers.has("cache-control")).toBe(false);
+      expect(response.headers.has("cloudflare-cdn-cache-control")).toBe(false);
+      expect(response.headers.has("cache-tag")).toBe(false);
+      expect(response.headers.get("vary")).toBe(vary);
+    }
+  });
 });
 
 describe("preventHeuristicCaching", () => {


### PR DESCRIPTION
### Motivation
- The Cloudflare Workers Caching path was stamping public edge-cache headers on 200 responses without consulting the framework's ISG cache-safety signals, which could cause responses that vary by `Cookie`/`Authorization` or carry `private`/`no-store` to be cached at the edge and replayed across users.

### Description
- Reuse the shared ISG safety check by importing and calling `isCacheableISGResponse()` from `@pracht/core/server` inside `applyWorkersCacheHeaders()` and skip stamping when it returns `false`.
- Update documentation in `docs/ADAPTERS.md` and `docs/RENDERING_MODES.md` to explain that Workers Caching only stamps edge headers for ISG responses that pass the shared cache-safety policy (`Set-Cookie`, `Cache-Control: private`/`no-store`, `Vary: Cookie`/`Authorization`/`*` are treated as unsafe).
- Add unit coverage in `packages/adapter-cloudflare/test/cache.test.ts` to assert that responses with `Vary: Cookie`, `Vary: Accept, Authorization`, and `Vary: *` are not stamped with `Cache-Control`, `cloudflare-cdn-cache-control`, or `Cache-Tag`.
- Add a patch changeset `.changeset/cloudflare-workers-cache-vary-safety.md` describing the fix for `@pracht/adapter-cloudflare`.

### Testing
- Built the framework with `pnpm --filter @pracht/core run build` and ran the targeted adapter tests with `pnpm exec vitest run packages/adapter-cloudflare/test/cache.test.ts`, and the modified adapter tests passed.
- Ran `pnpm run format` and `pnpm run lint`, both succeeded.
- Attempted the full checks (`pnpm run e2e` and `pnpm run test`) in this environment but `pnpm run e2e` failed because Playwright/Chromium could not launch due to a missing system library (`libatk-1.0.so.0`), and the full `pnpm test` run included unrelated scaffold tests that timed out; the targeted Cloudflare cache tests relevant to this change passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a511d0b5afc832fb970f0ad91099bfa)