### PR TITLE
Run API middleware for capability endpoints

### DIFF
--- a/.changeset/secure-capability-api-middleware.md
+++ b/.changeset/secure-capability-api-middleware.md
@@ -1,0 +1,7 @@
+---
+"@pracht/core": patch
+---
+
+Run app-level API middleware around generated capability HTTP endpoints before
+capability-specific middleware and request parsing, so centralized API
+authentication and authorization policies cannot be bypassed.

--- a/VISION_MVP.md
+++ b/VISION_MVP.md
@@ -110,7 +110,8 @@ Standalone server endpoints independent of the page rendering pipeline:
 - Receive the same `LoaderArgs`-style context (request, params, context, signal).
 - Return `Response` objects directly — full control over status, headers, body.
 - API routes are independent of page-route middleware by default. Shared API
-  policy can be attached explicitly via `defineApp({ api: { middleware: [...] } })`.
+  policy can be attached explicitly via `defineApp({ api: { middleware: [...] } })`;
+  the same chain wraps generated capability HTTP endpoints.
 - Opt-in request validation via `defineApi()` with any
   [Standard Schema](https://standardschema.dev) validator (body, query,
   params), standardized 422 issue responses, and JSON-value handler returns.

--- a/docs/CAPABILITIES.md
+++ b/docs/CAPABILITIES.md
@@ -144,7 +144,8 @@ export async function loader({ request, context, signal }: LoaderArgs) {
 Direct invocation works for private capabilities too and runs the full
 pipeline, including the capability's middleware. It is available while
 `handlePrachtRequest()` is serving requests (loaders, API routes,
-middleware).
+middleware). App-level `api.middleware` is HTTP policy and does not run for
+direct invocation.
 
 ### HTTP projection
 
@@ -154,6 +155,12 @@ With `expose.http` set, the capability is dispatched at
 happens in the framework's request handler, so every adapter (Node,
 Cloudflare, Vercel) gets it without adapter changes. Explicit files in
 `src/api/` take precedence on path collisions.
+
+The app-level API middleware configured with
+`defineApp({ api: { middleware: [...] } })` wraps every matched capability HTTP
+endpoint before request parsing and before the capability's own middleware.
+This keeps centralized authentication, authorization, rate limiting, and
+custom CSRF policy consistent across explicit and generated API endpoints.
 
 Custom paths must be exact same-origin pathnames beginning with `/`. Protocol-
 relative URLs, backslashes, dot-segment normalization, query strings, and
@@ -298,6 +305,9 @@ file, and `pracht verify` reports the same projection constraints.
 
 - **Private by default** — a capability without `expose` is never reachable
   over the network.
+- **Shared API policy** — every HTTP-exposed capability runs app-level
+  `api.middleware` first, then its capability-specific middleware. Direct
+  server invocation runs only the capability-specific chain.
 - **Exposure requires a complete contract** — `pracht verify` fails for
   exposed capabilities missing a description, input schema, output schema, or
   effect classification.

--- a/docs/DATA_LOADING.md
+++ b/docs/DATA_LOADING.md
@@ -602,7 +602,9 @@ API routes:
   or one default handler that branches on `args.request.method`
 - Return `Response` objects directly
 - Share the same request context shape as page routes
-- Can opt into app-level API middleware via `defineApp({ api: { middleware } })`
+- Can opt into app-level API middleware via `defineApp({ api: { middleware } })`;
+  this chain also wraps generated capability HTTP endpoints before their own
+  capability middleware
 - Are excluded from client bundles entirely
 
 For request validation with Standard Schema (zod, valibot, …) and an

--- a/packages/framework/src/runtime-capabilities.ts
+++ b/packages/framework/src/runtime-capabilities.ts
@@ -268,7 +268,7 @@ type CapabilityPipelineOutcome =
 async function runCapabilityPipeline<TContext>(
   options: CapabilityPipelineOptions<TContext>,
 ): Promise<CapabilityPipelineOutcome> {
-  const { capability, name, file, httpPath, middlewareFiles } = options.resolved;
+  const { capability, name, middlewareFiles } = options.resolved;
 
   const validatedInput = capability.validateInput(options.input);
   if (!validatedInput.ok) {
@@ -281,11 +281,7 @@ async function runCapabilityPipeline<TContext>(
   }
 
   // Synthetic route descriptor handed to middleware, mirroring API dispatch.
-  const syntheticRoute: ResolvedApiRoute = {
-    path: httpPath ?? `capability:${name}`,
-    file,
-    segments: [],
-  };
+  const syntheticRoute = capabilityMiddlewareRoute(options.resolved);
 
   // Holder object rather than a plain `let`: the value is assigned inside
   // the terminal closure, which TypeScript's control-flow analysis cannot see.
@@ -414,6 +410,8 @@ export interface HandleCapabilityRequestOptions<TContext> {
   request: Request;
   url: URL;
   exposeErrors: boolean;
+  /** App-level `api.middleware`, wrapped around the HTTP projection only. */
+  apiMiddlewareFiles?: string[];
   /** App-level agent trust config (`defineApp({ agents })`). */
   agents?: PrachtAgentsConfig;
   /** Verified agent identity for this request, `null` when unsigned/unverified. */
@@ -431,7 +429,7 @@ export async function handleCapabilityRequest<TContext>(
   options: HandleCapabilityRequestOptions<TContext>,
 ): Promise<Response> {
   const started = performance.now();
-  const { response, outcome } = await dispatchCapabilityHttp(options);
+  const { response, outcome } = await dispatchCapabilityHttpWithApiMiddleware(options);
   const responseWithEffect = withCapabilityEffect(response, options.match.capability.effect);
   emitCapabilityAudit(
     {
@@ -450,6 +448,61 @@ export async function handleCapabilityRequest<TContext>(
     options.onAudit,
   );
   return responseWithEffect;
+}
+
+/**
+ * Capability endpoints are part of the application's HTTP API surface, so the
+ * app-level API middleware chain wraps the complete dispatch. This deliberately
+ * stays outside `runCapabilityPipeline`: direct server invocation should run
+ * capability middleware, but must not inherit HTTP-only API policy.
+ */
+async function dispatchCapabilityHttpWithApiMiddleware<TContext>(
+  options: HandleCapabilityRequestOptions<TContext>,
+): Promise<{ response: Response; outcome: string }> {
+  const middlewareFiles = options.apiMiddlewareFiles ?? [];
+  if (middlewareFiles.length === 0) {
+    return dispatchCapabilityHttp(options);
+  }
+
+  // Holder object because the value is assigned inside the terminal closure;
+  // TypeScript does not carry that assignment into the outer control flow.
+  const holder: { dispatched: { response: Response; outcome: string } | null } = {
+    dispatched: null,
+  };
+  try {
+    const response = await runMiddlewareChain({
+      context: options.context,
+      middlewareFiles,
+      params: {},
+      registry: options.registry,
+      request: options.request,
+      route: capabilityMiddlewareRoute(options.match),
+      signal: AbortSignal.timeout(CAPABILITY_TIMEOUT_MS),
+      url: options.url,
+      terminal: async () => {
+        holder.dispatched = await dispatchCapabilityHttp(options);
+        return holder.dispatched.response;
+      },
+    });
+
+    const dispatched = holder.dispatched;
+    if (dispatched && response === dispatched.response) {
+      return dispatched;
+    }
+
+    const normalized = normalizeMiddlewareShortCircuit(response);
+    return audited(normalized, `middleware_${normalized.status}`);
+  } catch (error: unknown) {
+    return audited(capabilityInternalErrorResponse(options, error), "internal_error");
+  }
+}
+
+function capabilityMiddlewareRoute(resolved: ResolvedCapability): ResolvedApiRoute {
+  return {
+    path: resolved.httpPath ?? `capability:${resolved.name}`,
+    file: resolved.file,
+    segments: [],
+  };
 }
 
 function withCapabilityEffect(response: Response, effect: string): Response {
@@ -581,19 +634,23 @@ async function dispatchCapabilityHttp<TContext>(
     const normalized = normalizeMiddlewareShortCircuit(outcome.response);
     return audited(normalized, `middleware_${normalized.status}`);
   } catch (error: unknown) {
-    return audited(
-      envelopeResponse(
-        500,
-        errorEnvelope({
-          code: "internal_error",
-          message: options.exposeErrors
-            ? `Capability "${name}" failed: ${error instanceof Error ? error.message : String(error)}`
-            : "Capability failed.",
-        }),
-      ),
-      "internal_error",
-    );
+    return audited(capabilityInternalErrorResponse(options, error), "internal_error");
   }
+}
+
+function capabilityInternalErrorResponse<TContext>(
+  options: HandleCapabilityRequestOptions<TContext>,
+  error: unknown,
+): Response {
+  return envelopeResponse(
+    500,
+    errorEnvelope({
+      code: "internal_error",
+      message: options.exposeErrors
+        ? `Capability "${options.match.name}" failed: ${error instanceof Error ? error.message : String(error)}`
+        : "Capability failed.",
+    }),
+  );
 }
 
 function audited(response: Response, outcome: string): { response: Response; outcome: string } {

--- a/packages/framework/src/runtime.ts
+++ b/packages/framework/src/runtime.ts
@@ -407,6 +407,10 @@ export async function handlePrachtRequest<TContext>(
           request: options.request,
           url,
           exposeErrors: exposeDiagnostics,
+          apiMiddlewareFiles: (options.app.api.middleware ?? []).flatMap((name) => {
+            const middlewareFile = options.app.middleware[name];
+            return middlewareFile ? [middlewareFile] : [];
+          }),
           agents: options.app.agents,
           agent,
           onAudit: options.onCapabilityAudit,

--- a/packages/framework/test/capabilities.test.ts
+++ b/packages/framework/test/capabilities.test.ts
@@ -49,6 +49,8 @@ function createApp(capabilityModule: unknown, options: Record<string, unknown> =
     middleware: {
       deny: "./middleware/deny.ts",
       passthrough: "./middleware/passthrough.ts",
+      apiMarker: "./middleware/api-marker.ts",
+      capabilityMarker: "./middleware/capability-marker.ts",
       redirect: "./middleware/redirect.ts",
       relativeRedirect: "./middleware/relative-redirect.ts",
     },
@@ -73,6 +75,24 @@ function createApp(capabilityModule: unknown, options: Record<string, unknown> =
           next: () => Promise<Response>,
         ) => {
           args.context.fromMiddleware = true;
+          return next();
+        },
+      }),
+      "./middleware/api-marker.ts": async () => ({
+        middleware: async (
+          args: { context: { middlewareOrder?: string[] } },
+          next: () => Promise<Response>,
+        ) => {
+          (args.context.middlewareOrder ??= []).push("api");
+          return next();
+        },
+      }),
+      "./middleware/capability-marker.ts": async () => ({
+        middleware: async (
+          args: { context: { middlewareOrder?: string[] } },
+          next: () => Promise<Response>,
+        ) => {
+          (args.context.middlewareOrder ??= []).push("capability");
           return next();
         },
       }),
@@ -237,6 +257,56 @@ describe("resolveAppCapabilities", () => {
 });
 
 describe("capability HTTP projection", () => {
+  it("runs app-level API middleware around exposed capability endpoints", async () => {
+    const capability = createSearchCapability({
+      middleware: ["capabilityMarker"],
+      async run({ context }: { context: Record<string, unknown> }) {
+        return { notes: [(context.middlewareOrder as string[]).join(",")] };
+      },
+    });
+    const { app, registry } = createApp(capability, {
+      api: { middleware: ["apiMarker"] },
+    });
+
+    const response = await handlePrachtRequest({
+      app,
+      registry,
+      request: postCapability("/api/capabilities/notes/search", { query: "hello" }),
+    });
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      ok: true,
+      data: { notes: ["api,capability"] },
+    });
+  });
+
+  it("lets app-level API middleware reject before capability input is parsed", async () => {
+    let capabilityRan = false;
+    const capability = createSearchCapability({
+      async run() {
+        capabilityRan = true;
+        return { notes: [] };
+      },
+    });
+    const { app, registry } = createApp(capability, {
+      api: { middleware: ["deny"] },
+    });
+
+    const response = await handlePrachtRequest({
+      app,
+      registry,
+      request: new Request("http://localhost/api/capabilities/notes/search", {
+        method: "POST",
+        body: "{malformed",
+      }),
+    });
+
+    expect(response.status).toBe(401);
+    expect((await response.json()).error.code).toBe("unauthorized");
+    expect(capabilityRan).toBe(false);
+  });
+
   it("returns enhanced form redirects without fetching the external target", async () => {
     const { app, registry } = createApp(createSearchCapability({ middleware: ["redirect"] }));
     const request = postCapability("/api/capabilities/notes/search", { query: "hello" });
@@ -577,6 +647,31 @@ describe("capability HTTP projection", () => {
 });
 
 describe("invokeCapability", () => {
+  it("does not apply HTTP-only API middleware to direct server invocation", async () => {
+    const { app, registry } = createApp(createSearchCapability(), {
+      api: { middleware: ["deny"] },
+      routes: [route("/notes", "./routes/notes.tsx", { id: "notes" })],
+    });
+    registry.routeModules = {
+      "./routes/notes.tsx": async () => ({
+        loader: async ({ request, context, signal }: LoaderArgs) =>
+          invokeCapability("notes.search", { query: "from-loader" }, { request, context, signal }),
+        Component: () => null,
+      }),
+    };
+
+    const response = await handlePrachtRequest({
+      app,
+      registry,
+      request: new Request("http://localhost/notes?_data=1"),
+    });
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      data: { ok: true, data: { notes: ["from-loader:10"] } },
+    });
+  });
+
   it("invokes a capability directly from a loader through the same pipeline", async () => {
     const { app, registry } = createApp(createSearchCapability(), {
       routes: [route("/notes", "./routes/notes.tsx", { id: "notes" })],

--- a/skills/audit-auth/SKILL.md
+++ b/skills/audit-auth/SKILL.md
@@ -91,9 +91,11 @@ target. From `pracht inspect api --json`:
   serves ALL methods but reports `methods: []` — treat
   `hasDefaultHandler: true` as "every method exposed". On older CLIs where
   the field is missing, grep the handler file for `export default` instead.
-- For each mutation handler (named method export or default handler), check
-  whether `defineApp({ api: { middleware } })` applies a Gate, OR the handler
-  reads/validates a session itself.
+- For each mutation handler (named method export or default handler) and each
+  HTTP-exposed capability, check whether
+  `defineApp({ api: { middleware } })` applies a Gate, OR the handler/capability
+  reads and validates a session itself. App-level API middleware wraps generated
+  capability endpoints before capability-specific middleware.
 - Common bug: dashboard route is protected by middleware, but
   `POST /api/items` is not — attacker bypasses the UI entirely.
 

--- a/skills/audit-csrf/SKILL.md
+++ b/skills/audit-csrf/SKILL.md
@@ -128,7 +128,8 @@ The canonical shape is in `recipes-auth.md` (the `origin-check.ts` example).
 
 Verify the wiring: the middleware name must appear in
 `defineApp({ api: { middleware: [...] } })` — that single global list applies
-to every API route. There is no per-group API middleware, and
+to every API route and generated capability HTTP endpoint. There is no
+per-group API middleware, and
 `pracht inspect api --json` output has no middleware field, so the manifest is
 the only place to check.
 


### PR DESCRIPTION
## Summary

- Apply app-level API middleware to generated capability HTTP endpoints.
- Preserve middleware ordering: app-level API middleware runs before capability-specific middleware.
- Keep direct server invocation behavior unchanged.
- The capability HTTP dispatcher used a separate runtime branch that only passed capability-specific middleware; this aligns its behavior with file-based API routes.
- Update the relevant docs and audit skills, with a patch changeset for `@pracht/core`.

## Testing

- [x] `pnpm e2e`
- [x] `pnpm format`
- [x] `pnpm lint`
- [x] `pnpm test`

## Checklist

- [x] Docs updated if needed
- [x] Skills updated if needed
- [x] Changeset added if published packages changed