### PR TITLE
Prevent dev flashes of unstyled content

### DIFF
--- a/.changeset/bright-dogs-style.md
+++ b/.changeset/bright-dogs-style.md
@@ -1,0 +1,5 @@
+---
+"@pracht/vite-plugin": patch
+---
+
+Prevent flashes of unstyled content in development by linking each matched route and shell's transitive Vite CSS dependencies in the initial HTML, including for adapter-owned dev servers such as Cloudflare.

--- a/docs/STYLING.md
+++ b/docs/STYLING.md
@@ -25,6 +25,12 @@ the relevant `<link rel="stylesheet">` tags into the server-rendered HTML. See
 [RENDERING_MODES.md](RENDERING_MODES.md) and the per-page CSS section in the
 performance docs.
 
+Development uses the same first-paint contract: `pracht dev` discovers the
+matched route and shell's transitive CSS in Vite's live module graph and adds
+stylesheet links to the initial HTML before the client entry. Apps should only
+need to import their CSS from a route, shell, or one of their dependencies — a
+development-only `<link>` in `head()` is unnecessary.
+
 ---
 
 ## CSS-in-JS

--- a/e2e/basic.test.ts
+++ b/e2e/basic.test.ts
@@ -28,6 +28,15 @@ test("home page HTML includes hydration state", async ({ request }) => {
   expect(html).toContain("Hybrid route manifest");
 });
 
+test("home page HTML includes shell CSS before the client entry", async ({ request }) => {
+  const response = await request.get("/", { headers: { accept: "text/html" } });
+  const html = await response.text();
+
+  const stylesheet = '<link rel="stylesheet" href="/src/styles/global.css">';
+  expect(html).toContain(stylesheet);
+  expect(html.indexOf(stylesheet)).toBeLessThan(html.indexOf('src="/@pracht/client.js"'));
+});
+
 test("home page includes default security headers", async ({ request }) => {
   const response = await request.get("/");
 

--- a/examples/cloudflare/src/shells/public.tsx
+++ b/examples/cloudflare/src/shells/public.tsx
@@ -1,5 +1,6 @@
 import { useNavigation } from "@pracht/core";
 import type { ShellProps } from "@pracht/core";
+import "../styles/global.css";
 
 function NavigationStatus() {
   const navigation = useNavigation();

--- a/examples/cloudflare/src/styles/global.css
+++ b/examples/cloudflare/src/styles/global.css
@@ -1,0 +1,13 @@
+:root {
+  color: #172033;
+  font-family: Inter, ui-sans-serif, system-ui, sans-serif;
+  background: #f7f8fc;
+}
+
+body {
+  margin: 0;
+}
+
+.public-shell {
+  min-height: 100vh;
+}

--- a/examples/docs/src/routes/docs/styling.md
+++ b/examples/docs/src/routes/docs/styling.md
@@ -39,6 +39,8 @@ export default defineConfig({
 
 See [Performance → CSS Per Page](/docs/performance) for how pracht maps routes to their transitive CSS dependencies.
 
+The same behavior applies during development. `pracht dev` discovers the matched route and shell's CSS through Vite's live module graph and places stylesheet links in the initial HTML before the client entry runs. Import the CSS normally from your route or shell; you do not need a development-only `<link>` in `head()`.
+
 ---
 
 ## CSS-in-JS — Use With Care

--- a/examples/docs/src/shells/docs.tsx
+++ b/examples/docs/src/shells/docs.tsx
@@ -205,7 +205,6 @@ export function head() {
         rel: "stylesheet",
         href: "https://fonts.googleapis.com/css2?family=Inter:wght@400;450;500;550;600;650;700&display=swap",
       },
-      ...(import.meta.env.DEV ? [{ rel: "stylesheet", href: "/src/styles/global.css" }] : []),
     ],
   };
 }

--- a/examples/docs/src/shells/home.tsx
+++ b/examples/docs/src/shells/home.tsx
@@ -74,7 +74,6 @@ export function head() {
         rel: "stylesheet",
         href: "https://fonts.googleapis.com/css2?family=Inter:wght@400;450;500;550;600;650;700&display=swap",
       },
-      ...(import.meta.env.DEV ? [{ rel: "stylesheet", href: "/src/styles/global.css" }] : []),
     ],
   };
 }

--- a/packages/vite-plugin/src/index.ts
+++ b/packages/vite-plugin/src/index.ts
@@ -13,11 +13,13 @@ import { createEnvSafetyPlugin, PUBLIC_ENV_PREFIX, SERVER_ENV_MODULE_ID } from "
 import {
   PRACHT_CAPABILITIES_MODULE_ID,
   PRACHT_CLIENT_MODULE_ID,
+  PRACHT_DEV_MODULE_ID,
   PRACHT_ISLANDS_CLIENT_MODULE_ID,
   PRACHT_SERVER_MODULE_ID,
   PRACHT_WEBMCP_MODULE_ID,
   isCapabilitiesModule,
   isClientModule,
+  isDevModule,
   isIslandsClientModule,
   isServerModule,
   isWebmcpModule,
@@ -29,11 +31,16 @@ import {
 import {
   clearPagesAppSourceCache,
   createPrachtClientModuleSource,
+  createPrachtDevModuleSource,
   createPrachtIslandsClientModuleSource,
   createPrachtServerModuleSource,
 } from "./plugin-codegen.ts";
 import { existsSync } from "node:fs";
-import { createDevSSRMiddleware } from "./plugin-dev-ssr.ts";
+import {
+  createDevCssInjectionMiddleware,
+  createDevSSRMiddleware,
+  injectDevCssForPath,
+} from "./plugin-dev-ssr.ts";
 import {
   resolveOptions,
   type PrachtPluginOptions,
@@ -165,6 +172,7 @@ export function pracht(options: PrachtPluginOptions = {}): Plugin[] {
     resolveId(id, importer, resolveIdOptions) {
       if (isIslandsClientModule(id)) return PRACHT_ISLANDS_CLIENT_MODULE_ID;
       if (isClientModule(id)) return PRACHT_CLIENT_MODULE_ID;
+      if (isDevModule(id)) return PRACHT_DEV_MODULE_ID;
       if (isServerModule(id)) return PRACHT_SERVER_MODULE_ID;
       if (isCapabilitiesModule(id)) return PRACHT_CAPABILITIES_MODULE_ID;
       if (isWebmcpModule(id)) return PRACHT_WEBMCP_MODULE_ID;
@@ -195,6 +203,9 @@ export function pracht(options: PrachtPluginOptions = {}): Plugin[] {
       }
       if (isClientModule(id)) {
         return createPrachtClientModuleSource(resolved, { root });
+      }
+      if (isDevModule(id)) {
+        return createPrachtDevModuleSource(resolved, { root });
       }
       if (isServerModule(id)) {
         return createPrachtServerModuleSource(resolved, { root, isBuild });
@@ -230,7 +241,10 @@ export function pracht(options: PrachtPluginOptions = {}): Plugin[] {
         watchPagesDirectory(server, resolved, root);
       }
 
-      if (resolved.adapter.ownsDevServer) return;
+      if (resolved.adapter.ownsDevServer) {
+        server.middlewares.use(createDevCssInjectionMiddleware(server));
+        return;
+      }
       return () => {
         server.middlewares.use(
           createDevSSRMiddleware(server, {
@@ -239,6 +253,19 @@ export function pracht(options: PrachtPluginOptions = {}): Plugin[] {
           }),
         );
       };
+    },
+
+    async transformIndexHtml(html, context) {
+      if (isBuild || !context.server || !html.includes("</head>")) return html;
+
+      try {
+        return await injectDevCssForPath(context.server, context.path, html);
+      } catch {
+        // The original request path owns development error reporting. CSS
+        // discovery must not replace its overlay or response with a second
+        // module-loading failure from this HTML transform.
+        return html;
+      }
     },
 
     handleHotUpdate({ file, server }) {
@@ -271,6 +298,8 @@ export function pracht(options: PrachtPluginOptions = {}): Plugin[] {
       if (dirs.some((dir) => relative.startsWith(dir))) {
         const serverMod = server.moduleGraph.getModuleById(PRACHT_SERVER_MODULE_ID);
         if (serverMod) server.moduleGraph.invalidateModule(serverMod);
+        const devMod = server.moduleGraph.getModuleById(PRACHT_DEV_MODULE_ID);
+        if (devMod) server.moduleGraph.invalidateModule(devMod);
         if (relative.startsWith(resolved.routesDir)) {
           const clientMod = server.moduleGraph.getModuleById(PRACHT_CLIENT_MODULE_ID);
           if (clientMod) server.moduleGraph.invalidateModule(clientMod);
@@ -497,8 +526,10 @@ function watchPagesDirectory(
 function invalidateVirtualModules(server: import("vite").ViteDevServer): void {
   const clientMod = server.moduleGraph.getModuleById(PRACHT_CLIENT_MODULE_ID);
   const serverMod = server.moduleGraph.getModuleById(PRACHT_SERVER_MODULE_ID);
+  const devMod = server.moduleGraph.getModuleById(PRACHT_DEV_MODULE_ID);
   if (clientMod) server.moduleGraph.invalidateModule(clientMod);
   if (serverMod) server.moduleGraph.invalidateModule(serverMod);
+  if (devMod) server.moduleGraph.invalidateModule(devMod);
 }
 
 const ROUTE_FILE_EXTENSIONS = new Set([".ts", ".tsx", ".js", ".jsx", ".md", ".mdx", ".tsrx"]);

--- a/packages/vite-plugin/src/plugin-assets.ts
+++ b/packages/vite-plugin/src/plugin-assets.ts
@@ -4,6 +4,7 @@ import { stripPrachtClientModuleQuery } from "./client-module-query.ts";
 
 export const PRACHT_CLIENT_MODULE_ID = "virtual:pracht/client";
 export const PRACHT_SERVER_MODULE_ID = "virtual:pracht/server";
+export const PRACHT_DEV_MODULE_ID = "virtual:pracht/dev-metadata";
 export const PRACHT_ISLANDS_CLIENT_MODULE_ID = "virtual:pracht/islands-client";
 export const PRACHT_CAPABILITIES_MODULE_ID = "virtual:pracht/capabilities";
 export const PRACHT_WEBMCP_MODULE_ID = "virtual:pracht/webmcp";
@@ -118,6 +119,10 @@ export function isClientModule(id: string): boolean {
 
 export function isServerModule(id: string): boolean {
   return id === PRACHT_SERVER_MODULE_ID || id.endsWith(PRACHT_SERVER_MODULE_ID);
+}
+
+export function isDevModule(id: string): boolean {
+  return id === PRACHT_DEV_MODULE_ID || id.endsWith(PRACHT_DEV_MODULE_ID);
 }
 
 export function isIslandsClientModule(id: string): boolean {

--- a/packages/vite-plugin/src/plugin-codegen.ts
+++ b/packages/vite-plugin/src/plugin-codegen.ts
@@ -370,6 +370,31 @@ export function createPrachtServerModuleSource(
   return source.join("\n");
 }
 
+/**
+ * Adapter-neutral app metadata used by development tooling. Keeping this
+ * separate from the server entry avoids evaluating worker-only imports (for
+ * example `cloudflare:workers`) in Vite's Node SSR environment.
+ */
+export function createPrachtDevModuleSource(
+  options: PrachtPluginOptions = {},
+  buildOptions: { root?: string } = {},
+): string {
+  const resolved = resolveOptions(options);
+  const appImport = resolved.pagesDir
+    ? generatePagesAppInlineSource(resolved, buildOptions.root)
+    : `import { app } from ${JSON.stringify(resolved.appFile)};`;
+
+  return [
+    'import { resolveApp } from "@pracht/core/server";',
+    appImport,
+    "",
+    createPrachtRegistryModuleSource(resolved),
+    "",
+    "export const resolvedApp = resolveApp(app);",
+    "",
+  ].join("\n");
+}
+
 interface ResolvedLlmsTxtConfig {
   title: string;
   description?: string;

--- a/packages/vite-plugin/src/plugin-dev-ssr.ts
+++ b/packages/vite-plugin/src/plugin-dev-ssr.ts
@@ -1,17 +1,25 @@
 import { existsSync, readFileSync } from "node:fs";
 import type { IncomingMessage, ServerResponse } from "node:http";
 import { join, resolve } from "node:path";
-import type { Connect, ViteDevServer } from "vite";
-import type { PrachtPhaseTimings, ResolvedApiRoute, ResolvedPrachtApp } from "@pracht/core";
+import type { Connect, EnvironmentModuleNode, ViteDevServer } from "vite";
+import type {
+  ModuleRegistry,
+  PrachtPhaseTimings,
+  ResolvedApiRoute,
+  ResolvedPrachtApp,
+  ResolvedRoute,
+} from "@pracht/core";
 import { resolveRegistryModule } from "@pracht/core";
 import {
   CLIENT_BROWSER_PATH,
   ISLANDS_CLIENT_BROWSER_PATH,
+  PRACHT_DEV_MODULE_ID,
   PRACHT_SERVER_MODULE_ID,
 } from "./plugin-assets.ts";
 
 const BODYLESS_METHODS = new Set(["GET", "HEAD"]);
 const DEFAULT_MAX_BODY_SIZE = 1024 * 1024; // 1 MiB
+const CSS_MODULE_URL_RE = /\.(?:css|less|sass|scss|styl|stylus|pcss|postcss|sss)(?:$|\?)/;
 
 export const DEVTOOLS_PATH = "/_pracht";
 export const DEVTOOLS_JSON_PATH = "/_pracht.json";
@@ -169,6 +177,267 @@ export function createDevSSRMiddleware(
       await handleDevError(server, req, res, next, url, error);
     }
   };
+}
+
+/**
+ * Build the development equivalent of the production CSS manifest for the
+ * current route. Vite turns CSS imports into client-side style injection by
+ * default; resolving the same imports through the active server environment
+ * graphs lets pracht put real stylesheet links in the initial document and
+ * avoid a first-paint FOUC.
+ */
+export async function createDevCssManifest(
+  server: ViteDevServer,
+  options: {
+    app: ResolvedPrachtApp;
+    matchAppRoute: (
+      app: ResolvedPrachtApp,
+      pathname: string,
+    ) => { route: ResolvedRoute } | undefined;
+    pathname: string;
+    registry: ModuleRegistry;
+  },
+): Promise<Record<string, string[]>> {
+  const route = options.matchAppRoute(options.app, options.pathname)?.route ?? options.app.notFound;
+  if (!route) return {};
+
+  const manifest: Record<string, string[]> = {};
+  const modules = [
+    ...(route.shellFile
+      ? [{ file: route.shellFile, registry: options.registry.shellModules }]
+      : []),
+    { file: route.file, registry: options.registry.routeModules },
+  ];
+
+  const results = await Promise.all(
+    modules.map(async ({ file, registry }) => {
+      if (!registry) return { file, urls: [] };
+      const moduleKey = findRegistryModuleKey(registry, file);
+      if (!moduleKey) return { file, urls: [] };
+
+      // Adapters can name their server environment (for example, Cloudflare
+      // does), so inspect every graph instead of assuming `ssr`.
+      const entries = await Promise.all(
+        Object.values(server.environments).map((environment) =>
+          environment.moduleGraph.getModuleByUrl(moduleKey),
+        ),
+      );
+      const urls = [...new Set(entries.flatMap((entry) => collectDevCssUrls(entry)))];
+      return { file, urls };
+    }),
+  );
+
+  for (const { file, urls } of results) {
+    if (urls.length > 0) manifest[file] = urls;
+  }
+
+  return manifest;
+}
+
+function findRegistryModuleKey(
+  modules: Record<string, () => Promise<unknown>> | undefined,
+  file: string,
+): string | undefined {
+  if (!modules) return undefined;
+  if (file in modules) return file;
+
+  const suffix = `/${file
+    .split("?")[0]
+    .replace(/\\/g, "/")
+    .replace(/^\.?\//, "")}`;
+  return Object.keys(modules).find((key) => key.split("?")[0].replace(/\\/g, "/").endsWith(suffix));
+}
+
+export function collectDevCssUrls(entry: EnvironmentModuleNode | undefined): string[] {
+  if (!entry) return [];
+
+  const urls = new Set<string>();
+  const visited = new Set<EnvironmentModuleNode>();
+  const pending = [entry];
+
+  while (pending.length > 0) {
+    const module = pending.pop()!;
+    if (visited.has(module)) continue;
+    visited.add(module);
+
+    // SSR transforms CSS imports into JavaScript modules, so Vite can label
+    // these nodes as `js`. The URL remains the reliable signal for CSS and
+    // preprocessor requests; asset/string queries are intentionally excluded.
+    if (
+      (module.type === "css" || CSS_MODULE_URL_RE.test(module.url)) &&
+      !/[?&](?:inline|raw|url)(?:[=&]|$)/.test(module.url)
+    ) {
+      urls.add(module.url);
+    }
+    pending.push(...[...module.importedModules].reverse());
+  }
+
+  return [...urls];
+}
+
+export function injectDevCssLinks(html: string, manifest: Record<string, string[]>): string {
+  if (!html.includes("</head>")) return html;
+
+  const urls = [...new Set(Object.values(manifest).flat())];
+  const tags = urls
+    .map((url) => escapeHtmlAttribute(url))
+    .filter((escapedUrl) => !html.includes(`href="${escapedUrl}"`))
+    .map((escapedUrl) => `<link rel="stylesheet" href="${escapedUrl}">`);
+  if (tags.length === 0) return html;
+
+  return html.replace("</head>", `    ${tags.join("\n    ")}\n  </head>`);
+}
+
+export async function injectDevCssForPath(
+  server: ViteDevServer,
+  path: string,
+  html: string,
+): Promise<string> {
+  const context = await resolveDevCssContextForPath(server, path);
+  const manifest = await createDevCssManifest(server, context);
+  return injectDevCssLinks(html, manifest);
+}
+
+async function resolveDevCssContextForPath(
+  server: ViteDevServer,
+  path: string,
+): Promise<Parameters<typeof createDevCssManifest>[1]> {
+  const [framework, serverMod] = await Promise.all([
+    server.ssrLoadModule("@pracht/core/server"),
+    server.ssrLoadModule(PRACHT_DEV_MODULE_ID),
+  ]);
+  const pathname = new URL(path, "http://localhost").pathname;
+  return {
+    app: serverMod.resolvedApp,
+    matchAppRoute: framework.matchAppRoute,
+    pathname,
+    registry: serverMod.registry,
+  };
+}
+
+/**
+ * Adapter-owned dev servers (for example Cloudflare's worker runtime) bypass
+ * Vite's HTML transform hooks. Install this before the adapter middleware so
+ * document responses still receive the same parser-blocking stylesheet links.
+ */
+export function createDevCssInjectionMiddleware(server: ViteDevServer): Connect.NextHandleFunction {
+  let warned = false;
+  return (req: IncomingMessage, res: ServerResponse, next: Connect.NextFunction) => {
+    const method = (req.method ?? "GET").toUpperCase();
+    const accept = readRequestHeader(req.headers.accept).toLowerCase();
+    if (method !== "GET" || !accept.includes("text/html")) {
+      next();
+      return;
+    }
+
+    // Resolve the route before the adapter begins its request. Remote dev
+    // runtimes can serialize module-runner work while a response is open. CSS
+    // traversal itself waits until res.end(), after that runtime has populated
+    // its environment graph with the matched route and shell.
+    const contextPromise = resolveDevCssContextForPath(server, req.url ?? "/").catch((error) => {
+      if (!warned) {
+        warned = true;
+        server.config.logger.warn(
+          `[pracht] Could not discover development stylesheets: ${error instanceof Error ? error.message : String(error)}`,
+        );
+      }
+      return null;
+    });
+    const chunks: Buffer[] = [];
+    const originalEnd = res.end.bind(res);
+    const originalWriteHead = res.writeHead.bind(res);
+
+    res.writeHead = ((statusCode: number, ...args: unknown[]) => {
+      res.removeHeader("content-length");
+      return Reflect.apply(originalWriteHead, res, [
+        statusCode,
+        ...args.map(stripContentLengthHeader),
+      ]);
+    }) as typeof res.writeHead;
+
+    res.write = ((chunk: unknown, encodingOrCallback?: unknown, callback?: unknown) => {
+      chunks.push(toBuffer(chunk, encodingOrCallback));
+      const done: (() => void) | undefined =
+        typeof encodingOrCallback === "function"
+          ? (encodingOrCallback as () => void)
+          : typeof callback === "function"
+            ? (callback as () => void)
+            : undefined;
+      done?.();
+      return true;
+    }) as typeof res.write;
+
+    res.end = ((chunk?: unknown, encodingOrCallback?: unknown, callback?: unknown) => {
+      if (chunk != null) chunks.push(toBuffer(chunk, encodingOrCallback));
+      const done: (() => void) | undefined =
+        typeof encodingOrCallback === "function"
+          ? (encodingOrCallback as () => void)
+          : typeof callback === "function"
+            ? (callback as () => void)
+            : undefined;
+
+      void (async () => {
+        const body = Buffer.concat(chunks);
+        const contentType = String(res.getHeader("content-type") ?? "");
+        if (!contentType.includes("text/html")) {
+          originalEnd(body, done);
+          return;
+        }
+
+        try {
+          const context = await contextPromise;
+          const manifest = context ? await createDevCssManifest(server, context) : null;
+          const html = manifest
+            ? injectDevCssLinks(body.toString("utf-8"), manifest)
+            : body.toString("utf-8");
+          originalEnd(html, done);
+        } catch {
+          originalEnd(body, done);
+        }
+      })();
+
+      return res;
+    }) as typeof res.end;
+
+    next();
+  };
+}
+
+function toBuffer(chunk: unknown, encoding: unknown): Buffer {
+  if (Buffer.isBuffer(chunk)) return chunk;
+  if (chunk instanceof Uint8Array) return Buffer.from(chunk);
+  return Buffer.from(
+    String(chunk),
+    typeof encoding === "string" ? (encoding as BufferEncoding) : undefined,
+  );
+}
+
+function stripContentLengthHeader(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    const headers: unknown[] = [];
+    for (let index = 0; index < value.length; index += 2) {
+      if (String(value[index]).toLowerCase() !== "content-length") {
+        headers.push(value[index], value[index + 1]);
+      }
+    }
+    return headers;
+  }
+
+  if (value && typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value).filter(([name]) => name.toLowerCase() !== "content-length"),
+    );
+  }
+
+  return value;
+}
+
+function escapeHtmlAttribute(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/"/g, "&quot;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
 }
 
 /**

--- a/packages/vite-plugin/test/dev-middleware.test.ts
+++ b/packages/vite-plugin/test/dev-middleware.test.ts
@@ -1,6 +1,95 @@
 import { describe, expect, it } from "vitest";
 
-import { isDevNotFoundRequest, shouldBypassDevSSR } from "../src/plugin-dev-ssr.ts";
+import {
+  collectDevCssUrls,
+  createDevCssManifest,
+  injectDevCssLinks,
+  isDevNotFoundRequest,
+  shouldBypassDevSSR,
+} from "../src/plugin-dev-ssr.ts";
+
+function moduleNode(url: string, type: "js" | "css" = "js", importedModules: any[] = []): any {
+  return { importedModules: new Set(importedModules), type, url };
+}
+
+describe("development CSS discovery", () => {
+  it("collects transitive stylesheets once", () => {
+    const sharedCss = moduleNode("/src/styles/shared.css");
+    const component = moduleNode("/src/components/card.tsx", "js", [
+      moduleNode("/src/components/card.module.css"),
+      moduleNode("/src/styles/tokens.css?raw"),
+      sharedCss,
+    ]);
+    const entry = moduleNode("/src/routes/home.tsx", "js", [component, sharedCss]);
+
+    expect(collectDevCssUrls(entry)).toEqual([
+      "/src/components/card.module.css",
+      "/src/styles/shared.css",
+    ]);
+  });
+
+  it("builds a route and shell CSS manifest from Vite's SSR graph", async () => {
+    const routeEntry = moduleNode("/src/routes/home.tsx", "js", [
+      moduleNode("/src/routes/home.module.css", "css"),
+    ]);
+    const shellEntry = moduleNode("/src/shells/public.tsx", "js", [
+      moduleNode("/src/styles/global.css", "css"),
+    ]);
+    const graph = new Map([
+      ["/src/routes/home.tsx", routeEntry],
+      ["/src/shells/public.tsx", shellEntry],
+    ]);
+
+    const manifest = await createDevCssManifest(
+      {
+        environments: {
+          ssr: { moduleGraph: { getModuleByUrl: async (url: string) => graph.get(url) } },
+        },
+      } as any,
+      {
+        app: {
+          routes: [],
+        } as any,
+        matchAppRoute: () => ({
+          route: {
+            file: "./routes/home.tsx",
+            shellFile: "./shells/public.tsx",
+          } as any,
+        }),
+        pathname: "/",
+        registry: {
+          routeModules: {
+            "/src/routes/home.tsx": async () => ({}) as any,
+          },
+          shellModules: {
+            "/src/shells/public.tsx": async () => ({}) as any,
+          },
+        },
+      },
+    );
+
+    expect(manifest).toEqual({
+      "./shells/public.tsx": ["/src/styles/global.css"],
+      "./routes/home.tsx": ["/src/routes/home.module.css"],
+    });
+  });
+
+  it("injects discovered styles into the document head without duplicates", () => {
+    const html =
+      '<html><head><link rel="stylesheet" href="/existing.css"></head><body></body></html>';
+
+    expect(
+      injectDevCssLinks(html, {
+        route: ["/route.css", "/existing.css"],
+        shell: ["/global.css", "/route.css"],
+      }),
+    ).toBe(
+      '<html><head><link rel="stylesheet" href="/existing.css">    <link rel="stylesheet" href="/route.css">\n' +
+        '    <link rel="stylesheet" href="/global.css">\n' +
+        "  </head><body></body></html>",
+    );
+  });
+});
 
 const routeMatchers = {
   app: {} as any,

--- a/packages/vite-plugin/test/pages-router.test.ts
+++ b/packages/vite-plugin/test/pages-router.test.ts
@@ -5,6 +5,7 @@ import type { ConfigEnv, UserConfig } from "vite";
 import { afterEach, describe, expect, it } from "vitest";
 
 import { createPrachtRegistryModuleSource, pracht } from "../src/index.ts";
+import { createPrachtDevModuleSource } from "../src/plugin-codegen.ts";
 import { generatePagesManifestSource, scanPagesDirectory } from "../src/pages-router.ts";
 
 const tempDirs: string[] = [];
@@ -223,5 +224,14 @@ describe("createPrachtRegistryModuleSource", () => {
     expect(source).toContain("/src/api/**/*.{ts,js,tsx,jsx}");
     expect(source).toContain("/src/server/**/*.{ts,js,tsx,jsx}");
     expect(source).toContain("/src/middleware/**/*.{ts,tsx,js,jsx}");
+  });
+
+  it("creates adapter-neutral development metadata", () => {
+    const source = createPrachtDevModuleSource({ appFile: "/src/routes.ts" });
+
+    expect(source).toContain('import { app } from "/src/routes.ts"');
+    expect(source).toContain("export const resolvedApp = resolveApp(app)");
+    expect(source).toContain("export const registry = {");
+    expect(source).not.toContain("createCloudflareFetchHandler");
   });
 });


### PR DESCRIPTION
## Summary

- Prevent development FOUC by injecting matched shell and route CSS from Vite's live module graph before the client entry, including adapter-owned dev servers such as Cloudflare.
- Add adapter-neutral development metadata, remove the docs example workarounds, document the behavior, and add regression coverage.
- Issue: N/A.

## Testing

- [ ] `pnpm e2e` — standard ports 3101/3103 are occupied by another Conductor workspace; an isolated run passed 107/111, with the remaining four capability tests hard-coding port 3103, and the new CSS regression passed against the correct server.
- [x] `pnpm format`
- [x] `pnpm lint`
- [x] `pnpm test` (1,279 tests)

## Checklist

- [x] Docs updated if needed
- [x] Skills updated if needed (N/A; no skill workflow changed)
- [x] Changeset added if published packages changed
