### PR TITLE
fix: normalize Cloudflare Workers cache variants

### DIFF
--- a/.changeset/normalize-cloudflare-cache-variants.md
+++ b/.changeset/normalize-cloudflare-cache-variants.md
@@ -1,0 +1,6 @@
+---
+"@pracht/core": patch
+"@pracht/adapter-cloudflare": patch
+---
+
+Limit `Vary: Accept` to routes that export a Markdown representation while applying it to both their HTML and Markdown responses. Cloudflare Workers Caching no longer fragments every ISG route by verbatim browser `Accept` strings, and its path, query-string, trailing-slash, and remaining Markdown variant behavior is now documented with bounded-query and gateway-normalization guidance.

--- a/docs/ADAPTERS.md
+++ b/docs/ADAPTERS.md
@@ -305,8 +305,9 @@ With the option on:
   browser-facing header is `Cache-Control: public, max-age=0,
   must-revalidate`, matching the Node adapter's ISG behavior.
 - Responses carry `Cache-Tag: pracht:isg,pracht:route:<id>` so they can be
-  purged, and `Vary: Accept` so Markdown-for-Agents negotiation caches HTML
-  and markdown variants separately.
+  purged. Routes that export `markdown` also carry `Vary: Accept` on both
+  their HTML and markdown responses so the representations stay separate;
+  routes without that export do not vary on `Accept`.
 - A route/shell `headers()` export that sets `Cache-Control` (or
   `cloudflare-cdn-cache-control`) takes full precedence — pracht adds
   nothing, so individual routes can opt out or tune their own policy.
@@ -320,6 +321,38 @@ With the option on:
   carry no `Cache-Control` header — and `Cookie` is not part of the cache
   key, so SSR pages (including authenticated ones) and API GET responses
   would be edge-cached across users.
+
+#### Cache-key cardinality
+
+Workers Caching keys inbound requests by the exact path and query string.
+Query parameter order and trailing slashes are significant, so `/pricing`,
+`/pricing?ref=a`, and `/pricing?ref=b` populate independent entries with
+independent revalidation cycles. This differs from Pracht's Node and
+worker-managed Cloudflare ISG caches, which key generated pages by pathname.
+It also means arbitrary public query values can create unbounded edge entries
+and force cold renders.
+
+Pracht cannot replace the cache key from inside the cached entrypoint: on a
+hit, Workers Caching answers before that Worker runs, and custom `cf.cacheKey`
+values are only honored for same-account calls from another entrypoint. Before
+enabling Workers Caching, keep ISG query shapes bounded and canonical:
+
+- Redirect or reject unsupported query parameters and enforce one trailing-
+  slash form in an uncached gateway before it calls the cached entrypoint.
+- If query parameters do not affect the page, have that gateway call a cached
+  entrypoint with a pathname-only `cf.cacheKey`. This adds a gateway invocation
+  but collapses tracking and attacker-chosen values onto one cache entry.
+- If a route genuinely renders different content for an unbounded query space,
+  opt it out with a route `Cache-Control: private, no-store` header or do not
+  enable Workers Caching for that deployment.
+
+Cloudflare compares request-header values named by `Vary` verbatim. Pracht
+therefore adds `Vary: Accept` only to routes that actually export `markdown`,
+but those routes can still accumulate variants for semantically equivalent
+browser and agent `Accept` strings. For high-traffic markdown-capable routes,
+normalize `Accept` to a small HTML/markdown set in the same uncached-gateway
+pattern. Purges by Pracht's cache tags or path prefixes invalidate all variants
+of the matching URL together.
 
 Because cache hits skip the Worker entirely, middleware does not run for
 cached ISG pages. That matches the previous behavior (static snapshots were

--- a/docs/DATA_LOADING.md
+++ b/docs/DATA_LOADING.md
@@ -34,7 +34,8 @@ A `markdown` string export opts the route into Markdown-for-Agents content
 negotiation: when a request arrives with `Accept: text/markdown`, the runtime
 still executes middleware, the route loader, and document header resolution
 first, then returns the raw markdown source with `Content-Type: text/markdown`
-instead of rendering the component.
+instead of rendering the component. Both the HTML and markdown responses carry
+`Vary: Accept`; routes without a `markdown` export do not vary on `Accept`.
 
 ### LoaderArgs
 

--- a/examples/docs/src/routes/docs/llms.md
+++ b/examples/docs/src/routes/docs/llms.md
@@ -22,7 +22,7 @@ curl https://pracht.resynapse.dev/docs/routing
 curl -H "Accept: text/markdown" https://pracht.resynapse.dev/docs/routing
 ```
 
-The response includes `Content-Type: text/markdown; charset=utf-8` and `Vary: Accept`, so caches keep the HTML and Markdown variants separate.
+The HTML and Markdown responses include `Vary: Accept`, so caches keep both representations separate. Routes without a `markdown` export do not vary on `Accept`.
 
 ---
 

--- a/packages/adapter-cloudflare/src/cache.ts
+++ b/packages/adapter-cloudflare/src/cache.ts
@@ -118,9 +118,10 @@ export function findCacheableIsgRoute(
  * - `Cache-Control: public, max-age=0, must-revalidate` — browsers keep
  *   revalidating, matching the Node adapter's ISG responses.
  * - `Cache-Tag` — `pracht:isg` plus the route tag, for `purgeCache()`.
- * - `Vary: Accept` — Markdown-for-Agents negotiation returns a different
- *   body for `Accept: text/markdown`, so cached variants must be keyed by
- *   the Accept header.
+ * Markdown-capable routes already carry `Vary: Accept` from the core runtime
+ * on both their HTML and markdown responses. Routes without a `markdown`
+ * export deliberately do not vary so verbatim Accept values cannot fragment
+ * their edge cache.
  *
  * A user-set `Cache-Control` or `cloudflare-cdn-cache-control` (via a
  * route/shell `headers()` export or middleware) takes full precedence:
@@ -148,7 +149,6 @@ export function applyWorkersCacheHeaders(
   );
   headers.set("cache-control", "public, max-age=0, must-revalidate");
   headers.set("cache-tag", `${ISG_CACHE_TAG},${routeCacheTag(route.id ?? route.path)}`);
-  appendVary(headers, "Accept");
 
   return new Response(response.body, {
     status: response.status,
@@ -191,17 +191,6 @@ export function preventHeuristicCaching(request: Request, response: Response): R
       headers,
     });
   }
-}
-
-function appendVary(headers: Headers, value: string): void {
-  const current = headers.get("vary");
-  if (!current) {
-    headers.set("vary", value);
-    return;
-  }
-  const values = current.split(",").map((part) => part.trim().toLowerCase());
-  if (values.includes("*") || values.includes(value.toLowerCase())) return;
-  headers.set("vary", `${current}, ${value}`);
 }
 
 export interface PurgeCacheOptions {

--- a/packages/adapter-cloudflare/test/cache.test.ts
+++ b/packages/adapter-cloudflare/test/cache.test.ts
@@ -109,7 +109,7 @@ describe("findCacheableIsgRoute", () => {
 });
 
 describe("applyWorkersCacheHeaders", () => {
-  it("stamps edge and browser cache headers, cache-tag, and Vary: Accept on ISG pages", () => {
+  it("stamps edge and browser cache headers and a cache tag on ISG pages", () => {
     const response = applyWorkersCacheHeaders(
       new Response("<html></html>", {
         headers: { "content-type": "text/html", vary: "x-pracht-route-state-request" },
@@ -126,7 +126,19 @@ describe("applyWorkersCacheHeaders", () => {
     );
     expect(response.headers.get("cache-control")).toBe("public, max-age=0, must-revalidate");
     expect(response.headers.get("cache-tag")).toBe(`${ISG_CACHE_TAG},pracht:route:pricing`);
-    expect(response.headers.get("vary")).toBe("x-pracht-route-state-request, Accept");
+    expect(response.headers.get("vary")).toBe("x-pracht-route-state-request");
+  });
+
+  it("preserves route-aware Accept variance from the core runtime", () => {
+    const response = applyWorkersCacheHeaders(
+      new Response("<html></html>", {
+        headers: { "content-type": "text/html", vary: "Accept" },
+      }),
+      isgRoute(),
+      cacheOptions,
+    );
+
+    expect(response.headers.get("vary")).toBe("Accept");
   });
 
   it("leaves a user-set cache-control alone", () => {

--- a/packages/framework/src/runtime.ts
+++ b/packages/framework/src/runtime.ts
@@ -9,7 +9,7 @@ import {
   shouldExposeServerErrors,
   type PrachtRuntimeDiagnosticPhase,
 } from "./runtime-errors.ts";
-import { withDefaultSecurityHeaders } from "./runtime-headers.ts";
+import { appendVaryHeader, withDefaultSecurityHeaders } from "./runtime-headers.ts";
 import { PrachtRuntimeProvider } from "./runtime-context.ts";
 import { buildHtmlDocument, htmlResponse } from "./runtime-html.ts";
 import {
@@ -426,14 +426,25 @@ export async function handlePrachtRequest<TContext>(
         mergeDocumentHeaders(shellModule, routeModule, routeArgs, data),
       ]);
 
+      // Both representations must carry the same Vary header so a cache
+      // filled by an HTML request can never satisfy a later markdown request
+      // (or vice versa). Keep the variance scoped to routes that actually
+      // export markdown: raw Accept values create distinct cache variants on
+      // CDNs such as Cloudflare Workers Caching.
+      const markdownRepresentation =
+        typeof routeModule.markdown === "string" ? routeModule.markdown : undefined;
+      if (markdownRepresentation !== undefined) {
+        appendVaryHeader(documentHeaders, "Accept");
+      }
+
       // Markdown-for-Agents negotiation must run after loader + header
       // resolution so auth redirects/401s and cache policies still apply.
       if (
         !isRouteStateRequest &&
-        typeof routeModule.markdown === "string" &&
+        markdownRepresentation !== undefined &&
         prefersMarkdown(options.request.headers.get("accept"))
       ) {
-        return markdownResponse(routeModule.markdown, documentHeaders);
+        return markdownResponse(markdownRepresentation, documentHeaders);
       }
 
       const cssUrls = resolvePageCssUrls(

--- a/packages/framework/test/runtime-negotiation.test.ts
+++ b/packages/framework/test/runtime-negotiation.test.ts
@@ -78,6 +78,7 @@ describe("handlePrachtRequest markdown negotiation", () => {
 
     expect(response.status).toBe(200);
     expect(response.headers.get("content-type")?.includes("text/html")).toBe(true);
+    expect(response.headers.get("vary")?.toLowerCase()).toContain("accept");
   });
 
   it("falls through to HTML when the route has no markdown export", async () => {
@@ -97,6 +98,7 @@ describe("handlePrachtRequest markdown negotiation", () => {
 
     expect(response.status).toBe(200);
     expect(response.headers.get("content-type")?.includes("text/html")).toBe(true);
+    expect(response.headers.get("vary")?.toLowerCase()).not.toContain("accept");
   });
 
   it("runs loader and preserves document headers before returning markdown", async () => {

--- a/skills/deploy/SKILL.md
+++ b/skills/deploy/SKILL.md
@@ -142,6 +142,12 @@ pracht({ adapter: cloudflareAdapter({ cache: true }) });
 { "cache": { "enabled": true } }
 ```
 
+Before enabling it, audit ISG URLs for unbounded query strings. Workers Caching
+keys the exact path and query string, including parameter order and trailing
+slashes; use a bounded query allowlist/canonical redirect or an uncached gateway
+with a pathname-only `cf.cacheKey`, and normalize `Accept` there for routes that
+export markdown. See `docs/ADAPTERS.md#cache-key-cardinality`.
+
 ISG pages then render on demand, are cached at the edge for their
 `revalidate` window, and can be purged early with `purgeCache()` from
 `@pracht/adapter-cloudflare/cache`. Without this, ISG routes are served as

--- a/skills/pre-deploy/SKILL.md
+++ b/skills/pre-deploy/SKILL.md
@@ -83,6 +83,10 @@ These catch app-graph wiring problems independent of the adapter. Resolve all
   sides — `cloudflareAdapter({ cache: true })` in vite config and
   `"cache": { "enabled": true }` in wrangler config. Without it, ISG pages
   are static snapshots that never revalidate.
+- When Workers Caching is enabled, flag ISG routes reachable through unbounded
+  query strings. Require a bounded allowlist/canonical redirect or an uncached
+  gateway with a normalized `cf.cacheKey`; also check that markdown-capable
+  routes normalize `Accept` at the gateway when variant fan-out matters.
 - Bundle size: report the size of `dist/server/server.js`. Workers limit is
   ~1 MB compressed for free tier, ~10 MB on paid. Warn at 80% of the active
   limit.


### PR DESCRIPTION
## Summary

- Scope `Vary: Accept` to routes that export Markdown while keeping their HTML and Markdown cache variants correct.
- Document Workers Caching query-string, trailing-slash, and verbatim `Accept` key cardinality with gateway normalization guidance. Closes #203.

## Testing

- [x] `pnpm e2e`
- [x] `pnpm format`
- [x] `pnpm lint`
- [x] `pnpm test`

## Checklist

- [x] Docs updated if needed
- [x] Skills updated if needed
- [x] Changeset added if published packages changed
