### PR TITLE
feat: add data-only initial rendering

### DIFF
--- a/.changeset/data-render-mode.md
+++ b/.changeset/data-render-mode.md
@@ -1,0 +1,7 @@
+---
+"@pracht/core": minor
+"@pracht/cli": minor
+"create-pracht": patch
+---
+
+Add the data render mode for server-loaded state with browser-rendered route components and no duplicate startup fetch.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 **Full-stack Preact, per route.** _(pracht /praxt/ — Dutch & German for splendor. Also: how you've always mispronounced Preact.)_
 
-Pick SPA, SSR, SSG, or ISG on a route-by-route basis. Ship less JavaScript by default. Deploy the same codebase to Node, Cloudflare, or Vercel.
+Pick data-only, SPA, SSR, SSG, or ISG rendering on a route-by-route basis. Ship less JavaScript by default. Deploy the same codebase to Node, Cloudflare, or Vercel.
 
 ```bash
 npm create pracht@latest my-app
@@ -24,7 +24,7 @@ npm create pracht@latest my-app
 ## Why pracht
 
 - **Preact-first** — the low bundle size that you know and love with a familiar API.
-- **Per-route render modes** — SPA, SSR, SSG, and ISG in the same app. No global default fighting you.
+- **Per-route render modes** — data-only, SPA, SSR, SSG, and ISG in the same app. No global default fighting you.
 - **Explicit over magic** — a typed `defineApp()` manifest wires routes, shells, and middleware. What runs where is never a mystery. Prefer file-based routing? Opt in to the pages router and skip the manifest entirely.
 - **Vite-native** — instant HMR, fast builds, multi-environment output out of the box.
 - **Performance budgets built in** — `pracht build --analyze` reports per-route client JS (gzip + raw), and per-route `budgets` fail the build when a route ships too much.

--- a/VISION_MVP.md
+++ b/VISION_MVP.md
@@ -39,14 +39,15 @@ Pracht is a full-stack Preact framework built on Vite. It draws routing and rend
 
 ### Rendering Modes
 
-Per-route render mode via `{ render: "spa" | "ssr" | "ssg" | "isg" }`:
+Per-route render mode via `{ render: "data" | "spa" | "ssr" | "ssg" | "isg" }`:
 
-| Mode | When HTML is generated | Use case                      |
-| ---- | ---------------------- | ----------------------------- |
-| SPA  | Client only            | Dashboards, auth-gated UI     |
-| SSR  | Every request          | Personalized / dynamic pages  |
-| SSG  | Build time             | Marketing, docs, blog         |
-| ISG  | Build + revalidation   | Pricing, catalog, semi-static |
+| Mode | When route HTML is generated | Use case                              |
+| ---- | ---------------------------- | ------------------------------------- |
+| Data | Browser from embedded data   | Browser-heavy personalized app routes |
+| SPA  | Browser after state fetch    | Dashboards that avoid embedded data   |
+| SSR  | Every request                | Personalized / dynamic pages          |
+| SSG  | Build time                   | Marketing, docs, blog                 |
+| ISG  | Build + revalidation         | Pricing, catalog, semi-static         |
 
 ISG supports time-based and webhook-based revalidation policies.
 

--- a/docs/DATA_LOADING.md
+++ b/docs/DATA_LOADING.md
@@ -54,6 +54,7 @@ instead of rendering the component. Both the HTML and markdown responses carry
 | ----------------- | ----------------------------------------------------------------- |
 | SSG build         | Build machine, once per path                                      |
 | SSR request       | Server, every request                                             |
+| Data initial load | Server, embedded once; the browser renders the route component    |
 | ISG initial       | Build machine, then adapter runtime where supported              |
 | SPA               | Server, during route-state fetches; initial HTML stays shell-only |
 | Client navigation | Server (fetched as JSON via `x-pracht-route-state-request`)       |

--- a/docs/ISLANDS.md
+++ b/docs/ISLANDS.md
@@ -84,8 +84,8 @@ route(path, file, { render: "ssg", hydration: "islands" });
 
 - `hydration` works with `ssg`, `isg`, and `ssr` render modes and can be set
   per route or inherited from a `group(...)`.
-- `render: "spa"` always uses full hydration; combining it with
-  `hydration: "islands"` or `"none"` is a configuration error.
+- `render: "spa"` and `render: "data"` always use full hydration; combining
+  either with `hydration: "islands"` or `"none"` is a configuration error.
 - Groups inherit: `group({ hydration: "islands" }, [...])` applies to every
   route in the group unless a route overrides it.
 

--- a/docs/RENDERING_MODES.md
+++ b/docs/RENDERING_MODES.md
@@ -1,6 +1,6 @@
 # Rendering Modes
 
-Pracht supports four rendering modes, configured per-route. Each route declares
+Pracht supports five rendering modes, configured per-route. Each route declares
 how and when its HTML is generated.
 
 ---
@@ -12,7 +12,8 @@ how and when its HTML is generated.
 | **SSG** | Build time           | Build time               | Static content: marketing, docs, blog |
 | **SSR** | Every request        | Every request            | Personalized/dynamic pages            |
 | **ISG** | Build + revalidation | Build + on stale request | Semi-static: pricing, catalogs        |
-| **SPA** | Client only          | Client navigation        | Auth-gated dashboards, admin UI       |
+| **Data** | Browser from embedded state | Initial server request | Personalized apps without component SSR |
+| **SPA** | Client only          | Route-state request      | Shell-first apps that avoid embedded data |
 
 ---
 
@@ -219,6 +220,35 @@ export function Loading() {
 This improves first paint for auth-gated apps without serializing loader data
 into the initial document by default.
 
+---
+
+## Data — Server Data, Browser Rendering
+
+```typescript
+route("/inbox", () => import("./routes/inbox.tsx"), { render: "data" });
+```
+
+Data mode runs middleware, the loader, and document metadata on the initial
+server request, then embeds the loader result in the hydration state. The
+server sends the assigned shell and its `Loading` placeholder instead of route
+component HTML. The browser renders the component directly from the embedded
+data, so startup needs no second route-state request.
+
+Use it when loader data must be ready immediately but component SSR is too
+expensive, browser-only libraries dominate the route, or you want to isolate
+hydration mismatch risk. Embedded data remains visible in the document; use
+`spa` when the initial response must not contain it.
+
+Data routes require full hydration. Subsequent client navigations use the same
+server-owned route-state endpoint as the other interactive modes, so loaders
+never move into the browser.
+
+### When to use Data
+
+- Personalized app screens where SEO and route-component HTML are unnecessary
+- Routes dominated by browser-only UI with server-owned loading
+- Pages where avoiding a duplicate startup data request matters more than SSR
+
 ### When to use SPA
 
 - Auth-gated pages where SEO doesn't matter, but shell chrome should paint fast
@@ -277,9 +307,9 @@ route("/", () => import("./routes/home.tsx"), {
 | `"islands"`          | Only components from `src/islands/` hydrate; the page is otherwise static. |
 | `"none"`             | Fully static output — no JavaScript is injected at all.                  |
 
-`hydration` combines with `ssg`, `isg`, and `ssr`. `render: "spa"` always
-implies full hydration (combining it with `"islands"`/`"none"` is a config
-error). Routes with `"islands"` or `"none"` use regular full-document
+`hydration` combines with `ssg`, `isg`, and `ssr`. `render: "spa"` and
+`render: "data"` always imply full hydration (combining either with
+`"islands"`/`"none"` is a config error). Routes with `"islands"` or `"none"` use regular full-document
 navigation instead of the client router. See [ISLANDS.md](ISLANDS.md) for the
 full picture: island discovery, hydration strategies (`load`/`idle`/`visible`),
 prop serialization rules, and limitations.

--- a/docs/ROUTING.md
+++ b/docs/ROUTING.md
@@ -121,7 +121,7 @@ Group properties cascade to children. A route's own meta overrides the group's.
 interface RouteMeta {
   id?: string; // Explicit route ID (auto-generated if omitted)
   shell?: string; // Named shell from defineApp.shells
-  render?: "spa" | "ssr" | "ssg" | "isg";
+  render?: "data" | "spa" | "ssr" | "ssg" | "isg";
   hydration?: "full" | "islands" | "none"; // Partial hydration (see ISLANDS.md)
   middleware?: string[]; // Named middleware from defineApp.middleware
   revalidate?: RouteRevalidate; // ISG revalidation policy
@@ -704,7 +704,7 @@ export default function About() {
 }
 ```
 
-Valid values: `"ssr"` | `"ssg"` | `"isg"` | `"spa"`. The default is `"ssr"`,
+Valid values: `"ssr"` | `"data"` | `"ssg"` | `"isg"` | `"spa"`. The default is `"ssr"`,
 overridable globally via `pagesDefaultRender`:
 
 ```typescript

--- a/packages/cli/src/authoring-guide.ts
+++ b/packages/cli/src/authoring-guide.ts
@@ -7,7 +7,7 @@
 export const AUTHORING_GUIDE = `# Pracht — authoring guide for coding agents
 
 Pracht is a full-stack Preact framework on Vite. Per-route render modes
-(spa | ssr | ssg | isg), optional islands hydration, explicit routing, and
+(data | spa | ssr | ssg | isg), optional islands hydration, explicit routing, and
 adapters for Node, Cloudflare Workers, and Vercel.
 
 ## Golden rules

--- a/packages/cli/src/commands/generate.ts
+++ b/packages/cli/src/commands/generate.ts
@@ -59,7 +59,7 @@ const routeCommand = defineCommand({
   },
   args: {
     path: { type: "string", required: true, description: "Route path (e.g. /dashboard)" },
-    render: { type: "string", description: "Render mode: ssr, spa, ssg, or isg" },
+    render: { type: "string", description: "Render mode: ssr, data, spa, ssg, or isg" },
     shell: { type: "string", description: "Shell name" },
     middleware: { type: "string", description: "Middleware names (comma-separated)" },
     loader: { type: "boolean", description: "Include loader" },
@@ -173,7 +173,7 @@ export interface RouteArgs {
 
 export function generateRoute(args: RouteArgs, project: ProjectConfig): GenerateResult {
   const routePath = normalizeRoutePathString(args.path);
-  const render = requireEnum(args.render, "render", ["spa", "ssr", "ssg", "isg"], "ssr");
+  const render = requireEnum(args.render, "render", ["data", "spa", "ssr", "ssg", "isg"], "ssr");
   const includeLoader = Boolean(args.loader);
   const includeErrorBoundary = Boolean(args["error-boundary"]);
   const middleware = parseCommaList(args.middleware);

--- a/packages/cli/src/mcp-server.ts
+++ b/packages/cli/src/mcp-server.ts
@@ -154,7 +154,7 @@ export function createPrachtMcpServer(): McpServer {
         ...cwdInput,
         path: z.string().describe("Route path, e.g. /dashboard or /blog/:slug"),
         render: z
-          .enum(["spa", "ssr", "ssg", "isg"])
+          .enum(["data", "spa", "ssr", "ssg", "isg"])
           .optional()
           .describe("Render mode (defaults to ssr)."),
         shell: z.string().optional().describe("Registered shell name (manifest apps only)."),

--- a/packages/cli/test/pracht-cli.test.js
+++ b/packages/cli/test/pracht-cli.test.js
@@ -960,6 +960,13 @@ export const routes = [
     expect(routeSource).toContain('export const RENDER_MODE = "ssg";');
     expect(routeSource).toContain("export function getStaticPaths()");
     expect(routeSource).toContain('slug: "example-slug"');
+
+    runCli(["generate", "route", "--path", "/inbox", "--render", "data"], {
+      cwd: appDir,
+    });
+    expect(readFileSync(join(appDir, "src/pages/inbox.tsx"), "utf-8")).toContain(
+      'export const RENDER_MODE = "data";',
+    );
   });
 });
 

--- a/packages/framework/src/app.ts
+++ b/packages/framework/src/app.ts
@@ -311,10 +311,14 @@ function flattenRouteNode(
   if (VALIDATE_MANIFEST) {
     assertValidLoaderCache(node.loaderCache, `route "${fullPath}"`);
 
-    if (render === "spa" && hydration !== undefined && hydration !== "full") {
+    if (
+      (render === "spa" || render === "data") &&
+      hydration !== undefined &&
+      hydration !== "full"
+    ) {
       throw new Error(
-        `Route "${fullPath}" combines render: "spa" with hydration: "${hydration}". ` +
-          "SPA routes render entirely in the browser and always use full hydration — " +
+        `Route "${fullPath}" combines render: "${render}" with hydration: "${hydration}". ` +
+          "Browser-rendered routes always use full hydration — " +
           'remove the hydration option or use render: "ssg" / "isg" / "ssr".',
       );
     }

--- a/packages/framework/src/router.ts
+++ b/packages/framework/src/router.ts
@@ -683,7 +683,7 @@ export async function initClientRouter(options: InitClientRouterOptions): Promis
         initialShellPromise,
       );
       if (initialRouteState) {
-        if (initialMatch.route.render === "spa") {
+        if (initialMatch.route.render === "spa" || initialMatch.route.render === "data") {
           render(h(RouterRoot, { initialState: initialRouteState }), root);
         } else {
           markHydrating();

--- a/packages/framework/src/runtime.ts
+++ b/packages/framework/src/runtime.ts
@@ -640,7 +640,7 @@ export async function handlePrachtRequest<TContext>(
           resolvePageJsUrls(options.jsManifest, match.route.shellFile, match.route.file),
         );
 
-        if (match.route.render === "spa") {
+        if (match.route.render === "spa" || match.route.render === "data") {
           let body = "";
           const Shell = shellModule?.Shell as FunctionComponent | undefined;
           const Loading = shellModule?.Loading as FunctionComponent | undefined;
@@ -674,14 +674,17 @@ export async function handlePrachtRequest<TContext>(
               hydrationState: {
                 url: requestPath,
                 routeId: match.route.id ?? "",
-                data: null,
+                data: match.route.render === "data" ? data : null,
                 error: null,
-                pending: true,
+                pending: match.route.render === "spa" ? true : undefined,
               },
               clientEntryUrl: options.clientEntryUrl,
               cssUrls,
               modulePreloadUrls,
-              routeStatePreloadUrl: loader ? buildRouteStateUrl(requestPath) : undefined,
+              routeStatePreloadUrl:
+                match.route.render === "spa" && loader
+                  ? buildRouteStateUrl(requestPath)
+                  : undefined,
               speculationRules: getAppSpeculationRules(resolvedApp),
             }),
             pageOptions.status,

--- a/packages/framework/src/types.ts
+++ b/packages/framework/src/types.ts
@@ -49,7 +49,7 @@ export type RegisteredContext = (Register extends { context: infer T } ? T : unk
  */
 export type PrachtRequestContext = RegisteredContext;
 
-export type RenderMode = "spa" | "ssr" | "ssg" | "isg";
+export type RenderMode = "data" | "spa" | "ssr" | "ssg" | "isg";
 
 /**
  * Per-route hydration mode.

--- a/packages/framework/test/islands.test.ts
+++ b/packages/framework/test/islands.test.ts
@@ -94,6 +94,14 @@ describe("islands route config", () => {
     expect(() => resolveApp(app)).toThrowError(/render: "spa" with hydration: "islands"/);
   });
 
+  it("rejects data render combined with islands hydration", () => {
+    const app = defineApp({
+      routes: [route("/inbox", "./routes/inbox.tsx", { render: "data", hydration: "islands" })],
+    });
+
+    expect(() => resolveApp(app)).toThrowError(/render: "data" with hydration: "islands"/);
+  });
+
   it("allows spa render with explicit full hydration", () => {
     const app = defineApp({
       routes: [route("/settings", "./routes/settings.tsx", { render: "spa", hydration: "full" })],

--- a/packages/framework/test/router-client.test.ts
+++ b/packages/framework/test/router-client.test.ts
@@ -96,6 +96,37 @@ describe("initClientRouter", () => {
     expect(root.textContent).toContain("Hello Jovi");
   });
 
+  it("renders data-mode routes from embedded loader data without fetching", async () => {
+    const app = resolveApp(
+      defineApp({
+        routes: [route("/inbox", "./routes/inbox.tsx", { render: "data" })],
+      }),
+    );
+
+    await initClientRouter({
+      app,
+      routeModules: {
+        "./routes/inbox.tsx": async () => ({
+          default: function Inbox() {
+            const data = useRouteData<{ user: string }>();
+            return h("main", null, `Hello ${data.user}`);
+          },
+        }),
+      },
+      shellModules: {},
+      initialState: {
+        data: { user: "Ada" },
+        routeId: "inbox",
+        url: "/inbox",
+      },
+      root,
+      findModuleKey: (_modules, file) => file,
+    });
+
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(root.textContent).toContain("Hello Ada");
+  });
+
   it("renders typed links and navigates by route target objects", async () => {
     function Home() {
       const navigate = useNavigate();

--- a/packages/framework/test/runtime.test.ts
+++ b/packages/framework/test/runtime.test.ts
@@ -1043,6 +1043,46 @@ describe("handlePrachtRequest document headers", () => {
 });
 
 describe("handlePrachtRequest SPA shell fallback", () => {
+  it("serializes loader data without server-rendering the route in data mode", async () => {
+    const app = defineApp({
+      shells: { app: "./shells/app.tsx" },
+      routes: [route("/inbox", "./routes/inbox.tsx", { render: "data", shell: "app" })],
+    });
+    let loaderCalls = 0;
+
+    const response = await handlePrachtRequest({
+      app,
+      registry: {
+        routeModules: {
+          "./routes/inbox.tsx": async () => ({
+            Component: ({ data }) => h("main", null, `Hello ${(data as any).user}`),
+            loader: async () => {
+              loaderCalls += 1;
+              return { user: "Ada" };
+            },
+          }),
+        },
+        shellModules: {
+          "./shells/app.tsx": async () => ({
+            Shell: ({ children }) => h("div", { class: "app-shell" }, children),
+            Loading: () => h("p", null, "Opening inbox..."),
+          }),
+        },
+      },
+      request: new Request("http://localhost/inbox"),
+    });
+
+    expect(response.status).toBe(200);
+    expect(loaderCalls).toBe(1);
+    const html = await response.text();
+    expect(html).toContain("app-shell");
+    expect(html).toContain("Opening inbox...");
+    expect(html).toContain('"user":"Ada"');
+    expect(html).not.toContain("Hello Ada");
+    expect(html).not.toContain("?_data=1");
+    expect(html).not.toContain('"pending":true');
+  });
+
   it("renders shell chrome and loading UI for SPA routes without serializing loader data", async () => {
     const app = defineApp({
       shells: {

--- a/skills/audit-islands/SKILL.md
+++ b/skills/audit-islands/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: audit-islands
-version: 1.0.0
+version: 1.1.0
 description: |
   Audit pracht islands usage: find over-hydrated routes that should use
   `hydration: "islands"` or `"none"`, dead interactivity outside the islands
@@ -105,9 +105,9 @@ suggest `client="visible"` or `client="idle"`.
 
 ### 3e. Invalid combinations (`error`)
 
-`render: "spa"` always implies full hydration; combining it with
-`hydration: "islands"` or `"none"` is a configuration error. Flag any such
-route (manifest field or pages-router `RENDER_MODE`/`HYDRATION` pair).
+`render: "spa"` and `render: "data"` always imply full hydration; combining
+either with `hydration: "islands"` or `"none"` is a configuration error. Flag
+any such route (manifest field or pages-router `RENDER_MODE`/`HYDRATION` pair).
 
 ### 3f. MPA navigation assumptions (`warn`)
 

--- a/skills/audit-shells/SKILL.md
+++ b/skills/audit-shells/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: audit-shells
-version: 1.1.0
+version: 1.2.0
 description: |
-  Audit pracht shells for composition bugs: missing `Loading()` on SPA-using
-  shells, accidental `<html>`/`<head>`/`<body>` rendering, shells that swallow
+  Audit pracht shells for composition bugs: missing `Loading()` on browser-rendered
+  routes, accidental `<html>`/`<head>`/`<body>` rendering, shells that swallow
   children, unused shells, and redundant `ErrorBoundary` exports (shell-level
   boundaries are valid fallbacks; routes win when both declare one).
   Use when asked to "audit shells", "check shell composition", "find unused
@@ -58,11 +58,11 @@ removing the JSX tags.
 - Must render `{children}` somewhere — flag shells that never render
   `children` (hard to spot, blank page everywhere).
 
-### 2c. `Loading()` for SPA routes
+### 2c. `Loading()` for browser-rendered routes
 
-If any route assigned to this shell has `render: "spa"`, the shell SHOULD
-export a `Loading()` function that renders a placeholder during the
-client-only data fetch. Without it, users see blank content during navigation.
+If any route assigned to this shell has `render: "spa"` or `render: "data"`,
+the shell SHOULD export a `Loading()` function. It fills the initial document
+while SPA routes fetch state or data routes bootstrap from embedded state.
 
 ### 2d. `head()` export
 

--- a/skills/pracht-scaffold/SKILL.md
+++ b/skills/pracht-scaffold/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pracht-scaffold
-version: 1.1.0
+version: 1.2.0
 description: |
   Pracht code scaffolding. Prefer the framework-native CLI generators
   (`pracht generate route|shell|middleware|api`) and only fall back to manual
@@ -173,7 +173,7 @@ Only when you created module files by hand, update `src/routes.ts` to register t
 - **Middleware**: Add to the `middleware` record: `mwName: () => import("./middleware/filename.ts")` (or `"./middleware/filename.ts"`).
 - **API routes**: No manifest change needed — auto-discovered from `src/api/` by the Vite plugin.
 
-Available render modes: `"ssr"` (default), `"ssg"` (static at build), `"isg"` (incremental static with `revalidate: timeRevalidate(seconds)`), `"spa"` (client-only).
+Available render modes: `"ssr"` (default), `"data"` (server-loaded data with browser-rendered components), `"ssg"` (static at build), `"isg"` (incremental static with `revalidate: timeRevalidate(seconds)`), `"spa"` (client-only startup fetch).
 
 Import `timeRevalidate` from `"@pracht/core"` when using ISG.
 

--- a/skills/tune-render-mode/SKILL.md
+++ b/skills/tune-render-mode/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: tune-render-mode
-version: 1.1.0
+version: 1.2.0
 description: |
-  Recommend the right pracht render mode (ssg, isg, ssr, spa) for each route
+  Recommend the right pracht render mode (ssg, isg, ssr, data, spa) for each route
   based on what its loader actually does. Most apps pick a mode once and never
   revisit; this skill surfaces routes that are mis-tuned.
   Use when asked to "tune render modes", "make my site faster", "should this
@@ -55,9 +55,11 @@ For each route:
    - Auth dashboards, anything user-specific, anything that varies by user
      identity at request time.
 
-6. **Heavy client interactivity, no SEO need, auth-gated** → **`spa`**
-   - Internal admin tools, post-login dashboards where the first paint can be a
-     skeleton.
+6. **Heavy client interactivity, no SEO need, auth-gated** → **`data`** or **`spa`**
+   - Pick `data` when loader results may be embedded and avoiding a second
+     startup request matters. The server renders only shell/loading UI.
+   - Pick `spa` when initial loader data must not appear in the document; it
+     starts with shell/loading UI and fetches route state separately.
 
 ## Step 1: Enumerate
 
@@ -139,7 +141,7 @@ on the router `mode` from Step 1:
   way.
 - **Pages apps**: render mode is a per-file constant —
   `export const RENDER_MODE = "ssg"` in the page module (valid values
-  `"ssr" | "ssg" | "isg" | "spa"`; the default is `"ssr"`, overridable
+  `"ssr" | "data" | "ssg" | "isg" | "spa"`; the default is `"ssr"`, overridable
   globally via `pracht({ pagesDefaultRender: "..." })` in vite config).
   Hydration is `export const HYDRATION = "..."` in the same file. If most
   pages want the same mode, prefer changing `pagesDefaultRender` over adding


### PR DESCRIPTION
## Summary

- add a `data` render mode that runs server loaders but renders route components in the browser
- embed initial loader state so browser startup does not make a duplicate route-state request
- keep shell/loading markup in the initial document and preserve server-owned loaders on navigation
- support manifest and pages-router generation, validation, docs, and skill guidance
- Issue: N/A

## Testing

- [x] `pnpm run e2e`
- [x] `pnpm run format`
- [x] `pnpm run lint`
- [x] `pnpm run test`
- [x] `pnpm typecheck`

## Checklist

- [x] Tests added or updated
- [x] Docs updated
- [x] Skill guidance updated
- [x] Changeset added for published packages
- [x] Existing render modes remain unchanged
