### PR TITLE
Add configurable route loader cache duration

### DIFF
--- a/.changeset/loader-cache-duration.md
+++ b/.changeset/loader-cache-duration.md
@@ -1,0 +1,8 @@
+---
+"@pracht/core": patch
+"@pracht/cli": patch
+---
+
+Add an inheritable `loaderCache` route option for controlling how long browsers privately cache successful route-state loader data. Positive durations emit `Cache-Control: private, max-age=<seconds>`, while `false`, `0`, and the default remain `no-store`.
+
+Expose the resolved loader cache policy in `pracht inspect routes --json` and the MCP route graph.

--- a/.changeset/loader-cache-duration.md
+++ b/.changeset/loader-cache-duration.md
@@ -6,3 +6,5 @@
 Add an inheritable `loaderCache` route option for controlling how long browsers privately cache successful route-state loader data. Positive durations emit `Cache-Control: private, max-age=<seconds>`, while `false`, `0`, and the default remain `no-store`.
 
 Expose the resolved loader cache policy in `pracht inspect routes --json` and the MCP route graph.
+
+Manual `useRevalidate()` calls bypass route-state browser caching so explicit refreshes and post-mutation reloads still re-run the loader.

--- a/.changeset/loader-cache-duration.md
+++ b/.changeset/loader-cache-duration.md
@@ -8,3 +8,5 @@ Add an inheritable `loaderCache` route option for controlling how long browsers 
 Expose the resolved loader cache policy in `pracht inspect routes --json` and the MCP route graph.
 
 Manual `useRevalidate()` calls bypass route-state browser caching so explicit refreshes and post-mutation reloads still re-run the loader.
+
+Form redirects after state-changing submissions also bypass cached route-state data when reloading the destination route.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -294,12 +294,15 @@ User clicks <a> or calls navigate()
       └─ Import shell module chunk (if applicable)
   → Otherwise, import the route/shell modules only and skip the server fetch
   → Server runs middleware + loader when needed and returns JSON (no HTML rendering)
+    with no-store by default or the route's private loaderCache duration
   → Client updates component tree with new data + loaded modules
   → Update URL via history.pushState
 ```
 
 Module imports are cached so repeated navigations to the same shell skip the import.
 Prefetching (hover/intent/viewport) also warms module chunks alongside route-state data.
+Its bounded 30-second in-memory reuse window is independent of the route-state
+response's browser HTTP cache policy.
 
 This "server-owned navigation" pattern means loaders never run in the browser.
 Secrets in loader code stay server-side. The client only receives serialized data.

--- a/docs/DATA_LOADING.md
+++ b/docs/DATA_LOADING.md
@@ -91,7 +91,9 @@ responses remain `no-store`. If a loader returns a `Response` with an explicit
 `loaderCache` is client-side browser caching only. It does not change ISG
 `revalidate`, and the prefetcher's bounded 30-second in-memory cache remains
 independent so an intent prefetch can still be consumed by the navigation that
-immediately follows it.
+immediately follows it. Explicit `useRevalidate()` calls bypass this browser
+cache so user-triggered refreshes and post-mutation reloads still re-run the
+loader.
 
 For SPA routes, the initial HTML can still include the matched shell and an
 optional shell `Loading` export so the page is not blank before the route-state

--- a/docs/DATA_LOADING.md
+++ b/docs/DATA_LOADING.md
@@ -70,7 +70,28 @@ plugins turn Markdown/MDX or TypeScript route files into JavaScript.
 
 Framework-generated route-state responses add `Vary: x-pracht-route-state-request`
 so caches keep HTML and JSON variants separate. Those JSON responses also default
-to `Cache-Control: no-store` unless your app sets a stricter policy explicitly.
+to `Cache-Control: no-store`.
+
+Use `loaderCache` in route metadata when loader data can safely be reused by the
+same browser:
+
+```typescript
+route("/settings", () => import("./routes/settings.tsx"), {
+  render: "spa",
+  loaderCache: 3600,
+});
+```
+
+A positive integer sets `Cache-Control: private, max-age=<seconds>` on successful
+route-state data responses. `loaderCache: false` and `loaderCache: 0` both produce
+`no-store`, which also lets a route opt out of a group default. Redirects and error
+responses remain `no-store`. If a loader returns a `Response` with an explicit
+`Cache-Control` header, that header takes precedence over route metadata.
+
+`loaderCache` is client-side browser caching only. It does not change ISG
+`revalidate`, and the prefetcher's bounded 30-second in-memory cache remains
+independent so an intent prefetch can still be consumed by the navigation that
+immediately follows it.
 
 For SPA routes, the initial HTML can still include the matched shell and an
 optional shell `Loading` export so the page is not blank before the route-state

--- a/docs/REQUEST_FLOWS.md
+++ b/docs/REQUEST_FLOWS.md
@@ -26,7 +26,8 @@ and returns a small JSON envelope:
 
 The `Vary: x-pracht-route-state-request` response header tells caches to keep
 the HTML and JSON variants separate. JSON responses default to
-`Cache-Control: no-store`.
+`Cache-Control: no-store`; a positive route `loaderCache` value changes
+successful loader-data responses to `private, max-age=<seconds>`.
 
 If the target route has neither a loader nor middleware, client navigation can
 skip the route-state request entirely and only load the route/shell modules.
@@ -396,6 +397,10 @@ x-pracht-route-state-request: 1
 Vary: x-pracht-route-state-request
 Cache-Control: no-store
 ```
+
+`Cache-Control` above is the default. Routes configured with
+`loaderCache: <seconds>` return `private, max-age=<seconds>` for successful data;
+redirects and errors remain `no-store`.
 
 No HTML is rendered during navigation regardless of the target route's mode.
 The client updates the component tree in-place.

--- a/docs/ROUTING.md
+++ b/docs/ROUTING.md
@@ -93,7 +93,7 @@ Defines a single route:
 | ------ | ----------- | ------------------------------------------------------ |
 | `path` | `string`    | URL pattern (e.g. `/blog/:slug`)                       |
 | `file` | `ModuleRef` | Module reference — `() => import("./path")` or string  |
-| `meta` | `RouteMeta` | Optional: render mode, shell, middleware, revalidation |
+| `meta` | `RouteMeta` | Optional: render mode, shell, middleware, revalidation, loader caching |
 
 > [!IMPORTANT]
 > Function module refs must use the exact inline form `() => import("./path")`
@@ -107,7 +107,7 @@ Groups routes with shared configuration:
 
 | Param    | Type                | Description                                           |
 | -------- | ------------------- | ----------------------------------------------------- |
-| `meta`   | `GroupMeta`         | Shell, middleware, render mode, pathPrefix to inherit |
+| `meta`   | `GroupMeta`         | Shell, middleware, render mode, loader cache, pathPrefix to inherit |
 | `routes` | `RouteDefinition[]` | Routes in this group                                  |
 
 Group properties cascade to children. A route's own meta overrides the group's.
@@ -124,6 +124,7 @@ interface RouteMeta {
   hydration?: "full" | "islands" | "none"; // Partial hydration (see ISLANDS.md)
   middleware?: string[]; // Named middleware from defineApp.middleware
   revalidate?: RouteRevalidate; // ISG revalidation policy
+  loaderCache?: number | false; // Browser cache seconds for route-state loader data
   prefetch?: "none" | "hover" | "viewport" | "intent"; // Route-level prefetch strategy (default: "intent")
   speculation?: "prefetch" | "prerender" | { mode; eagerness };
 }
@@ -133,6 +134,13 @@ interface RouteMeta {
 `src/islands/`; `"none"` ships no JavaScript at all. Both are inherited
 through `group(...)` like `render` and documented in
 [ISLANDS.md](ISLANDS.md).
+
+`loaderCache` accepts a non-negative integer number of seconds or `false`.
+Positive values set `Cache-Control: private, max-age=<seconds>` on successful
+route-state loader data. `0`, `false`, and an omitted value use `no-store`.
+It inherits through `group(...)`, and a route-level value overrides the group.
+This browser cache is independent of ISG `revalidate` and the client's 30-second
+in-memory prefetch cache. See [DATA_LOADING.md](DATA_LOADING.md#loaders).
 
 See [Speculation Rules](#speculation-rules) for `speculation` semantics and how
 it composes with the JS-based `prefetch` strategy.
@@ -263,7 +271,8 @@ and `<Link prefetch>` overrides it per link:
 Prefetching warms the route's JS chunks and caches the route-state JSON in a
 bounded LRU cache (30s TTL); a subsequent navigation consumes the cached
 result instead of fetching again. Failed prefetches are evicted so they never
-poison a later navigation.
+poison a later navigation. This short-lived in-memory cache is independent of
+the route's HTTP `loaderCache` policy.
 
 There is also an imperative API for warming a route from code (e.g. before
 opening a client-side dialog that links somewhere):

--- a/e2e/basic.test.ts
+++ b/e2e/basic.test.ts
@@ -230,6 +230,15 @@ test("route state request returns JSON", async ({ request }) => {
   expect(json.data.highlights).toContain("Hybrid route manifest");
 });
 
+test("route state request uses the configured loader cache duration", async ({ request }) => {
+  const response = await request.get("/pricing", {
+    headers: { "x-pracht-route-state-request": "1" },
+  });
+
+  expect(response.status()).toBe(200);
+  expect(response.headers()["cache-control"]).toBe("private, max-age=60");
+});
+
 // ---------------------------------------------------------------------------
 // 404 handling
 // ---------------------------------------------------------------------------

--- a/examples/cloudflare/src/routes.ts
+++ b/examples/cloudflare/src/routes.ts
@@ -17,6 +17,7 @@ export const app = defineApp({
       }),
       route("/pricing", () => import("./routes/pricing.tsx"), {
         id: "pricing",
+        loaderCache: 60,
         render: "isg",
         revalidate: timeRevalidate(3600),
         speculation: "prefetch",

--- a/examples/docs/src/routes/docs/data-loading.md
+++ b/examples/docs/src/routes/docs/data-loading.md
@@ -64,6 +64,32 @@ export. Named route exports such as `loader`, `head`, `headers`,
 > [!NOTE]
 > Loaders **never** run in the browser. Database connections, API keys, and secrets in loader code stay server-side permanently.
 
+### Route-state caching
+
+Client navigation fetches loader data through Pracht's route-state endpoint. By
+default those JSON responses use `Cache-Control: no-store`, so every navigation
+asks the server for fresh loader data.
+
+Use `loaderCache` in route metadata when the returned data can safely be reused
+by the same browser for a short time:
+
+```ts [src/routes.ts]
+route("/pricing", "./routes/pricing.tsx", {
+  render: "isg",
+  loaderCache: 60,
+});
+```
+
+A positive value sets `Cache-Control: private, max-age=<seconds>` on successful
+route-state responses. `loaderCache: false` and `loaderCache: 0` keep `no-store`
+and can opt a route out of a group default.
+
+Only cache data that is safe to reuse for the configured duration in the same
+browser. Avoid positive `loaderCache` values for loader data that depends on the
+current user, permissions, session, or cookies. `loaderCache` does not change
+ISG `revalidate`, and it is separate from Pracht's short in-memory prefetch
+cache.
+
 ### Error handling
 
 Throw `PrachtHttpError` for structured error responses. Pair it with an `ErrorBoundary` export to render a fallback UI:

--- a/examples/docs/src/routes/docs/data-loading.md
+++ b/examples/docs/src/routes/docs/data-loading.md
@@ -258,6 +258,10 @@ export function Component() {
 }
 ```
 
+Manual revalidation bypasses route-state browser caching, including
+`loaderCache`, so refresh buttons and post-mutation reloads fetch fresh loader
+data.
+
 ### useNavigation()
 
 Reactive pending state for the current navigation or `<Form>` submission — the

--- a/packages/cli/src/app-graph.ts
+++ b/packages/cli/src/app-graph.ts
@@ -10,6 +10,7 @@ const METHOD_ORDER: HttpMethod[] = [...HTTP_METHODS];
 export interface AppGraphRoute {
   file: string;
   id: string;
+  loaderCache: number | false | null;
   loaderFile: string | null;
   middleware: string[];
   path: string;
@@ -33,6 +34,7 @@ export interface AppGraph {
 interface ResolvedRouteEntry {
   file: string;
   id: string;
+  loaderCache?: number | false;
   loaderFile?: string;
   middleware: string[];
   path: string;
@@ -67,6 +69,7 @@ export function serializeResolvedRoutes(routes: ResolvedRouteEntry[]): AppGraphR
   return routes.map((route) => ({
     file: route.file,
     id: route.id,
+    loaderCache: route.loaderCache ?? null,
     loaderFile: route.loaderFile ?? null,
     middleware: route.middleware,
     path: route.path,

--- a/packages/cli/test/mcp-server.test.ts
+++ b/packages/cli/test/mcp-server.test.ts
@@ -173,6 +173,7 @@ export const app = defineApp({
         {
           file: "./routes/dashboard.tsx",
           id: "dashboard",
+          loaderCache: null,
           loaderFile: null,
           middleware: [],
           path: "/dashboard",

--- a/packages/cli/test/pracht-cli.test.js
+++ b/packages/cli/test/pracht-cli.test.js
@@ -303,6 +303,7 @@ export const app = defineApp({
         {
           file: "./routes/dashboard.tsx",
           id: "dashboard",
+          loaderCache: null,
           loaderFile: "./server/dashboard-loader.ts",
           middleware: ["auth"],
           path: "/dashboard",

--- a/packages/framework/src/app-graph.ts
+++ b/packages/framework/src/app-graph.ts
@@ -22,6 +22,7 @@ export const API_METHOD_ORDER: readonly HttpMethod[] = [
 export interface AppGraphRoute {
   file: string;
   id: string;
+  loaderCache: number | false | null;
   loaderFile: string | null;
   middleware: string[];
   path: string;
@@ -53,6 +54,7 @@ export function serializeAppRoutes(routes: readonly ResolvedRoute[]): AppGraphRo
   return routes.map((route) => ({
     file: route.file,
     id: route.id ?? "",
+    loaderCache: route.loaderCache ?? null,
     loaderFile: route.loaderFile ?? null,
     middleware: route.middleware,
     path: route.path,

--- a/packages/framework/src/app.ts
+++ b/packages/framework/src/app.ts
@@ -31,6 +31,7 @@ interface InheritedRouteConfig {
   shell?: string;
   render?: ResolvedRoute["render"];
   hydration?: ResolvedRoute["hydration"];
+  loaderCache?: ResolvedRoute["loaderCache"];
   middleware: string[];
   speculation?: SpeculationOption;
 }
@@ -186,11 +187,14 @@ function flattenRouteNode(
   routes: ResolvedRoute[],
 ): void {
   if (node.kind === "group") {
+    const pathPrefix = mergeRoutePaths(inherited.pathPrefix, node.meta.pathPrefix);
+    assertValidLoaderCache(node.meta.loaderCache, `group at "${pathPrefix}"`);
     const nextInherited: InheritedRouteConfig = {
-      pathPrefix: mergeRoutePaths(inherited.pathPrefix, node.meta.pathPrefix),
+      pathPrefix,
       shell: node.meta.shell ?? inherited.shell,
       render: node.meta.render ?? inherited.render,
       hydration: node.meta.hydration ?? inherited.hydration,
+      loaderCache: node.meta.loaderCache ?? inherited.loaderCache,
       middleware: [...inherited.middleware, ...(node.meta.middleware ?? [])],
       speculation: node.meta.speculation ?? inherited.speculation,
     };
@@ -203,10 +207,12 @@ function flattenRouteNode(
   }
 
   const fullPath = mergeRoutePaths(inherited.pathPrefix, node.path);
+  assertValidLoaderCache(node.loaderCache, `route "${fullPath}"`);
   const shell = node.shell ?? inherited.shell;
   const middleware = [...inherited.middleware, ...(node.middleware ?? [])];
   const render = node.render ?? inherited.render;
   const hydration = node.hydration ?? inherited.hydration;
+  const loaderCache = node.loaderCache ?? inherited.loaderCache;
 
   if (render === "spa" && hydration !== undefined && hydration !== "full") {
     throw new Error(
@@ -237,6 +243,7 @@ function flattenRouteNode(
     shellFile: shell !== undefined ? app.shells[shell] : undefined,
     render,
     hydration,
+    loaderCache,
     middleware,
     middlewareFiles: middleware.map((name) => {
       if (!hasOwnEntry(app.middleware, name)) {
@@ -257,6 +264,18 @@ function flattenRouteNode(
     speculation: node.speculation ?? inherited.speculation,
     segments: parseRouteSegments(fullPath),
   });
+}
+
+function assertValidLoaderCache(loaderCache: ResolvedRoute["loaderCache"], context: string): void {
+  if (
+    loaderCache !== undefined &&
+    loaderCache !== false &&
+    (!Number.isInteger(loaderCache) || loaderCache < 0)
+  ) {
+    throw new Error(
+      `Invalid loaderCache for ${context}: expected false or a non-negative integer number of seconds.`,
+    );
+  }
 }
 
 /** `in` would also match `Object.prototype` keys such as `constructor`. */

--- a/packages/framework/src/browser.ts
+++ b/packages/framework/src/browser.ts
@@ -58,6 +58,7 @@ export type {
   LoaderArgs,
   LoaderData,
   LoaderFn,
+  LoaderCache,
   MiddlewareArgs,
   MiddlewareFn,
   MiddlewareModule,

--- a/packages/framework/src/index.ts
+++ b/packages/framework/src/index.ts
@@ -98,6 +98,7 @@ export type {
   LoaderArgs,
   LoaderData,
   LoaderFn,
+  LoaderCache,
   MiddlewareArgs,
   MiddlewareFn,
   MiddlewareModule,

--- a/packages/framework/src/manifest.ts
+++ b/packages/framework/src/manifest.ts
@@ -10,6 +10,7 @@ export type {
   HydrationMode,
   IslandStrategy,
   IslandProps,
+  LoaderCache,
   RouteConfig,
   RouteDefinition,
   RouteMeta,

--- a/packages/framework/src/router.ts
+++ b/packages/framework/src/router.ts
@@ -387,7 +387,7 @@ export async function initClientRouter(options: InitClientRouterOptions): Promis
       if (routeNeedsServerFetch(match.route)) {
         statePromise = opts?._reloadRouteState
           ? fetchPrachtRouteState(target.requestUrl, {
-              cache: "no-store",
+              cache: "reload",
               signal: abortController.signal,
             })
           : (getCachedRouteState(target.requestUrl) ??

--- a/packages/framework/src/router.ts
+++ b/packages/framework/src/router.ts
@@ -53,7 +53,7 @@ interface RouteRenderState {
 
 declare global {
   interface Window {
-    __PRACHT_NAVIGATE__?: NavigateFn;
+    __PRACHT_NAVIGATE__?: InternalNavigateFn;
     __PRACHT_ROUTER_READY__?: boolean;
   }
 }
@@ -67,6 +67,15 @@ export interface NavigateFn {
 
 interface InternalNavigateOptions extends NavigateOptions {
   _popstate?: boolean;
+  _reloadRouteState?: boolean;
+}
+
+interface InternalNavigateFn {
+  (to: string, options?: InternalNavigateOptions): Promise<void>;
+  <TRoute extends RouteId>(
+    to: RouteTarget<TRoute>,
+    options?: InternalNavigateOptions,
+  ): Promise<void>;
 }
 
 interface BrowserRouteTarget {
@@ -376,9 +385,13 @@ export async function initClientRouter(options: InitClientRouterOptions): Promis
       // Start route-state fetch and module imports in parallel
       let statePromise: Promise<RouteStateResult>;
       if (routeNeedsServerFetch(match.route)) {
-        statePromise =
-          getCachedRouteState(target.requestUrl) ??
-          fetchPrachtRouteState(target.requestUrl, { signal: abortController.signal });
+        statePromise = opts?._reloadRouteState
+          ? fetchPrachtRouteState(target.requestUrl, {
+              cache: "no-store",
+              signal: abortController.signal,
+            })
+          : (getCachedRouteState(target.requestUrl) ??
+            fetchPrachtRouteState(target.requestUrl, { signal: abortController.signal }));
       } else {
         statePromise = Promise.resolve({ type: "data" as const, data: undefined });
       }

--- a/packages/framework/src/runtime-client-fetch.ts
+++ b/packages/framework/src/runtime-client-fetch.ts
@@ -93,7 +93,7 @@ export async function fetchPrachtRouteState(
 
 export async function navigateToClientLocation(
   location: string,
-  options?: { replace?: boolean },
+  options?: { reloadRouteState?: boolean; replace?: boolean },
 ): Promise<void> {
   if (typeof window === "undefined") {
     return;
@@ -107,7 +107,10 @@ export async function navigateToClientLocation(
 
   const target = targetUrl.pathname + targetUrl.search + targetUrl.hash;
   if (targetUrl.origin === window.location.origin && window.__PRACHT_NAVIGATE__) {
-    await window.__PRACHT_NAVIGATE__(target, options);
+    await window.__PRACHT_NAVIGATE__(target, {
+      _reloadRouteState: options?.reloadRouteState,
+      replace: options?.replace,
+    });
     return;
   }
 

--- a/packages/framework/src/runtime-client-fetch.ts
+++ b/packages/framework/src/runtime-client-fetch.ts
@@ -44,10 +44,11 @@ export function buildRouteStateUrl(url: string): string {
 
 export async function fetchPrachtRouteState(
   url: string,
-  options?: { signal?: AbortSignal; useDataParam?: boolean },
+  options?: { cache?: RequestCache; signal?: AbortSignal; useDataParam?: boolean },
 ): Promise<RouteStateResult> {
   const fetchUrl = options?.useDataParam ? buildRouteStateUrl(url) : url;
   const response = await fetch(fetchUrl, {
+    cache: options?.cache,
     headers: options?.useDataParam ? {} : { [ROUTE_STATE_REQUEST_HEADER]: "1" },
     redirect: "manual",
     signal: options?.signal,

--- a/packages/framework/src/runtime-client-fetch.ts
+++ b/packages/framework/src/runtime-client-fetch.ts
@@ -48,9 +48,7 @@ export async function fetchPrachtRouteState(
 ): Promise<RouteStateResult> {
   const fetchUrl = options?.useDataParam ? buildRouteStateUrl(url) : url;
   const response = await fetch(fetchUrl, {
-    headers: options?.useDataParam
-      ? {}
-      : { [ROUTE_STATE_REQUEST_HEADER]: "1", "Cache-Control": "no-cache" },
+    headers: options?.useDataParam ? {} : { [ROUTE_STATE_REQUEST_HEADER]: "1" },
     redirect: "manual",
     signal: options?.signal,
   });

--- a/packages/framework/src/runtime-headers.ts
+++ b/packages/framework/src/runtime-headers.ts
@@ -1,4 +1,5 @@
 import { ROUTE_STATE_CACHE_CONTROL, ROUTE_STATE_REQUEST_HEADER } from "./runtime-constants.ts";
+import type { LoaderCache } from "./types.ts";
 
 const HEADER_CRLF_RE = /[\r\n]/;
 
@@ -72,13 +73,13 @@ export function applyDefaultSecurityHeaders(headers: Headers): Headers {
 
 export function applySecurityAndRouteHeaders(
   headers: Headers,
-  options?: { isRouteStateRequest: boolean },
+  options?: { isRouteStateRequest: boolean; loaderCache?: LoaderCache },
 ): Headers {
   applyDefaultSecurityHeaders(headers);
   if (options) {
     appendVaryHeader(headers, ROUTE_STATE_REQUEST_HEADER);
     if (options.isRouteStateRequest && !headers.has("cache-control")) {
-      headers.set("cache-control", ROUTE_STATE_CACHE_CONTROL);
+      headers.set("cache-control", getRouteStateCacheControl(options.loaderCache));
     }
   }
   return headers;
@@ -96,7 +97,7 @@ export function withDefaultSecurityHeaders(response: Response): Response {
 
 export function withRouteResponseHeaders(
   response: Response,
-  options: { isRouteStateRequest: boolean },
+  options: { isRouteStateRequest: boolean; loaderCache?: LoaderCache },
 ): Response {
   const headers = new Headers(response.headers);
   applySecurityAndRouteHeaders(headers, options);
@@ -105,6 +106,13 @@ export function withRouteResponseHeaders(
     statusText: response.statusText,
     headers,
   });
+}
+
+function getRouteStateCacheControl(loaderCache: LoaderCache | undefined): string {
+  if (loaderCache === undefined || loaderCache === false || loaderCache === 0) {
+    return ROUTE_STATE_CACHE_CONTROL;
+  }
+  return `private, max-age=${loaderCache}`;
 }
 
 export function appendVaryHeader(headers: Headers, value: string): void {

--- a/packages/framework/src/runtime-hooks.ts
+++ b/packages/framework/src/runtime-hooks.ts
@@ -106,7 +106,7 @@ export function useRevalidate() {
     }
 
     const path = runtime?.url || window.location.pathname + window.location.search;
-    const result = await fetchPrachtRouteState(path, { cache: "no-store" });
+    const result = await fetchPrachtRouteState(path, { cache: "reload" });
 
     if (result.type === "redirect") {
       await navigateToClientLocation(result.location);

--- a/packages/framework/src/runtime-hooks.ts
+++ b/packages/framework/src/runtime-hooks.ts
@@ -209,7 +209,7 @@ export function Form(props: FormProps) {
           (response.status >= 300 && response.status < 400)
         ) {
           const location = response.headers.get("location");
-          await navigateToClientLocation(location ?? actionUrl);
+          await navigateToClientLocation(location ?? actionUrl, { reloadRouteState: true });
         }
       } finally {
         settleNavigation(navigationToken);

--- a/packages/framework/src/runtime-hooks.ts
+++ b/packages/framework/src/runtime-hooks.ts
@@ -106,7 +106,7 @@ export function useRevalidate() {
     }
 
     const path = runtime?.url || window.location.pathname + window.location.search;
-    const result = await fetchPrachtRouteState(path);
+    const result = await fetchPrachtRouteState(path, { cache: "no-store" });
 
     if (result.type === "redirect") {
       await navigateToClientLocation(result.location);

--- a/packages/framework/src/runtime-response.ts
+++ b/packages/framework/src/runtime-response.ts
@@ -31,6 +31,7 @@ import {
 import type {
   BaseRouteArgs,
   HrefRouteDefinition,
+  LoaderCache,
   ResolvedApiRoute,
   RouteModule,
   ShellModule,
@@ -82,7 +83,7 @@ export function jsonRedirectResponse(
 
 export function normalizePageResponse(
   response: Response,
-  options: { isRouteStateRequest: boolean },
+  options: { isRouteStateRequest: boolean; loaderCache?: LoaderCache },
 ): Response {
   if (options.isRouteStateRequest && response.status >= 300 && response.status < 400) {
     const location = response.headers.get("location");
@@ -94,7 +95,10 @@ export function normalizePageResponse(
     }
   }
 
-  return withRouteResponseHeaders(response, options);
+  return withRouteResponseHeaders(response, {
+    isRouteStateRequest: options.isRouteStateRequest,
+    loaderCache: response.ok ? options.loaderCache : undefined,
+  });
 }
 
 export function renderApiErrorResponse<TContext>(options: {

--- a/packages/framework/src/runtime.ts
+++ b/packages/framework/src/runtime.ts
@@ -413,7 +413,10 @@ export async function handlePrachtRequest<TContext>(
       const data = loaderResult;
 
       if (isRouteStateRequest) {
-        return Response.json({ data });
+        return withRouteResponseHeaders(Response.json({ data }), {
+          isRouteStateRequest: true,
+          loaderCache: match.route.loaderCache,
+        });
       }
 
       // Shell import was kicked off up front; this await is usually already

--- a/packages/framework/src/runtime.ts
+++ b/packages/framework/src/runtime.ts
@@ -660,7 +660,10 @@ export async function handlePrachtRequest<TContext>(
     if (timings) {
       timings.mw = performance.now() - chainStart - (timings.render ?? 0) - (timings.loader ?? 0);
     }
-    return normalizePageResponse(response, { isRouteStateRequest });
+    return normalizePageResponse(response, {
+      isRouteStateRequest,
+      loaderCache: match.route.loaderCache,
+    });
   } catch (error: unknown) {
     return renderRouteErrorResponse({
       error,

--- a/packages/framework/src/server.ts
+++ b/packages/framework/src/server.ts
@@ -87,6 +87,7 @@ export type {
   LoaderArgs,
   LoaderData,
   LoaderFn,
+  LoaderCache,
   MiddlewareArgs,
   MiddlewareFn,
   MiddlewareModule,

--- a/packages/framework/src/types.ts
+++ b/packages/framework/src/types.ts
@@ -221,6 +221,12 @@ export interface ApiRouteMatch {
 export type PrefetchStrategy = "none" | "hover" | "viewport" | "intent";
 
 /**
+ * Browser cache duration for route-state loader responses, in seconds.
+ * `false` and `0` disable storage with `Cache-Control: no-store`.
+ */
+export type LoaderCache = number | false;
+
+/**
  * Per-link prefetch strategy accepted by `<Link prefetch>`. Extends the
  * route-level strategies with `"render"`, which prefetches as soon as the
  * link is rendered.
@@ -260,6 +266,7 @@ export interface RouteMeta {
   hydration?: HydrationMode;
   middleware?: string[];
   revalidate?: RouteRevalidate;
+  loaderCache?: LoaderCache;
   prefetch?: PrefetchStrategy;
   speculation?: SpeculationOption;
   hasLoader?: boolean;
@@ -270,6 +277,7 @@ export interface GroupMeta {
   render?: RenderMode;
   hydration?: HydrationMode;
   middleware?: string[];
+  loaderCache?: LoaderCache;
   pathPrefix?: string;
   speculation?: SpeculationOption;
 }

--- a/packages/framework/test/devtools.test.ts
+++ b/packages/framework/test/devtools.test.ts
@@ -22,6 +22,7 @@ const graphFixture: AppGraph = {
     {
       file: "./routes/home.tsx",
       id: "home",
+      loaderCache: null,
       loaderFile: null,
       middleware: [],
       path: "/",
@@ -33,6 +34,7 @@ const graphFixture: AppGraph = {
     {
       file: "./routes/user.tsx",
       id: "user",
+      loaderCache: null,
       loaderFile: "./routes/user.data.ts",
       middleware: ["auth", "logger"],
       path: "/users/:id",
@@ -85,6 +87,7 @@ describe("buildDevtoolsHtml", () => {
         {
           file: "./routes/<script>alert(1)</script>.tsx",
           id: "xss",
+          loaderCache: null,
           loaderFile: null,
           middleware: [],
           path: "/xss",
@@ -113,7 +116,12 @@ describe("buildAppGraph", () => {
       defineApp({
         middleware: { auth: "./middleware/auth.ts" },
         routes: [
-          route("/", "./routes/home.tsx", { id: "home", render: "ssg", shell: "public" }),
+          route("/", "./routes/home.tsx", {
+            id: "home",
+            loaderCache: 60,
+            render: "ssg",
+            shell: "public",
+          }),
           route("/users/:id", "./routes/user.tsx", { middleware: ["auth"] }),
         ],
         shells: { public: "./shells/public.tsx" },
@@ -139,6 +147,7 @@ describe("buildAppGraph", () => {
         {
           file: "./routes/home.tsx",
           id: "home",
+          loaderCache: 60,
           loaderFile: null,
           middleware: [],
           path: "/",
@@ -150,6 +159,7 @@ describe("buildAppGraph", () => {
         {
           file: "./routes/user.tsx",
           id: expect.any(String),
+          loaderCache: null,
           loaderFile: null,
           middleware: ["auth"],
           path: "/users/:id",
@@ -217,6 +227,7 @@ describe("serializeAppRoutes", () => {
     expect(serialized).toEqual({
       file: "./routes/home.tsx",
       id: "",
+      loaderCache: null,
       loaderFile: null,
       middleware: [],
       path: "/",

--- a/packages/framework/test/prefetch.test.ts
+++ b/packages/framework/test/prefetch.test.ts
@@ -112,6 +112,7 @@ describe("prefetch strategies", () => {
         headers: expect.objectContaining({ "x-pracht-route-state-request": "1" }),
       }),
     );
+    expect(fetchSpy.mock.calls[0][1].headers).not.toHaveProperty("Cache-Control");
 
     // The navigation path reads the same cache — no second request.
     const cached = getCachedRouteState("/pricing");

--- a/packages/framework/test/router-client.test.ts
+++ b/packages/framework/test/router-client.test.ts
@@ -211,7 +211,7 @@ describe("initClientRouter", () => {
     expect(fetchSpy).toHaveBeenCalledWith(
       "/dashboard",
       expect.objectContaining({
-        cache: "no-store",
+        cache: "reload",
         headers: expect.objectContaining({ "x-pracht-route-state-request": "1" }),
         redirect: "manual",
       }),
@@ -277,7 +277,7 @@ describe("initClientRouter", () => {
       2,
       "/cart",
       expect.objectContaining({
-        cache: "no-store",
+        cache: "reload",
         headers: expect.objectContaining({ "x-pracht-route-state-request": "1" }),
         redirect: "manual",
       }),

--- a/packages/framework/test/router-client.test.ts
+++ b/packages/framework/test/router-client.test.ts
@@ -13,6 +13,7 @@ import {
   route,
   useLocation,
   useNavigate,
+  useRevalidate,
   useRouteData,
 } from "../src/index.ts";
 
@@ -158,6 +159,64 @@ describe("initClientRouter", () => {
     );
     expect(window.location.pathname).toBe("/products/2");
     expect(root.textContent).toContain("Product 2");
+  });
+
+  it("bypasses the HTTP cache when revalidating route data", async () => {
+    function Dashboard() {
+      const data = useRouteData<{ count: number }>();
+      const revalidate = useRevalidate();
+      return h(
+        "main",
+        null,
+        h("span", { id: "count" }, String(data.count)),
+        h("button", { id: "refresh", onClick: () => void revalidate() }, "Refresh"),
+      );
+    }
+
+    const app = resolveApp(
+      defineApp({
+        routes: [
+          route("/dashboard", "./routes/dashboard.tsx", {
+            id: "dashboard",
+            loaderCache: 60,
+            render: "ssr",
+          }),
+        ],
+      }),
+    );
+
+    root.innerHTML = '<main><span id="count">1</span><button id="refresh">Refresh</button></main>';
+    history.replaceState(null, "", "/dashboard");
+    fetchSpy.mockResolvedValue(createJsonResponse({ data: { count: 2 } }));
+
+    await initClientRouter({
+      app,
+      routeModules: {
+        "./routes/dashboard.tsx": async () => ({ default: Dashboard }),
+      },
+      shellModules: {},
+      initialState: {
+        data: { count: 1 },
+        routeId: "dashboard",
+        url: "/dashboard",
+      },
+      root,
+      findModuleKey: (_modules, file) => file,
+    });
+
+    root.querySelector<HTMLButtonElement>("#refresh")?.click();
+    await flush();
+    await flush();
+
+    expect(fetchSpy).toHaveBeenCalledWith(
+      "/dashboard",
+      expect.objectContaining({
+        cache: "no-store",
+        headers: expect.objectContaining({ "x-pracht-route-state-request": "1" }),
+        redirect: "manual",
+      }),
+    );
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
   });
 
   it("preserves same-shell instances without exposing stale route data to useRouteData()", async () => {

--- a/packages/framework/test/router-client.test.ts
+++ b/packages/framework/test/router-client.test.ts
@@ -219,6 +219,72 @@ describe("initClientRouter", () => {
     expect(fetchSpy).toHaveBeenCalledTimes(1);
   });
 
+  it("bypasses the HTTP cache when a form redirect reloads cached route data", async () => {
+    function Cart() {
+      const data = useRouteData<{ count: number }>();
+      return h(
+        "main",
+        null,
+        h(Form, { action: "/api/cart", method: "post" }, h("button", null, "Add")),
+        h("span", { id: "count" }, String(data.count)),
+      );
+    }
+
+    const app = resolveApp(
+      defineApp({
+        routes: [
+          route("/cart", "./routes/cart.tsx", {
+            id: "cart",
+            loaderCache: 60,
+            render: "ssr",
+          }),
+        ],
+      }),
+    );
+
+    root.innerHTML =
+      '<main><form action="/api/cart" method="post"><button>Add</button></form><span id="count">1</span></main>';
+    history.replaceState(null, "", "/cart");
+    fetchSpy.mockImplementation(async (input: RequestInfo | URL) => {
+      if (String(input) === "/api/cart") {
+        return new Response(null, { headers: { location: "/cart" }, status: 302 });
+      }
+
+      return createJsonResponse({ data: { count: 2 } });
+    });
+
+    await initClientRouter({
+      app,
+      routeModules: {
+        "./routes/cart.tsx": async () => ({ default: Cart }),
+      },
+      shellModules: {},
+      initialState: {
+        data: { count: 1 },
+        routeId: "cart",
+        url: "/cart",
+      },
+      root,
+      findModuleKey: (_modules, file) => file,
+    });
+
+    const submitEvent = new Event("submit", { bubbles: true, cancelable: true });
+    root.querySelector("form")?.dispatchEvent(submitEvent);
+    await flush();
+    await flush();
+
+    expect(fetchSpy).toHaveBeenNthCalledWith(
+      2,
+      "/cart",
+      expect.objectContaining({
+        cache: "no-store",
+        headers: expect.objectContaining({ "x-pracht-route-state-request": "1" }),
+        redirect: "manual",
+      }),
+    );
+    expect(root.querySelector("#count")?.textContent).toBe("2");
+  });
+
   it("preserves same-shell instances without exposing stale route data to useRouteData()", async () => {
     const renderLog: Array<{ label: string; pathname: string }> = [];
     let shellMountCount = 0;

--- a/packages/framework/test/router.test.ts
+++ b/packages/framework/test/router.test.ts
@@ -42,6 +42,32 @@ describe("resolveApp", () => {
       shellFile: "./shells/public.tsx",
     });
   });
+
+  it("inherits loader cache durations and allows routes to opt out", () => {
+    const app = defineApp({
+      routes: [
+        group({ loaderCache: 300 }, [
+          route("/cached", "./routes/cached.tsx"),
+          route("/fresh", "./routes/fresh.tsx", { loaderCache: false }),
+        ]),
+      ],
+    });
+
+    const resolved = resolveApp(app);
+
+    expect(resolved.routes[0].loaderCache).toBe(300);
+    expect(resolved.routes[1].loaderCache).toBe(false);
+  });
+
+  it("rejects invalid loader cache durations", () => {
+    const app = defineApp({
+      routes: [route("/invalid", "./routes/invalid.tsx", { loaderCache: -1 })],
+    });
+
+    expect(() => resolveApp(app)).toThrow(
+      'Invalid loaderCache for route "/invalid": expected false or a non-negative integer number of seconds.',
+    );
+  });
 });
 
 describe("resolveApp wiring errors", () => {

--- a/packages/framework/test/runtime.test.ts
+++ b/packages/framework/test/runtime.test.ts
@@ -631,6 +631,80 @@ describe("handlePrachtRequest cache variance", () => {
     await expect(response.json()).resolves.toEqual({ data: { plan: "MVP" } });
   });
 
+  it("uses a route loaderCache duration for successful route-state data", async () => {
+    const app = defineApp({
+      routes: [route("/pricing", "./routes/pricing.tsx", { render: "ssr", loaderCache: 3600 })],
+    });
+
+    const response = await handlePrachtRequest({
+      app,
+      registry: {
+        routeModules: {
+          "./routes/pricing.tsx": async () => ({
+            Component: ({ data }) => h("main", null, (data as { plan: string }).plan),
+            loader: async () => ({ plan: "MVP" }),
+          }),
+        },
+      },
+      request: new Request("http://localhost/pricing", {
+        headers: { "x-pracht-route-state-request": "1" },
+      }),
+    });
+
+    expect(response.headers.get("cache-control")).toBe("private, max-age=3600");
+    await expect(response.json()).resolves.toEqual({ data: { plan: "MVP" } });
+  });
+
+  it.each([false, 0] as const)("treats loaderCache %s as no-store", async (loaderCache) => {
+    const app = defineApp({
+      routes: [route("/pricing", "./routes/pricing.tsx", { render: "ssr", loaderCache })],
+    });
+
+    const response = await handlePrachtRequest({
+      app,
+      registry: {
+        routeModules: {
+          "./routes/pricing.tsx": async () => ({
+            Component: () => h("main", null, "MVP"),
+            loader: async () => ({ plan: "MVP" }),
+          }),
+        },
+      },
+      request: new Request("http://localhost/pricing", {
+        headers: { "x-pracht-route-state-request": "1" },
+      }),
+    });
+
+    expect(response.headers.get("cache-control")).toBe("no-store");
+  });
+
+  it("preserves an explicit loader Response cache policy", async () => {
+    const app = defineApp({
+      routes: [route("/pricing", "./routes/pricing.tsx", { render: "ssr", loaderCache: 3600 })],
+    });
+
+    const response = await handlePrachtRequest({
+      app,
+      registry: {
+        routeModules: {
+          "./routes/pricing.tsx": async () => ({
+            Component: () => h("main", null, "MVP"),
+            loader: async () =>
+              Response.json(
+                { data: { plan: "MVP" } },
+                { headers: { "cache-control": "private, max-age=5" } },
+              ),
+          }),
+        },
+      },
+      request: new Request("http://localhost/pricing", {
+        headers: { "x-pracht-route-state-request": "1" },
+      }),
+    });
+
+    expect(response.headers.get("cache-control")).toBe("private, max-age=5");
+  });
+
   it("treats _data=1 query parameter as a route-state request", async () => {
     const app = defineApp({
       routes: [route("/pricing", "./routes/pricing.tsx", { render: "ssr" })],

--- a/packages/framework/test/runtime.test.ts
+++ b/packages/framework/test/runtime.test.ts
@@ -705,6 +705,53 @@ describe("handlePrachtRequest cache variance", () => {
     expect(response.headers.get("cache-control")).toBe("private, max-age=5");
   });
 
+  it("applies a route loaderCache duration to loader Response data", async () => {
+    const app = defineApp({
+      routes: [route("/pricing", "./routes/pricing.tsx", { render: "ssr", loaderCache: 3600 })],
+    });
+
+    const response = await handlePrachtRequest({
+      app,
+      registry: {
+        routeModules: {
+          "./routes/pricing.tsx": async () => ({
+            Component: () => h("main", null, "MVP"),
+            loader: async () => Response.json({ data: { plan: "MVP" } }),
+          }),
+        },
+      },
+      request: new Request("http://localhost/pricing", {
+        headers: { "x-pracht-route-state-request": "1" },
+      }),
+    });
+
+    expect(response.headers.get("cache-control")).toBe("private, max-age=3600");
+    await expect(response.json()).resolves.toEqual({ data: { plan: "MVP" } });
+  });
+
+  it("keeps loader Response errors out of the route loaderCache policy", async () => {
+    const app = defineApp({
+      routes: [route("/pricing", "./routes/pricing.tsx", { render: "ssr", loaderCache: 3600 })],
+    });
+
+    const response = await handlePrachtRequest({
+      app,
+      registry: {
+        routeModules: {
+          "./routes/pricing.tsx": async () => ({
+            Component: () => h("main", null, "MVP"),
+            loader: async () => Response.json({ error: { message: "nope" } }, { status: 500 }),
+          }),
+        },
+      },
+      request: new Request("http://localhost/pricing", {
+        headers: { "x-pracht-route-state-request": "1" },
+      }),
+    });
+
+    expect(response.headers.get("cache-control")).toBe("no-store");
+  });
+
   it("treats _data=1 query parameter as a route-state request", async () => {
     const app = defineApp({
       routes: [route("/pricing", "./routes/pricing.tsx", { render: "ssr" })],

--- a/packages/vite-plugin/test/devtools-route.test.ts
+++ b/packages/vite-plugin/test/devtools-route.test.ts
@@ -130,6 +130,7 @@ describe("dev middleware /_pracht devtools route", () => {
       {
         file: "./routes/home.tsx",
         id: "home",
+        loaderCache: null,
         loaderFile: null,
         middleware: [],
         path: "/",
@@ -141,6 +142,7 @@ describe("dev middleware /_pracht devtools route", () => {
       {
         file: "./routes/user.tsx",
         id: expect.any(String),
+        loaderCache: null,
         loaderFile: null,
         middleware: ["auth"],
         path: "/users/:id",

--- a/skills/audit-loaders/SKILL.md
+++ b/skills/audit-loaders/SKILL.md
@@ -3,7 +3,7 @@ name: audit-loaders
 version: 1.0.0
 description: |
   Audit pracht route loaders for serializability, leaked secrets,
-  browser-only API misuse, and missing AbortSignal plumbing.
+  unsafe loader caching, browser-only API misuse, and missing AbortSignal plumbing.
   Use when asked to "audit loaders", "check loader data", "find serialization
   bugs", "are my loaders safe", or "loader security review".
 allowed-tools:
@@ -28,7 +28,7 @@ pracht inspect routes --json
 For every route entry, read the `file` it resolves to and inspect the `loader`
 export.
 
-## Step 2: Run the four checks
+## Step 2: Run the five checks
 
 For each `loader` (and `getStaticPaths` when present):
 
@@ -83,6 +83,19 @@ For loaders that call `fetch` or any I/O:
   database client that accepts cancellation.
 - A loader that ignores `signal` keeps work running after the client navigates
   away.
+
+### 2e. Loader cache safety
+
+For routes with a positive `loaderCache` value, flag loader data whose freshness
+or visibility depends on cookies, authorization headers, sessions, user identity,
+permissions, or request-specific context. Route-state HTTP caching is `private`,
+so shared proxies cannot reuse it, but a stale response can still survive logout,
+account switching, or permission changes in the same browser.
+
+Recommend `loaderCache: false`/`0` for personalized or authorization-sensitive
+loaders. Use a positive duration only when every field in the returned data can be
+safely reused for that long. Do not confuse `loaderCache` with ISG `revalidate` or
+the short-lived in-memory prefetch cache; they are independent policies.
 
 ## Step 3: Report
 


### PR DESCRIPTION
## Summary

- Add a validated, group-inheritable `loaderCache` route option for private browser caching of successful route-state loader data.
- Keep redirects, errors, opt-outs, and default behavior on `no-store`, while preserving explicit loader `Response` cache headers and the independent prefetch cache.
- Expose the policy through inspect/MCP tooling and update examples, documentation, audit guidance, tests, and package changesets.
- Closes #106.

## Testing

- [x] `pnpm e2e`
- [x] `pnpm format`
- [x] `pnpm lint`
- [x] `pnpm test`

## Checklist

- [x] Docs updated if needed
- [x] Skills updated if needed
- [x] Changeset added if published packages changed
