### PR TITLE
Harden webhook revalidation batches

### DIFF
--- a/.changeset/harden-webhook-batches.md
+++ b/.changeset/harden-webhook-batches.md
@@ -1,0 +1,9 @@
+---
+"@pracht/core": patch
+"@pracht/adapter-node": patch
+"@pracht/adapter-cloudflare": patch
+"@pracht/adapter-vercel": patch
+---
+
+Limit webhook revalidation requests to 64 paths and keep malformed Node or
+Cloudflare manifest entries isolated to their individual batch result.

--- a/docs/ADAPTERS.md
+++ b/docs/ADAPTERS.md
@@ -595,13 +595,15 @@ curl -X POST https://example.com/__pracht/revalidate \
   -d '{"paths":["/pricing"]}'
 ```
 
-The body must include `paths` as an array of concrete URL paths. The endpoint
-returns JSON with `revalidated`, `skipped`, and `failed` path arrays. A path is
-skipped when it is not an ISG route, is not in the prerender manifest, or does
-not opt into `webhookRevalidate()`. A path lands in `failed` when regeneration
-did not produce cacheable 200 HTML (loader error, `Set-Cookie`, `Cache-Control:
-private`/`no-store`, cache write failure); the previously generated copy stays
-live, and the batch continues instead of aborting with a 500.
+The body must include `paths` as an array of at most 64 concrete URL paths;
+larger batches are rejected with `400`. The endpoint returns JSON with
+`revalidated`, `skipped`, and `failed` path arrays. A path is skipped when it is
+not an ISG route, is not in the prerender manifest, or does not opt into
+`webhookRevalidate()`. A path lands in `failed` when regeneration did not
+produce cacheable 200 HTML (loader error, malformed manifest metadata,
+`Set-Cookie`, `Cache-Control: private`/`no-store`, cache write failure); the
+previously generated copy stays live, and the batch continues instead of
+aborting with a 500.
 
 Set `PRACHT_REVALIDATE_TOKEN` in the deployment environment. Auth uses a
 constant-time comparison and fails closed with `401` when the token is missing
@@ -615,6 +617,12 @@ headers, locale, or other user-specific headers. Adapters synthesize a clean
 Concurrent regenerations of the same path are single-flighted: a stampede of
 stale requests (or repeated webhook posts) share one in-flight render per
 process/isolate instead of racing N parallel regenerations.
+
+Single-flight callers join the render that is already running. A webhook that
+arrives during a stale-request regeneration can therefore report the path as
+`revalidated` even when that render started before the content change that
+triggered the webhook. Send a later webhook when strict post-change freshness
+is required.
 
 Dynamic ISG paths that `getStaticPaths()` did not enumerate at build time are
 not in the prerender manifest. Regular requests for such paths still work —

--- a/docs/RENDERING_MODES.md
+++ b/docs/RENDERING_MODES.md
@@ -149,12 +149,16 @@ closed with `401` when the token is unset or incorrect. Pracht also accepts the
 same secret in the `x-pracht-revalidate-token` header for webhook providers
 that cannot send bearer auth.
 
-The response reports `revalidated`, `skipped`, and `failed` path arrays.
-Ineligible paths (not ISG, not prerendered, no `webhookRevalidate()`) are
-skipped; paths whose regeneration errored are reported in `failed` and keep
-serving the previously generated copy. Concurrent regenerations of the same
-path are single-flighted, so a burst of stale traffic or webhook posts
-triggers one render, not N.
+The request accepts at most 64 paths; larger batches receive `400`. The
+response reports `revalidated`, `skipped`, and `failed` path arrays. Ineligible
+paths (not ISG, not prerendered, no `webhookRevalidate()`) are skipped; paths
+whose regeneration errored are reported in `failed` and keep serving the
+previously generated copy. Concurrent regenerations of the same path are
+single-flighted, so a burst of stale traffic or webhook posts triggers one
+render, not N. A webhook arriving during a stale-request regeneration joins
+that existing render and can report `revalidated` even if the render started
+before the content change; send a later webhook when strict post-change
+freshness is required.
 
 Dynamic ISG paths that `getStaticPaths()` did not enumerate at build time are
 rendered on demand per request (uncached); webhook posts naming them are

--- a/packages/adapter-cloudflare/src/runtime.ts
+++ b/packages/adapter-cloudflare/src/runtime.ts
@@ -305,30 +305,35 @@ async function handleCloudflareRevalidationEndpoint(
   const failed: string[] = [];
 
   for (const pathname of parsed.paths) {
-    const entry = isgManifest[pathname];
-    if (!entry || !hasWebhookRevalidate(entry.revalidate)) {
-      skipped.push(pathname);
-      continue;
-    }
-
-    const cacheKey = createISGCacheKey(request, pathname);
-    // A failed regeneration keeps the existing cached copy and is reported
-    // in `failed` instead of aborting the whole batch with a 500.
-    if (await regenerateCloudflareISGPage(cache, cacheKey, pathname, request, renderISGPage)) {
-      revalidated.push(pathname);
-      // Routes with both a time and a webhook policy are served through
-      // Workers Caching when the `cache` option is on — the edge copy must
-      // be purged too, or it keeps serving the old page until its TTL. A
-      // purge failure keeps the path in `revalidated` (the worker-managed
-      // copy is fresh); the edge falls back to its time window.
-      if (edgeCacheEnabled && getTimeRevalidateSeconds(entry.revalidate) !== null) {
-        try {
-          await purgeCache({ pathPrefixes: [pathname] });
-        } catch (err) {
-          console.error(`ISG edge cache purge failed for ${pathname}:`, err);
-        }
+    try {
+      const entry = isgManifest[pathname];
+      if (!entry || !hasWebhookRevalidate(entry.revalidate)) {
+        skipped.push(pathname);
+        continue;
       }
-    } else {
+
+      const cacheKey = createISGCacheKey(request, pathname);
+      // A failed regeneration keeps the existing cached copy and is reported
+      // in `failed` instead of aborting the whole batch with a 500.
+      if (await regenerateCloudflareISGPage(cache, cacheKey, pathname, request, renderISGPage)) {
+        revalidated.push(pathname);
+        // Routes with both a time and a webhook policy are served through
+        // Workers Caching when the `cache` option is on — the edge copy must
+        // be purged too, or it keeps serving the old page until its TTL. A
+        // purge failure keeps the path in `revalidated` (the worker-managed
+        // copy is fresh); the edge falls back to its time window.
+        if (edgeCacheEnabled && getTimeRevalidateSeconds(entry.revalidate) !== null) {
+          try {
+            await purgeCache({ pathPrefixes: [pathname] });
+          } catch (err) {
+            console.error(`ISG edge cache purge failed for ${pathname}:`, err);
+          }
+        }
+      } else {
+        failed.push(pathname);
+      }
+    } catch (err) {
+      console.error(`ISG webhook revalidation failed for ${pathname}:`, err);
       failed.push(pathname);
     }
   }

--- a/packages/adapter-cloudflare/test/runtime.test.ts
+++ b/packages/adapter-cloudflare/test/runtime.test.ts
@@ -353,6 +353,40 @@ describe("createCloudflareFetchHandler webhook revalidation", () => {
     await expect(store.get(keyUrl)!.clone().text()).resolves.toContain("fresh-content");
   });
 
+  it("isolates malformed manifest metadata to one webhook path", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    const { cache, store } = createMockCaches();
+    vi.stubGlobal("caches", { default: cache });
+    const { executionContext } = createExecutionContext();
+    const host = "hook-malformed.example";
+    const keyUrl = cacheKeyUrl("/pricing", host);
+    putCachedISGPage(store, keyUrl, "<html>old</html>", Date.now() - 10_000);
+
+    const { app, registry } = createPricingApp();
+    const handler = createCloudflareFetchHandler({
+      app,
+      registry,
+      isgManifest: {
+        "/malformed": { revalidate: { kind: "cms" } as never },
+        "/pricing": { revalidate: isgRevalidate },
+      },
+    });
+
+    const response = await handler(
+      createWebhookRequest(host, ["/malformed", "/pricing"], "secret"),
+      { ASSETS: create404Assets(), PRACHT_REVALIDATE_TOKEN: "secret" },
+      executionContext,
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      failed: ["/malformed"],
+      revalidated: ["/pricing"],
+      skipped: [],
+    });
+    await expect(store.get(keyUrl)!.clone().text()).resolves.toContain("fresh-content");
+  });
+
   it("reports failed regenerations and keeps the cached copy", async () => {
     vi.spyOn(console, "error").mockImplementation(() => {});
     const { cache, store } = createMockCaches();

--- a/packages/adapter-node/src/node-handler.ts
+++ b/packages/adapter-node/src/node-handler.ts
@@ -317,16 +317,16 @@ async function handleRevalidationEndpoint<TContext>(
   const failed: string[] = [];
 
   for (const pathname of parsed.paths) {
-    const entry = isgManifest[pathname];
-    const htmlPath = resolveContainedPath(staticDir, pathname);
-    if (!entry || !hasWebhookRevalidate(entry.revalidate) || !htmlPath) {
-      skipped.push(pathname);
-      continue;
-    }
-
-    // A failed regeneration keeps the existing on-disk HTML and is reported
-    // in `failed` instead of aborting the whole batch with a 500.
     try {
+      const entry = isgManifest[pathname];
+      const htmlPath = resolveContainedPath(staticDir, pathname);
+      if (!entry || !htmlPath || !hasWebhookRevalidate(entry.revalidate)) {
+        skipped.push(pathname);
+        continue;
+      }
+
+      // A failed regeneration keeps the existing on-disk HTML and is reported
+      // in `failed` instead of aborting the whole batch with a 500.
       if (await regenerateISGPage(options, pathname, htmlPath, contextArgs)) {
         revalidated.push(pathname);
       } else {

--- a/packages/adapter-node/test/index.test.ts
+++ b/packages/adapter-node/test/index.test.ts
@@ -431,4 +431,74 @@ describe("createNodeRequestHandler", () => {
       }
     }
   });
+
+  it("isolates malformed manifest metadata to one webhook path", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    const staticDir = makeTempDir();
+    const htmlDir = join(staticDir, "pricing");
+    const htmlPath = join(htmlDir, "index.html");
+    mkdirSync(htmlDir, { recursive: true });
+    writeFileSync(htmlPath, "<html><body>old</body></html>", "utf-8");
+
+    const previousToken = process.env.PRACHT_REVALIDATE_TOKEN;
+    process.env.PRACHT_REVALIDATE_TOKEN = "secret";
+
+    const app = defineApp({
+      routes: [
+        route("/pricing", "./routes/pricing.tsx", {
+          render: "isg",
+          revalidate: webhookRevalidate(),
+        }),
+      ],
+    });
+    const handler = createNodeRequestHandler({
+      app,
+      isgManifest: {
+        "/malformed": { revalidate: { kind: "cms" } as never },
+        "/pricing": { revalidate: webhookRevalidate() },
+      },
+      registry: {
+        routeModules: {
+          "./routes/pricing.tsx": async () => ({
+            Component: () => "<main>fresh</main>",
+          }),
+        },
+      },
+      staticDir,
+    });
+
+    const server = createServer((req: IncomingMessage, res: ServerResponse) => {
+      void handler(req, res);
+    });
+    servers.add(server);
+
+    try {
+      server.listen(0, "127.0.0.1");
+      await once(server, "listening");
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        throw new Error("Expected TCP server address");
+      }
+
+      const response = await fetch(`http://127.0.0.1:${address.port}/__pracht/revalidate`, {
+        body: JSON.stringify({ paths: ["/malformed", "/pricing"] }),
+        headers: { authorization: "Bearer secret", "content-type": "application/json" },
+        method: "POST",
+      });
+
+      expect(response.status).toBe(200);
+      await expect(response.json()).resolves.toEqual({
+        failed: ["/malformed"],
+        revalidated: ["/pricing"],
+        skipped: [],
+      });
+      expect(readFileSync(htmlPath, "utf-8")).toContain("fresh");
+    } finally {
+      if (previousToken === undefined) {
+        delete process.env.PRACHT_REVALIDATE_TOKEN;
+      } else {
+        process.env.PRACHT_REVALIDATE_TOKEN = previousToken;
+      }
+    }
+  });
 });

--- a/packages/framework/src/revalidation.ts
+++ b/packages/framework/src/revalidation.ts
@@ -4,6 +4,8 @@ export const PRACHT_REVALIDATE_ENDPOINT = "/__pracht/revalidate";
 export const PRACHT_REVALIDATE_TOKEN_ENV = "PRACHT_REVALIDATE_TOKEN";
 export const PRACHT_REVALIDATE_TOKEN_HEADER = "x-pracht-revalidate-token";
 
+const MAX_REVALIDATION_PATHS = 64;
+
 export interface ParsedRevalidationRequest {
   paths: string[];
 }
@@ -147,6 +149,16 @@ export async function readRevalidationRequest(
     };
   }
 
+  if (hasTooManyRevalidationPaths(body)) {
+    return {
+      ok: false,
+      response: jsonResponse(
+        { error: `Expected at most ${MAX_REVALIDATION_PATHS} revalidation paths.` },
+        400,
+      ),
+    };
+  }
+
   const paths = parseRevalidationPaths(body);
   if (!paths) {
     return {
@@ -205,8 +217,7 @@ function getRevalidationToken(request: Request): string | null {
 
 function parseRevalidationPaths(body: unknown): string[] | null {
   if (!body || typeof body !== "object") return null;
-  const value =
-    (body as { paths?: unknown; path?: unknown }).paths ?? (body as { path?: unknown }).path;
+  const value = getRevalidationPathsValue(body);
   const paths = Array.isArray(value) ? value : typeof value === "string" ? [value] : null;
   if (!paths || paths.length === 0) return null;
 
@@ -216,6 +227,16 @@ function parseRevalidationPaths(body: unknown): string[] | null {
     unique.add(path);
   }
   return [...unique];
+}
+
+function hasTooManyRevalidationPaths(body: unknown): boolean {
+  if (!body || typeof body !== "object") return false;
+  const value = getRevalidationPathsValue(body);
+  return Array.isArray(value) && value.length > MAX_REVALIDATION_PATHS;
+}
+
+function getRevalidationPathsValue(body: object): unknown {
+  return (body as { paths?: unknown; path?: unknown }).paths ?? (body as { path?: unknown }).path;
 }
 
 function isValidRevalidationPath(value: unknown): value is string {

--- a/packages/framework/test/revalidation.test.ts
+++ b/packages/framework/test/revalidation.test.ts
@@ -83,6 +83,34 @@ describe("revalidation endpoint auth", () => {
     expect(authorized).toEqual({ ok: true, paths: ["/pricing"] });
   });
 
+  it("rejects batches over 64 paths before deduplicating them", async () => {
+    const atLimit = await readRevalidationRequest(
+      new Request("https://app.example/__pracht/revalidate", {
+        body: JSON.stringify({ paths: Array.from({ length: 64 }, () => "/pricing") }),
+        headers: { authorization: "Bearer secret" },
+        method: "POST",
+      }),
+      "secret",
+    );
+    expect(atLimit).toEqual({ ok: true, paths: ["/pricing"] });
+
+    const overLimit = await readRevalidationRequest(
+      new Request("https://app.example/__pracht/revalidate", {
+        body: JSON.stringify({ paths: Array.from({ length: 65 }, () => "/pricing") }),
+        headers: { authorization: "Bearer secret" },
+        method: "POST",
+      }),
+      "secret",
+    );
+    expect(overLimit.ok).toBe(false);
+    if (!overLimit.ok) {
+      expect(overLimit.response.status).toBe(400);
+      await expect(overLimit.response.json()).resolves.toEqual({
+        error: "Expected at most 64 revalidation paths.",
+      });
+    }
+  });
+
   it("rejects traversal segments and backslashes in paths", async () => {
     const invalidPaths = [
       "/../secret",


### PR DESCRIPTION
## Summary

- The shared webhook parser accepted unbounded path arrays, while Node and Cloudflare normalized potentially malformed manifest policies before per-path error isolation; cap batches at 64 and report malformed entries as individual failures so later paths still regenerate.
- Document the single-flight join race and add regression coverage for the batch boundary and both adapter runtimes.
- Closes #202.

## Testing

- [x] `pnpm run e2e`
- [x] `pnpm run format`
- [x] `pnpm run lint`
- [x] `pnpm run test`
- [x] `pnpm run typecheck`

## Checklist

- [x] Docs updated if needed
- [x] Skills updated if needed (N/A; no skill workflow changed)
- [x] Changeset added if published packages changed
