### PR TITLE
Fix repeat fragment link clicks doing nothing

### DIFF
--- a/.changeset/dull-otters-arrive.md
+++ b/.changeset/dull-otters-arrive.md
@@ -1,0 +1,20 @@
+---
+"@pracht/core": patch
+---
+
+Fix a repeat click on an in-page fragment link doing nothing.
+
+Fragment links were left to the browser, which works once: the browser pushes an
+entry with no scroll key, and the router recognizes the `popstate` that follows
+as a fragment navigation rather than a traversal — but stamps a scroll key onto
+that entry in the process. Clicking the same link again reuses the entry, so the
+key is now there, the `popstate` reads as a back/forward traversal, and the
+position saved for the entry (the top of the page, where the user had scrolled
+back to) is faithfully restored. The click was dead.
+
+The client router now commits fragment link clicks itself — pushing the history
+entry, scrolling to the target, and moving focus there — so a repeat click always
+scrolls, and `popstate` is left to mean "traversal", which is what the
+scroll-key logic assumes. `hashchange` is dispatched for the intercepted
+navigation, since `pushState` fires none. The `popstate` guard stays as the
+fallback for fragment entries created another way (`location.hash = "…"`).

--- a/docs/ROUTING.md
+++ b/docs/ROUTING.md
@@ -385,20 +385,34 @@ The client router owns scrolling (`history.scrollRestoration = "manual"`):
   in `sessionStorage`, so they survive reloads and back-navigation from
   external sites. If an entry has no saved position but its URL carries a
   fragment, the fragment wins over a reset to the top.
-- **In-page fragment links** (`<a href="#section">`) are left to the browser.
-  These fire `popstate` for a *new* history entry rather than a traversal; the
+- **In-page fragment links** (`<a href="#section">`) are committed by the router
+  itself: it pushes the history entry, scrolls to the target, and moves focus
+  there. Leaving them to the browser only works for the first click — clicking a
+  link to the fragment you are already at reuses the current history entry, and
+  the `popstate` that follows is indistinguishable from a back/forward
+  traversal, so the router would restore the position saved for that entry and
+  the click would do nothing. Because `history.pushState()` fires no
+  `hashchange` of its own, the router dispatches one, so app code listening for
+  the platform event still hears about the fragment change.
+- **Fragment entries the router did not create** — `location.hash = "…"`, say —
+  still arrive as a `popstate` for a *new* entry rather than a traversal. The
   router tells the two apart by the scroll key it stamps into `history.state`
-  for every entry it creates, and stays out of the way so the browser's own
-  jump stands.
+  for every entry it creates, and stays out of the way so the browser's own jump
+  stands.
 - Opt out per navigation with `<Link preserveScroll>` or
-  `navigate(to, { preserveScroll: true })`.
+  `navigate(to, { preserveScroll: true })`. On a fragment link this updates the
+  URL without moving the viewport.
 
-Whenever the router scrolls to a fragment itself — a client-side navigation to
-`/docs/routing#loaders`, or a traversal onto a URL with a fragment — it also
-moves focus to the target, adding a temporary `tabindex="-1"` when the element
-is not natively focusable and removing it again on blur. Without this a skip
-link scrolls but leaves the next Tab stop at the top of the page, sending the
-user back into the navigation they just skipped.
+Whenever the router scrolls to a fragment — an in-page fragment link, a
+client-side navigation to `/docs/routing#loaders`, or a traversal onto a URL
+with a fragment — it also moves focus to the target, adding a temporary
+`tabindex="-1"` when the element is not natively focusable and removing it again
+on blur. Without this a skip link scrolls but leaves the next Tab stop at the
+top of the page, sending the user back into the navigation they just skipped.
+
+When a fragment matches no element the router does what the browser does: it
+scrolls to the top of the document only for the empty fragment and the legacy
+`#top`, and stays exactly where it is otherwise.
 
 `scrollIntoView()` is called with no `behavior` option, so how the page scrolls
 stays a CSS decision:

--- a/e2e/navigation.test.ts
+++ b/e2e/navigation.test.ts
@@ -131,6 +131,34 @@ test("an in-page fragment link moves focus to its target", async ({ page }) => {
   await expect(page.locator("#fragment-home-link")).toBeFocused();
 });
 
+test("clicking the same fragment link again scrolls back to its target", async ({ page }) => {
+  await page.goto("/fragment");
+  await waitForRouter(page);
+
+  await page.evaluate(() => document.getElementById("skip-link")!.click());
+  await page.waitForFunction(() => window.location.hash === "#fragment-main");
+
+  const target = await fragmentTargetOffset(page);
+  await page.waitForFunction((y) => Math.abs(window.scrollY - y) <= 1, target);
+
+  await page.evaluate(() => window.scrollTo(0, 0));
+  await page.waitForFunction(() => window.scrollY === 0);
+
+  // The regression this guards: a repeat click reuses the history entry rather
+  // than pushing a new one, so the entry already carries the router's scroll
+  // key. Read as a back/forward traversal, the router restored the position
+  // saved for it — the top of the page — and the click did nothing at all.
+  await page.evaluate(() => document.getElementById("skip-link")!.click());
+  await page.waitForFunction((y) => Math.abs(window.scrollY - y) <= 1, target);
+
+  await page.waitForTimeout(250);
+  expect(Math.abs((await page.evaluate(() => window.scrollY)) - target)).toBeLessThanOrEqual(1);
+
+  // Two clicks, one entry: going back once leaves the fragment behind.
+  await page.goBack();
+  await page.waitForFunction(() => window.location.hash === "");
+});
+
 test("going back from a fragment link returns to the previous scroll position", async ({
   page,
 }) => {

--- a/packages/framework/src/router.ts
+++ b/packages/framework/src/router.ts
@@ -5,6 +5,7 @@ import type { FunctionComponent } from "preact";
 
 import { buildHref, matchResolvedRoute } from "./route-matching.ts";
 import {
+  decodeFragmentId,
   findFragmentTarget,
   focusFragmentTarget,
   scrollToFragmentTarget,
@@ -207,6 +208,75 @@ export async function initClientRouter(options: InitClientRouterOptions): Promis
     }
 
     window.scrollTo(0, 0);
+  }
+
+  /**
+   * Scroll to (and focus) a fragment the way a browser would.
+   *
+   * When nothing matches there is no indicated part to scroll to: the browser
+   * goes to the top of the document only for the empty fragment and the
+   * legacy `#top`, and stays exactly where it is otherwise.
+   */
+  function scrollToFragment(hash: string): void {
+    const target = findFragmentTarget(document, hash);
+    if (target) {
+      scrollToFragmentTarget(target);
+      return;
+    }
+
+    const id = decodeFragmentId(hash);
+    if (id === "" || id.toLowerCase() === "top") {
+      window.scrollTo(0, 0);
+    }
+  }
+
+  /**
+   * Commit an in-page fragment navigation from a link click.
+   *
+   * The browser does this itself, but only the first time. Clicking a link to
+   * the fragment you are already at reuses the current history entry instead
+   * of pushing a new one, and `popstate` alone cannot tell that reuse apart
+   * from a back/forward traversal — the entry already carries a scroll key, so
+   * the router would read it as a traversal and restore the position saved for
+   * it, undoing the browser's jump. (The Navigation API's `navigationType`
+   * would separate the two, but it is not available everywhere.)
+   *
+   * Owning the whole interaction here makes a repeat click scroll every time
+   * and leaves `popstate` to mean "traversal", which is what the scroll-key
+   * logic assumes. The guard in the popstate handler stays as the fallback for
+   * fragment entries created some other way (`location.hash = …`).
+   */
+  function commitFragmentNavigation(url: URL, preserveScroll: boolean): void {
+    const previousUrl = window.location.href;
+
+    if (url.href !== previousUrl) {
+      // The entry being left keeps the position it was actually at.
+      saveScrollPosition();
+      const nextScrollKey = generateScrollKey();
+      try {
+        history.pushState(
+          withScrollKeyInHistoryState(null, nextScrollKey),
+          "",
+          url.pathname + url.search + url.hash,
+        );
+        currentScrollKey = nextScrollKey;
+      } catch {
+        // History mutation restricted — the scroll below still lands, the
+        // entry just is not recorded.
+      }
+    }
+    currentDocumentPath = url.pathname + url.search;
+
+    if (!preserveScroll) {
+      scrollToFragment(url.hash);
+    }
+
+    // `pushState` fires neither `hashchange` nor `popstate`, so app code
+    // listening for the platform event still needs to hear about this.
+    const nextUrl = window.location.href;
+    if (nextUrl !== previousUrl) {
+      dispatchHashChange(previousUrl, nextUrl);
+    }
   }
 
   // Runs after the DOM for a newly committed route state is in place —
@@ -640,18 +710,31 @@ export async function initClientRouter(options: InitClientRouterOptions): Promis
     if (anchor.hasAttribute("download")) return;
 
     const href = anchor.getAttribute("href");
-    if (!href || href.startsWith("#")) return;
+    if (!href) return;
 
-    // Resolve relative URLs
+    // Resolve relative URLs. A bare `#fragment` resolves against the full
+    // current URL — against the origin alone it would lose the path.
+    const isFragmentHref = href.startsWith("#");
     let url: URL;
     try {
-      url = new URL(href, window.location.origin);
+      url = new URL(href, isFragmentHref ? window.location.href : window.location.origin);
     } catch {
       return;
     }
 
     // Skip external origins
     if (url.origin !== window.location.origin) return;
+
+    // In-page fragment navigation: same document, only the fragment differs.
+    // Handled before the speculation check below because no document is
+    // fetched here, so prerendering has nothing to activate.
+    const isSameDocument =
+      url.pathname + url.search === window.location.pathname + window.location.search;
+    if (isSameDocument && (url.hash !== "" || isFragmentHref)) {
+      e.preventDefault();
+      commitFragmentNavigation(url, anchor.hasAttribute(PRESERVE_SCROLL_ATTRIBUTE));
+      return;
+    }
 
     // If the destination route opted into `prerender` speculation rules, let
     // the browser perform a normal navigation so it can activate the
@@ -681,14 +764,19 @@ export async function initClientRouter(options: InitClientRouterOptions): Promis
     let nextScrollKey = readScrollKeyFromHistoryState(history.state);
     const nextDocumentPath = window.location.pathname + window.location.search;
 
-    // `<a href="#section">` fires popstate too, for a brand new entry rather
-    // than a traversal. Two signals separate the cases: the router stamps a
-    // scroll key into `history.state` for every entry it creates, so a
+    // A fragment navigation the router did not commit itself — `location.hash
+    // = "…"`, or an anchor click it never saw — fires popstate for a brand new
+    // entry rather than a traversal. Two signals separate the cases: the router
+    // stamps a scroll key into `history.state` for every entry it creates, so a
     // missing key means this entry came from somewhere else; and a fragment
     // navigation cannot change the path or query. Requiring both means an
     // entry whose state was wiped by app code (a stray
     // `history.replaceState(null, …)`) is still re-resolved when the route
     // really did change.
+    //
+    // Link clicks no longer reach this branch: they are committed in the click
+    // handler, because a repeat click on the fragment you are already at reuses
+    // the entry and so arrives here indistinguishable from a traversal.
     const isFragmentNavigation = !nextScrollKey && nextDocumentPath === currentDocumentPath;
 
     if (!nextScrollKey) {
@@ -748,6 +836,23 @@ export async function initClientRouter(options: InitClientRouterOptions): Promis
   void import("./prefetch.ts").then(({ setupPrefetching }) => {
     setupPrefetching(app, warmModules);
   });
+}
+
+/**
+ * Fire the `hashchange` the platform would have fired for a fragment
+ * navigation the router intercepted. Both URLs are absolute, as the event's
+ * `oldURL`/`newURL` are specified to be.
+ */
+function dispatchHashChange(oldURL: string, newURL: string): void {
+  let event: Event;
+  try {
+    event = new HashChangeEvent("hashchange", { oldURL, newURL });
+  } catch {
+    // Environments without the HashChangeEvent constructor still get the
+    // notification, just without the URL details.
+    event = new Event("hashchange");
+  }
+  window.dispatchEvent(event);
 }
 
 interface ViewTransitionLike {

--- a/packages/framework/test/router-navigation.test.ts
+++ b/packages/framework/test/router-navigation.test.ts
@@ -10,6 +10,7 @@ import {
   type Navigation,
 } from "../src/navigation-state.ts";
 import { clearPrefetchCache } from "../src/prefetch-cache.ts";
+import { PRESERVE_SCROLL_ATTRIBUTE } from "../src/runtime-constants.ts";
 import { HISTORY_STATE_KEY } from "../src/scroll-restoration.ts";
 
 function createJsonResponse(body: unknown, init?: ResponseInit): Response {
@@ -97,6 +98,27 @@ describe("navigation UX primitives (client router)", () => {
         target.addEventListener = originals[i] as typeof target.addEventListener;
       });
     }
+  }
+
+  /** A skip-link-shaped fragment link plus the target it points at. */
+  function mountFragmentLink(): {
+    link: HTMLAnchorElement;
+    target: HTMLElement;
+    scrollIntoView: ReturnType<typeof vi.fn>;
+  } {
+    document.body.insertAdjacentHTML(
+      "beforeend",
+      `<a id="fragment-link" href="#main">skip to content</a><main id="main">main content</main>`,
+    );
+    const target = document.getElementById("main")!;
+    // jsdom does not implement scrollIntoView unless a test provides it.
+    const scrollIntoView = vi.fn();
+    target.scrollIntoView = scrollIntoView;
+    return {
+      link: document.getElementById("fragment-link") as HTMLAnchorElement,
+      target,
+      scrollIntoView,
+    };
   }
 
   beforeEach(() => {
@@ -249,7 +271,7 @@ describe("navigation UX primitives (client router)", () => {
     Object.defineProperty(window, "scrollY", { configurable: true, value: 0 });
   });
 
-  it("leaves a same-document fragment navigation to the browser", async () => {
+  it("leaves a fragment entry the router did not create to the browser", async () => {
     fetchSpy.mockImplementation(async () => createJsonResponse({ data: null }));
     await initRouter();
     document.body.insertAdjacentHTML("beforeend", `<main id="main">main content</main>`);
@@ -257,9 +279,9 @@ describe("navigation UX primitives (client router)", () => {
     fetchSpy.mockClear();
     scrollToSpy.mockClear();
 
-    // A fragment navigation from `<a href="#main">`: the browser pushes an
-    // entry of its own (no scroll key on `history.state`) and fires popstate
-    // *before* scrolling to the fragment.
+    // A fragment navigation the click handler never saw — `location.hash =
+    // "…"`, say: the browser pushes an entry of its own (no scroll key on
+    // `history.state`) and fires popstate *before* scrolling to the fragment.
     history.pushState(null, "", "/#main");
     window.dispatchEvent(new PopStateEvent("popstate", { state: null }));
     await flush();
@@ -312,6 +334,113 @@ describe("navigation UX primitives (client router)", () => {
 
     expect(scrollIntoView).toHaveBeenCalled();
     expect(scrollToSpy).not.toHaveBeenCalledWith(0, 0);
+  });
+
+  it("commits an in-page fragment link click itself", async () => {
+    fetchSpy.mockImplementation(async () => createJsonResponse({ data: null }));
+    await initRouter();
+    const { link, target, scrollIntoView } = mountFragmentLink();
+    fetchSpy.mockClear();
+    scrollToSpy.mockClear();
+
+    link.click();
+    await flush();
+
+    expect(window.location.hash).toBe("#main");
+    expect(scrollIntoView).toHaveBeenCalled();
+    expect(document.activeElement).toBe(target);
+    // The route is already rendered — there is no document to fetch.
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(scrollToSpy).not.toHaveBeenCalled();
+    // The pushed entry carries a scroll key, so traversing back onto it later
+    // restores like any other entry the router created.
+    expect(typeof (history.state as Record<string, unknown>)?.[HISTORY_STATE_KEY]).toBe("string");
+  });
+
+  it("scrolls again when the same fragment link is clicked a second time", async () => {
+    fetchSpy.mockImplementation(async () => createJsonResponse({ data: null }));
+    await initRouter();
+    const { link, scrollIntoView } = mountFragmentLink();
+
+    link.click();
+    await flush();
+
+    const entriesAfterFirstClick = history.length;
+    scrollIntoView.mockClear();
+    scrollToSpy.mockClear();
+    fetchSpy.mockClear();
+
+    // The user scrolled away and clicked the same link again. The browser
+    // reuses the history entry for a repeat click, so the entry already
+    // carries a scroll key — read as a traversal, the router would restore the
+    // position saved for it (the top of the page) and the click would do
+    // nothing at all.
+    link.click();
+    await flush();
+
+    expect(scrollIntoView).toHaveBeenCalled();
+    expect(scrollToSpy).not.toHaveBeenCalled();
+    expect(fetchSpy).not.toHaveBeenCalled();
+    // …and it must not pile up a duplicate history entry either.
+    expect(history.length).toBe(entriesAfterFirstClick);
+  });
+
+  it("fires hashchange for a fragment link click, but not for a repeat click", async () => {
+    fetchSpy.mockImplementation(async () => createJsonResponse({ data: null }));
+    await initRouter();
+    const { link } = mountFragmentLink();
+
+    const events: HashChangeEvent[] = [];
+    const listener = (event: Event) => events.push(event as HashChangeEvent);
+    window.addEventListener("hashchange", listener);
+    try {
+      link.click();
+      await flush();
+
+      // `pushState` fires nothing on its own; app code listening for the
+      // platform event still needs to hear about the fragment change.
+      expect(events).toHaveLength(1);
+      expect(events[0].newURL).toContain("#main");
+
+      link.click();
+      await flush();
+
+      // The hash did not change this time, so neither would the platform.
+      expect(events).toHaveLength(1);
+    } finally {
+      window.removeEventListener("hashchange", listener);
+    }
+  });
+
+  it("skips the fragment scroll when the link opts out with preserveScroll", async () => {
+    fetchSpy.mockImplementation(async () => createJsonResponse({ data: null }));
+    await initRouter();
+    const { link, scrollIntoView } = mountFragmentLink();
+    link.setAttribute(PRESERVE_SCROLL_ATTRIBUTE, "");
+    scrollToSpy.mockClear();
+
+    link.click();
+    await flush();
+
+    // The URL still updates — only the viewport is left alone.
+    expect(window.location.hash).toBe("#main");
+    expect(scrollIntoView).not.toHaveBeenCalled();
+    expect(scrollToSpy).not.toHaveBeenCalled();
+  });
+
+  it("still resolves the route for a link that changes the path and carries a fragment", async () => {
+    fetchSpy.mockImplementation(async () => createJsonResponse({ data: null }));
+    await initRouter();
+    document.body.insertAdjacentHTML("beforeend", `<a id="cross-doc" href="/next#main">next</a>`);
+    fetchSpy.mockClear();
+
+    (document.getElementById("cross-doc") as HTMLAnchorElement).click();
+    await flush();
+    await flush();
+
+    expect(fetchSpy).toHaveBeenCalled();
+    expect(root.textContent).toContain("next");
+    expect(window.location.pathname).toBe("/next");
   });
 
   it("sets history.scrollRestoration to manual when supported", async () => {


### PR DESCRIPTION
## Summary

Fragment links were left to the browser, which works once: the browser pushes an entry with no scroll key, and the router recognizes the `popstate` that follows as a fragment navigation rather than a traversal — but stamps a scroll key onto that entry in the process. Clicking the same link again reuses the entry, so the key is now there, the `popstate` reads as a back/forward traversal, and the position saved for the entry is faithfully restored. The click was dead.

The client router now commits fragment link clicks itself — pushing the history entry, scrolling to the target, and moving focus there — so a repeat click always scrolls, and `popstate` is left to mean "traversal", which is what the scroll-key logic assumes. `hashchange` is dispatched for the intercepted navigation, since `pushState` fires none. The `popstate` guard stays as the fallback for fragment entries created another way (`location.hash = "…"`).

## Testing

- [x] `pnpm e2e` — Added e2e test for repeat fragment link clicks
- [x] `pnpm format`
- [x] `pnpm lint`
- [x] `pnpm test` — Added comprehensive unit tests covering:
  - In-page fragment link clicks are committed by the router
  - Repeat clicks on the same fragment link scroll again
  - `hashchange` fires for first click but not repeat clicks
  - `preserveScroll` attribute skips fragment scrolling
  - Cross-document links with fragments still resolve the route

## Checklist

- [x] Docs updated if needed — Updated ROUTING.md to reflect new fragment link behavior
- [x] Skills updated if needed — N/A
- [x] Changeset added if published packages changed — Added changeset for @pracht/core

https://claude.ai/code/session_013UFWjaW9edaC5UZeNgbaMH