### PR TITLE
Fix Vercel ISG function name collisions

### DIFF
--- a/.changeset/vercel-isg-function-collision.md
+++ b/.changeset/vercel-isg-function-collision.md
@@ -1,0 +1,7 @@
+---
+"@pracht/cli": patch
+---
+
+Fail Vercel builds with a clear error when an ISG route's prerender function
+name collides with the main edge function directory, preventing the main
+function from being silently converted into a prerender function.

--- a/docs/ADAPTERS.md
+++ b/docs/ADAPTERS.md
@@ -516,6 +516,10 @@ export default {
   cache — such paths are reported as `failed` (detected via the
   `x-vercel-cache` response header) until you rebuild with
   `PRACHT_REVALIDATE_TOKEN` set.
+- **Function-name safety**: the build fails with a descriptive error when an ISG
+  route would use the same `.func` directory as the main edge function (for
+  example, `/render` with the default `functionName: "render"`). Rename the
+  route or set a non-conflicting `functionName` in `vercelAdapter()`.
 - **Dynamic fallback**: SSR and API routes are routed to the generated edge
   function. ISG document requests are handled by route-named prerender functions,
   while route-state requests still bypass static/prerender output and reach the

--- a/packages/cli/src/build-shared.ts
+++ b/packages/cli/src/build-shared.ts
@@ -29,7 +29,15 @@ export function writeVercelBuildOutput({
   const outputDir = join(root, ".vercel/output");
   const staticDir = join(outputDir, "static");
   const functionsDir = join(outputDir, "functions");
-  const functionDir = join(outputDir, "functions", `${functionName || "render"}.func`);
+  const resolvedFunctionName = functionName || "render";
+  const functionDir = join(functionsDir, `${resolvedFunctionName}.func`);
+
+  assertNoVercelPrerenderFunctionCollisions({
+    functionDir,
+    functionName: resolvedFunctionName,
+    functionsDir,
+    isgRoutes: Object.keys(isgManifest),
+  });
 
   rmSync(outputDir, { force: true, recursive: true });
   mkdirSync(outputDir, { recursive: true });
@@ -65,6 +73,28 @@ export function writeVercelBuildOutput({
   );
 
   return ".vercel/output";
+}
+
+function assertNoVercelPrerenderFunctionCollisions({
+  functionDir,
+  functionName,
+  functionsDir,
+  isgRoutes,
+}: {
+  functionDir: string;
+  functionName: string;
+  functionsDir: string;
+  isgRoutes: string[];
+}): void {
+  for (const route of isgRoutes) {
+    const prerenderName = routeToPrerenderFunctionName(route);
+    const routeFunctionDir = join(functionsDir, `${prerenderName}.func`);
+    if (routeFunctionDir !== functionDir) continue;
+
+    throw new Error(
+      `Cannot emit Vercel ISG route ${JSON.stringify(route)} because its prerender function ${JSON.stringify(`${prerenderName}.func`)} collides with the main edge function ${JSON.stringify(`${functionName}.func`)}. Rename the route or configure vercelAdapter({ functionName: "..." }) with a non-conflicting name.`,
+    );
+  }
 }
 
 function writeVercelPrerenderFunctions({

--- a/packages/cli/test/vercel-build-output.test.ts
+++ b/packages/cli/test/vercel-build-output.test.ts
@@ -1,0 +1,59 @@
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { timeRevalidate } from "@pracht/core";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { writeVercelBuildOutput } from "../src/build-shared.ts";
+
+describe("writeVercelBuildOutput", () => {
+  const roots: string[] = [];
+
+  afterEach(() => {
+    for (const root of roots.splice(0)) {
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+
+  function createBuildRoot(): string {
+    const root = mkdtempSync(join(tmpdir(), "pracht-vercel-build-output-"));
+    roots.push(root);
+    mkdirSync(join(root, "dist/client"), { recursive: true });
+    mkdirSync(join(root, "dist/server"), { recursive: true });
+    writeFileSync(join(root, "dist/server/server.js"), "export default {}\n", "utf-8");
+    return root;
+  }
+
+  it("rejects an ISG route that collides with the default edge function", () => {
+    const root = createBuildRoot();
+
+    expect(() =>
+      writeVercelBuildOutput({
+        isgManifest: {
+          "/render": { revalidate: timeRevalidate(60) },
+        },
+        root,
+        staticRoutes: [],
+      }),
+    ).toThrow(
+      'Cannot emit Vercel ISG route "/render" because its prerender function "render.func" collides with the main edge function "render.func".',
+    );
+    expect(existsSync(join(root, ".vercel/output"))).toBe(false);
+  });
+
+  it("rejects an ISG route that collides with a custom edge function name", () => {
+    const root = createBuildRoot();
+
+    expect(() =>
+      writeVercelBuildOutput({
+        functionName: "app",
+        isgManifest: {
+          "/app": { revalidate: timeRevalidate(60) },
+        },
+        root,
+        staticRoutes: [],
+      }),
+    ).toThrow(/ISG route "\/app".*"app\.func".*main edge function "app\.func"/);
+  });
+});


### PR DESCRIPTION
## Summary

- Fail Vercel builds before writing output when an ISG prerender function name collides with the main edge function directory.
- Add regression coverage for default and custom function names, document the constraint, and include a patch changeset for `@pracht/cli`.
- Closes #200.

## Testing

- [x] `pnpm e2e`
- [x] `pnpm format`
- [x] `pnpm lint`
- [x] `pnpm test`

## Checklist

- [x] Docs updated if needed
- [x] Skills updated if needed (N/A — no skill changes needed)
- [x] Changeset added if published packages changed
