### PR TITLE
fix: read env one key at a time instead of enumerating import.meta.env

### DIFF
--- a/.changeset/public-env-whole-object-reads.md
+++ b/.changeset/public-env-whole-object-reads.md
@@ -1,0 +1,28 @@
+---
+"@pracht/core": patch
+"@pracht/vite-plugin": patch
+"@pracht/image": patch
+"@pracht/cli": patch
+---
+
+Stop whole-object `import.meta.env` reads from inlining non-public env values
+into client bundles.
+
+Vite only replaces single-key `import.meta.env.KEY` accesses with their value.
+Every other read — a bare reference, destructuring, a spread, or bracket
+access — is replaced by an object literal holding all exposed variables,
+including the `VITE_`-prefixed ones Pracht does not treat as public. Because
+that leaves no accessor text behind, the name-based env leak scan could not see
+those values in the output.
+
+- `publicEnv` now reads a `PRACHT_PUBLIC_`-only snapshot injected by the pracht
+  Vite plugin instead of enumerating `import.meta.env`, so builds inline public
+  values only. Dev and non-Vite (plain Node, tests) behaviour is unchanged.
+- `@pracht/image` reads `import.meta.env?.MODE` / `?.DEV` directly for its dev
+  warnings instead of pulling in the whole env object.
+- Env leak detection (`pracht build` and `pracht verify`) now reports
+  whole-object `import.meta.env` reads in first-party client code, and also
+  matches optional-chained accesses such as `import.meta.env?.VITE_SECRET`,
+  which Vite replaces exactly like dot access but the scan previously ignored.
+  Allowlist a deliberate whole-object read with
+  `pracht({ envSafety: { allow: ["*"] } })`.

--- a/docs/ENV.md
+++ b/docs/ENV.md
@@ -37,10 +37,32 @@ compatibility, Pracht does not treat `VITE_` as an intentionally public prefix:
 client references such as `import.meta.env.VITE_SECRET` fail env leak detection
 unless explicitly allowlisted.
 
-`publicEnv` reads `import.meta.env` when Vite provides it and falls back to
-`process.env` outside Vite (plain Node entries, tests). It is a snapshot of
-build-time values on the client; prefer reading it over `import.meta.env` for
-the typing below.
+In builds, `publicEnv` reads a `PRACHT_PUBLIC_`-only snapshot the pracht Vite
+plugin injects; in dev it reads Vite's live env, and outside Vite (plain Node
+entries, tests) it falls back to `process.env`. It is a snapshot of build-time
+values on the client; prefer reading it over `import.meta.env` for the typing
+below.
+
+### Read one key at a time
+
+Vite only replaces single-key `import.meta.env.KEY` accesses with their value.
+Any other read — a bare reference, destructuring, a spread, or bracket
+access — is replaced by an object literal holding **every** exposed variable,
+including the `VITE_` values Pracht does not treat as public:
+
+```ts
+// Leaks every VITE_ value into the client bundle.
+const env = import.meta.env;
+const { PRACHT_PUBLIC_API_BASE } = import.meta.env;
+const mode = import.meta.env["MODE"];
+
+// Fine — each access is replaced by just that value.
+const apiBase = import.meta.env.PRACHT_PUBLIC_API_BASE;
+const isDev = import.meta.env?.DEV;
+```
+
+Env leak detection fails the build on whole-object reads in first-party client
+code. Use `publicEnv` when you need to enumerate public values.
 
 ## Typing your env once
 

--- a/examples/docs/src/routes/docs/env.md
+++ b/examples/docs/src/routes/docs/env.md
@@ -58,9 +58,31 @@ PRACHT_PUBLIC_APP_NAME=Acme
 PRACHT_PUBLIC_API_BASE=https://api.example.com
 ```
 
-`publicEnv` reads `import.meta.env` when Vite provides it and falls back to
-`process.env` outside Vite (plain Node entries, tests). It is a frozen snapshot
-of build-time values on the client.
+In builds, `publicEnv` reads a `PRACHT_PUBLIC_`-only snapshot the pracht Vite
+plugin injects; in dev it reads Vite's live env, and outside Vite (plain Node
+entries, tests) it falls back to `process.env`. It is a frozen snapshot of
+build-time values on the client.
+
+### Read One Key at a Time
+
+Vite only replaces single-key `import.meta.env.KEY` accesses with their value.
+Any other read — a bare reference, destructuring, a spread, or bracket
+access — is replaced by an object literal holding **every** exposed variable,
+including the `VITE_` values Pracht does not treat as public:
+
+```ts
+// Leaks every VITE_ value into the client bundle.
+const env = import.meta.env;
+const { PRACHT_PUBLIC_API_BASE } = import.meta.env;
+const mode = import.meta.env["MODE"];
+
+// Fine — each access is replaced by just that value.
+const apiBase = import.meta.env.PRACHT_PUBLIC_API_BASE;
+const isDev = import.meta.env?.DEV;
+```
+
+Env leak detection fails the build on whole-object reads in first-party client
+code. Use `publicEnv` when you need to enumerate public values.
 
 ---
 

--- a/packages/cli/src/verification-env.ts
+++ b/packages/cli/src/verification-env.ts
@@ -9,7 +9,11 @@ import { createCheck, type Check } from "./verification-helpers.js";
 const VITE_BUILTIN_ENV_VARS = new Set(["MODE", "DEV", "PROD", "SSR", "BASE_URL", "NODE_ENV"]);
 const PUBLIC_ENV_PREFIX = "PRACHT_PUBLIC_";
 const ENV_REFERENCE_RE =
-  /\b(process\.env|import\.meta\.env)(?:\.([A-Za-z_$][A-Za-z0-9_$]*)|\[\s*(["'])([A-Za-z_$][A-Za-z0-9_$]*)\3\s*\])/g;
+  /\b(process\.env|import\.meta\.env)(?:\??\.([A-Za-z_$][A-Za-z0-9_$]*)|(?:\?\.)?\[\s*(["'])([A-Za-z_$][A-Za-z0-9_$]*)\3\s*\])/g;
+// `import.meta.env` reads that are not a single-key access; Vite replaces those
+// with an object literal holding every exposed variable.
+const WHOLE_ENV_READ_RE = /\bimport\.meta\.env\b(?!\s*\??\.\s*[A-Za-z_$])/g;
+const WHOLE_ENV_READ = "*";
 
 export interface EnvLeakFinding {
   accessor: string;
@@ -30,19 +34,32 @@ export function scanSourceForEnvLeaks(
   code: string,
   allow: ReadonlySet<string>,
 ): { accessor: string; name: string }[] {
-  const findings: { accessor: string; name: string }[] = [];
-  const seen = new Set<string>();
   const codePositions = getCodePositionMask(code);
+  const matches: Array<{ accessor: string; index: number; name: string }> = [];
 
   for (const match of code.matchAll(ENV_REFERENCE_RE)) {
-    if (!codePositions[match.index ?? -1]) continue;
+    const index = match.index ?? -1;
+    if (!codePositions[index]) continue;
     const accessor = match[1];
     const name = match[2] ?? match[4];
     if (!name) continue;
     if (name.startsWith(PUBLIC_ENV_PREFIX)) continue;
     if (VITE_BUILTIN_ENV_VARS.has(name)) continue;
     if (allow.has(name)) continue;
+    matches.push({ accessor, index, name });
+  }
 
+  if (!allow.has(WHOLE_ENV_READ)) {
+    for (const match of code.matchAll(WHOLE_ENV_READ_RE)) {
+      const index = match.index ?? -1;
+      if (!codePositions[index]) continue;
+      matches.push({ accessor: "import.meta.env", index, name: WHOLE_ENV_READ });
+    }
+  }
+
+  const findings: { accessor: string; name: string }[] = [];
+  const seen = new Set<string>();
+  for (const { accessor, name } of matches.sort((a, b) => a.index - b.index)) {
     const key = `${accessor}.${name}`;
     if (seen.has(key)) continue;
     seen.add(key);
@@ -340,9 +357,13 @@ export function collectEnvLeakVerification(
       createCheck(
         "error",
         `Client bundle references non-public env vars: ${findings
-          .map(
-            (finding) => `${finding.accessor}.${finding.name} in ${JSON.stringify(finding.file)}`,
-          )
+          .map((finding) => {
+            const reference =
+              finding.name === WHOLE_ENV_READ
+                ? "import.meta.env read as a whole object"
+                : `${finding.accessor}.${finding.name}`;
+            return `${reference} in ${JSON.stringify(finding.file)}`;
+          })
           .join("; ")}. Only PRACHT_PUBLIC_-prefixed variables are safe client-side.`,
       ),
     );

--- a/packages/cli/test/verification-env.test.ts
+++ b/packages/cli/test/verification-env.test.ts
@@ -46,6 +46,30 @@ describe("scanSourceForEnvLeaks", () => {
     ]);
   });
 
+  it("flags optional-chained and whole-object import.meta.env reads", () => {
+    expect(scanSourceForEnvLeaks(`a(import.meta.env?.VITE_SECRET);`, new Set())).toEqual([
+      { accessor: "import.meta.env", name: "VITE_SECRET" },
+    ]);
+
+    for (const code of [
+      "const env = import.meta.env;",
+      "const { VITE_SECRET } = import.meta.env;",
+      `const mode = import.meta.env["MODE"];`,
+    ]) {
+      expect(scanSourceForEnvLeaks(code, new Set())).toContainEqual({
+        accessor: "import.meta.env",
+        name: "*",
+      });
+    }
+
+    expect(
+      scanSourceForEnvLeaks(
+        `a(import.meta.env.MODE, import.meta.env?.DEV, import.meta.env.PRACHT_PUBLIC_X, process.env);`,
+        new Set(),
+      ),
+    ).toEqual([]);
+  });
+
   it("ignores comments and literal text while preserving real code references", () => {
     const code = `
       // process.env.COMMENT_SECRET

--- a/packages/framework/src/env.ts
+++ b/packages/framework/src/env.ts
@@ -58,11 +58,21 @@ export function filterPublicEnv(source: Record<string, unknown> | undefined): Fa
   return result;
 }
 
+/** Injected by the pracht Vite plugin; holds only the PRACHT_PUBLIC_ subset. */
+declare const __PRACHT_PUBLIC_ENV__: Record<string, string> | undefined;
+
 function readPublicEnvSource(): Record<string, unknown> | undefined {
-  // Vite injects `import.meta.env` in dev and statically replaces it at build
-  // time, so client and SSR bundles read the same build-time values.
-  const viteEnv = (import.meta as { env?: Record<string, unknown> }).env;
-  if (viteEnv) return viteEnv;
+  // Builds read the plugin-injected subset. Enumerating `import.meta.env`
+  // instead would make Vite inline the entire env object — including the
+  // `VITE_`-prefixed values pracht does not treat as public — into the client
+  // bundle, where the name-based leak scan cannot see them.
+  if (typeof __PRACHT_PUBLIC_ENV__ !== "undefined") return __PRACHT_PUBLIC_ENV__;
+  // Dev only: Vite serves a live `import.meta.env`. The computed access is
+  // deliberate — Vite's define pass matches the literal `import.meta.env` text,
+  // so this form is never replaced and cannot materialize the env object in a
+  // build. Outside Vite it is simply undefined.
+  const devEnv = (import.meta as { env?: Record<string, unknown> })["env"];
+  if (devEnv) return devEnv;
   // Outside Vite (plain Node server entries, tests) fall back to process.env.
   if (typeof process !== "undefined" && process.env) return process.env;
   return undefined;

--- a/packages/framework/test/env.test.ts
+++ b/packages/framework/test/env.test.ts
@@ -1,4 +1,7 @@
+import { readFile } from "node:fs/promises";
 import { afterEach, describe, expect, it } from "vitest";
+
+import { scanCodeForEnvLeaks } from "../../vite-plugin/src/env-safety.ts";
 
 import { filterPublicEnv, PRACHT_PUBLIC_ENV_PREFIX } from "../src/env.ts";
 import { serverEnv, setServerEnv } from "../src/env-server.ts";
@@ -41,6 +44,15 @@ describe("publicEnv", () => {
     for (const key of Object.keys(publicEnv)) {
       expect(key.startsWith(PRACHT_PUBLIC_ENV_PREFIX)).toBe(true);
     }
+  });
+
+  it("reads its source without enumerating the env object", async () => {
+    // Enumerating the whole object makes Vite inline every exposed variable —
+    // VITE_ values included — into the client bundle, so the source must only
+    // ever reach it through the plugin-injected define, a computed access, or
+    // process.env. Checked with the shipped scanner so comments do not count.
+    const source = await readFile(new URL("../src/env.ts", import.meta.url), "utf-8");
+    expect(scanCodeForEnvLeaks(source)).toEqual([]);
   });
 });
 

--- a/packages/image/src/image.ts
+++ b/packages/image/src/image.ts
@@ -54,11 +54,19 @@ function getNodeEnv(): string | undefined {
   return (globalThis as { process?: { env?: { NODE_ENV?: string } } }).process?.env?.NODE_ENV;
 }
 
+// Every read must spell out `import.meta.env?.<KEY>` literally. Vite statically
+// replaces those exact member expressions at build time, but a bare
+// `import.meta.env` read is materialized into an object literal holding every
+// exposed env value — including `VITE_`-prefixed ones — which would ship those
+// values in the client bundle and slip past the name-based env leak scan. In
+// Node (CLI builds, tests) `import.meta.env` is undefined and the optional
+// chain yields undefined.
 function getImportMetaDev(): boolean | undefined {
-  const env = (import.meta as ImportMeta & { env?: { DEV?: boolean; MODE?: string } }).env;
-  if (env?.MODE === "production") return false;
-  if (typeof env?.DEV === "boolean") return env.DEV;
-  if (typeof env?.MODE === "string") return env.MODE !== "production";
+  const mode = import.meta.env?.MODE;
+  if (mode === "production") return false;
+  const dev = import.meta.env?.DEV;
+  if (typeof dev === "boolean") return dev;
+  if (typeof mode === "string") return mode !== "production";
   return undefined;
 }
 

--- a/packages/image/test/image.test.ts
+++ b/packages/image/test/image.test.ts
@@ -1,6 +1,9 @@
+import { readFile } from "node:fs/promises";
 import { h } from "preact";
 import { render } from "preact-render-to-string";
 import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { scanCodeForEnvLeaks } from "../../vite-plugin/src/env-safety.ts";
 
 import {
   cloudflareLoader,
@@ -230,5 +233,14 @@ describe("<Image> dev warnings", () => {
     expect(error).toHaveBeenCalledWith(
       expect.stringContaining('missing required "width" and "height" props'),
     );
+  });
+
+  it("detects dev mode without enumerating the env object", async () => {
+    // A whole-object read is replaced at build time by an object literal
+    // holding every exposed variable, which would ship the app's VITE_ values
+    // in any client bundle that imports <Image>. Checked with the shipped
+    // scanner so comments and strings do not count.
+    const source = await readFile(new URL("../src/image.ts", import.meta.url), "utf-8");
+    expect(scanCodeForEnvLeaks(source)).toEqual([]);
   });
 });

--- a/packages/vite-plugin/src/env-safety.ts
+++ b/packages/vite-plugin/src/env-safety.ts
@@ -35,36 +35,66 @@ export interface EnvLeakReference {
   name: string;
 }
 
-// Matches `process.env.X`, `import.meta.env.X`, and the equivalent
-// bracket-string forms (`process.env["X"]`, `import.meta.env['X']`).
+/**
+ * Sentinel `name` for an `import.meta.env` read that is not a static single-key
+ * access. Vite only narrows `import.meta.env.KEY` / `import.meta.env?.KEY`
+ * member expressions to their value; every other read — a bare reference,
+ * destructuring, a spread, or bracket access — is replaced by an object literal
+ * holding every exposed variable, so the `VITE_` values Pracht treats as
+ * non-public end up verbatim in the client bundle. Those reads leave no
+ * accessor text behind, so the name-based scan below cannot see them.
+ */
+export const WHOLE_ENV_READ = "*";
+
+// Matches `process.env.X`, `import.meta.env.X`, their optional-chained forms
+// (`import.meta.env?.X`), and the equivalent bracket-string forms
+// (`process.env["X"]`, `import.meta.env['X']`).
 const ENV_REFERENCE_RE =
-  /\b(process\.env|import\.meta\.env)(?:\.([A-Za-z_$][A-Za-z0-9_$]*)|\[\s*(["'])([A-Za-z_$][A-Za-z0-9_$]*)\3\s*\])/g;
+  /\b(process\.env|import\.meta\.env)(?:\??\.([A-Za-z_$][A-Za-z0-9_$]*)|(?:\?\.)?\[\s*(["'])([A-Za-z_$][A-Za-z0-9_$]*)\3\s*\])/g;
+
+// Matches `import.meta.env` that is *not* followed by a single-key access, i.e.
+// exactly the reads Vite materializes into the full env object.
+const WHOLE_ENV_READ_RE = /\bimport\.meta\.env\b(?!\s*\??\.\s*[A-Za-z_$])/g;
 
 /**
  * Scans JavaScript source for references to environment variables that are
- * neither public-prefixed, Vite built-ins, nor explicitly allowed.
+ * neither public-prefixed, Vite built-ins, nor explicitly allowed, plus reads
+ * that pull in the whole `import.meta.env` object.
  */
 export function scanCodeForEnvLeaks(
   code: string,
   allow: ReadonlySet<string> = new Set(),
 ): EnvLeakReference[] {
-  const findings: EnvLeakReference[] = [];
-  const seen = new Set<string>();
   const codePositions = getCodePositionMask(code);
+  const matches: Array<{ index: number; reference: EnvLeakReference }> = [];
 
   for (const match of code.matchAll(ENV_REFERENCE_RE)) {
-    if (!codePositions[match.index ?? -1]) continue;
+    const index = match.index ?? -1;
+    if (!codePositions[index]) continue;
     const accessor = match[1] as EnvLeakReference["accessor"];
     const name = match[2] ?? match[4];
     if (!name) continue;
     if (name.startsWith(PUBLIC_ENV_PREFIX)) continue;
     if (VITE_BUILTIN_ENV_VARS.has(name)) continue;
     if (allow.has(name)) continue;
+    matches.push({ index, reference: { accessor, name } });
+  }
 
-    const key = `${accessor}.${name}`;
+  if (!allow.has(WHOLE_ENV_READ)) {
+    for (const match of code.matchAll(WHOLE_ENV_READ_RE)) {
+      const index = match.index ?? -1;
+      if (!codePositions[index]) continue;
+      matches.push({ index, reference: { accessor: "import.meta.env", name: WHOLE_ENV_READ } });
+    }
+  }
+
+  const findings: EnvLeakReference[] = [];
+  const seen = new Set<string>();
+  for (const { reference } of matches.sort((a, b) => a.index - b.index)) {
+    const key = `${reference.accessor}.${reference.name}`;
     if (seen.has(key)) continue;
     seen.add(key);
-    findings.push({ accessor, name });
+    findings.push(reference);
   }
 
   return findings;
@@ -275,12 +305,26 @@ export function formatEnvLeakError(problems: EnvLeakProblem[]): string {
       problem.sources.length > 0
         ? ` (likely from ${problem.sources.map((file) => JSON.stringify(file)).join(", ")})`
         : "";
-    return `  - ${problem.accessor}.${problem.name} in chunk "${problem.chunk}"${source}`;
+    const reference =
+      problem.name === WHOLE_ENV_READ
+        ? "import.meta.env read as a whole object"
+        : `${problem.accessor}.${problem.name}`;
+    return `  - ${reference} in chunk "${problem.chunk}"${source}`;
   });
+
+  const wholeEnvGuidance = problems.some((problem) => problem.name === WHOLE_ENV_READ)
+    ? [
+        "",
+        "A whole-object `import.meta.env` read (bare reference, destructuring, spread, or bracket access)",
+        "is replaced at build time by an object literal containing every exposed variable — including the",
+        "`VITE_` values Pracht does not treat as public. Read one key at a time (`import.meta.env.KEY`).",
+      ]
+    : [];
 
   return [
     "[pracht] Environment variable leak detected in the client bundle:",
     ...lines,
+    ...wholeEnvGuidance,
     "",
     `Only PRACHT_PUBLIC_-prefixed variables may be referenced in client code (prefer publicEnv from "@pracht/core" for typed public values).`,
     `Move server-only reads into loaders/API routes and access them via serverEnv from "@pracht/core/env/server",`,

--- a/packages/vite-plugin/src/index.ts
+++ b/packages/vite-plugin/src/index.ts
@@ -2,7 +2,7 @@ import { preactSsrPrecompile } from "@pracht/preact-ssr-precompile";
 import preact from "@preact/preset-vite";
 import { createRequire } from "node:module";
 import { join, resolve } from "node:path";
-import type { Plugin, UserConfig } from "vite";
+import { loadEnv, type Plugin, type UserConfig } from "vite";
 import {
   isPrachtClientModuleId,
   stripServerOnlyExportsForClient,
@@ -107,11 +107,19 @@ export function pracht(options: PrachtPluginOptions = {}): Plugin[] {
         !isSSRBuild &&
         existsSync(resolveConfigPath(configRoot, resolved.islandsDir));
 
+      // `publicEnv` needs every PRACHT_PUBLIC_ key, but reading the whole
+      // `import.meta.env` object to enumerate them makes Vite inline *all*
+      // exposed vars — VITE_ ones included — into the client bundle. Injecting
+      // the pre-filtered subset keeps that enumeration public-only.
+      const envDir = _config.envDir ? resolve(configRoot, _config.envDir) : configRoot;
+      const publicEnvDefine = JSON.stringify(loadEnv(env.mode, envDir, PUBLIC_ENV_PREFIX));
+
       return {
         appType: "custom" as const,
         // Expose PRACHT_PUBLIC_-prefixed vars on import.meta.env (client and
         // server) while keeping Vite's default VITE_ prefix working.
         envPrefix: ["VITE_", PUBLIC_ENV_PREFIX],
+        define: { __PRACHT_PUBLIC_ENV__: publicEnvDefine },
         // The vendor split only makes sense for the client bundle; SSR builds
         // that disable code splitting (e.g. webworker targets) reject
         // `manualChunks` outright.

--- a/packages/vite-plugin/test/env-safety.test.ts
+++ b/packages/vite-plugin/test/env-safety.test.ts
@@ -1,7 +1,7 @@
 import type { Plugin } from "vite";
 import { describe, expect, it } from "vitest";
 
-import { createEnvSafetyPlugin, scanCodeForEnvLeaks } from "../src/env-safety.ts";
+import { createEnvSafetyPlugin, scanCodeForEnvLeaks, WHOLE_ENV_READ } from "../src/env-safety.ts";
 import { pracht } from "../src/index.ts";
 
 function getHook<T>(plugin: Plugin, name: keyof Plugin): T {
@@ -70,6 +70,9 @@ describe("scanCodeForEnvLeaks", () => {
       { accessor: "import.meta.env", name: "API_TOKEN" },
       { accessor: "process.env", name: "DATABASE_URL" },
       { accessor: "import.meta.env", name: "STRIPE_KEY" },
+      // The bracket form is not statically replaced, so Vite also inlines the
+      // full env object at that site.
+      { accessor: "import.meta.env", name: WHOLE_ENV_READ },
     ]);
   });
 
@@ -86,6 +89,56 @@ describe("scanCodeForEnvLeaks", () => {
     );
 
     expect(findings).toEqual([]);
+  });
+
+  it("flags optional-chained references, which Vite replaces just like dot access", () => {
+    const findings = scanCodeForEnvLeaks(
+      `const a = import.meta.env?.VITE_SECRET;
+       const b = import.meta.env?.["API_TOKEN"];
+       const c = import.meta.env?.DEV;`,
+    );
+
+    expect(findings).toEqual([
+      { accessor: "import.meta.env", name: "VITE_SECRET" },
+      { accessor: "import.meta.env", name: "API_TOKEN" },
+      // `import.meta.env?.["API_TOKEN"]` also pulls in the whole object.
+      { accessor: "import.meta.env", name: WHOLE_ENV_READ },
+    ]);
+  });
+
+  it("flags whole-object import.meta.env reads that no accessor scan can see", () => {
+    for (const code of [
+      "const env = import.meta.env;",
+      "const { VITE_SECRET } = import.meta.env;",
+      "const merged = { ...import.meta.env };",
+      "report(import.meta.env);",
+      // Bracket access is not statically replaced, so Vite inlines everything.
+      `const mode = import.meta.env["MODE"];`,
+      "const value = import.meta.env[key];",
+    ]) {
+      expect(scanCodeForEnvLeaks(code)).toContainEqual({
+        accessor: "import.meta.env",
+        name: WHOLE_ENV_READ,
+      });
+    }
+  });
+
+  it("does not flag single-key import.meta.env access or a bare process.env read", () => {
+    const findings = scanCodeForEnvLeaks(
+      `const mode = import.meta.env.MODE;
+       const dev = import.meta.env?.DEV;
+       const name = import.meta.env.PRACHT_PUBLIC_APP_NAME;
+       const base = import.meta.env.BASE_URL;
+       const all = process.env;`,
+    );
+
+    expect(findings).toEqual([]);
+  });
+
+  it("allows whole-object reads when the sentinel is allowlisted", () => {
+    expect(scanCodeForEnvLeaks("const env = import.meta.env;", new Set([WHOLE_ENV_READ]))).toEqual(
+      [],
+    );
   });
 
   it("flags VITE-prefixed variables as non-public unless allowlisted", () => {
@@ -269,6 +322,29 @@ describe("pracht plugin env wiring", () => {
     const result = config.call({}, {}, { command: "build", mode: "production" });
 
     expect(result.envPrefix).toEqual(["VITE_", "PRACHT_PUBLIC_"]);
+  });
+
+  it("injects only PRACHT_PUBLIC_ values as the publicEnv define", () => {
+    const plugin = findPlugin("pracht");
+    const config = getHook<ConfigHook>(plugin, "config");
+    process.env.PRACHT_PUBLIC_FROM_TEST = "public-value";
+    process.env.VITE_FROM_TEST = "vite-value";
+    process.env.SECRET_FROM_TEST = "secret-value";
+
+    try {
+      const result = config.call({}, {}, { command: "build", mode: "production" });
+      const define = result.define as Record<string, string>;
+      const injected = JSON.parse(define.__PRACHT_PUBLIC_ENV__) as Record<string, string>;
+
+      expect(injected.PRACHT_PUBLIC_FROM_TEST).toBe("public-value");
+      expect(Object.keys(injected).every((key) => key.startsWith("PRACHT_PUBLIC_"))).toBe(true);
+      expect(define.__PRACHT_PUBLIC_ENV__).not.toContain("vite-value");
+      expect(define.__PRACHT_PUBLIC_ENV__).not.toContain("secret-value");
+    } finally {
+      delete process.env.PRACHT_PUBLIC_FROM_TEST;
+      delete process.env.VITE_FROM_TEST;
+      delete process.env.SECRET_FROM_TEST;
+    }
   });
 
   it("registers the env safety plugin", () => {

--- a/skills/audit-secrets/SKILL.md
+++ b/skills/audit-secrets/SKILL.md
@@ -115,6 +115,12 @@ Check for accidental exposure outside loaders:
   intentionally public, so flag client-side `VITE_*` references unless they are
   explicitly allowlisted and reviewed. Warn loudly if a public env name has a
   secret-shaped name.
+- Flag any client-side read of `import.meta.env` that is not a single-key
+  access — a bare reference, destructuring, a spread, or bracket access such as
+  `const env = import.meta.env` or `import.meta.env["MODE"]`. Vite replaces
+  those with an object literal holding **every** exposed variable, so the
+  `VITE_*` values land in the bundle with no accessor text left for a
+  name-based grep to find. Use `publicEnv` to enumerate public values.
 - Confirm server-side env access uses `serverEnv` (from
   `@pracht/core/env/server`) or `context.env` rather than ad-hoc globals.
 


### PR DESCRIPTION
## Summary

Vite only replaces single-key `import.meta.env.KEY` accesses with their value. Every other read — a bare reference, destructuring, a spread, or bracket access — is replaced by an object literal holding **all** exposed variables, including the `VITE_`-prefixed ones pracht does not treat as public. Because those reads leave no accessor text behind, the name-based env scan could not see the resulting values in the output.

Verified against a real `pracht build` of `examples/basic` with a `VITE_` variable in `.env`: its value appeared verbatim in `dist/client/assets/browser-*.js` and `gallery-*.js` before this change, and is absent after, while `PRACHT_PUBLIC_*` values still resolve in SSR, hydration, and the built bundle.

- **`publicEnv`** now reads a `PRACHT_PUBLIC_`-only snapshot injected by the pracht Vite plugin (`__PRACHT_PUBLIC_ENV__`) instead of enumerating `import.meta.env`, so builds inline public values only. Dev (live `import.meta.env`) and non-Vite (plain Node entries, tests) behaviour is unchanged.
- **`@pracht/image`** reads `import.meta.env?.MODE` / `?.DEV` directly for its dev warnings, matching the idiom already used across `@pracht/core`.
- **Env leak detection** (`pracht build` and `pracht verify`) now reports whole-object `import.meta.env` reads in first-party client code, and also matches optional-chained accesses such as `import.meta.env?.VITE_SECRET` — which Vite replaces exactly like dot access, but the scan previously ignored entirely. A deliberate whole-object read can be allowlisted with `pracht({ envSafety: { allow: ["*"] } })`.

No linked issue.

## Testing

- [x] `pnpm e2e` — 110 passed
- [x] `pnpm format`
- [x] `pnpm lint` — 0 warnings, 0 errors
- [x] `pnpm test` — 1286 passed (77 files)

Additional manual verification: `pracht dev` for `examples/basic` checked in a real browser (SSR output, post-hydration DOM, and console) to confirm `publicEnv` still resolves in dev; `pracht build` + `pracht verify` on the same example to confirm the built client bundle is clean.

## Checklist

- [x] Docs updated if needed — `docs/ENV.md` and the docs-site env page gained a "read one key at a time" section
- [x] Skills updated if needed — `skills/audit-secrets` now flags whole-object reads
- [x] Changeset added if published packages changed — patch for `@pracht/core`, `@pracht/vite-plugin`, `@pracht/image`, `@pracht/cli`

🤖 Generated with [Claude Code](https://claude.com/claude-code)