### PR TITLE
Require explicit image local origin

### DIFF
--- a/.changeset/secure-image-local-origin.md
+++ b/.changeset/secure-image-local-origin.md
@@ -1,0 +1,5 @@
+---
+"@pracht/image": patch
+---
+
+Require an explicit trusted `localOrigin` for relative image optimization sources so forged loopback or metadata-service Host headers cannot trigger server-side requests.

--- a/docs/IMAGES.md
+++ b/docs/IMAGES.md
@@ -93,8 +93,8 @@ Mount it as an API route — this is the least invasive wiring and works with
 import { createImageHandler } from "@pracht/image/node";
 
 const imageHandler = createImageHandler({
-  // Required for relative sources outside local development. Use the same
-  // trusted value as nodeAdapter({ canonicalOrigin }).
+  // Required for relative sources in every environment. Use the same trusted
+  // value as nodeAdapter({ canonicalOrigin }).
   localOrigin: process.env.PRACHT_ORIGIN,
   // remotePatterns: [{ protocol: "https", hostname: "images.example.com" }],
 });
@@ -121,10 +121,11 @@ That file maps to `/api/_pracht/image`, which is exactly what
 
 ### Security
 
-- **Trusted local origin.** Relative `url` values resolve against `localOrigin`
-  in production, so a forged request `Host` cannot turn the endpoint into an
-  open proxy. Loopback request origins are accepted without configuration for
-  local development. With adapter-node, use the same trusted value for
+- **Trusted local origin.** Relative `url` values resolve only against the
+  explicitly configured `localOrigin`, so a forged request `Host` cannot turn
+  the endpoint into an open proxy. This is required in development too; the
+  handler never trusts the request origin, including loopback-looking origins.
+  With adapter-node, use the same trusted value for
   `nodeAdapter({ canonicalOrigin })` and `createImageHandler({ localOrigin })`.
 - **Remote allowlist.** `remotePatterns` allowlists specific hosts (exact
   hostname or `*.` suffix wildcard, optional protocol/port/path prefix).
@@ -162,8 +163,9 @@ cancelled.
 
 ## Per-target guidance
 
-- **adapter-node** — set one trusted public origin on both the Node adapter and
-  image handler, then put a CDN in front of the cacheable endpoint.
+- **adapter-node** — set one trusted origin on both the Node adapter and image
+  handler in development and production, then put a CDN in front of the
+  cacheable endpoint.
 - **adapter-cloudflare** — prefer `configureImage({ loader: cloudflareLoader })`;
   Cloudflare Image Resizing handles resizing at the edge and the endpoint is
   not needed (sharp does not run on Workers).
@@ -171,8 +173,9 @@ cancelled.
   an `images` section in your Vercel project config; keep `images.sizes` in
   sync with your device sizes.
 - **Static hosts** — use `passthroughLoader`.
-- **`pracht dev`** — API routes are served by the dev server, so the endpoint
-  works in dev exactly like in production (sharp required). Platform loaders
+- **`pracht dev`** — API routes are served by the dev server, so set
+  `PRACHT_ORIGIN` to its exact origin (for example,
+  `http://localhost:3000`) and install sharp. Platform loaders
   (`cloudflareLoader`, `vercelLoader`) generate URLs that only resolve on the
   deployed platform; if you want dev previews with those, pass
   `loader: passthroughLoader` conditionally (e.g. based on

--- a/e2e/node-build.test.ts
+++ b/e2e/node-build.test.ts
@@ -25,10 +25,12 @@ test("pracht build emits a deployable Node server entry", async () => {
   const { exampleDir, tempDir } = createTempExampleDir("pracht-node-build-");
   const distDir = resolve(exampleDir, "dist");
   const serverEntryPath = resolve(exampleDir, "dist/server/server.js");
+  const port = 4317;
+  const origin = `http://127.0.0.1:${port}`;
 
   rmSync(distDir, { force: true, recursive: true });
 
-  buildExample(exampleDir, { PRACHT_ADAPTER: "node" });
+  buildExample(exampleDir, { PRACHT_ADAPTER: "node", PRACHT_ORIGIN: origin });
 
   expect(existsSync(serverEntryPath)).toBe(true);
 
@@ -42,12 +44,12 @@ test("pracht build emits a deployable Node server entry", async () => {
   expect(serverSource).toContain("createNodeRequestHandler");
   expect(serverSource).toContain("createServer(handler)");
 
-  const port = 4317;
   const server = spawn(process.execPath, [serverEntryPath], {
     cwd: exampleDir,
     env: {
       ...process.env,
       PORT: String(port),
+      PRACHT_ORIGIN: origin,
     },
     stdio: "pipe",
   });

--- a/examples/basic/README.md
+++ b/examples/basic/README.md
@@ -4,9 +4,10 @@ This example uses the Node adapter by default. Set `PRACHT_ADAPTER=vercel`
 before building to emit Vercel's `.vercel/output/` directory, or
 `PRACHT_ADAPTER=cloudflare` to build the Cloudflare Worker output.
 
-For a deployed Node build, set `PRACHT_ORIGIN` to the app's trusted public
-origin. The value pins both request URL construction and relative image source
-fetches; local loopback development works without it.
+Set `PRACHT_ORIGIN` to the app's trusted origin in every environment (for
+example, `http://localhost:3000` in local development). The value pins both
+request URL construction and relative image source fetches; the image endpoint
+fails closed without it.
 
 ## Commands
 

--- a/examples/docs/src/routes/docs/images.md
+++ b/examples/docs/src/routes/docs/images.md
@@ -89,7 +89,7 @@ export const GET = imageHandler;
 export const HEAD = imageHandler;
 ```
 
-This endpoint works in `pracht dev`, adapter-node, and Node-compatible runtimes. Set `localOrigin` to the same trusted public URL used by `nodeAdapter({ canonicalOrigin })`; loopback origins work without configuration during local development. The endpoint returns cacheable, revalidated responses, varies on `Accept`, and negotiates modern output formats such as WebP.
+This endpoint works in `pracht dev`, adapter-node, and Node-compatible runtimes. Set `localOrigin` to the same trusted URL used by `nodeAdapter({ canonicalOrigin })` in every environment (for example, `http://localhost:3000` in local development). Relative sources fail closed when it is missing; the request `Host` is never trusted. The endpoint returns cacheable, revalidated responses, varies on `Accept`, and negotiates modern output formats such as WebP.
 
 ---
 

--- a/packages/image/README.md
+++ b/packages/image/README.md
@@ -40,8 +40,10 @@ export const GET = imageHandler;
 export const HEAD = imageHandler;
 ```
 
-Set `localOrigin` to the same trusted public origin used by
-`nodeAdapter({ canonicalOrigin })`. It may be omitted for loopback development.
+Set `localOrigin` to the same trusted origin used by
+`nodeAdapter({ canonicalOrigin })` in development and production. Relative
+sources fail closed when it is omitted; request and Host-derived origins are
+never trusted, even when they look like loopback addresses.
 
 See [docs/IMAGES.md](https://github.com/JoviDeCroock/pracht/blob/main/docs/IMAGES.md)
 for the full guide: loader configuration, endpoint security options, and

--- a/packages/image/src/node.ts
+++ b/packages/image/src/node.ts
@@ -21,10 +21,9 @@ export interface CreateImageHandlerOptions {
   /** Remote sources to allow. Defaults to none (same-origin only). */
   remotePatterns?: RemotePattern[];
   /**
-   * Trusted public origin used to resolve relative image paths in production.
-   * Required for non-loopback requests so an attacker-controlled Host header
-   * cannot turn the endpoint into an open proxy. Loopback origins remain
-   * available without configuration for local development.
+   * Trusted origin used to resolve relative image paths. Required whenever
+   * relative sources are served so an attacker-controlled Host header cannot
+   * turn the endpoint into an open proxy.
    */
   localOrigin?: string;
   /**
@@ -152,16 +151,6 @@ function normalizeLocalOrigin(value: string | undefined): string | undefined {
   return url.origin;
 }
 
-function isLoopbackHostname(hostname: string): boolean {
-  const host = hostname.toLowerCase();
-  return (
-    host === "localhost" ||
-    host.endsWith(".localhost") ||
-    host === "[::1]" ||
-    /^127(?:\.\d{1,3}){3}$/.test(host)
-  );
-}
-
 function isAllowedTarget(
   url: URL,
   localOrigin: string | undefined,
@@ -238,7 +227,9 @@ function imageResponseBody(request: Request, bytes: Uint8Array): ArrayBuffer | n
  * ```ts
  * // src/api/_pracht/image.ts
  * import { createImageHandler } from "@pracht/image/node";
- * const imageHandler = createImageHandler();
+ * const imageHandler = createImageHandler({
+ *   localOrigin: process.env.PRACHT_ORIGIN,
+ * });
  * export const GET = imageHandler;
  * export const HEAD = imageHandler;
  * ```
@@ -246,7 +237,7 @@ function imageResponseBody(request: Request, bytes: Uint8Array): ArrayBuffer | n
  * The handler resizes and re-encodes images with sharp (an optional peer
  * dependency — install it in your app), negotiates WebP/AVIF via the `Accept`
  * header, and answers with cacheable responses keyed on the query string.
- * Relative sources resolve against a trusted `localOrigin` in production;
+ * Relative sources resolve only against a configured, trusted `localOrigin`;
  * `remotePatterns` opts specific remote hosts in.
  */
 export function createImageHandler(
@@ -284,9 +275,6 @@ export function createImageHandler(
     }
 
     const requestUrl = new URL(request.url);
-    const localOrigin =
-      configuredLocalOrigin ??
-      (isLoopbackHostname(requestUrl.hostname) ? requestUrl.origin : undefined);
     const source = requestUrl.searchParams.get("url");
     const widthParam = requestUrl.searchParams.get("w");
     const qualityParam = requestUrl.searchParams.get("q");
@@ -316,13 +304,19 @@ export function createImageHandler(
         );
       }
     } else if (source.startsWith("/")) {
-      if (!localOrigin) {
+      if (!configuredLocalOrigin) {
         return errorResponse(
           500,
-          "Relative image sources require createImageHandler({ localOrigin }) outside local development.",
+          "Relative image sources require createImageHandler({ localOrigin }).",
         );
       }
-      target = new URL(source, localOrigin);
+      target = new URL(source, configuredLocalOrigin);
+      if (target.origin !== configuredLocalOrigin) {
+        return errorResponse(
+          400,
+          'Relative "url" values must remain on the configured localOrigin.',
+        );
+      }
     } else {
       return errorResponse(
         400,
@@ -383,7 +377,7 @@ export function createImageHandler(
       } catch {
         return errorResponse(502, `Source image "${source}" returned an invalid redirect.`);
       }
-      if (!isAllowedTarget(nextTarget, localOrigin, remotePatterns)) {
+      if (!isAllowedTarget(nextTarget, configuredLocalOrigin, remotePatterns)) {
         return errorResponse(
           403,
           `Source image "${source}" redirected to a host that is not allowed.`,
@@ -409,7 +403,7 @@ export function createImageHandler(
       } catch {
         finalUrl = undefined;
       }
-      if (finalUrl && !isAllowedTarget(finalUrl, localOrigin, remotePatterns)) {
+      if (finalUrl && !isAllowedTarget(finalUrl, configuredLocalOrigin, remotePatterns)) {
         return errorResponse(
           403,
           `Source image "${source}" redirected to a host that is not allowed.`,

--- a/packages/image/test/node-handler.test.ts
+++ b/packages/image/test/node-handler.test.ts
@@ -4,6 +4,7 @@ import { beforeAll, describe, expect, it } from "vitest";
 import { createImageHandler, type CreateImageHandlerOptions } from "../src/node.ts";
 
 let sourcePng: Uint8Array<ArrayBuffer>;
+const LOCAL_ORIGIN = "http://localhost:3000";
 
 beforeAll(async () => {
   sourcePng = new Uint8Array(
@@ -22,6 +23,10 @@ beforeAll(async () => {
 
 function pngFetcher(): CreateImageHandlerOptions["fetchImage"] {
   return async () => new Response(sourcePng, { headers: { "content-type": "image/png" } });
+}
+
+function createLocalImageHandler(options: CreateImageHandlerOptions = {}) {
+  return createImageHandler({ localOrigin: LOCAL_ORIGIN, ...options });
 }
 
 function imageRequest(query: string, accept = "image/webp,image/png,*/*"): { request: Request } {
@@ -45,7 +50,7 @@ function headImageRequest(
 }
 
 describe("createImageHandler validation", () => {
-  const handler = createImageHandler({ fetchImage: pngFetcher() });
+  const handler = createLocalImageHandler({ fetchImage: pngFetcher() });
 
   it("rejects requests without a url parameter", async () => {
     const response = await handler(imageRequest("w=640"));
@@ -57,6 +62,12 @@ describe("createImageHandler validation", () => {
     const response = await handler(imageRequest("url=%2F%2Fevil.com%2Fa.png&w=640"));
     expect(response.status).toBe(400);
     await expect(response.text()).resolves.toContain("Protocol-relative");
+  });
+
+  it("rejects backslash-normalized network paths", async () => {
+    const response = await handler(imageRequest("url=%2F%5C%5C169.254.169.254%2Fa.png&w=640"));
+    expect(response.status).toBe(400);
+    await expect(response.text()).resolves.toContain("localOrigin");
   });
 
   it("rejects non-relative, non-http urls", async () => {
@@ -71,7 +82,7 @@ describe("createImageHandler validation", () => {
   });
 
   it("rejects absolute urls containing credentials", async () => {
-    const handler = createImageHandler({
+    const handler = createLocalImageHandler({
       fetchImage: pngFetcher(),
       remotePatterns: [{ protocol: "https", hostname: "example.com" }],
     });
@@ -95,7 +106,7 @@ describe("createImageHandler validation", () => {
   });
 
   it("caps the maximum width", async () => {
-    const capped = createImageHandler({
+    const capped = createLocalImageHandler({
       fetchImage: pngFetcher(),
       allowedWidths: [],
       maxWidth: 1024,
@@ -123,7 +134,7 @@ describe("createImageHandler validation", () => {
   it("passes the API route abort signal to custom source fetchers", async () => {
     const controller = new AbortController();
     let seenSignal: AbortSignal | undefined;
-    const signalAware = createImageHandler({
+    const signalAware = createLocalImageHandler({
       fetchImage: async (_url, _request, signal) => {
         seenSignal = signal;
         return new Response(sourcePng, { headers: { "content-type": "image/png" } });
@@ -141,27 +152,32 @@ describe("createImageHandler validation", () => {
 });
 
 describe("createImageHandler remote allowlist", () => {
-  it("requires a trusted local origin for relative production requests", async () => {
-    let fetched = false;
+  it.each([
+    "https://attacker.example",
+    "http://localhost:8080",
+    "http://127.0.0.1:8080",
+    "http://169.254.169.254",
+  ])("requires a trusted local origin for relative requests from %s", async (requestOrigin) => {
+    const fetchedUrls: string[] = [];
     const handler = createImageHandler({
-      fetchImage: async () => {
-        fetched = true;
+      fetchImage: async (url) => {
+        fetchedUrls.push(url.href);
         return new Response(sourcePng, { headers: { "content-type": "image/png" } });
       },
     });
 
     const response = await handler({
-      request: new Request("https://attacker.example/api/_pracht/image?url=%2Fa.png&w=640"),
+      request: new Request(`${requestOrigin}/api/_pracht/image?url=%2Fa.png&w=640`),
     });
 
     expect(response.status).toBe(500);
-    expect(fetched).toBe(false);
+    expect(fetchedUrls).toEqual([]);
     await expect(response.text()).resolves.toContain("localOrigin");
   });
 
   it("pins relative fetches to localOrigin instead of the request Host", async () => {
     let fetchedUrl: string | undefined;
-    const handler = createImageHandler({
+    const handler = createLocalImageHandler({
       localOrigin: "https://app.example.com",
       fetchImage: async (url) => {
         fetchedUrl = url.href;
@@ -207,7 +223,7 @@ describe("createImageHandler remote allowlist", () => {
   it("rejects fetches that redirect outside the allowlist", async () => {
     const redirected = new Response(sourcePng, { headers: { "content-type": "image/png" } });
     Object.defineProperty(redirected, "url", { value: "https://evil.com/a.png" });
-    const handler = createImageHandler({ fetchImage: async () => redirected });
+    const handler = createLocalImageHandler({ fetchImage: async () => redirected });
 
     const response = await handler(imageRequest("url=%2Fa.png&w=640"));
     expect(response.status).toBe(403);
@@ -216,7 +232,7 @@ describe("createImageHandler remote allowlist", () => {
 
   it("validates redirects before requesting the next hop", async () => {
     const fetchedUrls: string[] = [];
-    const handler = createImageHandler({
+    const handler = createLocalImageHandler({
       localOrigin: "https://app.example.com",
       fetchImage: async (url) => {
         fetchedUrls.push(url.href);
@@ -262,7 +278,7 @@ describe("createImageHandler remote allowlist", () => {
 
 describe("createImageHandler optimization", () => {
   it("resizes and re-encodes to webp when the client accepts it", async () => {
-    const handler = createImageHandler({ fetchImage: pngFetcher() });
+    const handler = createLocalImageHandler({ fetchImage: pngFetcher() });
     const response = await handler(imageRequest("url=%2Fhero.png&w=640&q=75"));
 
     expect(response.status).toBe(200);
@@ -278,7 +294,7 @@ describe("createImageHandler optimization", () => {
   });
 
   it("answers HEAD with image headers and no body", async () => {
-    const handler = createImageHandler({ fetchImage: pngFetcher() });
+    const handler = createLocalImageHandler({ fetchImage: pngFetcher() });
     const response = await handler(headImageRequest("url=%2Fhero.png&w=640&q=75"));
 
     expect(response.status).toBe(200);
@@ -289,7 +305,7 @@ describe("createImageHandler optimization", () => {
   });
 
   it("never enlarges beyond the source width", async () => {
-    const handler = createImageHandler({ fetchImage: pngFetcher() });
+    const handler = createLocalImageHandler({ fetchImage: pngFetcher() });
     const response = await handler(imageRequest("url=%2Fhero.png&w=1920"));
 
     const metadata = await sharp(new Uint8Array(await response.arrayBuffer())).metadata();
@@ -297,7 +313,7 @@ describe("createImageHandler optimization", () => {
   });
 
   it("keeps png output when the client does not accept modern formats", async () => {
-    const handler = createImageHandler({ fetchImage: pngFetcher() });
+    const handler = createLocalImageHandler({ fetchImage: pngFetcher() });
     const response = await handler(imageRequest("url=%2Fhero.png&w=640", "image/png"));
 
     expect(response.headers.get("content-type")).toBe("image/png");
@@ -306,7 +322,7 @@ describe("createImageHandler optimization", () => {
   });
 
   it("serves avif when opted in and accepted", async () => {
-    const handler = createImageHandler({
+    const handler = createLocalImageHandler({
       fetchImage: pngFetcher(),
       formats: ["image/avif", "image/webp"],
     });
@@ -318,7 +334,7 @@ describe("createImageHandler optimization", () => {
   });
 
   it("does not select a format the client explicitly rejects", async () => {
-    const handler = createImageHandler({ fetchImage: pngFetcher() });
+    const handler = createLocalImageHandler({ fetchImage: pngFetcher() });
     const response = await handler(
       imageRequest("url=%2Fhero.png&w=640", "image/webp;q=0,image/png"),
     );
@@ -328,7 +344,7 @@ describe("createImageHandler optimization", () => {
 
   it("passes svg through untouched with a download disposition", async () => {
     const svg = '<svg xmlns="http://www.w3.org/2000/svg"></svg>';
-    const handler = createImageHandler({
+    const handler = createLocalImageHandler({
       fetchImage: async () => new Response(svg, { headers: { "content-type": "image/svg+xml" } }),
     });
     const response = await handler(imageRequest("url=%2Flogo.svg&w=640"));
@@ -341,7 +357,7 @@ describe("createImageHandler optimization", () => {
 
   it("answers passthrough HEAD responses with headers and no body", async () => {
     const svg = '<svg xmlns="http://www.w3.org/2000/svg"></svg>';
-    const handler = createImageHandler({
+    const handler = createLocalImageHandler({
       fetchImage: async () => new Response(svg, { headers: { "content-type": "image/svg+xml" } }),
     });
     const response = await handler(headImageRequest("url=%2Flogo.svg&w=640"));
@@ -354,7 +370,7 @@ describe("createImageHandler optimization", () => {
   });
 
   it("propagates upstream failures as 502", async () => {
-    const handler = createImageHandler({
+    const handler = createLocalImageHandler({
       fetchImage: async () => new Response("nope", { status: 404 }),
     });
     const response = await handler(imageRequest("url=%2Fmissing.png&w=640"));
@@ -362,7 +378,7 @@ describe("createImageHandler optimization", () => {
   });
 
   it("rejects non-image sources", async () => {
-    const handler = createImageHandler({
+    const handler = createLocalImageHandler({
       fetchImage: async () =>
         new Response("<html></html>", { headers: { "content-type": "text/html" } }),
     });
@@ -371,7 +387,7 @@ describe("createImageHandler optimization", () => {
   });
 
   it("rejects oversized sources", async () => {
-    const handler = createImageHandler({ fetchImage: pngFetcher(), maxSourceBytes: 10 });
+    const handler = createLocalImageHandler({ fetchImage: pngFetcher(), maxSourceBytes: 10 });
     const response = await handler(imageRequest("url=%2Fhero.png&w=640"));
     expect(response.status).toBe(413);
   });
@@ -386,7 +402,7 @@ describe("createImageHandler optimization", () => {
         canceled = true;
       },
     });
-    const handler = createImageHandler({
+    const handler = createLocalImageHandler({
       fetchImage: async () => new Response(body, { headers: { "content-type": "image/png" } }),
       maxSourceBytes: 10,
     });
@@ -398,7 +414,7 @@ describe("createImageHandler optimization", () => {
   });
 
   it("explains how to install sharp when it is missing", async () => {
-    const handler = createImageHandler({
+    const handler = createLocalImageHandler({
       fetchImage: pngFetcher(),
       loadSharp: () => Promise.reject(new Error("Cannot find module 'sharp'")),
     });

--- a/skills/pre-deploy/SKILL.md
+++ b/skills/pre-deploy/SKILL.md
@@ -77,8 +77,9 @@ a markdown summary (graph diff + verify + budgets) worth attaching to it.
   deployment environment. List them for the user.
 - If the app mounts `createImageHandler()` from `@pracht/image/node`, confirm
   `sharp` is installed and `localOrigin` is the same trusted public origin as
-  `nodeAdapter({ canonicalOrigin })`. A production-relative image endpoint
-  without both values is an error.
+  `nodeAdapter({ canonicalOrigin })`. A relative image endpoint without both
+  values is an error in every environment; loopback-looking request origins
+  are intentionally not trusted.
 - Reverse-proxy / TLS termination configured (out of scope for this skill —
   flag for confirmation).
 


### PR DESCRIPTION
## Summary

- Resolve relative image sources only against an explicitly configured `localOrigin`.
- Keep relative URL normalization on the configured origin and update the Node example, docs, and deployment guidance.
- Relevant issue: N/A.

## Testing

- [x] `pnpm e2e`
- [x] `pnpm format`
- [x] `pnpm lint`
- [x] `pnpm test`

## Checklist

- [x] Docs updated if needed
- [x] Skills updated if needed
- [x] Changeset added if published packages changed
