### PR TITLE
feat: enforce client and server import boundaries

### DIFF
--- a/.changeset/import-boundaries.md
+++ b/.changeset/import-boundaries.md
@@ -1,0 +1,7 @@
+---
+"@pracht/core": minor
+"@pracht/vite-plugin": minor
+"create-pracht": patch
+---
+
+Enforce first-party server and client import boundaries with filename conventions and explicit marker modules.

--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ The skills are distributed three ways (see the [catalog](skills/README.md)):
 - [docs/MCP.md](docs/MCP.md) — built-in MCP server for coding agents
 - [docs/AGENT_WORKFLOW.md](docs/AGENT_WORKFLOW.md) — constraints, app-graph snapshots, `pracht plan`/`report`
 - [docs/ENV.md](docs/ENV.md) — typed env access, `PRACHT_PUBLIC_` prefix rule, leak detection
+- [docs/IMPORT_BOUNDARIES.md](docs/IMPORT_BOUNDARIES.md) — enforced `.server.*`, `.client.*`, and explicit graph markers
 - [packages/start/README.md](packages/start/README.md) — starter CLI details
 
 ## Contributing

--- a/VISION_MVP.md
+++ b/VISION_MVP.md
@@ -36,6 +36,9 @@ Pracht is a full-stack Preact framework built on Vite. It draws routing and rend
 - **Route groups**: inherit shell, middleware, render mode, and path prefix.
 - **Navigation UX**: automatic scroll restoration, link prefetching
   (`intent`/`viewport`/`render`), and opt-in View Transitions.
+- **Import graph boundaries**: client builds reject `.server.*` modules and
+  `server-only` markers; server builds reject `.client.*` modules and
+  `client-only` markers, with importer-aware diagnostics.
 
 ### Rendering Modes
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -520,6 +520,9 @@ The published core package also exposes small browser-oriented entries:
   browser condition points at a throwing stub as a backstop for other bundlers.
 - The root `@pracht/core` export has a browser condition that points at a
   client-safe public entry for route and shell modules.
+- `@pracht/core/server-only` and `@pracht/core/client-only` are side-effect
+  markers enforced by the Vite plugin, alongside `.server.*` and `.client.*`
+  filename conventions. See [IMPORT_BOUNDARIES.md](IMPORT_BOUNDARIES.md).
 
 **Important:** `runtime.ts` imports `resolveApp` and `buildPathFromSegments` directly from
 `app.ts` via a static import. Earlier versions used `await import("./app.ts")` dynamic

--- a/docs/ENV.md
+++ b/docs/ENV.md
@@ -103,6 +103,10 @@ immediately. Route files may import it freely for `loader`/`headers`/
 `getStaticPaths` — the client transform strips those exports and the import
 with them (see `docs/ARCHITECTURE.md`, client module transform).
 
+For broader structural enforcement, use `.server.*` / `.client.*` filenames
+or the `@pracht/core/server-only` / `@pracht/core/client-only` markers. See
+[IMPORT_BOUNDARIES.md](IMPORT_BOUNDARIES.md).
+
 `pracht verify` (and `pracht doctor`) read the build-time env-safety report
 emitted to `dist/client/_pracht/env-safety.json` and also re-run the literal
 chunk scan against an existing `dist/client` output when one is present.

--- a/docs/IMPORT_BOUNDARIES.md
+++ b/docs/IMPORT_BOUNDARIES.md
@@ -1,0 +1,62 @@
+# Import Boundaries
+
+Pracht keeps server and browser module graphs explicit. The Vite plugin rejects
+a first-party module when its filename or marker conflicts with the graph that
+is currently being built.
+
+## Filename conventions
+
+Use `.server.*` for modules that may only enter server graphs and `.client.*`
+for modules that may only enter browser graphs:
+
+```ts
+// src/data/session.server.ts
+export async function readSession() {}
+
+// src/editor/shortcuts.client.ts
+export function bindShortcuts() {}
+```
+
+A component importing `session.server.ts` fails the client build. A loader,
+middleware, API route, or other server entry importing `shortcuts.client.ts`
+fails the server build. The diagnostic names the restricted module, importer,
+and target graph.
+
+The convention applies to first-party files under the Vite project root.
+Dependencies under `node_modules` retain their own environment conventions.
+
+## Explicit markers
+
+When a neutral filename is preferable, add a side-effect marker at the top of
+the module:
+
+```ts
+import "@pracht/core/server-only";
+// or
+import "@pracht/core/client-only";
+```
+
+The marker subpaths are type-resolvable no-op modules; the Pracht Vite plugin
+turns a cross-graph import into a build error.
+
+## Route modules
+
+Inline `loader`, `head`, `headers`, `getStaticPaths`, and `markdown` exports may
+import server-only modules. Pracht removes those exports and imports before it
+resolves the browser dependency graph. Shared component code must not reference
+the server-only import.
+
+Dependency-optimizer scans are ignored for the same reason: they inspect the
+unstripped source. The real client and server transforms remain enforced.
+
+## Configuration
+
+Boundaries are enabled by default. A migration can temporarily disable them:
+
+```ts
+pracht({ importBoundaries: false });
+```
+
+Treat this as a short-lived compatibility escape hatch. It removes structural
+protection against server code entering browser bundles and browser-only code
+executing during SSR.

--- a/e2e/import-boundaries.test.ts
+++ b/e2e/import-boundaries.test.ts
@@ -1,0 +1,121 @@
+import { execFileSync } from "node:child_process";
+import { cpSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { expect, test } from "@playwright/test";
+
+const repoRoot = resolve(fileURLToPath(new URL("..", import.meta.url)));
+const fixtureDir = resolve(repoRoot, "examples/basic");
+const cliEntry = resolve(repoRoot, "packages/cli/bin/pracht.js");
+
+function prepareProject(): { exampleDir: string; tempDir: string } {
+  const tempRoot = resolve(repoRoot, ".tmp");
+  mkdirSync(tempRoot, { recursive: true });
+  const tempDir = mkdtempSync(resolve(tempRoot, "pracht-import-boundaries-"));
+  const exampleDir = resolve(tempDir, "project");
+  cpSync(fixtureDir, exampleDir, {
+    filter(source) {
+      return ![".vercel", "dist", "test-results"].some((entry) =>
+        source.includes(`/examples/basic/${entry}`),
+      );
+    },
+    recursive: true,
+  });
+  return { exampleDir, tempDir };
+}
+
+function addRoute(exampleDir: string, name: string, source: string): void {
+  writeFileSync(resolve(exampleDir, `src/routes/${name}.tsx`), source, "utf-8");
+  const routesPath = resolve(exampleDir, "src/routes.ts");
+  const routesSource = readFileSync(routesPath, "utf-8");
+  writeFileSync(
+    routesPath,
+    routesSource.replace(
+      'route("/", () => import("./routes/home.tsx"), { id: "home", render: "ssg" }),',
+      `route("/", () => import("./routes/home.tsx"), { id: "home", render: "ssg" }),\n      route("/${name}", () => import("./routes/${name}.tsx"), { id: "${name}", render: "ssr" }),`,
+    ),
+    "utf-8",
+  );
+}
+
+function buildFailure(exampleDir: string): string {
+  try {
+    execFileSync(process.execPath, [cliEntry, "build"], {
+      cwd: exampleDir,
+      env: {
+        ...process.env,
+        NODE_OPTIONS: "--experimental-strip-types",
+        PRACHT_ADAPTER: "node",
+      },
+      stdio: "pipe",
+    });
+    return "build unexpectedly succeeded";
+  } catch (error) {
+    const failure = error as Error & { stderr?: Buffer; stdout?: Buffer };
+    return `${failure.message}\n${failure.stdout?.toString() ?? ""}\n${failure.stderr?.toString() ?? ""}`;
+  }
+}
+
+test("client graphs reject .server modules", async () => {
+  test.setTimeout(120_000);
+  const { exampleDir, tempDir } = prepareProject();
+
+  try {
+    writeFileSync(
+      resolve(exampleDir, "src/session.server.ts"),
+      'export const sessionSecret = "private";\n',
+      "utf-8",
+    );
+    addRoute(
+      exampleDir,
+      "boundary-client",
+      [
+        'import { sessionSecret } from "../session.server.ts";',
+        "export function Component() {",
+        "  return <main>{sessionSecret}</main>;",
+        "}",
+        "",
+      ].join("\n"),
+    );
+
+    expect(buildFailure(exampleDir)).toMatch(
+      /Import boundary violation.*server-only.*client graph/,
+    );
+  } finally {
+    rmSync(tempDir, { force: true, recursive: true });
+  }
+});
+
+test("server graphs reject .client modules", async () => {
+  test.setTimeout(120_000);
+  const { exampleDir, tempDir } = prepareProject();
+
+  try {
+    writeFileSync(
+      resolve(exampleDir, "src/browser.client.ts"),
+      'export const browserValue = "browser";\n',
+      "utf-8",
+    );
+    addRoute(
+      exampleDir,
+      "boundary-server",
+      [
+        'import { browserValue } from "../browser.client.ts";',
+        "export async function loader() {",
+        "  return { browserValue };",
+        "}",
+        "export function Component() {",
+        "  return <main>Boundary</main>;",
+        "}",
+        "",
+      ].join("\n"),
+    );
+
+    expect(buildFailure(exampleDir)).toMatch(
+      /Import boundary violation.*client-only.*server graph/,
+    );
+  } finally {
+    rmSync(tempDir, { force: true, recursive: true });
+  }
+});

--- a/packages/framework/package.json
+++ b/packages/framework/package.json
@@ -55,6 +55,14 @@
       "browser": "./dist/env-server.browser.mjs",
       "default": "./dist/env-server.mjs"
     },
+    "./server-only": {
+      "types": "./dist/server-only.d.mts",
+      "default": "./dist/server-only.mjs"
+    },
+    "./client-only": {
+      "types": "./dist/client-only.d.mts",
+      "default": "./dist/client-only.mjs"
+    },
     "./server": {
       "types": "./dist/server.d.mts",
       "default": "./dist/server.mjs"

--- a/packages/framework/src/client-only.ts
+++ b/packages/framework/src/client-only.ts
@@ -1,0 +1,5 @@
+/**
+ * Side-effect marker for modules that must not enter a server graph.
+ * The Pracht Vite plugin enforces this import boundary.
+ */
+export {};

--- a/packages/framework/src/server-only.ts
+++ b/packages/framework/src/server-only.ts
@@ -1,0 +1,5 @@
+/**
+ * Side-effect marker for modules that must not enter a client graph.
+ * The Pracht Vite plugin enforces this import boundary.
+ */
+export {};

--- a/packages/framework/tsdown.config.ts
+++ b/packages/framework/tsdown.config.ts
@@ -10,6 +10,8 @@ export default defineConfig({
     "src/env.ts",
     "src/env-server.ts",
     "src/env-server.browser.ts",
+    "src/server-only.ts",
+    "src/client-only.ts",
     "src/server.ts",
     "src/islands-client.ts",
     "src/error-overlay.ts",

--- a/packages/vite-plugin/README.md
+++ b/packages/vite-plugin/README.md
@@ -25,7 +25,16 @@ export default defineConfig({
 - Generates virtual modules (`virtual:pracht/client`, `virtual:pracht/server`) from your route manifest
 - Builds client and SSR bundles via Vite's multi-environment mode
 - Pre-renders SSG and ISG routes at build time (`prerenderConcurrency` controls parallelism)
+- Enforces first-party `.server.*` / `.client.*` modules and explicit graph markers
 - Provides HMR during development
+
+## Import boundaries
+
+Client graphs reject `.server.*` files and `@pracht/core/server-only`; server
+graphs reject `.client.*` files and `@pracht/core/client-only`. Boundaries are
+enabled by default and can be temporarily disabled with
+`pracht({ importBoundaries: false })`. See
+[`docs/IMPORT_BOUNDARIES.md`](../../docs/IMPORT_BOUNDARIES.md).
 
 ## Optional Preact SSR JSX precompile
 

--- a/packages/vite-plugin/src/import-boundaries.ts
+++ b/packages/vite-plugin/src/import-boundaries.ts
@@ -1,0 +1,88 @@
+import { resolve } from "node:path";
+import type { Plugin } from "vite";
+
+export const SERVER_ONLY_MODULE_ID = "@pracht/core/server-only";
+export const CLIENT_ONLY_MODULE_ID = "@pracht/core/client-only";
+
+type Boundary = "client-only" | "server-only";
+
+/** Enforce explicit and filename-based boundaries between app server and client graphs. */
+export function createImportBoundariesPlugin(enabled = true): Plugin {
+  let root = normalizePath(resolve(process.cwd()));
+
+  return {
+    name: "pracht:import-boundaries",
+    enforce: "pre",
+
+    configResolved(config) {
+      root = normalizePath(resolve(config.root));
+    },
+
+    async resolveId(source, importer, options) {
+      if (!enabled || (options as { scan?: boolean } | undefined)?.scan) return null;
+
+      const target = targetConsumer(this, options?.ssr);
+      const marker = markerBoundary(source);
+      if (marker) {
+        assertAllowed(marker, target, source, importer);
+        return null;
+      }
+
+      const resolved = await this.resolve(source, importer, { ...options, skipSelf: true });
+      const resolvedId = normalizePath((resolved?.id ?? source).split("?")[0]);
+      if (!isInsideRoot(resolvedId, root)) return null;
+
+      const boundary = filenameBoundary(resolvedId);
+      if (boundary) assertAllowed(boundary, target, resolvedId, importer);
+      return null;
+    },
+  };
+}
+
+export function filenameBoundary(id: string): Boundary | null {
+  const filename = normalizePath(id).split("?")[0].split("/").pop() ?? "";
+  if (/\.server(?:\.|$)/.test(filename)) return "server-only";
+  if (/\.client(?:\.|$)/.test(filename)) return "client-only";
+  return null;
+}
+
+function markerBoundary(source: string): Boundary | null {
+  if (source === SERVER_ONLY_MODULE_ID) return "server-only";
+  if (source === CLIENT_ONLY_MODULE_ID) return "client-only";
+  return null;
+}
+
+function targetConsumer(
+  context: { environment?: { config?: { consumer?: string } } },
+  ssr: boolean | undefined,
+): "client" | "server" {
+  const consumer = context.environment?.config?.consumer;
+  if (consumer === "client" || consumer === "server") return consumer;
+  return ssr ? "server" : "client";
+}
+
+function assertAllowed(
+  boundary: Boundary,
+  target: "client" | "server",
+  source: string,
+  importer: string | undefined,
+): void {
+  const invalid =
+    (boundary === "server-only" && target === "client") ||
+    (boundary === "client-only" && target === "server");
+  if (!invalid) return;
+
+  throw new Error(
+    `[pracht] Import boundary violation: ${JSON.stringify(source)} is ${boundary} but was imported by ` +
+      `${JSON.stringify(importer ?? "an entry module")} for the ${target} graph. ` +
+      `Move the import to ${boundary === "server-only" ? "a loader, middleware, API route, or .server.* module" : "a browser-only entry or a client-side effect"}.`,
+  );
+}
+
+function isInsideRoot(id: string, root: string): boolean {
+  return !id.includes("/node_modules/") && (id === root || id.startsWith(`${root}/`));
+}
+
+function normalizePath(value: string): string {
+  return value.replace(/\\/g, "/").replace(/\/$/, "");
+}

--- a/packages/vite-plugin/src/index.ts
+++ b/packages/vite-plugin/src/index.ts
@@ -11,6 +11,11 @@ import {
 import type { RenderMode } from "@pracht/core";
 import { createEnvSafetyPlugin, PUBLIC_ENV_PREFIX, SERVER_ENV_MODULE_ID } from "./env-safety.ts";
 import {
+  CLIENT_ONLY_MODULE_ID,
+  SERVER_ONLY_MODULE_ID,
+  createImportBoundariesPlugin,
+} from "./import-boundaries.ts";
+import {
   PRACHT_CAPABILITIES_MODULE_ID,
   PRACHT_CLIENT_MODULE_ID,
   PRACHT_ISLANDS_CLIENT_MODULE_ID,
@@ -62,6 +67,12 @@ export {
   type EnvLeakReference,
   type EnvSafetyOptions,
 } from "./env-safety.ts";
+export {
+  CLIENT_ONLY_MODULE_ID,
+  SERVER_ONLY_MODULE_ID,
+  createImportBoundariesPlugin,
+  filenameBoundary,
+} from "./import-boundaries.ts";
 export {
   createPrachtCapabilitiesClientModuleSource,
   createPrachtWebmcpModuleSource,
@@ -340,6 +351,7 @@ export function pracht(options: PrachtPluginOptions = {}): Plugin[] {
     ...preact(),
     prachtPlugin,
     clientModuleTransformPlugin,
+    createImportBoundariesPlugin(resolved.importBoundaries),
     createEnvSafetyPlugin(resolved.envSafety),
   ];
 

--- a/packages/vite-plugin/src/plugin-options.ts
+++ b/packages/vite-plugin/src/plugin-options.ts
@@ -68,6 +68,8 @@ export interface PrachtPluginOptions {
    * variables, or `false` to disable the check entirely.
    */
   envSafety?: false | EnvSafetyOptions;
+  /** Enforce .server.* / .client.* files and core boundary markers. Enabled by default. */
+  importBoundaries?: boolean;
   /**
    * Opt into emitting an llms.txt file (https://llmstxt.org) generated from
    * the resolved app graph. `pracht build` writes `dist/client/llms.txt` and
@@ -95,6 +97,7 @@ const DEFAULTS: ResolvedPrachtPluginOptions = {
   budgets: {},
   precompileSsrJsx: false,
   envSafety: {},
+  importBoundaries: true,
   llmsTxt: false,
 };
 
@@ -107,6 +110,9 @@ export function resolveOptions(options: PrachtPluginOptions): ResolvedPrachtPlug
   // spread over the `false` default — treat it as disabled, not invalid.
   if (resolved.llmsTxt === undefined) {
     resolved.llmsTxt = false;
+  }
+  if (resolved.importBoundaries === undefined) {
+    resolved.importBoundaries = true;
   }
   if (!Number.isInteger(resolved.prerenderConcurrency) || resolved.prerenderConcurrency <= 0) {
     throw new Error("pracht({ prerenderConcurrency }) expects a positive integer.");

--- a/packages/vite-plugin/test/import-boundaries.test.ts
+++ b/packages/vite-plugin/test/import-boundaries.test.ts
@@ -1,0 +1,97 @@
+import type { Plugin } from "vite";
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  CLIENT_ONLY_MODULE_ID,
+  SERVER_ONLY_MODULE_ID,
+  createImportBoundariesPlugin,
+  filenameBoundary,
+} from "../src/import-boundaries.ts";
+import { pracht } from "../src/index.ts";
+
+function getHook<T>(plugin: Plugin, name: keyof Plugin): T {
+  const hook = plugin[name] as unknown as T | { handler: T };
+  return typeof hook === "object" && hook !== null && "handler" in hook ? hook.handler : hook;
+}
+
+type ResolveIdHook = (
+  this: {
+    environment?: { config?: { consumer?: string } };
+    resolve: ReturnType<typeof vi.fn>;
+  },
+  source: string,
+  importer: string | undefined,
+  options?: { scan?: boolean; ssr?: boolean },
+) => Promise<unknown>;
+
+function context(consumer: "client" | "server", resolvedId?: string) {
+  return {
+    environment: { config: { consumer } },
+    resolve: vi.fn(async () => (resolvedId ? { id: resolvedId } : null)),
+  };
+}
+
+describe("import boundaries", () => {
+  it("classifies filename conventions", () => {
+    expect(filenameBoundary("/app/src/db.server.ts")).toBe("server-only");
+    expect(filenameBoundary("/app/src/chart.client.tsx?import")).toBe("client-only");
+    expect(filenameBoundary("/app/src/server.ts")).toBeNull();
+  });
+
+  it("rejects server-only files from client graphs", async () => {
+    const resolveId = getHook<ResolveIdHook>(createImportBoundariesPlugin(), "resolveId");
+    const resolvedId = `${process.cwd()}/src/session.server.ts`;
+
+    await expect(
+      resolveId.call(context("client", resolvedId), "./session.server.ts", "/app/src/widget.tsx"),
+    ).rejects.toThrowError(/Import boundary violation.*server-only.*client graph/);
+  });
+
+  it("rejects client-only files from server graphs", async () => {
+    const resolveId = getHook<ResolveIdHook>(createImportBoundariesPlugin(), "resolveId");
+    const resolvedId = `${process.cwd()}/src/editor.client.tsx`;
+
+    await expect(
+      resolveId.call(context("server", resolvedId), "./editor.client.tsx", "/app/src/loader.ts"),
+    ).rejects.toThrowError(/Import boundary violation.*client-only.*server graph/);
+  });
+
+  it("enforces explicit marker imports and permits the matching graph", async () => {
+    const resolveId = getHook<ResolveIdHook>(createImportBoundariesPlugin(), "resolveId");
+
+    await expect(
+      resolveId.call(context("client"), SERVER_ONLY_MODULE_ID, "/app/src/secrets.ts"),
+    ).rejects.toThrowError(/server-only.*client graph/);
+    await expect(
+      resolveId.call(context("server"), CLIENT_ONLY_MODULE_ID, "/app/src/widget.tsx"),
+    ).rejects.toThrowError(/client-only.*server graph/);
+    await expect(
+      resolveId.call(context("server"), SERVER_ONLY_MODULE_ID, "/app/src/secrets.ts"),
+    ).resolves.toBeNull();
+    await expect(
+      resolveId.call(context("client"), CLIENT_ONLY_MODULE_ID, "/app/src/widget.tsx"),
+    ).resolves.toBeNull();
+  });
+
+  it("skips dependency scanning and can be disabled", async () => {
+    const scanning = context("client", `${process.cwd()}/src/session.server.ts`);
+    const resolveId = getHook<ResolveIdHook>(createImportBoundariesPlugin(), "resolveId");
+    await expect(
+      resolveId.call(scanning, "./session.server.ts", "/app/src/route.tsx", { scan: true }),
+    ).resolves.toBeNull();
+    expect(scanning.resolve).not.toHaveBeenCalled();
+
+    const disabled = context("client", `${process.cwd()}/src/session.server.ts`);
+    const disabledResolve = getHook<ResolveIdHook>(
+      createImportBoundariesPlugin(false),
+      "resolveId",
+    );
+    await expect(
+      disabledResolve.call(disabled, "./session.server.ts", "/app/src/widget.tsx"),
+    ).resolves.toBeNull();
+  });
+
+  it("is enabled in the framework plugin by default", () => {
+    expect(pracht().some((plugin) => plugin.name === "pracht:import-boundaries")).toBe(true);
+  });
+});

--- a/packages/vite-plugin/test/plugin-options.test.ts
+++ b/packages/vite-plugin/test/plugin-options.test.ts
@@ -4,6 +4,17 @@ import { describe, expect, it } from "vitest";
 import { createPrachtServerModuleSource } from "../src/plugin-codegen.ts";
 import { resolveOptions } from "../src/plugin-options.ts";
 
+describe("resolveOptions import boundaries", () => {
+  it("defaults to enabled, including when undefined is spread explicitly", () => {
+    expect(resolveOptions({}).importBoundaries).toBe(true);
+    expect(resolveOptions({ importBoundaries: undefined }).importBoundaries).toBe(true);
+  });
+
+  it("supports a migration escape hatch", () => {
+    expect(resolveOptions({ importBoundaries: false }).importBoundaries).toBe(false);
+  });
+});
+
 describe("resolveOptions budgets", () => {
   it("defaults to no budgets", () => {
     expect(resolveOptions({}).budgets).toEqual({});

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -9,7 +9,7 @@ export default defineConfig({
     {
       name: "basic",
       testMatch:
-        /basic\.test\.ts|navigation\.test\.ts|node-build\.test\.ts|cloudflare-build\.test\.ts|vercel-build\.test\.ts|client-bundle-strip\.test\.ts|tsrx-build\.test\.ts|islands-build\.test\.ts|env-safety\.test\.ts|not-found\.test\.ts/,
+        /basic\.test\.ts|navigation\.test\.ts|node-build\.test\.ts|cloudflare-build\.test\.ts|vercel-build\.test\.ts|client-bundle-strip\.test\.ts|tsrx-build\.test\.ts|islands-build\.test\.ts|env-safety\.test\.ts|import-boundaries\.test\.ts|not-found\.test\.ts/,
       use: {
         baseURL: "http://localhost:3100",
       },

--- a/skills/audit-secrets/SKILL.md
+++ b/skills/audit-secrets/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: audit-secrets
-version: 1.1.0
+version: 1.2.0
 description: |
   Detect environment variables and secrets that leak from the server into
   the client bundle via loader return values, hydration state, or accidental
@@ -37,6 +37,8 @@ Pracht has built-in env leak detection (see `docs/ENV.md`):
 - `pracht verify` (and `pracht doctor`) check the build-time env-safety report
   and re-run the literal chunk scan against an existing `dist/client` output.
 - Client-side imports of `@pracht/core/env/server` (`serverEnv`) fail the build.
+- The build enforces `.server.*` / `.client.*` filenames and
+  `@pracht/core/server-only` / `@pracht/core/client-only` markers.
 
 Run `pracht verify` or `pracht doctor` (or a build) first and fold the
 findings into the report.
@@ -74,6 +76,10 @@ risk in the report.
 
 ## Step 3: Module import boundaries
 
+Run a build first so native import-boundary violations are reported with the
+restricted module, importer, and target graph. Check for
+`importBoundaries: false` in `vite.config.*`; disabling the gate is a finding.
+
 Grep client-rendered files (route components, shells, anything imported from
 them) for imports of:
 
@@ -86,8 +92,10 @@ The Vite plugin strips the server-only exports `loader`, `head`, `headers`,
 `getStaticPaths`, and `markdown` from route files when serving the client
 query (`middleware` is not a route-file export — middleware lives in the
 manifest); see the client module transform notes in `docs/ARCHITECTURE.md`
-and `docs/ENV.md`. But a component that imports `../server/db` will still
-pull `db` into the client bundle. Flag those imports.
+and `docs/ENV.md`. Prefer renaming sensitive modules to `.server.*` or adding
+the `server-only` marker so the build makes the boundary durable. A component
+that imports an unmarked `../server/db` can still pull it into the client
+bundle; flag those imports.
 
 ## Step 4: Hidden surfaces
 
@@ -130,6 +138,7 @@ Severities:
 - `error` — `PRACHT_PUBLIC_*_SECRET` style client-public or allowlisted `VITE_*_SECRET`
   secret-shaped name.
 - `error` — `envSafety: false` or an allowlisted name that looks secret-shaped.
+- `error` — `importBoundaries: false` without a documented migration window.
 - `warn` — spread of a row that may contain secret columns.
 - `warn` — client component imports a module that reads `process.env`.
 - `info` — header value that looks like a token.


### PR DESCRIPTION
## Summary

- reject first-party `.server.*` modules from client graphs and `.client.*` modules from server graphs
- add explicit `@pracht/core/server-only` and `@pracht/core/client-only` marker modules
- preserve inline route server-export stripping and dependency scanning behavior
- provide importer-aware diagnostics, migration configuration, docs, and audit guidance
- Issue: N/A

## Testing

- [x] `pnpm run e2e`
- [x] `pnpm run format`
- [x] `pnpm run lint`
- [x] `pnpm run test`
- [x] `pnpm typecheck`

## Checklist

- [x] Unit and real-build coverage added
- [x] Docs updated
- [x] Skill guidance updated
- [x] Changeset added for published packages
- [x] Dependency modules are excluded from first-party filename conventions
