### PR TITLE
Fix fragment navigation and focus handling in client router

### DIFF
--- a/.changeset/gentle-donuts-repeat.md
+++ b/.changeset/gentle-donuts-repeat.md
@@ -1,0 +1,21 @@
+---
+"@pracht/core": patch
+---
+
+Stop the client router from undoing in-page fragment scrolls, and move focus to fragment targets.
+
+Clicking `<a href="#section">` fires `popstate` for a brand new history entry rather than a
+traversal. The router read every `popstate` as a traversal and restored the saved scroll position,
+which scrolled the page straight back from the fragment the browser had just jumped to — so in-page
+anchors and skip links appeared not to work at all.
+
+The router now tells the two apart by the scroll key it stamps into `history.state` for every entry
+it creates: a keyless entry whose path and query are unchanged is a fragment navigation, so the
+browser's own jump is left to stand. A traversal onto an entry with no saved position now falls back
+to the URL's fragment instead of hard-resetting to the top.
+
+Wherever the router scrolls to a fragment itself, it now also moves focus to the target — adding a
+temporary `tabindex="-1"` for elements that are not natively focusable and removing it again on blur.
+Without this a skip link scrolled but left the next Tab stop at the top of the page, which defeats
+the purpose of the link. `scrollIntoView()` is still called with no `behavior` option, so a CSS
+`prefers-reduced-motion` rule can turn a smooth scroll off.

--- a/docs/ROUTING.md
+++ b/docs/ROUTING.md
@@ -383,9 +383,43 @@ The client router owns scrolling (`history.scrollRestoration = "manual"`):
 - **Back/forward navigations** (popstate) restore the scroll position the page
   had when the user left it. Positions are keyed per history entry and stored
   in `sessionStorage`, so they survive reloads and back-navigation from
-  external sites.
+  external sites. If an entry has no saved position but its URL carries a
+  fragment, the fragment wins over a reset to the top.
+- **In-page fragment links** (`<a href="#section">`) are left to the browser.
+  These fire `popstate` for a *new* history entry rather than a traversal; the
+  router tells the two apart by the scroll key it stamps into `history.state`
+  for every entry it creates, and stays out of the way so the browser's own
+  jump stands.
 - Opt out per navigation with `<Link preserveScroll>` or
   `navigate(to, { preserveScroll: true })`.
+
+Whenever the router scrolls to a fragment itself — a client-side navigation to
+`/docs/routing#loaders`, or a traversal onto a URL with a fragment — it also
+moves focus to the target, adding a temporary `tabindex="-1"` when the element
+is not natively focusable and removing it again on blur. Without this a skip
+link scrolls but leaves the next Tab stop at the top of the page, sending the
+user back into the navigation they just skipped.
+
+`scrollIntoView()` is called with no `behavior` option, so how the page scrolls
+stays a CSS decision:
+
+```css
+html {
+  scroll-behavior: smooth;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  html {
+    scroll-behavior: auto;
+  }
+}
+```
+
+> **Caveat for apps that sync state into the URL.** Calling
+> `history.replaceState(null, "", url)` — a common pattern for reflecting filter
+> or tab state — wipes the router's scroll key along with everything else on
+> `history.state`, and that entry loses its saved scroll position. Merge into
+> the existing state instead: `history.replaceState({ ...history.state }, "", url)`.
 
 ### View Transitions
 

--- a/e2e/navigation.test.ts
+++ b/e2e/navigation.test.ts
@@ -90,6 +90,66 @@ test("navigate with preserveScroll keeps the current scroll position", async ({ 
 });
 
 // ---------------------------------------------------------------------------
+// In-page fragment navigation
+// ---------------------------------------------------------------------------
+
+async function fragmentTargetOffset(page: Page): Promise<number> {
+  return page.evaluate(() => {
+    const el = document.getElementById("fragment-main")!;
+    return Math.round(el.getBoundingClientRect().top + window.scrollY);
+  });
+}
+
+test("an in-page fragment link scrolls to its target and stays there", async ({ page }) => {
+  await page.goto("/fragment");
+  await waitForRouter(page);
+
+  await page.click("#skip-link");
+  await page.waitForFunction(() => window.location.hash === "#fragment-main");
+
+  const target = await fragmentTargetOffset(page);
+  await page.waitForFunction((y) => Math.abs(window.scrollY - y) <= 1, target);
+
+  // The regression this guards: the router read the fragment navigation's
+  // popstate as a back/forward traversal and restored a saved scroll position,
+  // yanking the page back to the top a tick after the browser's jump.
+  await page.waitForTimeout(250);
+  expect(Math.abs((await page.evaluate(() => window.scrollY)) - target)).toBeLessThanOrEqual(1);
+});
+
+test("an in-page fragment link moves focus to its target", async ({ page }) => {
+  await page.goto("/fragment");
+  await waitForRouter(page);
+
+  await page.click("#skip-link");
+  await page.waitForFunction(() => window.location.hash === "#fragment-main");
+
+  // The point of a skip link: the next Tab must continue past the target, not
+  // drop the user back into the navigation they just skipped.
+  await expect(page.locator("#fragment-main")).toBeFocused();
+  await page.keyboard.press("Tab");
+  await expect(page.locator("#fragment-home-link")).toBeFocused();
+});
+
+test("going back from a fragment link returns to the previous scroll position", async ({
+  page,
+}) => {
+  await page.goto("/fragment");
+  await waitForRouter(page);
+
+  await page.evaluate(() => window.scrollTo(0, 800));
+  await page.waitForFunction(() => window.scrollY === 800);
+
+  // Click through the DOM: Playwright's own click scrolls the link into view
+  // first, which would move the page before the fragment navigation happens.
+  await page.evaluate(() => document.getElementById("skip-link")!.click());
+  await page.waitForFunction(() => window.location.hash === "#fragment-main");
+
+  await page.goBack();
+  await page.waitForFunction(() => window.scrollY === 800);
+});
+
+// ---------------------------------------------------------------------------
 // <Link prefetch>
 // ---------------------------------------------------------------------------
 

--- a/examples/cloudflare/src/routes.ts
+++ b/examples/cloudflare/src/routes.ts
@@ -33,6 +33,7 @@ export const app = defineApp({
       }),
       route("/slow", () => import("./routes/slow.tsx"), { id: "slow", render: "ssr" }),
       route("/long", () => import("./routes/long.tsx"), { id: "long", render: "ssr" }),
+      route("/fragment", () => import("./routes/fragment.tsx"), { id: "fragment", render: "ssr" }),
     ]),
     group({ shell: "app", middleware: ["auth"] }, [
       route("/dashboard", () => import("./routes/dashboard.tsx"), {

--- a/examples/cloudflare/src/routes/fragment.tsx
+++ b/examples/cloudflare/src/routes/fragment.tsx
@@ -1,0 +1,41 @@
+import type { LoaderArgs, RouteComponentProps } from "@pracht/core";
+
+// Tall page with a skip link, used by e2e tests for in-page fragment
+// navigation: scrolling to the target, moving focus to it, and restoring the
+// previous position on back. Kept separate from /long so its layout can change
+// without disturbing the scroll-restoration tests measured against that page.
+//
+// The loader matters. A fragment click fires popstate, which the router used to
+// treat as a back/forward traversal; the scroll restoration that followed only
+// overwrote the browser's jump once it ran *after* it. On a route with no
+// loader the router gets there first and the browser's jump wins anyway, hiding
+// the bug — the round trip a loader forces is what makes it observable.
+export async function loader(_args: LoaderArgs) {
+  return { message: "Fragment page loaded" };
+}
+
+export function head() {
+  return { title: "Fragment page" };
+}
+
+export function Component({ data }: RouteComponentProps<typeof loader>) {
+  return (
+    <section class="fragment-page">
+      <a href="#fragment-main" id="skip-link">
+        Skip to content
+      </a>
+      <h1>Fragment page</h1>
+      <p>{data.message}</p>
+      <div style={{ height: "3000px" }}>Tall content</div>
+      <main id="fragment-main">
+        <h2>Main content</h2>
+        <p>
+          <a href="/" id="fragment-home-link">
+            Back home
+          </a>
+        </p>
+      </main>
+      <div style={{ height: "3000px" }}>More tall content</div>
+    </section>
+  );
+}

--- a/packages/framework/src/fragment-navigation.ts
+++ b/packages/framework/src/fragment-navigation.ts
@@ -1,0 +1,87 @@
+/**
+ * Focus handling for fragment ("#hash") targets.
+ *
+ * Scrolling to a fragment is only half of what a fragment navigation does: it
+ * also moves the sequential focus navigation starting point, so the next Tab
+ * continues from the target rather than from the top of the page. That half is
+ * the entire point of a skip link, and it is missing wherever the router
+ * scrolls to a fragment itself instead of letting the browser navigate.
+ */
+
+/**
+ * Decode the id a URL fragment points at. Fragments arrive percent-encoded for
+ * non-ASCII ids (`#überblick` → `#%C3%BCberblick`); an invalid encoding is kept
+ * verbatim rather than throwing.
+ */
+export function decodeFragmentId(hash: string): string {
+  const raw = hash.startsWith("#") ? hash.slice(1) : hash;
+  if (!raw) return "";
+  try {
+    return decodeURIComponent(raw);
+  } catch {
+    return raw;
+  }
+}
+
+/** Find the element a fragment points at, or `null` when nothing matches. */
+export function findFragmentTarget(doc: Document, hash: string): HTMLElement | null {
+  const id = decodeFragmentId(hash);
+  if (!id) return null;
+  return doc.getElementById(id);
+}
+
+const NATIVELY_FOCUSABLE =
+  "a[href],area[href],button,input,select,textarea,summary,iframe,audio[controls],video[controls],[contenteditable],[tabindex]";
+
+const TEMPORARY_TABINDEX_ATTRIBUTE = "data-pracht-fragment-tabindex";
+
+function removeTemporaryTabIndex(event: Event): void {
+  const el = event.currentTarget as HTMLElement | null;
+  if (!el || typeof el.hasAttribute !== "function") return;
+  if (!el.hasAttribute(TEMPORARY_TABINDEX_ATTRIBUTE)) return;
+  el.removeAttribute("tabindex");
+  el.removeAttribute(TEMPORARY_TABINDEX_ATTRIBUTE);
+}
+
+/**
+ * Move focus to a fragment target the way a real fragment navigation does.
+ *
+ * Chromium sets the sequential focus navigation starting point on its own for
+ * a native fragment navigation, but not when the router scrolls to a fragment
+ * itself, and Safari has historically not set it at all — which is why
+ * `tabindex="-1"` on skip-link targets is the conventional belt and braces.
+ * Headings and landmarks are not focusable on their own, so they get a
+ * temporary `tabindex="-1"` that is removed again on blur: the DOM is left as
+ * the route authored it, and no permanent tab stop is introduced.
+ */
+export function focusFragmentTarget(el: HTMLElement): void {
+  if (typeof el.focus !== "function") return;
+
+  const isFocusable = typeof el.matches === "function" && el.matches(NATIVELY_FOCUSABLE);
+  if (!isFocusable) {
+    el.setAttribute("tabindex", "-1");
+    el.setAttribute(TEMPORARY_TABINDEX_ATTRIBUTE, "");
+    el.addEventListener("blur", removeTemporaryTabIndex, { once: true });
+  }
+
+  // `preventScroll` because scrolling is not this function's job: the caller
+  // has already scrolled, or the browser is about to. Letting `focus()` scroll
+  // as well would jump straight to the element and cut off a CSS
+  // `scroll-behavior: smooth` mid-animation.
+  el.focus({ preventScroll: true });
+}
+
+/**
+ * Scroll a fragment target into view and give it focus.
+ *
+ * `scrollIntoView()` is deliberately called with no `behavior` option: how the
+ * page scrolls belongs to CSS (`scroll-behavior`), where a
+ * `prefers-reduced-motion` query can turn a smooth scroll off. Passing
+ * `"smooth"` here would override that choice for everyone.
+ */
+export function scrollToFragmentTarget(el: HTMLElement): void {
+  if (typeof el.scrollIntoView === "function") {
+    el.scrollIntoView();
+  }
+  focusFragmentTarget(el);
+}

--- a/packages/framework/src/router.ts
+++ b/packages/framework/src/router.ts
@@ -4,6 +4,11 @@ import { useContext, useLayoutEffect, useMemo, useState } from "preact/hooks";
 import type { FunctionComponent } from "preact";
 
 import { buildHref, matchResolvedRoute } from "./route-matching.ts";
+import {
+  findFragmentTarget,
+  focusFragmentTarget,
+  scrollToFragmentTarget,
+} from "./fragment-navigation.ts";
 import { installHydrationMismatchWarning } from "./hydration-mismatch.ts";
 import { markHydrating } from "./hydration.ts";
 import {
@@ -170,6 +175,11 @@ export async function initClientRouter(options: InitClientRouterOptions): Promis
 
   window.addEventListener("pagehide", saveScrollPosition);
 
+  // The document (path + query) the router currently has rendered. Used on
+  // popstate to tell a same-document fragment navigation apart from a
+  // traversal that needs the route re-resolved.
+  let currentDocumentPath = window.location.pathname + window.location.search;
+
   function restoreOrResetScroll(
     opts: InternalNavigateOptions | undefined,
     browserUrl: string,
@@ -178,21 +188,20 @@ export async function initClientRouter(options: InitClientRouterOptions): Promis
 
     if (opts?._popstate) {
       const saved = scrollStore.get(currentScrollKey);
-      window.scrollTo(saved?.x ?? 0, saved?.y ?? 0);
-      return;
+      if (saved) {
+        window.scrollTo(saved.x, saved.y);
+        return;
+      }
+      // Nothing saved for this entry — fall through to the fragment lookup
+      // rather than hard-resetting to the top, so traversing onto a URL that
+      // carries a fragment still lands on the fragment.
     }
 
     const hashIndex = browserUrl.indexOf("#");
     if (hashIndex !== -1) {
-      let id = browserUrl.slice(hashIndex + 1);
-      try {
-        id = decodeURIComponent(id);
-      } catch {
-        // Keep the raw fragment when it is not valid percent-encoding.
-      }
-      const hashTarget = id ? document.getElementById(id) : null;
-      if (hashTarget && typeof hashTarget.scrollIntoView === "function") {
-        hashTarget.scrollIntoView();
+      const hashTarget = findFragmentTarget(document, browserUrl.slice(hashIndex));
+      if (hashTarget) {
+        scrollToFragmentTarget(hashTarget);
         return;
       }
     }
@@ -492,6 +501,9 @@ export async function initClientRouter(options: InitClientRouterOptions): Promis
           );
           currentScrollKey = nextScrollKey;
         }
+        const hashIndex = target.browserUrl.indexOf("#");
+        currentDocumentPath =
+          hashIndex === -1 ? target.browserUrl : target.browserUrl.slice(0, hashIndex);
       }
 
       // Module imports started above are already in-flight
@@ -661,9 +673,24 @@ export async function initClientRouter(options: InitClientRouterOptions): Promis
   window.addEventListener("popstate", () => {
     // The history entry already changed, but the on-screen scroll position
     // still belongs to the entry we are leaving — save it under its key
-    // before adopting the new entry's key.
+    // before adopting the new entry's key. A same-document fragment
+    // navigation fires popstate *before* the browser scrolls to the fragment,
+    // so this still records where the outgoing entry actually was.
     saveScrollPosition();
+
     let nextScrollKey = readScrollKeyFromHistoryState(history.state);
+    const nextDocumentPath = window.location.pathname + window.location.search;
+
+    // `<a href="#section">` fires popstate too, for a brand new entry rather
+    // than a traversal. Two signals separate the cases: the router stamps a
+    // scroll key into `history.state` for every entry it creates, so a
+    // missing key means this entry came from somewhere else; and a fragment
+    // navigation cannot change the path or query. Requiring both means an
+    // entry whose state was wiped by app code (a stray
+    // `history.replaceState(null, …)`) is still re-resolved when the route
+    // really did change.
+    const isFragmentNavigation = !nextScrollKey && nextDocumentPath === currentDocumentPath;
+
     if (!nextScrollKey) {
       nextScrollKey = generateScrollKey();
       try {
@@ -678,6 +705,18 @@ export async function initClientRouter(options: InitClientRouterOptions): Promis
     }
     currentScrollKey = nextScrollKey;
 
+    if (isFragmentNavigation) {
+      // The same route is already rendered, so there is nothing to
+      // re-resolve, and this entry has no saved position to restore. The
+      // browser's own scroll to the fragment is about to happen — treating
+      // this as a traversal would undo it. Focus still needs help: see
+      // `focusFragmentTarget`.
+      const fragmentTarget = findFragmentTarget(document, window.location.hash);
+      if (fragmentTarget) focusFragmentTarget(fragmentTarget);
+      return;
+    }
+
+    currentDocumentPath = nextDocumentPath;
     navigate(window.location.pathname + window.location.search + window.location.hash, {
       _popstate: true,
     });

--- a/packages/framework/test/fragment-navigation.test.ts
+++ b/packages/framework/test/fragment-navigation.test.ts
@@ -1,0 +1,128 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  decodeFragmentId,
+  findFragmentTarget,
+  focusFragmentTarget,
+  scrollToFragmentTarget,
+} from "../src/fragment-navigation.ts";
+
+describe("fragment navigation helpers", () => {
+  afterEach(() => {
+    document.body.innerHTML = "";
+    vi.restoreAllMocks();
+  });
+
+  describe("decodeFragmentId", () => {
+    it("strips the leading # and percent-decodes the id", () => {
+      expect(decodeFragmentId("#section")).toBe("section");
+      expect(decodeFragmentId("section")).toBe("section");
+      expect(decodeFragmentId("#%C3%BCberblick")).toBe("überblick");
+    });
+
+    it("returns an empty id for an empty fragment", () => {
+      expect(decodeFragmentId("#")).toBe("");
+      expect(decodeFragmentId("")).toBe("");
+    });
+
+    it("keeps a malformed encoding verbatim rather than throwing", () => {
+      expect(decodeFragmentId("#100%")).toBe("100%");
+    });
+  });
+
+  describe("findFragmentTarget", () => {
+    it("resolves an element by its decoded id", () => {
+      document.body.innerHTML = `<h2 id="überblick">Überblick</h2>`;
+      expect(findFragmentTarget(document, "#%C3%BCberblick")?.id).toBe("überblick");
+    });
+
+    it("returns null for an empty or unresolvable fragment", () => {
+      document.body.innerHTML = `<h2 id="here">here</h2>`;
+      expect(findFragmentTarget(document, "#")).toBeNull();
+      expect(findFragmentTarget(document, "#missing")).toBeNull();
+    });
+  });
+
+  describe("focusFragmentTarget", () => {
+    it("focuses a non-focusable target through a temporary tabindex", () => {
+      document.body.innerHTML = `<main id="main">content</main>`;
+      const main = document.getElementById("main")!;
+
+      focusFragmentTarget(main);
+
+      expect(document.activeElement).toBe(main);
+      expect(main.getAttribute("tabindex")).toBe("-1");
+    });
+
+    it("removes the temporary tabindex again on blur", () => {
+      document.body.innerHTML = `<main id="main">content</main><a id="next" href="/">next</a>`;
+      const main = document.getElementById("main")!;
+
+      focusFragmentTarget(main);
+      expect(main.getAttribute("tabindex")).toBe("-1");
+
+      document.getElementById("next")!.focus();
+
+      expect(main.hasAttribute("tabindex")).toBe(false);
+      expect(main.hasAttribute("data-pracht-fragment-tabindex")).toBe(false);
+    });
+
+    it("leaves a natively focusable target's attributes alone", () => {
+      document.body.innerHTML = `<a id="target" href="/somewhere">target</a>`;
+      const target = document.getElementById("target")!;
+
+      focusFragmentTarget(target);
+
+      expect(document.activeElement).toBe(target);
+      expect(target.hasAttribute("tabindex")).toBe(false);
+    });
+
+    it("does not clobber an author-provided tabindex", () => {
+      document.body.innerHTML = `<div id="target" tabindex="0">target</div>`;
+      const target = document.getElementById("target")!;
+
+      focusFragmentTarget(target);
+
+      expect(target.getAttribute("tabindex")).toBe("0");
+
+      // Blur must not strip an attribute the route authored.
+      target.dispatchEvent(new FocusEvent("blur"));
+      expect(target.getAttribute("tabindex")).toBe("0");
+    });
+
+    it("focuses without scrolling, leaving scroll behavior to the caller", () => {
+      document.body.innerHTML = `<main id="main">content</main>`;
+      const main = document.getElementById("main")!;
+      const focusSpy = vi.spyOn(main, "focus");
+
+      focusFragmentTarget(main);
+
+      expect(focusSpy).toHaveBeenCalledWith({ preventScroll: true });
+    });
+  });
+
+  describe("scrollToFragmentTarget", () => {
+    it("scrolls with no behavior option so CSS scroll-behavior decides", () => {
+      document.body.innerHTML = `<h2 id="section">section</h2>`;
+      const target = document.getElementById("section")!;
+      const scrollIntoView = vi.fn();
+      target.scrollIntoView = scrollIntoView;
+
+      scrollToFragmentTarget(target);
+
+      expect(scrollIntoView).toHaveBeenCalledWith();
+      expect(document.activeElement).toBe(target);
+    });
+
+    it("still focuses when scrollIntoView is unavailable", () => {
+      document.body.innerHTML = `<h2 id="section">section</h2>`;
+      const target = document.getElementById("section")!;
+      // jsdom does not implement scrollIntoView unless a test provides it.
+      (target as { scrollIntoView?: unknown }).scrollIntoView = undefined;
+
+      expect(() => scrollToFragmentTarget(target)).not.toThrow();
+      expect(document.activeElement).toBe(target);
+    });
+  });
+});

--- a/packages/framework/test/router-navigation.test.ts
+++ b/packages/framework/test/router-navigation.test.ts
@@ -44,6 +44,15 @@ describe("navigation UX primitives (client router)", () => {
   let root: HTMLDivElement;
   let fetchSpy: ReturnType<typeof vi.fn>;
   let scrollToSpy: ReturnType<typeof vi.fn>;
+  // `initClientRouter` has no teardown, so without this every router from an
+  // earlier test stays subscribed to the shared jsdom window and reacts to
+  // events a later test dispatches.
+  let routerListeners: Array<{
+    target: EventTarget;
+    type: string;
+    handler: EventListenerOrEventListenerObject;
+    options?: boolean | AddEventListenerOptions;
+  }> = [];
 
   function createRouterApp(options?: { viewTransitions?: boolean }) {
     return resolveApp(
@@ -58,20 +67,40 @@ describe("navigation UX primitives (client router)", () => {
   }
 
   async function initRouter(options?: { viewTransitions?: boolean }): Promise<void> {
-    await initClientRouter({
-      app: createRouterApp(options),
-      routeModules: {
-        "./routes/home.tsx": async () => ({ default: () => h("main", null, "home") }),
-        "./routes/next.tsx": async () => ({ default: () => h("main", null, "next") }),
-      },
-      shellModules: {},
-      initialState: { data: null, routeId: "home", url: "/" },
-      root,
-      findModuleKey: (_modules, file) => file,
+    const targets: EventTarget[] = [window, document];
+    const originals = targets.map((target) => target.addEventListener.bind(target));
+    targets.forEach((target, i) => {
+      target.addEventListener = ((
+        type: string,
+        handler: EventListenerOrEventListenerObject,
+        opts?: boolean | AddEventListenerOptions,
+      ) => {
+        routerListeners.push({ target, type, handler, options: opts });
+        originals[i](type, handler, opts);
+      }) as typeof target.addEventListener;
     });
+
+    try {
+      await initClientRouter({
+        app: createRouterApp(options),
+        routeModules: {
+          "./routes/home.tsx": async () => ({ default: () => h("main", null, "home") }),
+          "./routes/next.tsx": async () => ({ default: () => h("main", null, "next") }),
+        },
+        shellModules: {},
+        initialState: { data: null, routeId: "home", url: "/" },
+        root,
+        findModuleKey: (_modules, file) => file,
+      });
+    } finally {
+      targets.forEach((target, i) => {
+        target.addEventListener = originals[i] as typeof target.addEventListener;
+      });
+    }
   }
 
   beforeEach(() => {
+    routerListeners = [];
     document.body.innerHTML = "";
     root = document.createElement("div");
     document.body.appendChild(root);
@@ -86,6 +115,10 @@ describe("navigation UX primitives (client router)", () => {
   });
 
   afterEach(() => {
+    for (const { target, type, handler, options } of routerListeners) {
+      target.removeEventListener(type, handler, options as EventListenerOptions);
+    }
+    routerListeners = [];
     render(null, root);
     root.remove();
     vi.unstubAllGlobals();
@@ -214,6 +247,71 @@ describe("navigation UX primitives (client router)", () => {
 
     expect(scrollToSpy).toHaveBeenCalledWith(0, 800);
     Object.defineProperty(window, "scrollY", { configurable: true, value: 0 });
+  });
+
+  it("leaves a same-document fragment navigation to the browser", async () => {
+    fetchSpy.mockImplementation(async () => createJsonResponse({ data: null }));
+    await initRouter();
+    document.body.insertAdjacentHTML("beforeend", `<main id="main">main content</main>`);
+
+    fetchSpy.mockClear();
+    scrollToSpy.mockClear();
+
+    // A fragment navigation from `<a href="#main">`: the browser pushes an
+    // entry of its own (no scroll key on `history.state`) and fires popstate
+    // *before* scrolling to the fragment.
+    history.pushState(null, "", "/#main");
+    window.dispatchEvent(new PopStateEvent("popstate", { state: null }));
+    await flush();
+    await flush();
+
+    // Nothing to re-resolve, and no scroll of the router's own — restoring a
+    // saved position here is what used to undo the browser's jump.
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(scrollToSpy).not.toHaveBeenCalled();
+    // Focus follows the fragment, which is the half a skip link depends on.
+    expect(document.activeElement).toBe(document.getElementById("main"));
+  });
+
+  it("still re-resolves the route when a keyless entry changes the path", async () => {
+    fetchSpy.mockImplementation(async () => createJsonResponse({ data: null }));
+    await initRouter();
+    fetchSpy.mockClear();
+
+    // App code that wipes `history.state` (a stray `replaceState(null, …)`)
+    // leaves entries without a scroll key. A missing key alone must not be
+    // read as "fragment navigation" when the document actually changed.
+    history.pushState(null, "", "/next");
+    window.dispatchEvent(new PopStateEvent("popstate", { state: null }));
+    await flush();
+    await flush();
+
+    expect(fetchSpy).toHaveBeenCalled();
+    expect(root.textContent).toContain("next");
+  });
+
+  it("lands on the fragment when a traversal has no saved position", async () => {
+    fetchSpy.mockImplementation(async () => createJsonResponse({ data: null }));
+    await initRouter();
+    document.body.insertAdjacentHTML("beforeend", `<main id="main">main content</main>`);
+    const target = document.getElementById("main")!;
+    const scrollIntoView = vi.fn();
+    target.scrollIntoView = scrollIntoView;
+
+    await window.__PRACHT_NAVIGATE__!("/next");
+    await flush();
+    scrollToSpy.mockClear();
+
+    // Traverse back onto a URL that carries a fragment, under a scroll key
+    // nothing was ever saved for.
+    const entryState = { [HISTORY_STATE_KEY]: "never-saved" };
+    history.replaceState(entryState, "", "/#main");
+    window.dispatchEvent(new PopStateEvent("popstate", { state: entryState }));
+    await flush();
+    await flush();
+
+    expect(scrollIntoView).toHaveBeenCalled();
+    expect(scrollToSpy).not.toHaveBeenCalledWith(0, 0);
   });
 
   it("sets history.scrollRestoration to manual when supported", async () => {


### PR DESCRIPTION
## Summary

The client router was undoing in-page fragment scrolls and not moving focus to fragment targets, breaking skip links and in-page anchors.

**Root cause:** Clicking `<a href="#section">` fires `popstate` for a brand new history entry, not a traversal. The router treated every `popstate` as a back/forward navigation and restored the saved scroll position, which scrolled the page back from the fragment the browser had just jumped to.

**Solution:** The router now distinguishes fragment navigations from traversals by checking if the scroll key (stamped into `history.state` for every entry the router creates) is missing AND the path/query are unchanged. When detected, the browser's own jump is left to stand.

Additionally, when the router scrolls to a fragment itself (client-side navigation or traversal with no saved position), it now moves focus to the target by:
- Adding a temporary `tabindex="-1"` for non-focusable elements (headings, landmarks)
- Removing the attribute on blur to leave the DOM as authored
- Preserving author-provided `tabindex` attributes
- Calling `focus({ preventScroll: true })` to avoid interrupting CSS `scroll-behavior`

This restores the sequential focus navigation starting point, which is essential for skip links to work correctly.

**Changes:**
- New `fragment-navigation.ts` module with helpers: `decodeFragmentId()`, `findFragmentTarget()`, `focusFragmentTarget()`, `scrollToFragmentTarget()`
- Updated `router.ts` to detect and handle fragment navigations, and to focus fragment targets
- Added comprehensive unit tests for fragment navigation helpers
- Added e2e tests for in-page fragment links (scroll position, focus, back navigation)
- Added `/fragment` test route with skip link
- Updated routing documentation with scroll behavior details and caveats

## Testing

- [x] `pnpm e2e` — New e2e tests verify fragment link scrolling, focus movement, and back navigation
- [x] `pnpm test` — New unit tests for fragment navigation helpers and router popstate handling
- [x] `pnpm format`
- [x] `pnpm lint`

## Checklist

- [x] Docs updated (ROUTING.md with scroll behavior and fragment navigation details)
- [x] Changeset added (@pracht/core patch)

https://claude.ai/code/session_01WsGLt6Ro49zViRVddW1tHj