### PR TITLE
Fix the README front door: conflict marker, install CTA, dead links

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,12 @@
 
 Pick SPA, SSR, SSG, or ISG on a route-by-route basis. Ship less JavaScript by default. Deploy the same codebase to Node, Cloudflare, or Vercel.
 
+```bash
+npm create pracht@latest my-app
+```
+
+**[Documentation](https://pracht.resynapse.dev/docs)** · [Why pracht](https://pracht.resynapse.dev/docs/why-pracht) · [Getting started](https://pracht.resynapse.dev/docs/getting-started) · [Compare to other frameworks](https://pracht.resynapse.dev/docs/demo-comparison)
+
 ## Why pracht
 
 - **Preact-first** — the low bundle size that you know and love with a familiar API.
@@ -111,12 +117,11 @@ Pracht is built to be operated by coding agents as much as by humans — and for
 
 ## Agent skills
 
-The skills are distributed three ways ([docs](https://pracht.resynapse.dev/docs/agent-skills)):
+The skills are distributed three ways (see the [catalog](skills/README.md)):
 
 - **Discovery endpoint** — every skill is published at `https://pracht.resynapse.dev/skills/<name>/SKILL.md`, listed with SHA-256 digests in the manifest at [`/.well-known/agent-skills/index.json`](https://pracht.resynapse.dev/.well-known/agent-skills/index.json) and advertised via a `Link: rel="agent-skills"` header.
 - **create-pracht** — `npm create pracht@latest` seeds the full catalog into new apps' `.claude/skills/` and writes a `.mcp.json` registering the `pracht mcp` server (yes-default prompt, `--no-agent-tools` to skip).
 - **In this repo** — `.claude/skills` symlinks to [skills/](skills/README.md), so Claude Code loads them automatically for contributors.
->>>>>>> 463a134 (Ship the skills to users: create-pracht seeding, docs page, contributor loading)
 
 ## Repo map
 

--- a/VISION_MVP.md
+++ b/VISION_MVP.md
@@ -161,7 +161,7 @@ Agent skills for framework authors and app builders live in [skills/](skills/REA
 (one `SKILL.md` per skill; `.claude/skills` symlinks there so Claude Code picks them up
 in this repo). They are published with a discovery manifest at
 `https://pracht.resynapse.dev/.well-known/agent-skills/index.json` and seeded into new
-apps by `create-pracht` — see the [agent skills docs](https://pracht.resynapse.dev/docs/agent-skills):
+apps by `create-pracht` — see the [skills catalog](skills/README.md):
 
 - **Scaffold**: generate routes, shells, middleware, API routes with correct wiring
 - **Debug**: framework-aware debugging (route matching, loader errors, hydration)


### PR DESCRIPTION
## Summary

Act 0 of the marketing campaign — fix the page every visitor lands on before any launch push.

- **Removes a merge conflict marker from the published README.** `>>>>>>> 463a134` was sitting at line 119 in the Agent skills section on `main`, rendered on the GitHub landing page. Only the marker leaked; the surrounding content was already correctly resolved, so this deletes the one line.
- **Puts the install command above the fold.** `npm create pracht@latest my-app` plus a docs nav line now sits directly under the tagline. It previously appeared ~80 lines down, below two full manifest code blocks — the primary CTA was never in the first screen.
- **Fixes a dead docs link** in README and VISION_MVP. Both pointed at `https://pracht.resynapse.dev/docs/agent-skills`, which 404s in production. They now point at the in-repo [skills catalog](../blob/main/skills/README.md), which resolves today.

Docs-only; no package code touched.

### Follow-up not fixed here

`/docs/agent-skills` and `/docs/agent-workflow` 404 in production even though both routes are in `examples/docs/src/routes.ts` as SSG. Sibling pages (`/docs/routing`, `/docs/llms`, `/docs/rendering`, `/docs/performance`) all return 200, so **the deployed docs site is stale** — it predates the Jul 15 and Jul 22 commits that added those routes. Redeploying is the actual fix; the docs link can be restored afterwards.

Remaining Act 0 items that need a human: a hero GIF above the fold and a clickable deployed demo.

## Testing

- [x] `pnpm e2e` — 85 passed
- [x] `pnpm format` — no files reformatted
- [x] `pnpm lint` — 0 warnings, 0 errors (via `pnpm exec oxlint`; the `lint` script itself resolves to a missing `eslint` binary — pre-existing, unrelated)
- [x] `pnpm test` — 899 passed across 59 files

All external `pracht.resynapse.dev` links referenced from README, VISION_MVP, docs/, and package READMEs were checked for a 200 after redirects.

## Checklist

- [x] Docs updated if needed
- [ ] Skills updated if needed — N/A
- [ ] Changeset added if published packages changed — N/A, no published package changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)