### PR TITLE
Restore env-safety: stop treating VITE_ as a public env prefix

### DIFF
--- a/.changeset/env-safety-vite-prefix.md
+++ b/.changeset/env-safety-vite-prefix.md
@@ -1,0 +1,6 @@
+---
+"@pracht/cli": patch
+"@pracht/vite-plugin": patch
+---
+
+Treat `VITE_` environment variables as non-public in env leak detection unless explicitly allowlisted, preserving Pracht's `PRACHT_PUBLIC_` public-env boundary.

--- a/docs/ENV.md
+++ b/docs/ENV.md
@@ -9,10 +9,10 @@ code.
 
 ## The model
 
-| Surface     | Import                      | Contents                              | Where it works        |
-| ----------- | --------------------------- | ------------------------------------- | --------------------- |
-| `serverEnv` | `@pracht/core/env/server`   | The full platform env                 | Server code only      |
-| `publicEnv` | `@pracht/core` (any entry)  | Only `PRACHT_PUBLIC_`-prefixed vars   | Everywhere            |
+| Surface     | Import                     | Contents                            | Where it works   |
+| ----------- | -------------------------- | ----------------------------------- | ---------------- |
+| `serverEnv` | `@pracht/core/env/server`  | The full platform env               | Server code only |
+| `publicEnv` | `@pracht/core` (any entry) | Only `PRACHT_PUBLIC_`-prefixed vars | Everywhere       |
 
 ```ts
 // Server code (loaders, middleware, API routes, src/server/**):
@@ -31,7 +31,11 @@ The pracht Vite plugin adds `PRACHT_PUBLIC_` to Vite's
 [`envPrefix`](https://vite.dev/config/shared-options#envprefix) (alongside the
 default `VITE_`), so prefixed variables are also available directly as
 `import.meta.env.PRACHT_PUBLIC_*` in dev and statically inlined at build time.
-Because values are inlined, never put a secret behind the prefix.
+Because values are inlined, never put a secret behind `PRACHT_PUBLIC_`.
+Although Vite still exposes `VITE_` variables through `import.meta.env` for
+compatibility, Pracht does not treat `VITE_` as an intentionally public prefix:
+client references such as `import.meta.env.VITE_SECRET` fail env leak detection
+unless explicitly allowlisted.
 
 `publicEnv` reads `import.meta.env` when Vite provides it and falls back to
 `process.env` outside Vite (plain Node entries, tests). It is a snapshot of
@@ -85,9 +89,9 @@ Custom setups can call `setServerEnv(env)` (exported from
 
 During `pracht build` the plugin scans every client chunk for references to
 `process.env.X` / `import.meta.env.X` (including `["X"]` bracket access) where
-`X` is not `PRACHT_PUBLIC_`- or `VITE_`-prefixed and not a Vite built-in
-(`MODE`, `DEV`, `PROD`, `SSR`, `BASE_URL`, plus `NODE_ENV`, which Vite
-statically replaces).
+`X` is not `PRACHT_PUBLIC_`-prefixed and not a Vite built-in (`MODE`,
+`DEV`, `PROD`, `SSR`, `BASE_URL`, plus `NODE_ENV`, which Vite statically
+replaces).
 References are matched both in the rendered chunks and in the transformed
 sources of first-party modules that end up in a chunk — bundlers rewrite
 `process.env` in client output, so the source-level signal is what catches
@@ -116,7 +120,7 @@ pracht({
 
 ### Limits
 
-The check detects *references*, not values: a secret returned from a loader
+The check detects _references_, not values: a secret returned from a loader
 still reaches the client through hydration state, and a value inlined via a
 custom `define` is invisible to the scan. Use the `audit-secrets` skill for
 dataflow-level review of loader return values.

--- a/packages/cli/src/verification-env.ts
+++ b/packages/cli/src/verification-env.ts
@@ -8,8 +8,6 @@ import { createCheck, type Check } from "./verification-helpers.js";
 // depend on @pracht/vite-plugin, so the (small) scan logic is mirrored here.
 const VITE_BUILTIN_ENV_VARS = new Set(["MODE", "DEV", "PROD", "SSR", "BASE_URL", "NODE_ENV"]);
 const PUBLIC_ENV_PREFIX = "PRACHT_PUBLIC_";
-const VITE_PUBLIC_ENV_PREFIX = "VITE_";
-const PUBLIC_ENV_PREFIXES = [PUBLIC_ENV_PREFIX, VITE_PUBLIC_ENV_PREFIX] as const;
 const ENV_REFERENCE_RE =
   /\b(process\.env|import\.meta\.env)(?:\.([A-Za-z_$][A-Za-z0-9_$]*)|\[\s*(["'])([A-Za-z_$][A-Za-z0-9_$]*)\3\s*\])/g;
 
@@ -20,7 +18,12 @@ export interface EnvLeakFinding {
 }
 
 interface BuildEnvSafetyReport {
-  findings?: Array<{ accessor?: unknown; chunk?: unknown; name?: unknown; sources?: unknown }>;
+  findings?: Array<{
+    accessor?: unknown;
+    chunk?: unknown;
+    name?: unknown;
+    sources?: unknown;
+  }>;
 }
 
 export function scanSourceForEnvLeaks(
@@ -36,7 +39,7 @@ export function scanSourceForEnvLeaks(
     const accessor = match[1];
     const name = match[2] ?? match[4];
     if (!name) continue;
-    if (PUBLIC_ENV_PREFIXES.some((prefix) => name.startsWith(prefix))) continue;
+    if (name.startsWith(PUBLIC_ENV_PREFIX)) continue;
     if (VITE_BUILTIN_ENV_VARS.has(name)) continue;
     if (allow.has(name)) continue;
 
@@ -340,7 +343,7 @@ export function collectEnvLeakVerification(
           .map(
             (finding) => `${finding.accessor}.${finding.name} in ${JSON.stringify(finding.file)}`,
           )
-          .join("; ")}. Only PRACHT_PUBLIC_- or VITE_-prefixed variables are safe client-side.`,
+          .join("; ")}. Only PRACHT_PUBLIC_-prefixed variables are safe client-side.`,
       ),
     );
   } else if (!buildReportFindings) {

--- a/packages/cli/test/verification-env.test.ts
+++ b/packages/cli/test/verification-env.test.ts
@@ -26,11 +26,23 @@ function makeProject(rawConfig = ""): ProjectConfig {
 }
 
 describe("scanSourceForEnvLeaks", () => {
-  it("flags non-public references and skips public/built-in/allowed ones", () => {
-    const code = `a(process.env.API_SECRET, import.meta.env.PRACHT_PUBLIC_URL, import.meta.env.VITE_URL, import.meta.env.MODE, process.env.ALLOWED_ONE);`;
+  it("flags non-public references and skips PRACHT_PUBLIC/built-in/allowed ones", () => {
+    const code = `a(process.env.API_SECRET, import.meta.env.PRACHT_PUBLIC_URL, import.meta.env.MODE, process.env.ALLOWED_ONE);`;
 
     expect(scanSourceForEnvLeaks(code, new Set(["ALLOWED_ONE"]))).toEqual([
       { accessor: "process.env", name: "API_SECRET" },
+    ]);
+  });
+
+  it("flags VITE-prefixed references unless allowlisted", () => {
+    expect(
+      scanSourceForEnvLeaks(
+        `a(import.meta.env.VITE_SECRET, process.env.VITE_TOKEN, import.meta.env.VITE_ALLOWED);`,
+        new Set(["VITE_ALLOWED"]),
+      ),
+    ).toEqual([
+      { accessor: "import.meta.env", name: "VITE_SECRET" },
+      { accessor: "process.env", name: "VITE_TOKEN" },
     ]);
   });
 
@@ -119,7 +131,7 @@ describe("collectEnvLeakVerification", () => {
     writeFileSync(join(reportDir, "env-safety.json"), JSON.stringify({ findings: [], version: 1 }));
     writeFileSync(
       join(assetsDir, "index-abc.js"),
-      "use(import.meta.env.PRACHT_PUBLIC_NAME, import.meta.env.VITE_NAME, process.env.SENTRY_RELEASE);",
+      "use(import.meta.env.PRACHT_PUBLIC_NAME, process.env.SENTRY_RELEASE);",
     );
 
     const checks: Check[] = [];

--- a/packages/vite-plugin/src/env-safety.ts
+++ b/packages/vite-plugin/src/env-safety.ts
@@ -16,8 +16,6 @@ export const VITE_BUILTIN_ENV_VARS = new Set([
 
 /** Prefix that marks an env var as intentionally public. */
 export const PUBLIC_ENV_PREFIX = "PRACHT_PUBLIC_";
-export const VITE_PUBLIC_ENV_PREFIX = "VITE_";
-const PUBLIC_ENV_PREFIXES = [PUBLIC_ENV_PREFIX, VITE_PUBLIC_ENV_PREFIX] as const;
 
 /** Server-only core entry that must never resolve into client bundles. */
 export const SERVER_ENV_MODULE_ID = "@pracht/core/env/server";
@@ -59,7 +57,7 @@ export function scanCodeForEnvLeaks(
     const accessor = match[1] as EnvLeakReference["accessor"];
     const name = match[2] ?? match[4];
     if (!name) continue;
-    if (PUBLIC_ENV_PREFIXES.some((prefix) => name.startsWith(prefix))) continue;
+    if (name.startsWith(PUBLIC_ENV_PREFIX)) continue;
     if (VITE_BUILTIN_ENV_VARS.has(name)) continue;
     if (allow.has(name)) continue;
 
@@ -284,7 +282,7 @@ export function formatEnvLeakError(problems: EnvLeakProblem[]): string {
     "[pracht] Environment variable leak detected in the client bundle:",
     ...lines,
     "",
-    `Only PRACHT_PUBLIC_- or VITE_-prefixed variables may be referenced in client code (prefer publicEnv from "@pracht/core" for typed PRACHT_PUBLIC_ values).`,
+    `Only PRACHT_PUBLIC_-prefixed variables may be referenced in client code (prefer publicEnv from "@pracht/core" for typed public values).`,
     `Move server-only reads into loaders/API routes and access them via serverEnv from "@pracht/core/env/server",`,
     "or allowlist intentionally-safe names with pracht({ envSafety: { allow: [...] } }).",
   ].join("\n");

--- a/packages/vite-plugin/test/env-safety.test.ts
+++ b/packages/vite-plugin/test/env-safety.test.ts
@@ -73,11 +73,10 @@ describe("scanCodeForEnvLeaks", () => {
     ]);
   });
 
-  it("ignores public-prefixed vars, Vite built-ins, and NODE_ENV", () => {
+  it("ignores PRACHT_PUBLIC-prefixed vars, Vite built-ins, and NODE_ENV", () => {
     const findings = scanCodeForEnvLeaks(
       `const a = import.meta.env.PRACHT_PUBLIC_APP_NAME;
        const b = process.env.PRACHT_PUBLIC_API_BASE;
-       const c = import.meta.env.VITE_LEGACY_PUBLIC_VALUE;
        const d = import.meta.env.MODE;
        const e = import.meta.env.DEV;
        const f = import.meta.env.PROD;
@@ -87,6 +86,21 @@ describe("scanCodeForEnvLeaks", () => {
     );
 
     expect(findings).toEqual([]);
+  });
+
+  it("flags VITE-prefixed variables as non-public unless allowlisted", () => {
+    const findings = scanCodeForEnvLeaks(
+      `const legacy = import.meta.env.VITE_SECRET;
+       const token = process.env.VITE_TOKEN;`,
+    );
+
+    expect(findings).toEqual([
+      { accessor: "import.meta.env", name: "VITE_SECRET" },
+      { accessor: "process.env", name: "VITE_TOKEN" },
+    ]);
+    expect(scanCodeForEnvLeaks("import.meta.env.VITE_ALLOWED", new Set(["VITE_ALLOWED"]))).toEqual(
+      [],
+    );
   });
 
   it("respects the allowlist and dedupes repeated references", () => {
@@ -206,11 +220,11 @@ describe("createEnvSafetyPlugin", () => {
   it("passes clean client bundles and skips server bundles", () => {
     const plugin = createEnvSafetyPlugin({});
     const cleanBundle = {
-      "assets/index.js": chunk(
-        "assets/index.js",
-        "console.log(import.meta.env.PRACHT_PUBLIC_X, import.meta.env.VITE_PUBLIC_X);",
-      ),
-      "assets/style.css": { type: "asset" as const, fileName: "assets/style.css" },
+      "assets/index.js": chunk("assets/index.js", "console.log(import.meta.env.PRACHT_PUBLIC_X);"),
+      "assets/style.css": {
+        type: "asset" as const,
+        fileName: "assets/style.css",
+      },
     };
     const emitted = runGenerateBundle(plugin, cleanBundle);
     expect(emitted).toContainEqual({
@@ -275,7 +289,9 @@ describe("pracht plugin env wiring", () => {
     ).toThrowError(/server-only/);
 
     expect(
-      resolveId.call({}, "@pracht/core/env/server", "/src/server/db.ts", { ssr: true }),
+      resolveId.call({}, "@pracht/core/env/server", "/src/server/db.ts", {
+        ssr: true,
+      }),
     ).toBeNull();
     expect(
       resolveId.call({}, "@pracht/core/env/server", "/src/routes/page.tsx", {

--- a/skills/audit-secrets/SKILL.md
+++ b/skills/audit-secrets/SKILL.md
@@ -26,7 +26,7 @@ it cannot save you from a value that flows into the return.
 Pracht has built-in env leak detection (see `docs/ENV.md`):
 
 - `pracht build` fails when a client chunk references a non-public env var
-  (anything not `PRACHT_PUBLIC_`-/`VITE_`-prefixed and not a Vite built-in),
+  (anything not `PRACHT_PUBLIC_`-prefixed and not a Vite built-in),
   naming the variable, chunk, and likely source module.
 - `pracht verify` checks the build-time env-safety report and re-runs the
   literal chunk scan against an existing `dist/client` output.
@@ -35,7 +35,7 @@ Pracht has built-in env leak detection (see `docs/ENV.md`):
 Run `pracht verify` (or a build) first and fold its findings into the report.
 Check `vite.config.*` for `envSafety: { allow: [...] }` / `envSafety: false` —
 every allowlisted name and a disabled check are findings to review, since they
-bypass the native gate. The native check detects *references*, not values, so
+bypass the native gate. The native check detects _references_, not values, so
 the dataflow steps below are still required.
 
 ## Step 1: Identify "secret-shaped" identifiers
@@ -69,6 +69,7 @@ risk in the report.
 
 Grep client-rendered files (route components, shells, anything imported from
 them) for imports of:
+
 - `node:*` builtins
 - `@pracht/adapter-*`
 - Local `src/server/**` modules
@@ -98,9 +99,11 @@ Check for accidental exposure outside loaders:
 - Grep tracked files for likely committed secrets (long random strings near
   identifier names from step 1).
 - Confirm client-side env access goes through `publicEnv` (from
-  `@pracht/core`) or `import.meta.env.PRACHT_PUBLIC_*` / `import.meta.env.VITE_*`
-  — both prefixes are intentionally public and inlined into the client bundle;
-  warn loudly if a `PRACHT_PUBLIC_` or `VITE_` variable has a secret-shaped name.
+  `@pracht/core`) or `import.meta.env.PRACHT_PUBLIC_*`; `VITE_*` values are
+  still exposed by Vite compatibility wiring, but Pracht does not treat them as
+  intentionally public, so flag client-side `VITE_*` references unless they are
+  explicitly allowlisted and reviewed. Warn loudly if a public env name has a
+  secret-shaped name.
 - Confirm server-side env access uses `serverEnv` (from
   `@pracht/core/env/server`) or `context.env` rather than ad-hoc globals.
 
@@ -110,9 +113,10 @@ Check for accidental exposure outside loaders:
 | --------- | ------------------- | ------------------------------------------- | -------- |
 
 Severities:
+
 - `error` — direct flow from `process.env.SECRET_*` / `serverEnv.SECRET_*` to
   loader return.
-- `error` — `PRACHT_PUBLIC_*_SECRET` / `VITE_*_SECRET` style client-public
+- `error` — `PRACHT_PUBLIC_*_SECRET` style client-public or allowlisted `VITE_*_SECRET`
   secret-shaped name.
 - `error` — `envSafety: false` or an allowlisted name that looks secret-shaped.
 - `warn` — spread of a row that may contain secret columns.


### PR DESCRIPTION
### Motivation

- Fix a regression where the env-safety scanners classified `VITE_` as an intentionally public prefix, allowing `VITE_*` secrets referenced in client code to bypass build- and CLI-time leak detection.
- Re-establish Pracht's intended public-env boundary of `PRACHT_PUBLIC_` so only explicitly public variables are skipped by the detectors.

### Description

- Remove the `VITE_` public-prefix exemption from the build-time scanner in `packages/vite-plugin/src/env-safety.ts` so the scanner only skips `PRACHT_PUBLIC_`-prefixed names before checking built-ins and the allowlist. 
- Mirror the same stricter behavior in the CLI verifier by updating `packages/cli/src/verification-env.ts` to only treat `PRACHT_PUBLIC_` as public.
- Update tests to cover `VITE_`-prefixed references and allowlist behavior in `packages/vite-plugin/test/env-safety.test.ts` and `packages/cli/test/verification-env.test.ts`.
- Clarify the documentation in `docs/ENV.md` and the audit guidance in `skills/audit-secrets/SKILL.md` to state that Pracht treats only `PRACHT_PUBLIC_` as the public env prefix and that `VITE_*` references are flagged unless allowlisted and reviewed.
- Add a patch changeset `.changeset/env-safety-vite-prefix.md` for `@pracht/cli` and `@pracht/vite-plugin` to record the change.

### Testing

- Ran formatting with `pnpm run format` and linting with `pnpm run lint`, both completed successfully.
- Built packages with `pnpm run build`, which completed successfully and produced the expected package artifacts.
- Ran the targeted env-safety unit tests with `pnpm exec vitest run packages/vite-plugin/test/env-safety.test.ts packages/cli/test/verification-env.test.ts`, and both test files passed (all env-safety assertions succeeded).
- The full automated `pnpm run e2e && pnpm run test` workflow was attempted but the top-level `pnpm run e2e` step failed initially due to missing prebuilt CLI artifacts in the test runner environment (this is unrelated to the env-safety logic); the repository build and the env-safety-specific tests were otherwise verified to pass.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a51e51b80e0832f958c7e922f96fdd8)