### PR TITLE
Strip did-you-mean suggestions from production client bundles

### DIFF
--- a/.changeset/strip-name-suggestions-prod.md
+++ b/.changeset/strip-name-suggestions-prod.md
@@ -1,0 +1,5 @@
+---
+"@pracht/core": patch
+---
+
+Strip the "did you mean" edit-distance implementation from production client bundles. Manifest wiring errors still list the registered names in production, but the Levenshtein-based suggestion is now computed only in dev, tests, and CLI builds where `import.meta.env.DEV` is not statically `false` — saving ~560 B raw (~260 B gzip) from every production client bundle.

--- a/packages/framework/src/name-suggestions.ts
+++ b/packages/framework/src/name-suggestions.ts
@@ -72,7 +72,12 @@ export function formatUnknownNameError(options: UnknownNameErrorOptions): string
 
   let message = `Unknown ${kind} "${name}"${context ? ` for ${context}` : ""}.`;
 
-  const suggestion = closestName(name, registered);
+  // Suggestions are a dev/build-time aid: `import.meta.env.DEV` is statically
+  // `false` in production Vite bundles, so the ternary constant-folds and the
+  // edit-distance implementation is dead-code-eliminated from client builds.
+  // In Node (CLI builds, tests) `import.meta.env` is undefined and the
+  // comparison keeps suggestions enabled.
+  const suggestion = import.meta.env?.DEV === false ? undefined : closestName(name, registered);
   if (suggestion) {
     message += ` Did you mean "${suggestion}"?`;
   }


### PR DESCRIPTION
## Summary

- The Levenshtein edit-distance implementation in `name-suggestions.ts` (~776 B raw) shipped in every production client bundle, reachable through unguarded error paths in `resolveApp`/`buildHref`. Identified in the 2026-07 client bundle size audit (finding 2).
- The suggestion is now computed only when `import.meta.env.DEV` is not statically `false`, so production Vite builds constant-fold the ternary and dead-code-eliminate `closestName`/`levenshteinDistance`. Production errors still list all registered names; dev, vitest, and Node CLI builds keep the full "Did you mean" messages.
- Measured on `examples/basic`: shared runtime chunk 8.97 → 8.41 kB raw (3.61 → 3.35 kB gzip).

## Testing

- [x] `pnpm e2e` (80 passed)
- [x] `pnpm format`
- [x] `pnpm lint` (via `pnpm exec oxlint`, 0 errors)
- [x] `pnpm test` (605 passed)

## Checklist

- [x] Docs updated if needed (N/A — internal error-message behavior, dev output unchanged)
- [x] Skills updated if needed (N/A)
- [x] Changeset added if published packages changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)