### PR TITLE
Tree-shake manifest validation out of production client bundles

### DIFF
--- a/.changeset/client-treeshake-manifest-validation.md
+++ b/.changeset/client-treeshake-manifest-validation.md
@@ -1,0 +1,5 @@
+---
+"@pracht/core": patch
+---
+
+Stop shipping manifest validation to production client bundles. Route matching, path, and href primitives now live in a dependency-free module the client router imports directly, and `resolveApp`'s validation (unknown shell/middleware names, loaderCache checks, SPA+hydration conflicts, and their "did you mean" error formatting) runs only where `import.meta.env.DEV` is not statically `false` — dev servers, tests, and `pracht build` in Node, where invalid manifests still fail loudly. Production clients only flatten the already-validated manifest, cutting ~2 kB raw (~0.8 kB gzip) from the framework's client payload. Public API is unchanged: `buildHref`, `buildPathFromSegments`, and `matchAppRoute` keep their existing exports and signatures.

--- a/packages/framework/src/app.ts
+++ b/packages/framework/src/app.ts
@@ -1,23 +1,17 @@
 import type {
   ApiRouteMatch,
-  BuildHrefOptions,
   GroupDefinition,
   GroupMeta,
-  HrefArgs,
-  HrefRouteDefinition,
   ModuleRef,
   ResolvedApiRoute,
   ResolvedRoute,
   ResolvedPrachtApp,
   RouteConfig,
   RouteDefinition,
-  RouteId,
   RouteMatch,
   RouteMeta,
-  RouteParams,
   RouteSegment,
   RouteTreeNode,
-  SearchParamsInput,
   SpeculationOption,
   TimeRevalidatePolicy,
   WebhookRevalidatePolicy,
@@ -25,6 +19,23 @@ import type {
   PrachtAppConfig,
 } from "./types.ts";
 import { formatUnknownNameError } from "./name-suggestions.ts";
+import {
+  matchResolvedRoute,
+  matchRouteSegments,
+  normalizeRoutePath,
+  parseRouteSegments,
+  splitPathSegments,
+} from "./route-matching.ts";
+
+export { buildHref, buildPathFromSegments } from "./route-matching.ts";
+
+// Manifest validation is a dev/build-time aid: `import.meta.env.DEV` is
+// statically `false` in production Vite bundles, so this folds to `false`
+// and every validation branch (plus the error formatting it references) is
+// dead-code-eliminated from client builds. In Node (CLI builds, tests)
+// `import.meta.env` is undefined and validation stays on — `pracht build`
+// runs `resolveApp` there, so invalid manifests still fail the build.
+const VALIDATE_MANIFEST = import.meta.env?.DEV !== false;
 
 interface InheritedRouteConfig {
   pathPrefix: string;
@@ -130,17 +141,19 @@ export function resolveApp(app: PrachtApp): ResolvedPrachtApp {
     middleware: [],
   };
 
-  for (const name of app.api?.middleware ?? []) {
-    if (!hasOwnEntry(app.middleware, name)) {
-      throw new Error(
-        formatUnknownNameError({
-          kind: "middleware",
-          kindPlural: "middleware",
-          name,
-          registered: Object.keys(app.middleware),
-          context: "api routes",
-        }),
-      );
+  if (VALIDATE_MANIFEST) {
+    for (const name of app.api?.middleware ?? []) {
+      if (!hasOwnEntry(app.middleware, name)) {
+        throw new Error(
+          formatUnknownNameError({
+            kind: "middleware",
+            kindPlural: "middleware",
+            name,
+            registered: Object.keys(app.middleware),
+            context: "api routes",
+          }),
+        );
+      }
     }
   }
 
@@ -163,21 +176,7 @@ export function matchAppRoute(
   pathname: string,
 ): RouteMatch | undefined {
   const resolved = isResolvedApp(app) ? app : resolveApp(app);
-  const normalizedPathname = normalizeRoutePath(pathname);
-  const targetSegments = splitPathSegments(normalizedPathname);
-
-  for (const currentRoute of resolved.routes) {
-    const params = matchRouteSegments(currentRoute.segments, targetSegments);
-    if (params) {
-      return {
-        route: currentRoute,
-        params,
-        pathname: normalizedPathname,
-      };
-    }
-  }
-
-  return undefined;
+  return matchResolvedRoute(resolved, pathname);
 }
 
 function flattenRouteNode(
@@ -188,7 +187,9 @@ function flattenRouteNode(
 ): void {
   if (node.kind === "group") {
     const pathPrefix = mergeRoutePaths(inherited.pathPrefix, node.meta.pathPrefix);
-    assertValidLoaderCache(node.meta.loaderCache, `group at "${pathPrefix}"`);
+    if (VALIDATE_MANIFEST) {
+      assertValidLoaderCache(node.meta.loaderCache, `group at "${pathPrefix}"`);
+    }
     const nextInherited: InheritedRouteConfig = {
       pathPrefix,
       shell: node.meta.shell ?? inherited.shell,
@@ -207,30 +208,33 @@ function flattenRouteNode(
   }
 
   const fullPath = mergeRoutePaths(inherited.pathPrefix, node.path);
-  assertValidLoaderCache(node.loaderCache, `route "${fullPath}"`);
   const shell = node.shell ?? inherited.shell;
   const middleware = [...inherited.middleware, ...(node.middleware ?? [])];
   const render = node.render ?? inherited.render;
   const hydration = node.hydration ?? inherited.hydration;
   const loaderCache = node.loaderCache ?? inherited.loaderCache;
 
-  if (render === "spa" && hydration !== undefined && hydration !== "full") {
-    throw new Error(
-      `Route "${fullPath}" combines render: "spa" with hydration: "${hydration}". ` +
-        "SPA routes render entirely in the browser and always use full hydration — " +
-        'remove the hydration option or use render: "ssg" / "isg" / "ssr".',
-    );
-  }
+  if (VALIDATE_MANIFEST) {
+    assertValidLoaderCache(node.loaderCache, `route "${fullPath}"`);
 
-  if (shell !== undefined && !hasOwnEntry(app.shells, shell)) {
-    throw new Error(
-      formatUnknownNameError({
-        kind: "shell",
-        name: shell,
-        registered: Object.keys(app.shells),
-        context: `route "${fullPath}"`,
-      }),
-    );
+    if (render === "spa" && hydration !== undefined && hydration !== "full") {
+      throw new Error(
+        `Route "${fullPath}" combines render: "spa" with hydration: "${hydration}". ` +
+          "SPA routes render entirely in the browser and always use full hydration — " +
+          'remove the hydration option or use render: "ssg" / "isg" / "ssr".',
+      );
+    }
+
+    if (shell !== undefined && !hasOwnEntry(app.shells, shell)) {
+      throw new Error(
+        formatUnknownNameError({
+          kind: "shell",
+          name: shell,
+          registered: Object.keys(app.shells),
+          context: `route "${fullPath}"`,
+        }),
+      );
+    }
   }
 
   routes.push({
@@ -246,7 +250,7 @@ function flattenRouteNode(
     loaderCache,
     middleware,
     middlewareFiles: middleware.map((name) => {
-      if (!hasOwnEntry(app.middleware, name)) {
+      if (VALIDATE_MANIFEST && !hasOwnEntry(app.middleware, name)) {
         throw new Error(
           formatUnknownNameError({
             kind: "middleware",
@@ -287,98 +291,6 @@ function isResolvedApp(app: PrachtApp | ResolvedPrachtApp): app is ResolvedPrach
   return app.routes.length === 0 || "segments" in app.routes[0];
 }
 
-function matchRouteSegments(
-  routeSegments: RouteSegment[],
-  targetSegments: string[],
-): RouteParams | null {
-  const params: RouteParams = {};
-  let routeIndex = 0;
-  let targetIndex = 0;
-
-  while (routeIndex < routeSegments.length) {
-    const currentSegment = routeSegments[routeIndex];
-
-    if (currentSegment.type === "catchall") {
-      try {
-        params[currentSegment.name] = targetSegments
-          .slice(targetIndex)
-          .map(decodeURIComponent)
-          .join("/");
-      } catch {
-        return null;
-      }
-      return params;
-    }
-
-    const targetSegment = targetSegments[targetIndex];
-    if (typeof targetSegment === "undefined") {
-      return null;
-    }
-
-    if (currentSegment.type === "static") {
-      if (currentSegment.value !== targetSegment) {
-        return null;
-      }
-    } else {
-      try {
-        params[currentSegment.name] = decodeURIComponent(targetSegment);
-      } catch {
-        return null;
-      }
-    }
-
-    routeIndex += 1;
-    targetIndex += 1;
-  }
-
-  return targetIndex === targetSegments.length ? params : null;
-}
-
-function parseRouteSegments(path: string): RouteSegment[] {
-  return splitPathSegments(path).map((segment) => {
-    if (segment === "*") {
-      return {
-        type: "catchall",
-        name: "*",
-      } as const;
-    }
-
-    if (segment.startsWith(":") && segment.endsWith("*")) {
-      return {
-        type: "catchall",
-        name: segment.slice(1, -1) || "*",
-      } as const;
-    }
-
-    if (segment.startsWith(":")) {
-      return {
-        type: "param",
-        name: segment.slice(1),
-      } as const;
-    }
-
-    assertSafeStaticRouteSegment(segment);
-    return {
-      type: "static",
-      value: segment,
-    } as const;
-  });
-}
-
-function splitPathSegments(path: string): string[] {
-  return normalizeRoutePath(path).split("/").filter(Boolean);
-}
-
-function assertSafeStaticRouteSegment(segment: string): void {
-  if (segment === "." || segment === "..") {
-    throw new Error(`Unsafe static route segment "${segment}" is not allowed.`);
-  }
-
-  if (segment.includes("\0") || /[\r\n\\]/.test(segment)) {
-    throw new Error(`Unsafe static route segment "${segment}" contains a forbidden character.`);
-  }
-}
-
 function mergeRoutePaths(prefix: string, path?: string): string {
   if (!path) {
     return normalizeRoutePath(prefix);
@@ -396,147 +308,6 @@ function mergeRoutePaths(prefix: string, path?: string): string {
   }
 
   return normalizeRoutePath(`${normalizedPrefix}/${normalizedPath.slice(1)}`);
-}
-
-function normalizeRoutePath(path: string): string {
-  if (!path || path === "/") {
-    return "/";
-  }
-
-  const withLeadingSlash = path.startsWith("/") ? path : `/${path}`;
-  const collapsed = withLeadingSlash.replace(/\/{2,}/g, "/");
-
-  return collapsed.length > 1 && collapsed.endsWith("/") ? collapsed.slice(0, -1) : collapsed;
-}
-
-export function buildPathFromSegments(
-  segments: readonly RouteSegment[],
-  params: RouteParams,
-): string {
-  const parts = segments.map((segment) => {
-    if (segment.type === "static") return segment.value;
-    if (segment.type === "param") return encodeDynamicPathSegment(params[segment.name] ?? "");
-    // Catch-all routes preserve `/` between captured components, but each
-    // component is encoded as its own filesystem-safe URL segment.
-    const raw = params[segment.name] ?? params["*"] ?? "";
-    return raw
-      .split("/")
-      .map((part) => encodeDynamicPathSegment(part))
-      .join("/");
-  });
-
-  return normalizeRoutePath("/" + parts.join("/"));
-}
-
-export function buildHref<TRoute extends RouteId>(
-  routes: readonly HrefRouteDefinition[],
-  routeId: TRoute,
-  ...args: HrefArgs<TRoute>
-): string {
-  return buildHrefUntyped(routes, String(routeId), args[0] as BuildHrefOptions | undefined);
-}
-
-function buildHrefUntyped(
-  routes: readonly HrefRouteDefinition[],
-  routeId: string,
-  options: BuildHrefOptions = {},
-): string {
-  const route = routes.find((candidate) => candidate.id === routeId);
-  if (!route) {
-    throw new Error(
-      formatUnknownNameError({
-        kind: "pracht route id",
-        kindPlural: "route ids",
-        name: routeId,
-        registered: routes.flatMap((candidate) => (candidate.id ? [candidate.id] : [])),
-      }),
-    );
-  }
-
-  const segments = route.segments ?? parseRouteSegments(route.path);
-  const params = normalizeHrefParams(segments, options.params ?? {});
-  const path = buildPathFromSegments(segments, params);
-  return `${path}${serializeSearch(options.search)}${serializeHash(options.hash)}`;
-}
-
-function normalizeHrefParams(
-  segments: readonly RouteSegment[],
-  params: Record<string, unknown>,
-): RouteParams {
-  const expected = new Set(
-    segments
-      .filter((segment) => segment.type === "param" || segment.type === "catchall")
-      .map((segment) => segment.name),
-  );
-
-  for (const name of expected) {
-    if (params[name] == null) {
-      throw new Error(`Missing route param: ${name}.`);
-    }
-  }
-
-  for (const name of Object.keys(params)) {
-    if (!expected.has(name)) {
-      throw new Error(`Unexpected route param: ${name}.`);
-    }
-  }
-
-  const normalized: RouteParams = {};
-  for (const name of expected) {
-    normalized[name] = String(params[name]);
-  }
-  return normalized;
-}
-
-function serializeSearch(search: SearchParamsInput | undefined): string {
-  if (search == null) return "";
-
-  if (typeof search === "string") {
-    if (!search) return "";
-    return search.startsWith("?") ? search : `?${search}`;
-  }
-
-  const params = search instanceof URLSearchParams ? search : objectToSearchParams(search);
-  const serialized = params.toString();
-  return serialized ? `?${serialized}` : "";
-}
-
-function objectToSearchParams(search: Record<string, unknown>): URLSearchParams {
-  const params = new URLSearchParams();
-  for (const [key, value] of Object.entries(search)) {
-    if (Array.isArray(value)) {
-      for (const item of value) {
-        appendSearchValue(params, key, item);
-      }
-      continue;
-    }
-
-    appendSearchValue(params, key, value);
-  }
-  return params;
-}
-
-function appendSearchValue(params: URLSearchParams, key: string, value: unknown): void {
-  if (value == null) return;
-  params.append(key, String(value));
-}
-
-function serializeHash(hash: string | undefined): string {
-  if (!hash) return "";
-  return hash.startsWith("#") ? hash : `#${hash}`;
-}
-
-/**
- * Encode one dynamic URL path segment for SSG/ISG output. `encodeURIComponent`
- * leaves unreserved characters (including `.`) intact, and even percent-encoded
- * dot segments are normalized by URL parsers. Reject exact `.` / `..` segments
- * instead of allowing them to reach filesystem output path construction.
- */
-function encodeDynamicPathSegment(part: string): string {
-  if (part === "." || part === "..") {
-    throw new Error(`Unsafe dynamic route param segment "${part}" is not allowed.`);
-  }
-  return encodeURIComponent(part);
 }
 
 /**

--- a/packages/framework/src/href.ts
+++ b/packages/framework/src/href.ts
@@ -1,4 +1,4 @@
-import { buildHref } from "./app.ts";
+import { buildHref } from "./route-matching.ts";
 import type { BuildHrefOptions, HrefFn, HrefRouteDefinition } from "./types.ts";
 
 export function createHref(routes: readonly HrefRouteDefinition[]): HrefFn {

--- a/packages/framework/src/prefetch-api.ts
+++ b/packages/framework/src/prefetch-api.ts
@@ -7,7 +7,7 @@
  * the core client bundle.
  */
 
-import { buildHref, matchAppRoute } from "./app.ts";
+import { buildHref, matchResolvedRoute } from "./route-matching.ts";
 import {
   cacheRouteState,
   EMPTY_ROUTE_STATE_PROMISE,
@@ -96,7 +96,7 @@ export const prefetch: PrefetchFn = async (to: string | RouteTarget): Promise<vo
   }
   if (url.origin !== window.location.origin) return;
 
-  const match = matchAppRoute(target.app, url.pathname);
+  const match = matchResolvedRoute(target.app, url.pathname);
   if (!match) return;
 
   target.warmModules?.(match);

--- a/packages/framework/src/prefetch.ts
+++ b/packages/framework/src/prefetch.ts
@@ -1,4 +1,4 @@
-import { matchAppRoute } from "./app.ts";
+import { matchResolvedRoute } from "./route-matching.ts";
 import { clearPrefetchCache, getCachedRouteState, trimMapToSize } from "./prefetch-cache.ts";
 import { prefetchRouteState } from "./prefetch-api.ts";
 import { PREFETCH_ATTRIBUTE } from "./runtime-constants.ts";
@@ -68,7 +68,7 @@ export function setupPrefetching(app: ResolvedPrachtApp, warmModules?: ModuleWar
     }
 
     const routePathname = getRoutePathname(href);
-    const match = routePathname ? (matchAppRoute(app, routePathname) ?? null) : null;
+    const match = routePathname ? (matchResolvedRoute(app, routePathname) ?? null) : null;
     // Islands / no-hydration routes use full document navigation, so
     // prefetching route-state JSON or client modules for them is wasted work.
     const isFullDocumentRoute =

--- a/packages/framework/src/prerender.ts
+++ b/packages/framework/src/prerender.ts
@@ -1,4 +1,5 @@
-import { buildPathFromSegments, resolveApp } from "./app.ts";
+import { resolveApp } from "./app.ts";
+import { buildPathFromSegments } from "./route-matching.ts";
 import { normalizeRouteRevalidate } from "./revalidation.ts";
 import { resolveRegistryModule } from "./runtime-manifest.ts";
 import { handlePrachtRequest } from "./runtime.ts";

--- a/packages/framework/src/route-matching.ts
+++ b/packages/framework/src/route-matching.ts
@@ -1,0 +1,288 @@
+/**
+ * Pure route matching, path, and href primitives.
+ *
+ * This module is the only part of the manifest machinery the client router
+ * needs at runtime. It must NOT import `resolveApp` or the manifest DSL —
+ * keeping it dependency-free lets production client builds tree-shake the
+ * manifest resolution and validation code in `app.ts` that only ever needs
+ * to run in dev and at build time.
+ */
+
+import { formatUnknownNameError } from "./name-suggestions.ts";
+import type {
+  BuildHrefOptions,
+  HrefArgs,
+  HrefRouteDefinition,
+  ResolvedPrachtApp,
+  RouteId,
+  RouteMatch,
+  RouteParams,
+  RouteSegment,
+  SearchParamsInput,
+} from "./types.ts";
+
+export function normalizeRoutePath(path: string): string {
+  if (!path || path === "/") {
+    return "/";
+  }
+
+  const withLeadingSlash = path.startsWith("/") ? path : `/${path}`;
+  const collapsed = withLeadingSlash.replace(/\/{2,}/g, "/");
+
+  return collapsed.length > 1 && collapsed.endsWith("/") ? collapsed.slice(0, -1) : collapsed;
+}
+
+export function splitPathSegments(path: string): string[] {
+  return normalizeRoutePath(path).split("/").filter(Boolean);
+}
+
+export function parseRouteSegments(path: string): RouteSegment[] {
+  return splitPathSegments(path).map((segment) => {
+    if (segment === "*") {
+      return {
+        type: "catchall",
+        name: "*",
+      } as const;
+    }
+
+    if (segment.startsWith(":") && segment.endsWith("*")) {
+      return {
+        type: "catchall",
+        name: segment.slice(1, -1) || "*",
+      } as const;
+    }
+
+    if (segment.startsWith(":")) {
+      return {
+        type: "param",
+        name: segment.slice(1),
+      } as const;
+    }
+
+    assertSafeStaticRouteSegment(segment);
+    return {
+      type: "static",
+      value: segment,
+    } as const;
+  });
+}
+
+function assertSafeStaticRouteSegment(segment: string): void {
+  if (segment === "." || segment === "..") {
+    throw new Error(`Unsafe static route segment "${segment}" is not allowed.`);
+  }
+
+  if (segment.includes("\0") || /[\r\n\\]/.test(segment)) {
+    throw new Error(`Unsafe static route segment "${segment}" contains a forbidden character.`);
+  }
+}
+
+export function matchRouteSegments(
+  routeSegments: RouteSegment[],
+  targetSegments: string[],
+): RouteParams | null {
+  const params: RouteParams = {};
+  let routeIndex = 0;
+  let targetIndex = 0;
+
+  while (routeIndex < routeSegments.length) {
+    const currentSegment = routeSegments[routeIndex];
+
+    if (currentSegment.type === "catchall") {
+      try {
+        params[currentSegment.name] = targetSegments
+          .slice(targetIndex)
+          .map(decodeURIComponent)
+          .join("/");
+      } catch {
+        return null;
+      }
+      return params;
+    }
+
+    const targetSegment = targetSegments[targetIndex];
+    if (typeof targetSegment === "undefined") {
+      return null;
+    }
+
+    if (currentSegment.type === "static") {
+      if (currentSegment.value !== targetSegment) {
+        return null;
+      }
+    } else {
+      try {
+        params[currentSegment.name] = decodeURIComponent(targetSegment);
+      } catch {
+        return null;
+      }
+    }
+
+    routeIndex += 1;
+    targetIndex += 1;
+  }
+
+  return targetIndex === targetSegments.length ? params : null;
+}
+
+/**
+ * Match a pathname against an already-resolved app. The client router always
+ * holds a `ResolvedPrachtApp`, so unlike `matchAppRoute` this never falls
+ * back to `resolveApp` — that fallback would drag manifest resolution and
+ * validation into every production client bundle.
+ */
+export function matchResolvedRoute(
+  app: ResolvedPrachtApp,
+  pathname: string,
+): RouteMatch | undefined {
+  const normalizedPathname = normalizeRoutePath(pathname);
+  const targetSegments = splitPathSegments(normalizedPathname);
+
+  for (const currentRoute of app.routes) {
+    const params = matchRouteSegments(currentRoute.segments, targetSegments);
+    if (params) {
+      return {
+        route: currentRoute,
+        params,
+        pathname: normalizedPathname,
+      };
+    }
+  }
+
+  return undefined;
+}
+
+export function buildPathFromSegments(
+  segments: readonly RouteSegment[],
+  params: RouteParams,
+): string {
+  const parts = segments.map((segment) => {
+    if (segment.type === "static") return segment.value;
+    if (segment.type === "param") return encodeDynamicPathSegment(params[segment.name] ?? "");
+    // Catch-all routes preserve `/` between captured components, but each
+    // component is encoded as its own filesystem-safe URL segment.
+    const raw = params[segment.name] ?? params["*"] ?? "";
+    return raw
+      .split("/")
+      .map((part) => encodeDynamicPathSegment(part))
+      .join("/");
+  });
+
+  return normalizeRoutePath("/" + parts.join("/"));
+}
+
+export function buildHref<TRoute extends RouteId>(
+  routes: readonly HrefRouteDefinition[],
+  routeId: TRoute,
+  ...args: HrefArgs<TRoute>
+): string {
+  return buildHrefUntyped(routes, String(routeId), args[0] as BuildHrefOptions | undefined);
+}
+
+function buildHrefUntyped(
+  routes: readonly HrefRouteDefinition[],
+  routeId: string,
+  options: BuildHrefOptions = {},
+): string {
+  const route = routes.find((candidate) => candidate.id === routeId);
+  if (!route) {
+    // The rich "did you mean" error only exists where import.meta.env.DEV is
+    // not statically false (dev server, tests, Node CLI); production builds
+    // constant-fold the guard and tree-shake the error formatting away.
+    if (import.meta.env?.DEV !== false) {
+      throw new Error(
+        formatUnknownNameError({
+          kind: "pracht route id",
+          kindPlural: "route ids",
+          name: routeId,
+          registered: routes.flatMap((candidate) => (candidate.id ? [candidate.id] : [])),
+        }),
+      );
+    }
+    throw new Error(`Unknown pracht route id "${routeId}".`);
+  }
+
+  const segments = route.segments ?? parseRouteSegments(route.path);
+  const params = normalizeHrefParams(segments, options.params ?? {});
+  const path = buildPathFromSegments(segments, params);
+  return `${path}${serializeSearch(options.search)}${serializeHash(options.hash)}`;
+}
+
+function normalizeHrefParams(
+  segments: readonly RouteSegment[],
+  params: Record<string, unknown>,
+): RouteParams {
+  const expected = new Set(
+    segments
+      .filter((segment) => segment.type === "param" || segment.type === "catchall")
+      .map((segment) => segment.name),
+  );
+
+  for (const name of expected) {
+    if (params[name] == null) {
+      throw new Error(`Missing route param: ${name}.`);
+    }
+  }
+
+  for (const name of Object.keys(params)) {
+    if (!expected.has(name)) {
+      throw new Error(`Unexpected route param: ${name}.`);
+    }
+  }
+
+  const normalized: RouteParams = {};
+  for (const name of expected) {
+    normalized[name] = String(params[name]);
+  }
+  return normalized;
+}
+
+function serializeSearch(search: SearchParamsInput | undefined): string {
+  if (search == null) return "";
+
+  if (typeof search === "string") {
+    if (!search) return "";
+    return search.startsWith("?") ? search : `?${search}`;
+  }
+
+  const params = search instanceof URLSearchParams ? search : objectToSearchParams(search);
+  const serialized = params.toString();
+  return serialized ? `?${serialized}` : "";
+}
+
+function objectToSearchParams(search: Record<string, unknown>): URLSearchParams {
+  const params = new URLSearchParams();
+  for (const [key, value] of Object.entries(search)) {
+    if (Array.isArray(value)) {
+      for (const item of value) {
+        appendSearchValue(params, key, item);
+      }
+      continue;
+    }
+
+    appendSearchValue(params, key, value);
+  }
+  return params;
+}
+
+function appendSearchValue(params: URLSearchParams, key: string, value: unknown): void {
+  if (value == null) return;
+  params.append(key, String(value));
+}
+
+function serializeHash(hash: string | undefined): string {
+  if (!hash) return "";
+  return hash.startsWith("#") ? hash : `#${hash}`;
+}
+
+/**
+ * Encode one dynamic URL path segment for SSG/ISG output. `encodeURIComponent`
+ * leaves unreserved characters (including `.`) intact, and even percent-encoded
+ * dot segments are normalized by URL parsers. Reject exact `.` / `..` segments
+ * instead of allowing them to reach filesystem output path construction.
+ */
+function encodeDynamicPathSegment(part: string): string {
+  if (part === "." || part === "..") {
+    throw new Error(`Unsafe dynamic route param segment "${part}" is not allowed.`);
+  }
+  return encodeURIComponent(part);
+}

--- a/packages/framework/src/router.ts
+++ b/packages/framework/src/router.ts
@@ -3,7 +3,7 @@ import { hydrate, render } from "preact";
 import { useContext, useLayoutEffect, useMemo, useState } from "preact/hooks";
 import type { FunctionComponent } from "preact";
 
-import { buildHref, matchAppRoute } from "./app.ts";
+import { buildHref, matchResolvedRoute } from "./route-matching.ts";
 import { installHydrationMismatchWarning } from "./hydration-mismatch.ts";
 import { markHydrating } from "./hydration.ts";
 import {
@@ -362,7 +362,7 @@ export async function initClientRouter(options: InitClientRouterOptions): Promis
       return;
     }
 
-    const match = matchAppRoute(app, target.pathname);
+    const match = matchResolvedRoute(app, target.pathname);
     if (!match) {
       // No client route — fall back to full page load
       window.location.href = target.browserUrl;
@@ -509,7 +509,7 @@ export async function initClientRouter(options: InitClientRouterOptions): Promis
   const initialTarget = resolveBrowserRouteTarget(options.initialState.url);
   const initialRequestUrl = initialTarget?.requestUrl ?? options.initialState.url;
   const initialBrowserUrl = initialTarget?.browserUrl ?? options.initialState.url;
-  const initialMatch = matchAppRoute(app, initialTarget?.pathname ?? options.initialState.url);
+  const initialMatch = matchResolvedRoute(app, initialTarget?.pathname ?? options.initialState.url);
   if (initialMatch) {
     const initialShellPromise =
       initialMatch.route.render === "spa" && options.initialState.pending
@@ -624,7 +624,7 @@ export async function initClientRouter(options: InitClientRouterOptions): Promis
     // the browser perform a normal navigation so it can activate the
     // prerendered document. Intercepting here would cancel the activation
     // and force a redundant SPA fetch of the route-state JSON.
-    const targetMatch = matchAppRoute(app, url.pathname);
+    const targetMatch = matchResolvedRoute(app, url.pathname);
     if (targetMatch && supportsSpeculationRules()) {
       const spec = normalizeSpeculation(targetMatch.route.speculation);
       if (spec?.mode === "prerender") return;

--- a/packages/framework/src/runtime-hooks.ts
+++ b/packages/framework/src/runtime-hooks.ts
@@ -2,7 +2,7 @@ import { h } from "preact";
 import type { JSX } from "preact";
 import { useContext, useEffect, useState } from "preact/hooks";
 
-import { buildHref } from "./app.ts";
+import { buildHref } from "./route-matching.ts";
 import {
   beginSubmittingNavigation,
   createNavigationLocation,


### PR DESCRIPTION
## Summary

- Finding 1 of the 2026-07 client bundle audit: `resolveApp()` re-ran full manifest validation in the browser on every page load — unknown shell/middleware checks, loaderCache validation, SPA+hydration conflict checks, and the "did you mean" error formatting they pull in — even though `pracht build` already validated the manifest.
- Two structural changes make it tree-shakeable:
  1. Pure matching/path/href primitives move to a new dependency-free `route-matching.ts`; the client router, prefetch listeners, and hooks import it directly. The router previously reached `resolveApp` through `matchAppRoute`'s resolve fallback despite always holding an already-resolved app — it now uses `matchResolvedRoute` with no fallback edge.
  2. `resolveApp`'s validation branches are guarded by a module-level flag derived from `import.meta.env.DEV`, so production Vite builds constant-fold and eliminate them. Dev servers, vitest, and `pracht build` (Node, where `import.meta.env` is undefined) keep full validation — invalid manifests still fail the build with rich errors.
- Scope note: the audit originally sketched precompiling the resolved route table into the virtual client module. The plugin has no build-time manifest evaluation (route-loader hints are static file scans), so that would require executing user code inside the plugin. This PR delivers the same byte goal — no validation code on production clients — without that machinery; a precompiled table can build on the new split later.
- Measured on `examples/basic`: framework entry chunks 22.62 → 20.62 kB raw, 8.73 → 7.96 kB gzip (**−2.0 kB raw / −0.77 kB gzip**). Verified no validation/suggestion strings or Levenshtein code remain in any production client chunk, and the DEV guard survives the library build unevaluated.
- Public API unchanged: `buildHref`, `buildPathFromSegments`, `matchAppRoute`, `resolveApp` keep their exports and signatures. No conflicts with #221/#223/#224 (disjoint files).

## Testing

- [x] `pnpm e2e` (80 passed — dev + production navigation across example apps)
- [x] `pnpm format`
- [x] `pnpm lint` (via `pnpm exec oxlint`, 0 errors)
- [x] `pnpm test` (605 passed, including all manifest validation error tests)

## Checklist

- [x] Docs updated if needed (N/A — public API and dev/build behavior unchanged; prod-only internal behavior documented in the changeset)
- [x] Skills updated if needed (N/A)
- [x] Changeset added if published packages changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)