### PR TITLE
Experiment with Preact v11 streaming hydration

### DIFF
--- a/.changeset/preact-v11-jsx-types.md
+++ b/.changeset/preact-v11-jsx-types.md
@@ -1,0 +1,8 @@
+---
+"@pracht/core": patch
+"@pracht/image": patch
+---
+
+Derive element props from Preact's stable intrinsic-element map so public form,
+link, and image types work with both Preact 10 and Preact 11's reorganized JSX
+type exports.

--- a/docs/PREACT_V11_STREAMING_EXPERIMENT.md
+++ b/docs/PREACT_V11_STREAMING_EXPERIMENT.md
@@ -24,9 +24,98 @@ public streaming contract.
 | Hydration 2.0 handles a suspended component that returns `null` | The following sibling remains singular and in the correct position | Supported |
 | Hydration 2.0 handles a suspended component that returns multiple DOM nodes | Both nodes and the following sibling remain singular; the server button is reused and becomes interactive | Supported |
 | The existing Pracht hydration logic can execute on the pinned beta | The suspended-hydration and mismatch unit suites pass | Supported for the tested cases |
+| `<head>` and `<body>` can hold independent streaming boundaries | Each region resolves and patches on its own schedule, in either order | Supported, but not recommended — see the guidance below |
+| A shell-rendered `<head>` keeps streaming's body benefits without its head costs | The head is complete in the first flush and survives with scripting disabled, while the body still streams | Supported |
 
 All browser cases also fail on console warnings, console errors, and uncaught
 page errors, so a visually correct result cannot hide a hydration diagnostic.
+
+## Streaming Both Head and Body
+
+The `/head-body` fixture route puts a Suspense boundary inside `<head>`
+(resolving to `<title>`, `<meta name="description">`, and a canonical `<link>`)
+alongside one in `<body>`, and hydrates `document.documentElement` so Preact —
+not a hand-written shell — owns the whole document.
+
+It works. The two regions are independent: the body boundary can resolve first
+and land while the head still shows its fallback title, or the head can resolve
+first while the body fallback is still on screen. Both orders are asserted.
+
+Mechanically, `preact-render-to-string` flushes the shell up to the last
+`</body>`, then parks each resolved boundary in a trailing `<div hidden>` as a
+`<preact-island>` custom element. Its `connectedCallback` walks *the entire
+document* for the `<!--$s:ID-->` marker pair, so a marker pair in `<head>` is
+found and the resolved nodes are moved into `<head>`. Three things worth
+recording:
+
+- Full-document hydration reuses the streamed head nodes rather than replacing
+  them — the test tags the streamed `<meta>` with a JS property and the
+  property survives hydration. A streamed stylesheet or preload would therefore
+  not refetch.
+- Preact removes the leftover `<div hidden>` stream wrapper as an unmatched
+  trailing child of `<body>`, so the scaffolding cleans itself up.
+- There is no race between the island's `requestAnimationFrame` patch and
+  hydration. The client entry is a module script, so it is deferred until
+  parsing — that is, the stream — completes. Tests with the client boundary
+  resolving immediately (`clientDelay=0`) and with both server boundaries
+  resolving on the same tick are clean.
+
+### The scripting caveat
+
+Patching a resolved boundary into place is the inline init script's job, so
+**with scripting disabled nothing in a streamed `<head>` is applied**. The
+resolved head markup is not merely missing — it is stranded in the body, and
+the document ends up with two `<title>` elements: the fallback in `<head>` and
+the real one inside the hidden wrapper. `document.title` reports the fallback
+because it comes first in tree order.
+
+That makes a suspended `<head>` boundary meaningfully riskier than a suspended
+`<body>` boundary. Body content degrades to a visible fallback, which is
+recoverable. Head content is exactly what non-rendering consumers read, so a
+route whose title or description depends on an async loader would serve a
+placeholder title, no description, and no canonical URL to any client that does
+not run the patcher.
+
+## Guidance: Render the Head in the Shell, Stream the Body
+
+**Do not suspend inside `<head>`. Resolve head content synchronously in the
+shell so it lands complete in the first flush, and let only `<body>` stream.**
+
+The `/shell-head` fixture route is the recommended shape, and it is asserted
+alongside the `/head-body` one so the contrast stays honest. Its `<head>` has no
+Suspense boundary; the body keeps one. Preact still owns the whole document via
+`document.documentElement` hydration, so head content remains hydrated and
+client-updatable — it just never depends on the patcher script to be correct.
+
+What that buys, versus streaming the head:
+
+| | Streamed `<head>` (`/head-body`) | Shell `<head>` (`/shell-head`) |
+| --- | --- | --- |
+| Head in the first flush | Fallback title only | Complete and final |
+| With scripting disabled | Fallback title, no description, no canonical, and a second `<title>` stranded in `<body>` | Fully correct |
+| Body streaming | Yes | Yes, unchanged |
+| Cost | None at render time | The head's data must resolve before the first byte |
+
+The cost is real but small and predictable: whatever feeds `head()` has to be
+awaited before the stream opens, so it gates TTFB. Everything else on the page
+can still suspend. In exchange the head is correct for every client, and
+`<link rel="preload">` / `<link rel="stylesheet">` land early enough for the
+browser's preload scanner to act on them — which a streamed head cannot do
+anyway, since it arrives after the body has already been parsed. Streaming the
+head trades away correctness for no latency win.
+
+Concretely, for a future Pracht streaming mode:
+
+- `head()` output belongs in the shell. Await the loader data it depends on
+  before opening the stream.
+- Route components below the head may suspend freely; that is where streaming
+  pays off.
+- If a route genuinely needs late head mutation (an analytics tag, a
+  client-only theme color), do it from an effect after hydration rather than
+  from a `<head>` Suspense boundary — the failure mode is then "missing
+  enhancement" rather than "wrong metadata".
+- If streaming the head is ever exposed at all, it should be an explicit
+  per-route opt-in that documents the crawler cost, never the default.
 
 Run the focused experiment with:
 
@@ -43,7 +132,10 @@ or any route configuration.
 Before exposing streaming as framework behavior, a production design still
 needs to cover:
 
-- document head, hydration-state, preload, and client-entry ordering;
+- hydration-state, preload, and client-entry ordering;
+- how far up the tree the shell boundary sits, now that the head must resolve
+  before the first byte — which loader data gates TTFB is a routing decision
+  this experiment does not make;
 - redirects and errors before and after the first byte;
 - request cancellation, stream aborts, backpressure, and adapter lifetimes;
 - CSP treatment of the inline stream-patcher script;
@@ -66,9 +158,18 @@ settles.
 
 The Hydration 2.0 hypothesis is supported for the high-risk DOM-pointer cases
 that motivated it: empty results, multi-node results, and both sides of the
-stream/client race. This is strong enough to proceed to a Pracht-specific
-streaming design, but not enough to silently switch today's SSR responses from
-buffered strings to streams.
+stream/client race. Streaming both `<head>` and `<body>` in one document also
+works mechanically, including out-of-order resolution and full-document
+hydration.
+
+But "works" and "should" diverge here. Streaming the head costs correctness for
+every client that does not run the patcher script and wins no latency in
+return, so the recommended shape is a shell-rendered `<head>` with a streamed
+`<body>` — proven by the `/shell-head` route and its scripting-disabled case.
+
+This is strong enough to proceed to a Pracht-specific streaming design, but not
+enough to silently switch today's SSR responses from buffered strings to
+streams.
 
 Upstream context:
 

--- a/docs/PREACT_V11_STREAMING_EXPERIMENT.md
+++ b/docs/PREACT_V11_STREAMING_EXPERIMENT.md
@@ -1,0 +1,78 @@
+# Preact v11 Streaming SSR Experiment
+
+Status: successful upstream experiment, not a Pracht streaming API.
+
+This experiment pins the workspace to `preact@11.0.0-beta.2` and
+`preact-render-to-string@6.7.0`. It checks whether Preact v11's Hydration 2.0
+markers and streamed-hydration coordination are sound enough for Pracht to
+build on. The versions are workspace overrides so every existing Pracht test
+also runs against the same Preact pair without changing the published package
+peer ranges.
+
+The browser fixture lives in `e2e/fixtures/preact-v11-streaming`. It is a small
+Vite-backed Node server rather than a Pracht rendering path. That separation is
+intentional: the experiment tests upstream semantics before Pracht commits to a
+public streaming contract.
+
+## Hypotheses and Results
+
+| Hypothesis | Browser assertion | Result |
+| --- | --- | --- |
+| A streamed response exposes useful HTML before an async boundary resolves | The Suspense fallback is visible while the resolved button is still absent | Supported |
+| Hydration survives when the server stream wins the race | The streamed button keeps its DOM identity through client resumption, remains singular, and becomes interactive | Supported |
+| Hydration survives when the client promise wins the race | Preact keeps the fallback parked until the server boundary arrives, then hydrates one interactive result | Supported |
+| Hydration 2.0 handles a suspended component that returns `null` | The following sibling remains singular and in the correct position | Supported |
+| Hydration 2.0 handles a suspended component that returns multiple DOM nodes | Both nodes and the following sibling remain singular; the server button is reused and becomes interactive | Supported |
+| The existing Pracht hydration logic can execute on the pinned beta | The suspended-hydration and mismatch unit suites pass | Supported for the tested cases |
+
+All browser cases also fail on console warnings, console errors, and uncaught
+page errors, so a visually correct result cannot hide a hydration diagnostic.
+
+Run the focused experiment with:
+
+```sh
+pnpm exec playwright test --project preact-v11-streaming
+```
+
+## What This Does Not Prove
+
+Pracht still calls `renderToStringAsync()` and buffers a complete document.
+This experiment does not add streaming to `handlePrachtRequest()`, any adapter,
+or any route configuration.
+
+Before exposing streaming as framework behavior, a production design still
+needs to cover:
+
+- document head, hydration-state, preload, and client-entry ordering;
+- redirects and errors before and after the first byte;
+- request cancellation, stream aborts, backpressure, and adapter lifetimes;
+- CSP treatment of the inline stream-patcher script;
+- nested and concurrent Suspense boundaries;
+- islands, SSG/ISG caching, and client navigation interactions;
+- Node, Cloudflare, and Vercel deployment behavior.
+
+The experiment uses `Suspense` from `preact/compat`. Pracht's current
+`preact-suspense@0.3.0` dependency still declares a Preact 10 peer range. Its
+existing tests pass under the forced v11 resolution, but that is not an
+upstream compatibility guarantee and must be resolved before Pracht advertises
+Preact v11 support.
+
+The streamed marker protocol may also move: the template-based follow-up in
+`preact` and `preact-render-to-string` was still open when this experiment was
+recorded. Keep the exact beta and renderer versions pinned until that protocol
+settles.
+
+## Conclusion
+
+The Hydration 2.0 hypothesis is supported for the high-risk DOM-pointer cases
+that motivated it: empty results, multi-node results, and both sides of the
+stream/client race. This is strong enough to proceed to a Pracht-specific
+streaming design, but not enough to silently switch today's SSR responses from
+buffered strings to streams.
+
+Upstream context:
+
+- [Preact v11 beta.2 release](https://github.com/preactjs/preact/releases/tag/11.0.0-beta.2)
+- [Hydration 2.0 RFC](https://github.com/preactjs/preact/issues/4442)
+- [Streaming hydration coordination RFC](https://github.com/preactjs/preact/issues/5034)
+- [Open template-based streaming follow-up](https://github.com/preactjs/preact/pull/5153)

--- a/docs/RENDERING_MODES.md
+++ b/docs/RENDERING_MODES.md
@@ -75,7 +75,10 @@ fetch only the loader data as JSON, not full HTML.
 Pracht currently buffers SSR into a complete string. The
 [Preact v11 streaming experiment](PREACT_V11_STREAMING_EXPERIMENT.md) validates
 Hydration 2.0 and streamed Suspense behavior in an isolated browser fixture,
-but does not yet change this production rendering contract.
+but does not yet change this production rendering contract. Its standing
+guidance for any future streaming mode: render `<head>` in the shell and stream
+only `<body>`, because a suspended `<head>` serves placeholder metadata to any
+client that does not run the stream's patcher script.
 
 ### When to use SSR
 

--- a/docs/RENDERING_MODES.md
+++ b/docs/RENDERING_MODES.md
@@ -72,6 +72,11 @@ component renders to a string, and the full HTML is returned with hydration stat
 After hydration, client-side navigation takes over — subsequent navigations
 fetch only the loader data as JSON, not full HTML.
 
+Pracht currently buffers SSR into a complete string. The
+[Preact v11 streaming experiment](PREACT_V11_STREAMING_EXPERIMENT.md) validates
+Hydration 2.0 and streamed Suspense behavior in an isolated browser fixture,
+but does not yet change this production rendering contract.
+
 ### When to use SSR
 
 - Pages that depend on the request (cookies, auth, personalization)

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -3,6 +3,12 @@
 Playwright coverage now exercises `examples/cloudflare` in the browser dev loop
 plus the Cloudflare and Vercel deployment build outputs.
 
+The `preact-v11-streaming` project is an isolated upstream experiment covering
+streamed Suspense hydration races and Hydration 2.0's empty and multi-node
+boundary cases. See
+[`docs/PREACT_V11_STREAMING_EXPERIMENT.md`](../docs/PREACT_V11_STREAMING_EXPERIMENT.md)
+for its evidence and limits.
+
 Running `pnpm install` at the repo root also runs the `prepare` hook, which
 installs the Playwright Chromium browser used by this suite.
 

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -4,8 +4,10 @@ Playwright coverage now exercises `examples/cloudflare` in the browser dev loop
 plus the Cloudflare and Vercel deployment build outputs.
 
 The `preact-v11-streaming` project is an isolated upstream experiment covering
-streamed Suspense hydration races and Hydration 2.0's empty and multi-node
-boundary cases. See
+streamed Suspense hydration races, Hydration 2.0's empty and multi-node
+boundary cases, and `<head>` streaming — both the concurrent
+`<head>`/`<body>` boundary shape and the shell-rendered `<head>` shape the
+experiment recommends instead. See
 [`docs/PREACT_V11_STREAMING_EXPERIMENT.md`](../docs/PREACT_V11_STREAMING_EXPERIMENT.md)
 for its evidence and limits.
 

--- a/e2e/fixtures/preact-v11-streaming/app.d.mts
+++ b/e2e/fixtures/preact-v11-streaming/app.d.mts
@@ -1,10 +1,16 @@
 import type { ComponentType, VNode } from "preact";
 
 export interface ExperimentConfig {
+  /** Server-side delay for the `<body>` boundary in `head-body` mode. */
+  bodyDelay?: number;
   clientDelay: number;
-  mode: "hydration-2" | "stream";
+  /** Server-side delay for the `<head>` boundary in `head-body` mode. */
+  headDelay?: number;
+  mode: "head-body" | "hydration-2" | "shell-head" | "stream";
   serverDelay: number;
 }
 
 export function createExperimentApp(config: ExperimentConfig): ComponentType;
+export function createHeadBodyApp(config: ExperimentConfig): ComponentType;
+export function createShellHeadApp(config: ExperimentConfig): ComponentType;
 export function createDocument(config: ExperimentConfig): VNode;

--- a/e2e/fixtures/preact-v11-streaming/app.d.mts
+++ b/e2e/fixtures/preact-v11-streaming/app.d.mts
@@ -1,0 +1,10 @@
+import type { ComponentType, VNode } from "preact";
+
+export interface ExperimentConfig {
+  clientDelay: number;
+  mode: "hydration-2" | "stream";
+  serverDelay: number;
+}
+
+export function createExperimentApp(config: ExperimentConfig): ComponentType;
+export function createDocument(config: ExperimentConfig): VNode;

--- a/e2e/fixtures/preact-v11-streaming/app.mjs
+++ b/e2e/fixtures/preact-v11-streaming/app.mjs
@@ -1,0 +1,125 @@
+import { Fragment, h } from "preact";
+import { lazy, Suspense } from "preact/compat";
+import { useEffect, useState } from "preact/hooks";
+
+function after(delay, value) {
+  return new Promise((resolve) => setTimeout(() => resolve(value), delay));
+}
+
+function BoundaryReady({ name, children }) {
+  useEffect(() => {
+    document.documentElement.setAttribute(`data-${name}-hydrated`, "true");
+  }, [name]);
+  return children;
+}
+
+function StreamedContent() {
+  const [count, setCount] = useState(0);
+  return h(
+    BoundaryReady,
+    { name: "stream-boundary" },
+    h(
+      "button",
+      {
+        id: "stream-button",
+        onClick: () => setCount((value) => value + 1),
+      },
+      `stream count: ${count}`,
+    ),
+  );
+}
+
+function EmptyContent() {
+  useEffect(() => {
+    document.documentElement.setAttribute("data-empty-boundary-hydrated", "true");
+  }, []);
+  return null;
+}
+
+function MultipleContent() {
+  const [count, setCount] = useState(0);
+  return h(
+    BoundaryReady,
+    { name: "multiple-boundary" },
+    h(
+      Fragment,
+      null,
+      h(
+        "button",
+        {
+          id: "multiple-first",
+          onClick: () => setCount((value) => value + 1),
+        },
+        `multiple count: ${count}`,
+      ),
+      h("span", { id: "multiple-second" }, "second node"),
+    ),
+  );
+}
+
+function lazyAfter(Component, delay) {
+  return lazy(() => after(delay, { default: Component }));
+}
+
+export function createExperimentApp({ clientDelay, mode, serverDelay }) {
+  const delay = typeof window === "undefined" ? serverDelay : clientDelay;
+  const LazyStreamedContent = lazyAfter(StreamedContent, delay);
+  const LazyEmptyContent = lazyAfter(EmptyContent, delay);
+  const LazyMultipleContent = lazyAfter(MultipleContent, delay);
+
+  return function ExperimentApp() {
+    useEffect(() => {
+      document.documentElement.setAttribute("data-root-hydrated", "true");
+    }, []);
+
+    if (mode === "stream") {
+      return h(
+        "main",
+        { id: "stream-experiment" },
+        h("h1", null, "Preact v11 streamed hydration"),
+        h(
+          Suspense,
+          { fallback: h("p", { id: "stream-fallback" }, "stream fallback") },
+          h(LazyStreamedContent),
+        ),
+        h("p", { id: "stream-sibling" }, "stable sibling"),
+      );
+    }
+
+    return h(
+      "main",
+      { id: "hydration-2-experiment" },
+      h("h1", null, "Preact Hydration 2.0"),
+      h(
+        Suspense,
+        { fallback: h("p", { id: "empty-fallback" }, "empty fallback") },
+        h(LazyEmptyContent),
+      ),
+      h("p", { id: "after-empty" }, "sibling after empty boundary"),
+      h(
+        Suspense,
+        { fallback: h("p", { id: "multiple-fallback" }, "multiple fallback") },
+        h(LazyMultipleContent),
+      ),
+      h("p", { id: "after-multiple" }, "sibling after multiple boundary"),
+    );
+  };
+}
+
+export function createDocument(config) {
+  const App = createExperimentApp(config);
+  return h(
+    "html",
+    { lang: "en" },
+    h("head", null, h("meta", { charSet: "utf-8" }), h("title", null, "Preact v11 SSR experiment")),
+    h(
+      "body",
+      null,
+      h("div", { id: "experiment-root" }, h(App)),
+      h("script", {
+        type: "module",
+        src: `/client.ts?mode=${config.mode}&clientDelay=${config.clientDelay}`,
+      }),
+    ),
+  );
+}

--- a/e2e/fixtures/preact-v11-streaming/app.mjs
+++ b/e2e/fixtures/preact-v11-streaming/app.mjs
@@ -57,6 +57,35 @@ function MultipleContent() {
   );
 }
 
+function HeadContent() {
+  useEffect(() => {
+    document.documentElement.setAttribute("data-head-boundary-hydrated", "true");
+  }, []);
+  return h(
+    Fragment,
+    null,
+    h("title", null, "resolved title"),
+    h("meta", { name: "description", content: "resolved description" }),
+    h("link", { rel: "canonical", href: "/canonical" }),
+  );
+}
+
+function HeadBodyContent() {
+  const [count, setCount] = useState(0);
+  return h(
+    BoundaryReady,
+    { name: "head-body-boundary" },
+    h(
+      "button",
+      {
+        id: "head-body-button",
+        onClick: () => setCount((value) => value + 1),
+      },
+      `head-body count: ${count}`,
+    ),
+  );
+}
+
 function lazyAfter(Component, delay) {
   return lazy(() => after(delay, { default: Component }));
 }
@@ -106,7 +135,113 @@ export function createExperimentApp({ clientDelay, mode, serverDelay }) {
   };
 }
 
+function clientEntrySrc(config) {
+  return `/client.ts?mode=${config.mode}&clientDelay=${config.clientDelay}`;
+}
+
+/**
+ * The head/body mode owns the whole document so Preact — not a hand-written
+ * shell — is responsible for both `<head>` and `<body>`. That is the only way
+ * a `<head>` Suspense boundary can be hydrated rather than merely patched in
+ * by the stream's `<preact-island>` custom element.
+ */
+export function createHeadBodyApp(config) {
+  const isServer = typeof window === "undefined";
+  const headDelay = isServer ? config.headDelay : config.clientDelay;
+  const bodyDelay = isServer ? config.bodyDelay : config.clientDelay;
+  const LazyHeadContent = lazyAfter(HeadContent, headDelay);
+  const LazyBodyContent = lazyAfter(HeadBodyContent, bodyDelay);
+
+  return function HeadBodyDocument() {
+    useEffect(() => {
+      document.documentElement.setAttribute("data-root-hydrated", "true");
+    }, []);
+
+    return h(
+      Fragment,
+      null,
+      h(
+        "head",
+        null,
+        h("meta", { charSet: "utf-8" }),
+        h(Suspense, { fallback: h("title", null, "loading title") }, h(LazyHeadContent)),
+      ),
+      h(
+        "body",
+        null,
+        h(
+          "main",
+          { id: "head-body-experiment" },
+          h("h1", null, "Preact v11 head and body streaming"),
+          h(
+            Suspense,
+            { fallback: h("p", { id: "head-body-fallback" }, "body fallback") },
+            h(LazyBodyContent),
+          ),
+          h("p", { id: "head-body-sibling" }, "stable sibling"),
+        ),
+        h("script", { type: "module", src: clientEntrySrc(config) }),
+      ),
+    );
+  };
+}
+
+/**
+ * The recommended shape: `<head>` is fully resolved in the synchronous shell so
+ * it lands complete in the first flush, and only `<body>` suspends. Preact
+ * still owns the whole document, so head content stays hydrated and
+ * client-updatable — it just never depends on the stream's patcher script.
+ */
+export function createShellHeadApp(config) {
+  const isServer = typeof window === "undefined";
+  const bodyDelay = isServer ? config.bodyDelay : config.clientDelay;
+  const LazyBodyContent = lazyAfter(HeadBodyContent, bodyDelay);
+
+  return function ShellHeadDocument() {
+    useEffect(() => {
+      document.documentElement.setAttribute("data-root-hydrated", "true");
+    }, []);
+
+    return h(
+      Fragment,
+      null,
+      h(
+        "head",
+        null,
+        h("meta", { charSet: "utf-8" }),
+        h("title", null, "shell title"),
+        h("meta", { name: "description", content: "shell description" }),
+        h("link", { rel: "canonical", href: "/canonical" }),
+      ),
+      h(
+        "body",
+        null,
+        h(
+          "main",
+          { id: "head-body-experiment" },
+          h("h1", null, "Preact v11 shell head with streamed body"),
+          h(
+            Suspense,
+            { fallback: h("p", { id: "head-body-fallback" }, "body fallback") },
+            h(LazyBodyContent),
+          ),
+          h("p", { id: "head-body-sibling" }, "stable sibling"),
+        ),
+        h("script", { type: "module", src: clientEntrySrc(config) }),
+      ),
+    );
+  };
+}
+
 export function createDocument(config) {
+  if (config.mode === "head-body") {
+    return h("html", { lang: "en" }, h(createHeadBodyApp(config)));
+  }
+
+  if (config.mode === "shell-head") {
+    return h("html", { lang: "en" }, h(createShellHeadApp(config)));
+  }
+
   const App = createExperimentApp(config);
   return h(
     "html",
@@ -116,10 +251,7 @@ export function createDocument(config) {
       "body",
       null,
       h("div", { id: "experiment-root" }, h(App)),
-      h("script", {
-        type: "module",
-        src: `/client.ts?mode=${config.mode}&clientDelay=${config.clientDelay}`,
-      }),
+      h("script", { type: "module", src: clientEntrySrc(config) }),
     ),
   );
 }

--- a/e2e/fixtures/preact-v11-streaming/client.ts
+++ b/e2e/fixtures/preact-v11-streaming/client.ts
@@ -1,15 +1,35 @@
 import { h, hydrate } from "preact";
 
-import { createExperimentApp } from "./app.mjs";
+import { createExperimentApp, createHeadBodyApp, createShellHeadApp } from "./app.mjs";
 
 const params = new URL(import.meta.url).searchParams;
-const mode = params.get("mode") === "hydration-2" ? "hydration-2" : "stream";
+const rawMode = params.get("mode");
+const mode =
+  rawMode === "hydration-2" || rawMode === "head-body" || rawMode === "shell-head"
+    ? rawMode
+    : "stream";
 const clientDelay = Number(params.get("clientDelay") ?? 0);
-const root = document.getElementById("experiment-root");
 
-if (!root) {
-  throw new Error("The Preact v11 experiment root is missing.");
+if (mode === "head-body" || mode === "shell-head") {
+  // The whole document is Preact-owned, so hydration targets
+  // `document.documentElement` and the app renders `<head>` and `<body>` as
+  // siblings.
+  const createApp = mode === "head-body" ? createHeadBodyApp : createShellHeadApp;
+  const Document = createApp({
+    bodyDelay: 0,
+    clientDelay,
+    headDelay: 0,
+    mode,
+    serverDelay: 0,
+  });
+  hydrate(h(Document, null), document.documentElement);
+} else {
+  const root = document.getElementById("experiment-root");
+
+  if (!root) {
+    throw new Error("The Preact v11 experiment root is missing.");
+  }
+
+  const App = createExperimentApp({ clientDelay, mode, serverDelay: 0 });
+  hydrate(h(App, null), root);
 }
-
-const App = createExperimentApp({ clientDelay, mode, serverDelay: 0 });
-hydrate(h(App, null), root);

--- a/e2e/fixtures/preact-v11-streaming/client.ts
+++ b/e2e/fixtures/preact-v11-streaming/client.ts
@@ -1,0 +1,15 @@
+import { h, hydrate } from "preact";
+
+import { createExperimentApp } from "./app.mjs";
+
+const params = new URL(import.meta.url).searchParams;
+const mode = params.get("mode") === "hydration-2" ? "hydration-2" : "stream";
+const clientDelay = Number(params.get("clientDelay") ?? 0);
+const root = document.getElementById("experiment-root");
+
+if (!root) {
+  throw new Error("The Preact v11 experiment root is missing.");
+}
+
+const App = createExperimentApp({ clientDelay, mode, serverDelay: 0 });
+hydrate(h(App, null), root);

--- a/e2e/preact-v11-streaming.test.ts
+++ b/e2e/preact-v11-streaming.test.ts
@@ -1,0 +1,103 @@
+import { expect, test } from "@playwright/test";
+
+function collectBrowserProblems(page: import("@playwright/test").Page): string[] {
+  const problems: string[] = [];
+  page.on("console", (message) => {
+    if (message.type() === "error" || message.type() === "warning") {
+      problems.push(`${message.type()}: ${message.text()}`);
+    }
+  });
+  page.on("pageerror", (error) => problems.push(`pageerror: ${error.message}`));
+  return problems;
+}
+
+test("streams a Suspense fallback before content and hydrates the streamed DOM", async ({
+  page,
+}) => {
+  const problems = collectBrowserProblems(page);
+
+  await page.goto("/stream?serverDelay=1000&clientDelay=1800", { waitUntil: "commit" });
+  await expect(page.locator("#stream-fallback")).toBeVisible({ timeout: 500 });
+  await expect(page.locator("#stream-button")).toHaveCount(0);
+
+  await expect(page.locator("#stream-button")).toBeVisible({ timeout: 2_000 });
+  await expect(page.locator("#stream-fallback")).toHaveCount(0);
+  await expect(page.locator("html[data-stream-boundary-hydrated]")).toHaveCount(0);
+
+  await page.locator("#stream-button").evaluate((element) => {
+    (element as HTMLElement & { __streamIdentity?: object }).__streamIdentity = {};
+  });
+
+  await expect(page.locator('html[data-stream-boundary-hydrated="true"]')).toHaveCount(1, {
+    timeout: 2_000,
+  });
+  expect(
+    await page
+      .locator("#stream-button")
+      .evaluate((element) =>
+        Boolean((element as HTMLElement & { __streamIdentity?: object }).__streamIdentity),
+      ),
+  ).toBe(true);
+  await expect(page.locator("#stream-button")).toHaveCount(1);
+  await expect(page.locator("#stream-sibling")).toHaveCount(1);
+
+  await page.locator("#stream-button").click();
+  await expect(page.locator("#stream-button")).toHaveText("stream count: 1");
+  expect(problems).toEqual([]);
+});
+
+test("parks a resolved client boundary until the server stream arrives", async ({ page }) => {
+  const problems = collectBrowserProblems(page);
+
+  await page.goto("/stream?serverDelay=1200&clientDelay=200", { waitUntil: "commit" });
+  await expect(page.locator("#stream-fallback")).toBeVisible({ timeout: 500 });
+  await page.waitForTimeout(500);
+  await expect(page.locator("#stream-fallback")).toBeVisible();
+  await expect(page.locator("#stream-button")).toHaveCount(0);
+  await expect(page.locator("html[data-stream-boundary-hydrated]")).toHaveCount(0);
+
+  await page.waitForLoadState("load");
+  await expect(page.locator('html[data-stream-boundary-hydrated="true"]')).toHaveCount(1);
+  await expect(page.locator("#stream-button")).toHaveCount(1);
+  await expect(page.locator("#stream-fallback")).toHaveCount(0);
+  await expect(page.locator("#stream-sibling")).toHaveCount(1);
+
+  await page.locator("#stream-button").click();
+  await expect(page.locator("#stream-button")).toHaveText("stream count: 1");
+  expect(problems).toEqual([]);
+});
+
+test("Hydration 2.0 resumes empty and multi-node async boundaries without shifting siblings", async ({
+  page,
+}) => {
+  const problems = collectBrowserProblems(page);
+
+  await page.goto("/hydration-2?serverDelay=20&clientDelay=800");
+  await expect(page.locator("#multiple-first")).toBeVisible();
+  await expect(page.locator("#empty-fallback")).toHaveCount(0);
+  await expect(page.locator("#multiple-fallback")).toHaveCount(0);
+  await expect(page.locator("html[data-multiple-boundary-hydrated]")).toHaveCount(0);
+
+  await page.locator("#multiple-first").evaluate((element) => {
+    (element as HTMLElement & { __hydrationIdentity?: object }).__hydrationIdentity = {};
+  });
+
+  await expect(page.locator('html[data-empty-boundary-hydrated="true"]')).toHaveCount(1);
+  await expect(page.locator('html[data-multiple-boundary-hydrated="true"]')).toHaveCount(1);
+  expect(
+    await page
+      .locator("#multiple-first")
+      .evaluate((element) =>
+        Boolean((element as HTMLElement & { __hydrationIdentity?: object }).__hydrationIdentity),
+      ),
+  ).toBe(true);
+
+  await expect(page.locator("#after-empty")).toHaveCount(1);
+  await expect(page.locator("#multiple-first")).toHaveCount(1);
+  await expect(page.locator("#multiple-second")).toHaveCount(1);
+  await expect(page.locator("#after-multiple")).toHaveCount(1);
+
+  await page.locator("#multiple-first").click();
+  await expect(page.locator("#multiple-first")).toHaveText("multiple count: 1");
+  expect(problems).toEqual([]);
+});

--- a/e2e/preact-v11-streaming.test.ts
+++ b/e2e/preact-v11-streaming.test.ts
@@ -101,3 +101,223 @@ test("Hydration 2.0 resumes empty and multi-node async boundaries without shifti
   await expect(page.locator("#multiple-first")).toHaveText("multiple count: 1");
   expect(problems).toEqual([]);
 });
+
+/** Counts of every node the head/body experiment can duplicate or misplace. */
+function documentShape() {
+  return {
+    bodyMeta: document.querySelectorAll("body meta[name=description]").length,
+    bodyTitles: document.querySelectorAll("body title").length,
+    headLinks: document.head.querySelectorAll("link[rel=canonical]").length,
+    headMeta: document.head.querySelectorAll("meta[name=description]").length,
+    headTitles: document.head.querySelectorAll("title").length,
+    islands: document.querySelectorAll("preact-island").length,
+    streamWrappers: document.querySelectorAll("body > div[hidden]").length,
+  };
+}
+
+test("streams a head boundary into head while the body boundary streams ahead of it", async ({
+  page,
+}) => {
+  const problems = collectBrowserProblems(page);
+
+  await page.goto("/head-body?headDelay=1000&bodyDelay=120&clientDelay=1200", {
+    waitUntil: "commit",
+  });
+
+  // The shell flushes before either boundary resolves, so the head carries the
+  // Suspense fallback title.
+  await expect(page.locator("#head-body-fallback")).toBeVisible({ timeout: 500 });
+  expect(await page.title()).toBe("loading title");
+
+  // The body boundary resolves first and lands without waiting on the head.
+  await expect(page.locator("#head-body-button")).toBeVisible({ timeout: 2_000 });
+  await expect(page.locator("#head-body-fallback")).toHaveCount(0);
+  expect(await page.title()).toBe("loading title");
+
+  // The head boundary then patches into <head>, not into the <div hidden>
+  // wrapper the stream parked it in.
+  await expect(async () => expect(await page.title()).toBe("resolved title")).toPass({
+    timeout: 2_000,
+  });
+
+  await page.locator('head meta[name="description"]').evaluate((element) => {
+    (element as HTMLElement & { __headIdentity?: object }).__headIdentity = {};
+  });
+
+  await expect(page.locator('html[data-head-boundary-hydrated="true"]')).toHaveCount(1, {
+    timeout: 2_000,
+  });
+  await expect(page.locator('html[data-head-body-boundary-hydrated="true"]')).toHaveCount(1);
+
+  // Hydrating the whole document reuses the streamed head nodes rather than
+  // replacing them, so a late-arriving stylesheet or preload would not refetch.
+  expect(
+    await page
+      .locator('head meta[name="description"]')
+      .evaluate((element) =>
+        Boolean((element as HTMLElement & { __headIdentity?: object }).__headIdentity),
+      ),
+  ).toBe(true);
+
+  expect(await page.evaluate(documentShape)).toEqual({
+    bodyMeta: 0,
+    bodyTitles: 0,
+    headLinks: 1,
+    headMeta: 1,
+    headTitles: 1,
+    islands: 0,
+    streamWrappers: 0,
+  });
+
+  await page.locator("#head-body-button").click();
+  await expect(page.locator("#head-body-button")).toHaveText("head-body count: 1");
+  expect(problems).toEqual([]);
+});
+
+test("streams a head boundary ahead of a still-pending body boundary", async ({ page }) => {
+  const problems = collectBrowserProblems(page);
+
+  await page.goto("/head-body?headDelay=120&bodyDelay=1000&clientDelay=1200", {
+    waitUntil: "commit",
+  });
+
+  // The head resolves while the body is still showing its fallback, so the two
+  // regions stream independently in either order.
+  await expect(async () => expect(await page.title()).toBe("resolved title")).toPass({
+    timeout: 1_500,
+  });
+  await expect(page.locator("#head-body-fallback")).toBeVisible();
+  await expect(page.locator("#head-body-button")).toHaveCount(0);
+
+  await expect(page.locator("#head-body-button")).toBeVisible({ timeout: 2_000 });
+  await expect(page.locator("#head-body-fallback")).toHaveCount(0);
+
+  await expect(page.locator('html[data-head-boundary-hydrated="true"]')).toHaveCount(1, {
+    timeout: 2_000,
+  });
+  await expect(page.locator('html[data-head-body-boundary-hydrated="true"]')).toHaveCount(1);
+
+  expect(await page.evaluate(documentShape)).toEqual({
+    bodyMeta: 0,
+    bodyTitles: 0,
+    headLinks: 1,
+    headMeta: 1,
+    headTitles: 1,
+    islands: 0,
+    streamWrappers: 0,
+  });
+
+  await page.locator("#head-body-button").click();
+  await expect(page.locator("#head-body-button")).toHaveText("head-body count: 1");
+  expect(problems).toEqual([]);
+});
+
+test("leaves streamed head content unapplied when scripting is disabled", async ({
+  baseURL,
+  browser,
+}) => {
+  const context = await browser.newContext({ baseURL, javaScriptEnabled: false });
+  const page = await context.newPage();
+
+  try {
+    await page.goto("/head-body?headDelay=200&bodyDelay=80", { waitUntil: "load" });
+
+    // Moving a resolved boundary out of <div hidden> is the init script's job,
+    // so without scripting the head keeps the fallback title and never gains
+    // the description or canonical link. The resolved head markup is not just
+    // missing, it is stranded in the body: the document ends up with two
+    // <title> elements, and `document.title` reports the fallback because it
+    // is first in tree order.
+    expect(await page.title()).toBe("loading title");
+    expect(await page.evaluate(documentShape)).toEqual({
+      bodyMeta: 1,
+      bodyTitles: 1,
+      headLinks: 0,
+      headMeta: 0,
+      headTitles: 1,
+      islands: 2,
+      streamWrappers: 1,
+    });
+
+    // The body degrades too: the fallback stays and the resolved markup is
+    // stranded inside the hidden wrapper.
+    await expect(page.locator("#head-body-fallback")).toHaveCount(1);
+    await expect(page.locator("#head-body-button")).toHaveCount(1);
+    await expect(page.locator("#head-body-button")).toBeHidden();
+  } finally {
+    await context.close();
+  }
+});
+
+// The two tests below cover the shape this experiment recommends instead:
+// resolve the head in the synchronous shell and suspend only in the body.
+
+test("renders a complete head in the shell while the body still streams", async ({ page }) => {
+  const problems = collectBrowserProblems(page);
+
+  await page.goto("/shell-head?bodyDelay=800&clientDelay=900", { waitUntil: "commit" });
+
+  // The head is whole in the first flush — no fallback title, no dependency on
+  // the patcher script — while the body is still showing its fallback.
+  expect(await page.title()).toBe("shell title");
+  await expect(page.locator('head meta[name="description"]')).toHaveCount(1);
+  await expect(page.locator('head link[rel="canonical"]')).toHaveCount(1);
+  await expect(page.locator("#head-body-fallback")).toBeVisible();
+  await expect(page.locator("#head-body-button")).toHaveCount(0);
+
+  // Streaming still buys everything it bought before for the body.
+  await expect(page.locator("#head-body-button")).toBeVisible({ timeout: 2_000 });
+  await expect(page.locator("#head-body-fallback")).toHaveCount(0);
+
+  await expect(page.locator('html[data-head-body-boundary-hydrated="true"]')).toHaveCount(1, {
+    timeout: 2_000,
+  });
+  expect(await page.title()).toBe("shell title");
+
+  expect(await page.evaluate(documentShape)).toEqual({
+    bodyMeta: 0,
+    bodyTitles: 0,
+    headLinks: 1,
+    headMeta: 1,
+    headTitles: 1,
+    islands: 0,
+    streamWrappers: 0,
+  });
+
+  await page.locator("#head-body-button").click();
+  await expect(page.locator("#head-body-button")).toHaveText("head-body count: 1");
+  expect(problems).toEqual([]);
+});
+
+test("keeps a shell-rendered head correct when scripting is disabled", async ({
+  baseURL,
+  browser,
+}) => {
+  const context = await browser.newContext({ baseURL, javaScriptEnabled: false });
+  const page = await context.newPage();
+
+  try {
+    await page.goto("/shell-head?bodyDelay=100", { waitUntil: "load" });
+
+    // This is the payoff. A shell-rendered head survives with no scripting at
+    // all: correct title, one title element, description and canonical in
+    // place, nothing stranded in the body.
+    expect(await page.title()).toBe("shell title");
+    expect(await page.evaluate(documentShape)).toEqual({
+      bodyMeta: 0,
+      bodyTitles: 0,
+      headLinks: 1,
+      headMeta: 1,
+      headTitles: 1,
+      islands: 1,
+      streamWrappers: 1,
+    });
+
+    // Only the body degrades, and it degrades to a visible fallback rather
+    // than to wrong metadata.
+    await expect(page.locator("#head-body-fallback")).toBeVisible();
+    await expect(page.locator("#head-body-button")).toBeHidden();
+  } finally {
+    await context.close();
+  }
+});

--- a/e2e/start-v11-streaming-server.mjs
+++ b/e2e/start-v11-streaming-server.mjs
@@ -22,7 +22,14 @@ const vite = await createViteServer({
 
 const server = createServer(async (request, response) => {
   const url = new URL(request.url ?? "/", `http://${request.headers.host ?? `localhost:${port}`}`);
-  if (url.pathname !== "/stream" && url.pathname !== "/hydration-2") {
+  const routes = {
+    "/stream": "stream",
+    "/hydration-2": "hydration-2",
+    "/head-body": "head-body",
+    "/shell-head": "shell-head",
+  };
+  const mode = routes[url.pathname];
+  if (!mode) {
     vite.middlewares(request, response, () => {
       response.writeHead(404, { "content-type": "text/plain; charset=utf-8" });
       response.end("Not found");
@@ -30,11 +37,13 @@ const server = createServer(async (request, response) => {
     return;
   }
 
-  const mode = url.pathname === "/hydration-2" ? "hydration-2" : "stream";
+  const serverDelay = Number(url.searchParams.get("serverDelay") ?? 250);
   const config = {
+    bodyDelay: Number(url.searchParams.get("bodyDelay") ?? serverDelay),
     clientDelay: Number(url.searchParams.get("clientDelay") ?? 800),
+    headDelay: Number(url.searchParams.get("headDelay") ?? serverDelay),
     mode,
-    serverDelay: Number(url.searchParams.get("serverDelay") ?? 250),
+    serverDelay,
   };
 
   try {

--- a/e2e/start-v11-streaming-server.mjs
+++ b/e2e/start-v11-streaming-server.mjs
@@ -1,0 +1,80 @@
+import { createServer } from "node:http";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { renderToStringAsync } from "preact-render-to-string";
+import { renderToReadableStream } from "preact-render-to-string/stream";
+import { createServer as createViteServer } from "vite";
+
+import { createDocument } from "./fixtures/preact-v11-streaming/app.mjs";
+
+const port = Number(process.env.PORT ?? 3104);
+const fixtureRoot = resolve(
+  dirname(fileURLToPath(import.meta.url)),
+  "fixtures/preact-v11-streaming",
+);
+const vite = await createViteServer({
+  appType: "custom",
+  configFile: false,
+  root: fixtureRoot,
+  server: { middlewareMode: true },
+});
+
+const server = createServer(async (request, response) => {
+  const url = new URL(request.url ?? "/", `http://${request.headers.host ?? `localhost:${port}`}`);
+  if (url.pathname !== "/stream" && url.pathname !== "/hydration-2") {
+    vite.middlewares(request, response, () => {
+      response.writeHead(404, { "content-type": "text/plain; charset=utf-8" });
+      response.end("Not found");
+    });
+    return;
+  }
+
+  const mode = url.pathname === "/hydration-2" ? "hydration-2" : "stream";
+  const config = {
+    clientDelay: Number(url.searchParams.get("clientDelay") ?? 800),
+    mode,
+    serverDelay: Number(url.searchParams.get("serverDelay") ?? 250),
+  };
+
+  try {
+    response.writeHead(200, {
+      "content-type": "text/html; charset=utf-8",
+      "x-content-type-options": "nosniff",
+    });
+
+    if (mode === "hydration-2") {
+      const html = await renderToStringAsync(createDocument(config));
+      response.end(`<!DOCTYPE html>${html}`);
+      return;
+    }
+
+    const stream = renderToReadableStream(createDocument(config));
+    const reader = stream.getReader();
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      response.write(Buffer.from(value));
+    }
+    response.end();
+  } catch (error) {
+    if (!response.headersSent) {
+      response.writeHead(500, { "content-type": "text/plain; charset=utf-8" });
+    }
+    response.end(error instanceof Error ? error.stack : String(error));
+  }
+});
+
+server.listen(port, "127.0.0.1");
+
+let closing = false;
+async function close() {
+  if (closing) return;
+  closing = true;
+  await vite.close();
+  server.close(() => process.exit(0));
+}
+
+for (const signal of ["SIGINT", "SIGTERM"]) {
+  process.on(signal, () => void close());
+}

--- a/packages/framework/src/runtime-hooks.ts
+++ b/packages/framework/src/runtime-hooks.ts
@@ -66,7 +66,7 @@ type CapabilityFormResult<TName extends string> = TName extends RegisteredCapabi
   : CapabilityEnvelope;
 
 export interface FormProps<TName extends string = string> extends Omit<
-  JSX.HTMLAttributes<HTMLFormElement>,
+  JSX.IntrinsicElements["form"],
   "action" | "method"
 > {
   /**
@@ -111,10 +111,7 @@ export interface FormProps<TName extends string = string> extends Omit<
   onResponse?: (response: Response) => void;
 }
 
-export type LinkProps<TRoute extends RouteId = RouteId> = Omit<
-  JSX.HTMLAttributes<HTMLAnchorElement>,
-  "href"
-> &
+export type LinkProps<TRoute extends RouteId = RouteId> = Omit<JSX.IntrinsicElements["a"], "href"> &
   RouteTarget<TRoute> & {
     /**
      * Prefetch strategy for this link, overriding the route-level strategy:
@@ -210,7 +207,7 @@ export function Link<TRoute extends RouteId>(props: LinkProps<TRoute>) {
     [PREFETCH_ATTRIBUTE]: prefetch,
     [PRESERVE_SCROLL_ATTRIBUTE]: preserveScroll ? "" : undefined,
     [VIEW_TRANSITION_ATTRIBUTE]: viewTransition ? "" : undefined,
-  } as JSX.HTMLAttributes<HTMLAnchorElement>);
+  } as JSX.IntrinsicElements["a"] & { href: string });
 }
 
 export function Form<TName extends string = string>(props: FormProps<TName>) {
@@ -429,7 +426,7 @@ export function Form<TName extends string = string>(props: FormProps<TName>) {
         settleNavigation(navigationToken);
       }
     },
-  } as JSX.HTMLAttributes<HTMLFormElement>);
+  } as JSX.IntrinsicElements["form"]);
 }
 
 export function parseLocation(value: string): Location {

--- a/packages/framework/src/runtime-hooks.ts
+++ b/packages/framework/src/runtime-hooks.ts
@@ -226,7 +226,7 @@ export function Link<TRoute extends RouteId>(props: LinkProps<TRoute>) {
   }
 
   const { route, params, search, hash, prefetch, preserveScroll, viewTransition, ...anchorProps } =
-    props as unknown as Omit<JSX.HTMLAttributes<HTMLAnchorElement>, "href"> &
+    props as unknown as Omit<JSX.IntrinsicElements["a"], "href"> &
       UntypedRouteTarget & {
         prefetch?: LinkPrefetchStrategy;
         preserveScroll?: boolean;

--- a/packages/framework/src/runtime-hooks.ts
+++ b/packages/framework/src/runtime-hooks.ts
@@ -65,7 +65,7 @@ export type { Navigation, NavigationLocation } from "./navigation-state.ts";
 type CapabilityFormResult<TName extends string> = CapabilityEnvelope<CapabilityOutputFor<TName>>;
 
 export interface FormProps<TName extends HttpCapabilityName = HttpCapabilityName> extends Omit<
-  JSX.HTMLAttributes<HTMLFormElement>,
+  JSX.IntrinsicElements["form"],
   "action" | "method"
 > {
   /**
@@ -114,10 +114,7 @@ export interface FormProps<TName extends HttpCapabilityName = HttpCapabilityName
   onResponse?: (response: Response) => void;
 }
 
-export type LinkProps<TRoute extends RouteId = RouteId> = Omit<
-  JSX.HTMLAttributes<HTMLAnchorElement>,
-  "href"
-> &
+export type LinkProps<TRoute extends RouteId = RouteId> = Omit<JSX.IntrinsicElements["a"], "href"> &
   RouteTarget<TRoute> & {
     /**
      * Prefetch strategy for this link, overriding the route-level strategy:
@@ -243,7 +240,7 @@ export function Link<TRoute extends RouteId>(props: LinkProps<TRoute>) {
     [PREFETCH_ATTRIBUTE]: prefetch,
     [PRESERVE_SCROLL_ATTRIBUTE]: preserveScroll ? "" : undefined,
     [VIEW_TRANSITION_ATTRIBUTE]: viewTransition ? "" : undefined,
-  } as JSX.HTMLAttributes<HTMLAnchorElement>);
+  } as JSX.IntrinsicElements["a"] & { href: string });
 }
 
 export function Form<TName extends HttpCapabilityName = HttpCapabilityName>(
@@ -464,7 +461,7 @@ export function Form<TName extends HttpCapabilityName = HttpCapabilityName>(
         settleNavigation(navigationToken);
       }
     },
-  } as JSX.HTMLAttributes<HTMLFormElement>);
+  } as JSX.IntrinsicElements["form"]);
 }
 
 export function parseLocation(value: string): Location {

--- a/packages/framework/test/hydration.test.ts
+++ b/packages/framework/test/hydration.test.ts
@@ -33,9 +33,10 @@ describe("useIsHydrated", () => {
     setupScratch();
   });
 
-  afterEach(() => {
+  afterEach(async () => {
     if (scratch) {
       render(null, scratch);
+      await flush();
       scratch.remove();
     }
   });

--- a/packages/framework/test/hydration.test.ts
+++ b/packages/framework/test/hydration.test.ts
@@ -28,9 +28,10 @@ describe("useIsHydrated", () => {
     setupScratch();
   });
 
-  afterEach(() => {
+  afterEach(async () => {
     if (scratch) {
       render(null, scratch);
+      await flush();
       scratch.remove();
     }
   });

--- a/packages/image/src/image.ts
+++ b/packages/image/src/image.ts
@@ -4,8 +4,12 @@ import type { JSX, VNode } from "preact";
 import { getImageConfig } from "./config.ts";
 import type { ImageLoader } from "./loaders.ts";
 
+type ImageElementProps = JSX.IntrinsicElements["img"];
+type SignalValue = { value: unknown };
+type ImageCssProperties = Exclude<NonNullable<ImageElementProps["style"]>, string | SignalValue>;
+
 export interface ImageProps extends Omit<
-  JSX.HTMLAttributes<HTMLImageElement>,
+  ImageElementProps,
   "src" | "srcset" | "srcSet" | "width" | "height" | "sizes" | "loading" | "alt" | "style"
 > {
   /** Source path (`/hero.jpg`) or absolute URL. Passed to the loader. */
@@ -33,10 +37,10 @@ export interface ImageProps extends Omit<
   loading?: "lazy" | "eager";
   /** Per-component loader override; falls back to the configured loader. */
   loader?: ImageLoader;
-  style?: string | JSX.CSSProperties;
+  style?: string | ImageCssProperties;
 }
 
-const FILL_STYLE: JSX.CSSProperties = {
+const FILL_STYLE: ImageCssProperties = {
   position: "absolute",
   height: "100%",
   width: "100%",
@@ -205,12 +209,12 @@ export function Image(props: ImageProps): VNode {
         .join(", ")
     : undefined;
 
-  let mergedStyle: string | JSX.CSSProperties | undefined = style;
+  let mergedStyle: string | ImageCssProperties | undefined = style;
   if (fill) {
     mergedStyle =
       typeof style === "string"
         ? `${FILL_STYLE_STRING}${style}`
-        : { ...FILL_STYLE, ...(style as JSX.CSSProperties | undefined) };
+        : { ...FILL_STYLE, ...(style as ImageCssProperties | undefined) };
   }
 
   const imgProps: Record<string, unknown> = {

--- a/packages/image/src/image.ts
+++ b/packages/image/src/image.ts
@@ -5,8 +5,12 @@ import { getImageConfig } from "./config.ts";
 import type { ImageLoader } from "./loaders.ts";
 import type { PrachtImageMetadata } from "./metadata.ts";
 
+type ImageElementProps = JSX.IntrinsicElements["img"];
+type SignalValue = { value: unknown };
+type ImageCssProperties = Exclude<NonNullable<ImageElementProps["style"]>, string | SignalValue>;
+
 export interface ImageProps extends Omit<
-  JSX.HTMLAttributes<HTMLImageElement>,
+  ImageElementProps,
   | "src"
   | "srcset"
   | "srcSet"
@@ -63,10 +67,10 @@ export interface ImageProps extends Omit<
    * otherwise inject CSS via the style attribute).
    */
   blurDataURL?: string;
-  style?: string | JSX.CSSProperties;
+  style?: string | ImageCssProperties;
 }
 
-const FILL_STYLE: JSX.CSSProperties = {
+const FILL_STYLE: ImageCssProperties = {
   position: "absolute",
   height: "100%",
   width: "100%",
@@ -294,7 +298,7 @@ export function Image(props: ImageProps): VNode {
   // a plain CSS background on the <img> itself: SSR-safe, zero hydration —
   // the real image covers it as soon as it paints.
   const blur = safeBlurDataURL != null ? blurBackground(safeBlurDataURL) : undefined;
-  let mergedStyle: string | JSX.CSSProperties | undefined = style;
+  let mergedStyle: string | ImageCssProperties | undefined = style;
   if (blur || fill) {
     const baseString = `${blur?.styleString ?? ""}${fill ? FILL_STYLE_STRING : ""}`;
     mergedStyle =
@@ -303,7 +307,7 @@ export function Image(props: ImageProps): VNode {
         : {
             ...blur?.styleObject,
             ...(fill ? FILL_STYLE : undefined),
-            ...(style as JSX.CSSProperties | undefined),
+            ...(style as ImageCssProperties | undefined),
           };
   }
 

--- a/packages/image/src/image.ts
+++ b/packages/image/src/image.ts
@@ -90,7 +90,7 @@ const BLUR_DATA_URL_PATTERN = /^data:image\/[a-z0-9.+-]+(?:;[a-z0-9=+-]+)*,[a-z0
 
 function blurBackground(blurDataURL: string): {
   styleString: string;
-  styleObject: JSX.CSSProperties;
+  styleObject: ImageCssProperties;
 } {
   const image = `url("${blurDataURL}")`;
   return {

--- a/packages/vite-plugin/test/client-module-transform.test.ts
+++ b/packages/vite-plugin/test/client-module-transform.test.ts
@@ -8,6 +8,7 @@ import {
   symlinkSync,
   writeFileSync,
 } from "node:fs";
+import { createRequire } from "node:module";
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -23,6 +24,11 @@ import { stripServerOnlyExportsForClient } from "../src/client-module-transform.
 
 const tempDirs: string[] = [];
 const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "../../..");
+const require = createRequire(import.meta.url);
+
+function resolvePackageExport(specifier: string): string {
+  return require.resolve(specifier);
+}
 
 function makeTempProject(): string {
   const dir = mkdtempSync(join(tmpdir(), "pracht-client-route-"));
@@ -122,31 +128,25 @@ async function buildTempProject(
         },
         {
           find: "preact/jsx-dev-runtime",
-          replacement: resolve(
-            repoRoot,
-            "node_modules/preact/jsx-runtime/dist/jsxRuntime.module.js",
-          ),
+          replacement: resolvePackageExport("preact/jsx-dev-runtime"),
         },
         {
           find: "preact/jsx-runtime",
-          replacement: resolve(
-            repoRoot,
-            "node_modules/preact/jsx-runtime/dist/jsxRuntime.module.js",
-          ),
+          replacement: resolvePackageExport("preact/jsx-runtime"),
         },
         {
           find: "preact/hooks",
-          replacement: resolve(repoRoot, "node_modules/preact/hooks/dist/hooks.module.js"),
+          replacement: resolvePackageExport("preact/hooks"),
         },
         {
           find: "preact/devtools",
-          replacement: resolve(repoRoot, "node_modules/preact/devtools/dist/devtools.module.js"),
+          replacement: resolvePackageExport("preact/devtools"),
         },
         {
           find: "preact/debug",
-          replacement: resolve(repoRoot, "node_modules/preact/debug/dist/debug.module.js"),
+          replacement: resolvePackageExport("preact/debug"),
         },
-        { find: "preact", replacement: resolve(repoRoot, "node_modules/preact/dist/preact.mjs") },
+        { find: "preact", replacement: resolvePackageExport("preact") },
       ],
     },
     build: {

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -35,6 +35,13 @@ export default defineConfig({
         baseURL: "http://localhost:3103",
       },
     },
+    {
+      name: "preact-v11-streaming",
+      testMatch: /preact-v11-streaming\.test\.ts/,
+      use: {
+        baseURL: "http://localhost:3104",
+      },
+    },
   ],
   webServer: [
     {
@@ -65,6 +72,12 @@ export default defineConfig({
         // e2e/capabilities.test.ts and the example eval scenario exercise.
         PRACHT_CONFIRMATION_SECRET: "pracht-e2e-confirmation-secret",
       },
+    },
+    {
+      command: "node e2e/start-v11-streaming-server.mjs",
+      port: 3104,
+      reuseExistingServer: !process.env.CI,
+      timeout: 15_000,
     },
   ],
 });

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -70,6 +70,13 @@ export default defineConfig({
         baseURL: e2eUrls.capabilities,
       },
     },
+    {
+      name: "preact-v11-streaming",
+      testMatch: /preact-v11-streaming\.test\.ts/,
+      use: {
+        baseURL: "http://localhost:3104",
+      },
+    },
   ],
   webServer: [
     {
@@ -100,6 +107,12 @@ export default defineConfig({
         // e2e/capabilities.test.ts and the example eval scenario exercise.
         PRACHT_CONFIRMATION_SECRET: "pracht-e2e-confirmation-secret",
       },
+    },
+    {
+      command: "node e2e/start-v11-streaming-server.mjs",
+      port: 3104,
+      reuseExistingServer: !process.env.CI,
+      timeout: 15_000,
     },
   ],
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,10 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  preact: 11.0.0-beta.2
+  preact-render-to-string: 6.7.0
+
 importers:
 
   .:
@@ -33,11 +37,11 @@ importers:
         specifier: ^1.58.0
         version: 1.58.0
       preact:
-        specifier: ^10.26.9
-        version: 10.29.1
+        specifier: 11.0.0-beta.2
+        version: 11.0.0-beta.2(preact-render-to-string@6.7.0)
       preact-render-to-string:
-        specifier: ^6.5.13
-        version: 6.6.7(preact@10.29.1)
+        specifier: 6.7.0
+        version: 6.7.0(preact@11.0.0-beta.2)
       tsdown:
         specifier: ^0.21.10
         version: 0.21.10(typescript@6.0.3)
@@ -49,7 +53,7 @@ importers:
         version: 8.0.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@22.19.17)(esbuild@0.27.3)(yaml@2.9.0)
       vitest:
         specifier: ^3.2.4
-        version: 3.2.4(@types/node@22.19.17)(jsdom@29.0.2)(lightningcss@1.32.0)(yaml@2.9.0)
+        version: 3.2.4(@types/node@22.19.17)(jsdom@29.0.2)(lightningcss@1.32.0)(supports-color@10.2.2)(yaml@2.9.0)
 
   examples/basic:
     dependencies:
@@ -91,11 +95,11 @@ importers:
         specifier: workspace:*
         version: link:../../packages/vite-plugin
       preact:
-        specifier: ^10.26.9
-        version: 10.29.1
+        specifier: 11.0.0-beta.2
+        version: 11.0.0-beta.2(preact-render-to-string@6.7.0)
       preact-render-to-string:
-        specifier: ^6.5.13
-        version: 6.6.7(preact@10.29.1)
+        specifier: 6.7.0
+        version: 6.7.0(preact@11.0.0-beta.2)
       vite:
         specifier: ^8.0.0
         version: 8.0.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@22.19.17)(esbuild@0.27.3)(yaml@2.9.0)
@@ -122,11 +126,11 @@ importers:
         specifier: workspace:*
         version: link:../../packages/vite-plugin
       preact:
-        specifier: ^10.26.9
-        version: 10.29.1
+        specifier: 11.0.0-beta.2
+        version: 11.0.0-beta.2(preact-render-to-string@6.7.0)
       preact-render-to-string:
-        specifier: ^6.5.13
-        version: 6.6.7(preact@10.29.1)
+        specifier: 6.7.0
+        version: 6.7.0(preact@11.0.0-beta.2)
       vite:
         specifier: ^8.0.0
         version: 8.0.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@22.19.17)(esbuild@0.27.3)(yaml@2.9.0)
@@ -144,7 +148,7 @@ importers:
         version: link:../../packages/framework
       '@tabler/icons-preact':
         specifier: ^3.41.1
-        version: 3.41.1(preact@10.29.1)
+        version: 3.41.1(preact@11.0.0-beta.2)
       wrangler:
         specifier: ^4.80.0
         version: 4.80.0
@@ -159,11 +163,11 @@ importers:
         specifier: ^18.0.0
         version: 18.0.0
       preact:
-        specifier: ^10.26.9
-        version: 10.29.1
+        specifier: 11.0.0-beta.2
+        version: 11.0.0-beta.2(preact-render-to-string@6.7.0)
       preact-render-to-string:
-        specifier: ^6.5.13
-        version: 6.6.7(preact@10.29.1)
+        specifier: 6.7.0
+        version: 6.7.0(preact@11.0.0-beta.2)
       vite:
         specifier: ^8.0.0
         version: 8.0.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@22.19.17)(esbuild@0.27.3)(yaml@2.9.0)
@@ -184,11 +188,11 @@ importers:
         specifier: workspace:*
         version: link:../../packages/vite-plugin
       preact:
-        specifier: ^10.26.9
-        version: 10.29.1
+        specifier: 11.0.0-beta.2
+        version: 11.0.0-beta.2(preact-render-to-string@6.7.0)
       preact-render-to-string:
-        specifier: ^6.5.13
-        version: 6.6.7(preact@10.29.1)
+        specifier: 6.7.0
+        version: 6.7.0(preact@11.0.0-beta.2)
       vite:
         specifier: ^8.0.0
         version: 8.0.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@22.19.17)(esbuild@0.27.3)(yaml@2.9.0)
@@ -218,11 +222,11 @@ importers:
         specifier: workspace:*
         version: link:../../packages/vite-plugin
       preact:
-        specifier: ^10.26.9
-        version: 10.29.1
+        specifier: 11.0.0-beta.2
+        version: 11.0.0-beta.2(preact-render-to-string@6.7.0)
       preact-render-to-string:
-        specifier: ^6.5.13
-        version: 6.6.7(preact@10.29.1)
+        specifier: 6.7.0
+        version: 6.7.0(preact@11.0.0-beta.2)
       vite:
         specifier: ^8.0.0
         version: 8.0.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@22.19.17)(esbuild@0.27.3)(yaml@2.9.0)
@@ -246,11 +250,11 @@ importers:
         specifier: workspace:*
         version: link:../../packages/vite-plugin
       preact:
-        specifier: ^10.26.9
-        version: 10.29.1
+        specifier: 11.0.0-beta.2
+        version: 11.0.0-beta.2(preact-render-to-string@6.7.0)
       preact-render-to-string:
-        specifier: ^6.5.13
-        version: 6.6.7(preact@10.29.1)
+        specifier: 6.7.0
+        version: 6.7.0(preact@11.0.0-beta.2)
       vite:
         specifier: ^8.0.0
         version: 8.0.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@22.19.17)(esbuild@0.27.3)(yaml@2.9.0)
@@ -272,13 +276,13 @@ importers:
         version: link:../../packages/vite-plugin
       '@tsrx/vite-plugin-preact':
         specifier: ^0.0.3
-        version: 0.0.3(preact@10.29.1)(vite@8.0.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@22.19.17)(esbuild@0.27.3)(yaml@2.9.0))
+        version: 0.0.3(preact@11.0.0-beta.2)(vite@8.0.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@22.19.17)(esbuild@0.27.3)(yaml@2.9.0))
       preact:
-        specifier: ^10.26.9
-        version: 10.29.1
+        specifier: 11.0.0-beta.2
+        version: 11.0.0-beta.2(preact-render-to-string@6.7.0)
       preact-render-to-string:
-        specifier: ^6.5.13
-        version: 6.6.7(preact@10.29.1)
+        specifier: 6.7.0
+        version: 6.7.0(preact@11.0.0-beta.2)
       vite:
         specifier: ^8.0.0
         version: 8.0.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@22.19.17)(esbuild@0.27.3)(yaml@2.9.0)
@@ -328,7 +332,7 @@ importers:
     dependencies:
       '@modelcontextprotocol/sdk':
         specifier: ^1.29.0
-        version: 1.29.0(zod@4.4.3)
+        version: 1.29.0(supports-color@10.2.2)(zod@4.4.3)
       '@pracht/capabilities':
         specifier: workspace:*
         version: link:../capabilities
@@ -351,20 +355,20 @@ importers:
         specifier: ^1.0.0
         version: 1.1.0
       preact:
-        specifier: ^10.0.0 || ^11.0.0-0
-        version: 10.29.1
+        specifier: 11.0.0-beta.2
+        version: 11.0.0-beta.2(preact-render-to-string@6.7.0)
       preact-render-to-string:
-        specifier: ^6.0.0
-        version: 6.6.7(preact@10.29.1)
+        specifier: 6.7.0
+        version: 6.7.0(preact@11.0.0-beta.2)
       preact-suspense:
         specifier: ^0.3.0
-        version: 0.3.0(preact@10.29.1)
+        version: 0.3.0(preact@11.0.0-beta.2)
 
   packages/image:
     dependencies:
       preact:
-        specifier: ^10.0.0 || ^11.0.0-0
-        version: 10.29.1
+        specifier: 11.0.0-beta.2
+        version: 11.0.0-beta.2(preact-render-to-string@6.7.0)
     devDependencies:
       sharp:
         specifier: ^0.34.0
@@ -391,11 +395,11 @@ importers:
   packages/preact-ssr-precompile:
     dependencies:
       preact:
-        specifier: ^10.26.0 || ^11.0.0-0
-        version: 10.29.1
+        specifier: 11.0.0-beta.2
+        version: 11.0.0-beta.2(preact-render-to-string@6.7.0)
       preact-render-to-string:
-        specifier: ^6.5.13
-        version: 6.6.7(preact@10.29.1)
+        specifier: 6.7.0
+        version: 6.7.0(preact@11.0.0-beta.2)
       rolldown:
         specifier: ^1.0.0-rc.12
         version: 1.0.0-rc.12(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
@@ -434,10 +438,10 @@ importers:
         version: link:../preact-ssr-precompile
       '@preact/preset-vite':
         specifier: ^2.10.5
-        version: 2.10.5(@babel/core@7.29.0)(preact@10.29.1)(rollup@4.60.1)(vite@8.0.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@22.19.17)(esbuild@0.27.3)(yaml@2.9.0))
+        version: 2.10.5(@babel/core@7.29.0(supports-color@10.2.2))(preact@11.0.0-beta.2)(rollup@4.60.1)(supports-color@10.2.2)(vite@8.0.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@22.19.17)(esbuild@0.27.3)(yaml@2.9.0))
       '@prefresh/vite':
         specifier: ^2.0.0
-        version: 2.4.12(preact@10.29.1)(vite@8.0.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@22.19.17)(esbuild@0.27.3)(yaml@2.9.0))
+        version: 2.4.12(preact@11.0.0-beta.2)(supports-color@10.2.2)(vite@8.0.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@22.19.17)(esbuild@0.27.3)(yaml@2.9.0))
       vite:
         specifier: ^8.0.0
         version: 8.0.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@22.19.17)(esbuild@0.27.3)(yaml@2.9.0)
@@ -1603,7 +1607,7 @@ packages:
   '@prefresh/core@1.5.9':
     resolution: {integrity: sha512-IKBKCPaz34OFVC+adiQ2qaTF5qdztO2/4ZPf4KsRTgjKosWqxVXmEbxCiUydYZRY8GVie+DQlKzQr9gt6HQ+EQ==}
     peerDependencies:
-      preact: ^10.0.0 || ^11.0.0-0
+      preact: 11.0.0-beta.2
 
   '@prefresh/utils@1.2.1':
     resolution: {integrity: sha512-vq/sIuN5nYfYzvyayXI4C2QkprfNaHUQ9ZX+3xLD8nL3rWyzpxOm1+K7RtMbhd+66QcaISViK7amjnheQ/4WZw==}
@@ -1611,7 +1615,7 @@ packages:
   '@prefresh/vite@2.4.12':
     resolution: {integrity: sha512-FY1fzXpUjiuosznMV0YM7XAOPZjB5FIdWS0W24+XnlxYkt9hNAwwsiKYn+cuTEoMtD/ZVazS5QVssBr9YhpCQA==}
     peerDependencies:
-      preact: ^10.4.0 || ^11.0.0-0
+      preact: 11.0.0-beta.2
       vite: '>=2.0.0'
 
   '@quansync/fs@1.0.0':
@@ -1982,7 +1986,7 @@ packages:
   '@tabler/icons-preact@3.41.1':
     resolution: {integrity: sha512-H27Fzpk3lgj/AC4waJ/YGFPrvrR5MXeLbPhl23V6GWWC8uJ27rU7DVVVNI6hFoKVjpl+KlkmH2SUPissy5LJ+w==}
     peerDependencies:
-      preact: ^10.5.13
+      preact: 11.0.0-beta.2
 
   '@tabler/icons@3.41.1':
     resolution: {integrity: sha512-OaRnVbRmH2nHtFeg+RmMJ/7m2oBIF9XCJAUD5gQnMrpK9f05ydj8MZrAf3NZQqOXyxGN1UBL0D5IKLLEUfr74Q==}
@@ -1993,7 +1997,7 @@ packages:
   '@tsrx/preact@0.0.3':
     resolution: {integrity: sha512-OgbypbFLbLm/WJwSaRyUgR3Ew/qJGKhwzru9YHu8lj1DZNUf/NNiboiWlmfOahrg/r8MijSnUQKJH0Ubw3IeSg==}
     peerDependencies:
-      preact: '>=10'
+      preact: 11.0.0-beta.2
 
   '@tsrx/vite-plugin-preact@0.0.3':
     resolution: {integrity: sha512-0b0FEAema2TqmgguF/foiv/1jsMpiajylyK7seq9q3QLf+4evepupR0eDtD+xQV9Zt/rJ5A3g50qbCiSVaW6zg==}
@@ -2788,18 +2792,23 @@ packages:
     resolution: {integrity: sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==}
     engines: {node: ^10 || ^12 || >=14}
 
-  preact-render-to-string@6.6.7:
-    resolution: {integrity: sha512-3XdbsX3+vn9dQW+jJI/FsI9rlkgl6dbeUpqLsChak6jp3j3auFqBCkno7VChbMFs5Q8ylBj6DrUkKRwtVN3nvw==}
+  preact-render-to-string@6.7.0:
+    resolution: {integrity: sha512-Z4WR8fmLMRpdYqJ9i7vrlXSsSrxVJydwrkEXHapexfARbWfGb7vGcnvNQnIzN0cXciMVOlz/XLoiMCi9gUsy9Q==}
     peerDependencies:
-      preact: '>=10 || >= 11.0.0-0'
+      preact: 11.0.0-beta.2
 
   preact-suspense@0.3.0:
     resolution: {integrity: sha512-mKcwdDwvpEtRQ8dG8eNN2//GRxP84bI6q+j4D+WVkF8fSc7Aikk3sAhCj6SpGG8gyFUxE+Nu5ej6vqzPFqe8dg==}
     peerDependencies:
-      preact: ^10.0.0
+      preact: 11.0.0-beta.2
 
-  preact@10.29.1:
-    resolution: {integrity: sha512-gQCLc/vWroE8lIpleXtdJhTFDogTdZG9AjMUpVkDf2iTCNwYNWA+u16dL41TqUDJO4gm2IgrcMv3uTpjd4Pwmg==}
+  preact@11.0.0-beta.2:
+    resolution: {integrity: sha512-7nIgtr4wtls48+fuazknYNuZ3tOuJoo9ZrT+dzXrMBWkcQH5xmOJiibJpmbU8sFmo2IKLFe3eMp84n0Lq0dCHg==}
+    peerDependencies:
+      preact-render-to-string: 6.7.0
+    peerDependenciesMeta:
+      preact-render-to-string:
+        optional: true
 
   proxy-addr@2.0.7:
     resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
@@ -3384,20 +3393,20 @@ snapshots:
 
   '@babel/compat-data@7.29.0': {}
 
-  '@babel/core@7.29.0':
+  '@babel/core@7.29.0(supports-color@10.2.2)':
     dependencies:
       '@babel/code-frame': 7.29.0
       '@babel/generator': 7.29.1
       '@babel/helper-compilation-targets': 7.28.6
-      '@babel/helper-module-transforms': 7.28.6(@babel/core@7.29.0)
+      '@babel/helper-module-transforms': 7.28.6(@babel/core@7.29.0(supports-color@10.2.2))(supports-color@10.2.2)
       '@babel/helpers': 7.29.2
       '@babel/parser': 7.29.2
       '@babel/template': 7.28.6
-      '@babel/traverse': 7.29.0
+      '@babel/traverse': 7.29.0(supports-color@10.2.2)
       '@babel/types': 7.29.0
       '@jridgewell/remapping': 2.3.5
       convert-source-map: 2.0.0
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@10.2.2)
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
@@ -3435,19 +3444,19 @@ snapshots:
 
   '@babel/helper-globals@7.28.0': {}
 
-  '@babel/helper-module-imports@7.28.6':
+  '@babel/helper-module-imports@7.28.6(supports-color@10.2.2)':
     dependencies:
-      '@babel/traverse': 7.29.0
+      '@babel/traverse': 7.29.0(supports-color@10.2.2)
       '@babel/types': 7.29.0
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-module-transforms@7.28.6(@babel/core@7.29.0)':
+  '@babel/helper-module-transforms@7.28.6(@babel/core@7.29.0(supports-color@10.2.2))(supports-color@10.2.2)':
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-module-imports': 7.28.6
+      '@babel/core': 7.29.0(supports-color@10.2.2)
+      '@babel/helper-module-imports': 7.28.6(supports-color@10.2.2)
       '@babel/helper-validator-identifier': 7.28.5
-      '@babel/traverse': 7.29.0
+      '@babel/traverse': 7.29.0(supports-color@10.2.2)
     transitivePeerDependencies:
       - supports-color
 
@@ -3476,25 +3485,25 @@ snapshots:
     dependencies:
       '@babel/types': 8.0.0-rc.3
 
-  '@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0)':
+  '@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0(supports-color@10.2.2))':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@10.2.2)
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-react-jsx-development@7.27.1(@babel/core@7.29.0)':
+  '@babel/plugin-transform-react-jsx-development@7.27.1(@babel/core@7.29.0(supports-color@10.2.2))(supports-color@10.2.2)':
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/plugin-transform-react-jsx': 7.28.6(@babel/core@7.29.0)
+      '@babel/core': 7.29.0(supports-color@10.2.2)
+      '@babel/plugin-transform-react-jsx': 7.28.6(@babel/core@7.29.0(supports-color@10.2.2))(supports-color@10.2.2)
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-react-jsx@7.28.6(@babel/core@7.29.0)':
+  '@babel/plugin-transform-react-jsx@7.28.6(@babel/core@7.29.0(supports-color@10.2.2))(supports-color@10.2.2)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@10.2.2)
       '@babel/helper-annotate-as-pure': 7.27.3
-      '@babel/helper-module-imports': 7.28.6
+      '@babel/helper-module-imports': 7.28.6(supports-color@10.2.2)
       '@babel/helper-plugin-utils': 7.28.6
-      '@babel/plugin-syntax-jsx': 7.28.6(@babel/core@7.29.0)
+      '@babel/plugin-syntax-jsx': 7.28.6(@babel/core@7.29.0(supports-color@10.2.2))
       '@babel/types': 7.29.0
     transitivePeerDependencies:
       - supports-color
@@ -3505,7 +3514,7 @@ snapshots:
       '@babel/parser': 7.29.2
       '@babel/types': 7.29.0
 
-  '@babel/traverse@7.29.0':
+  '@babel/traverse@7.29.0(supports-color@10.2.2)':
     dependencies:
       '@babel/code-frame': 7.29.0
       '@babel/generator': 7.29.1
@@ -3513,7 +3522,7 @@ snapshots:
       '@babel/parser': 7.29.2
       '@babel/template': 7.28.6
       '@babel/types': 7.29.0
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@10.2.2)
     transitivePeerDependencies:
       - supports-color
 
@@ -4067,7 +4076,7 @@ snapshots:
       tinyglobby: 0.2.17
       yaml: 2.9.0
 
-  '@modelcontextprotocol/sdk@1.29.0(zod@4.4.3)':
+  '@modelcontextprotocol/sdk@1.29.0(supports-color@10.2.2)(zod@4.4.3)':
     dependencies:
       '@hono/node-server': 1.19.14(hono@4.12.27)
       ajv: 8.20.0
@@ -4077,8 +4086,8 @@ snapshots:
       cross-spawn: 7.0.6
       eventsource: 3.0.7
       eventsource-parser: 3.1.0
-      express: 5.2.1
-      express-rate-limit: 8.5.2(express@5.2.1)
+      express: 5.2.1(supports-color@10.2.2)
+      express-rate-limit: 8.5.2(express@5.2.1(supports-color@10.2.2))
       hono: 4.12.27
       jose: 6.2.3
       json-schema-typed: 8.0.2
@@ -4245,15 +4254,15 @@ snapshots:
 
   '@poppinss/exception@1.2.3': {}
 
-  '@preact/preset-vite@2.10.5(@babel/core@7.29.0)(preact@10.29.1)(rollup@4.60.1)(vite@8.0.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@22.19.17)(esbuild@0.27.3)(yaml@2.9.0))':
+  '@preact/preset-vite@2.10.5(@babel/core@7.29.0(supports-color@10.2.2))(preact@11.0.0-beta.2)(rollup@4.60.1)(supports-color@10.2.2)(vite@8.0.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@22.19.17)(esbuild@0.27.3)(yaml@2.9.0))':
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/plugin-transform-react-jsx': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-react-jsx-development': 7.27.1(@babel/core@7.29.0)
-      '@prefresh/vite': 2.4.12(preact@10.29.1)(vite@8.0.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@22.19.17)(esbuild@0.27.3)(yaml@2.9.0))
+      '@babel/core': 7.29.0(supports-color@10.2.2)
+      '@babel/plugin-transform-react-jsx': 7.28.6(@babel/core@7.29.0(supports-color@10.2.2))(supports-color@10.2.2)
+      '@babel/plugin-transform-react-jsx-development': 7.27.1(@babel/core@7.29.0(supports-color@10.2.2))(supports-color@10.2.2)
+      '@prefresh/vite': 2.4.12(preact@11.0.0-beta.2)(supports-color@10.2.2)(vite@8.0.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@22.19.17)(esbuild@0.27.3)(yaml@2.9.0))
       '@rollup/pluginutils': 5.3.0(rollup@4.60.1)
-      babel-plugin-transform-hook-names: 1.0.2(@babel/core@7.29.0)
-      debug: 4.4.3
+      babel-plugin-transform-hook-names: 1.0.2(@babel/core@7.29.0(supports-color@10.2.2))
+      debug: 4.4.3(supports-color@10.2.2)
       magic-string: 0.30.21
       picocolors: 1.1.1
       vite: 8.0.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@22.19.17)(esbuild@0.27.3)(yaml@2.9.0)
@@ -4266,20 +4275,20 @@ snapshots:
 
   '@prefresh/babel-plugin@0.5.3': {}
 
-  '@prefresh/core@1.5.9(preact@10.29.1)':
+  '@prefresh/core@1.5.9(preact@11.0.0-beta.2)':
     dependencies:
-      preact: 10.29.1
+      preact: 11.0.0-beta.2(preact-render-to-string@6.7.0)
 
   '@prefresh/utils@1.2.1': {}
 
-  '@prefresh/vite@2.4.12(preact@10.29.1)(vite@8.0.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@22.19.17)(esbuild@0.27.3)(yaml@2.9.0))':
+  '@prefresh/vite@2.4.12(preact@11.0.0-beta.2)(supports-color@10.2.2)(vite@8.0.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@22.19.17)(esbuild@0.27.3)(yaml@2.9.0))':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@10.2.2)
       '@prefresh/babel-plugin': 0.5.3
-      '@prefresh/core': 1.5.9(preact@10.29.1)
+      '@prefresh/core': 1.5.9(preact@11.0.0-beta.2)
       '@prefresh/utils': 1.2.1
       '@rollup/pluginutils': 4.2.1
-      preact: 10.29.1
+      preact: 11.0.0-beta.2(preact-render-to-string@6.7.0)
       vite: 8.0.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@22.19.17)(esbuild@0.27.3)(yaml@2.9.0)
     transitivePeerDependencies:
       - supports-color
@@ -4489,10 +4498,10 @@ snapshots:
     dependencies:
       acorn: 8.16.0
 
-  '@tabler/icons-preact@3.41.1(preact@10.29.1)':
+  '@tabler/icons-preact@3.41.1(preact@11.0.0-beta.2)':
     dependencies:
       '@tabler/icons': 3.41.1
-      preact: 10.29.1
+      preact: 11.0.0-beta.2(preact-render-to-string@6.7.0)
 
   '@tabler/icons@3.41.1': {}
 
@@ -4510,18 +4519,18 @@ snapshots:
     transitivePeerDependencies:
       - '@typescript-eslint/types'
 
-  '@tsrx/preact@0.0.3(preact@10.29.1)':
+  '@tsrx/preact@0.0.3(preact@11.0.0-beta.2)':
     dependencies:
       '@tsrx/core': 0.0.8
       esrap: 2.2.5
-      preact: 10.29.1
+      preact: 11.0.0-beta.2(preact-render-to-string@6.7.0)
       zimmerframe: 1.1.4
     transitivePeerDependencies:
       - '@typescript-eslint/types'
 
-  '@tsrx/vite-plugin-preact@0.0.3(preact@10.29.1)(vite@8.0.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@22.19.17)(esbuild@0.27.3)(yaml@2.9.0))':
+  '@tsrx/vite-plugin-preact@0.0.3(preact@11.0.0-beta.2)(vite@8.0.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@22.19.17)(esbuild@0.27.3)(yaml@2.9.0))':
     dependencies:
-      '@tsrx/preact': 0.0.3(preact@10.29.1)
+      '@tsrx/preact': 0.0.3(preact@11.0.0-beta.2)
       vite: 8.0.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@22.19.17)(esbuild@0.27.3)(yaml@2.9.0)
     transitivePeerDependencies:
       - '@typescript-eslint/types'
@@ -4626,9 +4635,9 @@ snapshots:
       estree-walker: 3.0.3
       pathe: 2.0.3
 
-  babel-plugin-transform-hook-names@1.0.2(@babel/core@7.29.0):
+  babel-plugin-transform-hook-names@1.0.2(@babel/core@7.29.0(supports-color@10.2.2)):
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@10.2.2)
 
   baseline-browser-mapping@2.10.15: {}
 
@@ -4640,11 +4649,11 @@ snapshots:
 
   blake3-wasm@2.1.5: {}
 
-  body-parser@2.3.0:
+  body-parser@2.3.0(supports-color@10.2.2):
     dependencies:
       bytes: 3.1.2
       content-type: 2.0.0
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@10.2.2)
       http-errors: 2.0.1
       iconv-lite: 0.7.2
       on-finished: 2.4.1
@@ -4747,9 +4756,11 @@ snapshots:
 
   dataloader@1.4.0: {}
 
-  debug@4.4.3:
+  debug@4.4.3(supports-color@10.2.2):
     dependencies:
       ms: 2.1.3
+    optionalDependencies:
+      supports-color: 10.2.2
 
   decimal.js@10.6.0: {}
 
@@ -4895,25 +4906,25 @@ snapshots:
 
   expect-type@1.3.0: {}
 
-  express-rate-limit@8.5.2(express@5.2.1):
+  express-rate-limit@8.5.2(express@5.2.1(supports-color@10.2.2)):
     dependencies:
-      express: 5.2.1
+      express: 5.2.1(supports-color@10.2.2)
       ip-address: 10.2.0
 
-  express@5.2.1:
+  express@5.2.1(supports-color@10.2.2):
     dependencies:
       accepts: 2.0.0
-      body-parser: 2.3.0
+      body-parser: 2.3.0(supports-color@10.2.2)
       content-disposition: 1.1.0
       content-type: 1.0.5
       cookie: 0.7.2
       cookie-signature: 1.2.2
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@10.2.2)
       depd: 2.0.0
       encodeurl: 2.0.0
       escape-html: 1.0.3
       etag: 1.8.1
-      finalhandler: 2.1.1
+      finalhandler: 2.1.1(supports-color@10.2.2)
       fresh: 2.0.0
       http-errors: 2.0.1
       merge-descriptors: 2.0.0
@@ -4924,9 +4935,9 @@ snapshots:
       proxy-addr: 2.0.7
       qs: 6.15.3
       range-parser: 1.3.0
-      router: 2.2.0
-      send: 1.2.1
-      serve-static: 2.2.1
+      router: 2.2.0(supports-color@10.2.2)
+      send: 1.2.1(supports-color@10.2.2)
+      serve-static: 2.2.1(supports-color@10.2.2)
       statuses: 2.0.2
       type-is: 2.1.0
       vary: 1.1.2
@@ -4951,9 +4962,9 @@ snapshots:
     optionalDependencies:
       picomatch: 4.0.4
 
-  finalhandler@2.1.1:
+  finalhandler@2.1.1(supports-color@10.2.2):
     dependencies:
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@10.2.2)
       encodeurl: 2.0.0
       escape-html: 1.0.3
       on-finished: 2.4.1
@@ -5327,15 +5338,17 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
-  preact-render-to-string@6.6.7(preact@10.29.1):
+  preact-render-to-string@6.7.0(preact@11.0.0-beta.2):
     dependencies:
-      preact: 10.29.1
+      preact: 11.0.0-beta.2(preact-render-to-string@6.7.0)
 
-  preact-suspense@0.3.0(preact@10.29.1):
+  preact-suspense@0.3.0(preact@11.0.0-beta.2):
     dependencies:
-      preact: 10.29.1
+      preact: 11.0.0-beta.2(preact-render-to-string@6.7.0)
 
-  preact@10.29.1: {}
+  preact@11.0.0-beta.2(preact-render-to-string@6.7.0):
+    optionalDependencies:
+      preact-render-to-string: 6.7.0(preact@11.0.0-beta.2)
 
   proxy-addr@2.0.7:
     dependencies:
@@ -5464,9 +5477,9 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.60.1
       fsevents: 2.3.3
 
-  router@2.2.0:
+  router@2.2.0(supports-color@10.2.2):
     dependencies:
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@10.2.2)
       depd: 2.0.0
       is-promise: 4.0.0
       parseurl: 1.3.3
@@ -5486,9 +5499,9 @@ snapshots:
 
   semver@7.8.5: {}
 
-  send@1.2.1:
+  send@1.2.1(supports-color@10.2.2):
     dependencies:
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@10.2.2)
       encodeurl: 2.0.0
       escape-html: 1.0.3
       etag: 1.8.1
@@ -5502,12 +5515,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  serve-static@2.2.1:
+  serve-static@2.2.1(supports-color@10.2.2):
     dependencies:
       encodeurl: 2.0.0
       escape-html: 1.0.3
       parseurl: 1.3.3
-      send: 1.2.1
+      send: 1.2.1(supports-color@10.2.2)
     transitivePeerDependencies:
       - supports-color
 
@@ -5721,10 +5734,10 @@ snapshots:
 
   vary@1.1.2: {}
 
-  vite-node@3.2.4(@types/node@22.19.17)(lightningcss@1.32.0)(yaml@2.9.0):
+  vite-node@3.2.4(@types/node@22.19.17)(lightningcss@1.32.0)(supports-color@10.2.2)(yaml@2.9.0):
     dependencies:
       cac: 6.7.14
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@10.2.2)
       es-module-lexer: 1.7.0
       pathe: 2.0.3
       vite: 6.4.1(@types/node@22.19.17)(lightningcss@1.32.0)(yaml@2.9.0)
@@ -5782,7 +5795,7 @@ snapshots:
       - '@emnapi/core'
       - '@emnapi/runtime'
 
-  vitest@3.2.4(@types/node@22.19.17)(jsdom@29.0.2)(lightningcss@1.32.0)(yaml@2.9.0):
+  vitest@3.2.4(@types/node@22.19.17)(jsdom@29.0.2)(lightningcss@1.32.0)(supports-color@10.2.2)(yaml@2.9.0):
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.4
@@ -5793,7 +5806,7 @@ snapshots:
       '@vitest/spy': 3.2.4
       '@vitest/utils': 3.2.4
       chai: 5.3.3
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@10.2.2)
       expect-type: 1.3.0
       magic-string: 0.30.21
       pathe: 2.0.3
@@ -5805,7 +5818,7 @@ snapshots:
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
       vite: 6.4.1(@types/node@22.19.17)(lightningcss@1.32.0)(yaml@2.9.0)
-      vite-node: 3.2.4(@types/node@22.19.17)(lightningcss@1.32.0)(yaml@2.9.0)
+      vite-node: 3.2.4(@types/node@22.19.17)(lightningcss@1.32.0)(supports-color@10.2.2)(yaml@2.9.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 22.19.17

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,10 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  preact: 11.0.0-beta.2
+  preact-render-to-string: 6.7.0
+
 importers:
 
   .:
@@ -33,11 +37,11 @@ importers:
         specifier: ^1.58.0
         version: 1.58.0
       preact:
-        specifier: ^10.26.9
-        version: 10.29.1
+        specifier: 11.0.0-beta.2
+        version: 11.0.0-beta.2(preact-render-to-string@6.7.0)
       preact-render-to-string:
-        specifier: ^6.5.13
-        version: 6.6.7(preact@10.29.1)
+        specifier: 6.7.0
+        version: 6.7.0(preact@11.0.0-beta.2)
       tsdown:
         specifier: ^0.21.10
         version: 0.21.10(typescript@6.0.3)
@@ -82,11 +86,11 @@ importers:
         specifier: workspace:*
         version: link:../../packages/vite-plugin
       preact:
-        specifier: ^10.26.9
-        version: 10.29.1
+        specifier: 11.0.0-beta.2
+        version: 11.0.0-beta.2(preact-render-to-string@6.7.0)
       preact-render-to-string:
-        specifier: ^6.5.13
-        version: 6.6.7(preact@10.29.1)
+        specifier: 6.7.0
+        version: 6.7.0(preact@11.0.0-beta.2)
       vite:
         specifier: ^8.0.0
         version: 8.0.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@22.19.17)(esbuild@0.27.3)
@@ -110,11 +114,11 @@ importers:
         specifier: workspace:*
         version: link:../../packages/vite-plugin
       preact:
-        specifier: ^10.26.9
-        version: 10.29.1
+        specifier: 11.0.0-beta.2
+        version: 11.0.0-beta.2(preact-render-to-string@6.7.0)
       preact-render-to-string:
-        specifier: ^6.5.13
-        version: 6.6.7(preact@10.29.1)
+        specifier: 6.7.0
+        version: 6.7.0(preact@11.0.0-beta.2)
       vite:
         specifier: ^8.0.0
         version: 8.0.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@22.19.17)(esbuild@0.27.3)
@@ -132,7 +136,7 @@ importers:
         version: link:../../packages/framework
       '@tabler/icons-preact':
         specifier: ^3.41.1
-        version: 3.41.1(preact@10.29.1)
+        version: 3.41.1(preact@11.0.0-beta.2)
       wrangler:
         specifier: ^4.80.0
         version: 4.80.0
@@ -147,11 +151,11 @@ importers:
         specifier: ^18.0.0
         version: 18.0.0
       preact:
-        specifier: ^10.26.9
-        version: 10.29.1
+        specifier: 11.0.0-beta.2
+        version: 11.0.0-beta.2(preact-render-to-string@6.7.0)
       preact-render-to-string:
-        specifier: ^6.5.13
-        version: 6.6.7(preact@10.29.1)
+        specifier: 6.7.0
+        version: 6.7.0(preact@11.0.0-beta.2)
       vite:
         specifier: ^8.0.0
         version: 8.0.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@22.19.17)(esbuild@0.27.3)
@@ -172,11 +176,11 @@ importers:
         specifier: workspace:*
         version: link:../../packages/vite-plugin
       preact:
-        specifier: ^10.26.9
-        version: 10.29.1
+        specifier: 11.0.0-beta.2
+        version: 11.0.0-beta.2(preact-render-to-string@6.7.0)
       preact-render-to-string:
-        specifier: ^6.5.13
-        version: 6.6.7(preact@10.29.1)
+        specifier: 6.7.0
+        version: 6.7.0(preact@11.0.0-beta.2)
       vite:
         specifier: ^8.0.0
         version: 8.0.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@22.19.17)(esbuild@0.27.3)
@@ -197,11 +201,11 @@ importers:
         specifier: workspace:*
         version: link:../../packages/vite-plugin
       preact:
-        specifier: ^10.26.9
-        version: 10.29.1
+        specifier: 11.0.0-beta.2
+        version: 11.0.0-beta.2(preact-render-to-string@6.7.0)
       preact-render-to-string:
-        specifier: ^6.5.13
-        version: 6.6.7(preact@10.29.1)
+        specifier: 6.7.0
+        version: 6.7.0(preact@11.0.0-beta.2)
       vite:
         specifier: ^8.0.0
         version: 8.0.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@22.19.17)(esbuild@0.27.3)
@@ -222,11 +226,11 @@ importers:
         specifier: workspace:*
         version: link:../../packages/vite-plugin
       preact:
-        specifier: ^10.26.9
-        version: 10.29.1
+        specifier: 11.0.0-beta.2
+        version: 11.0.0-beta.2(preact-render-to-string@6.7.0)
       preact-render-to-string:
-        specifier: ^6.5.13
-        version: 6.6.7(preact@10.29.1)
+        specifier: 6.7.0
+        version: 6.7.0(preact@11.0.0-beta.2)
       vite:
         specifier: ^8.0.0
         version: 8.0.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@22.19.17)(esbuild@0.27.3)
@@ -248,13 +252,13 @@ importers:
         version: link:../../packages/vite-plugin
       '@tsrx/vite-plugin-preact':
         specifier: ^0.0.3
-        version: 0.0.3(preact@10.29.1)(vite@8.0.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@22.19.17)(esbuild@0.27.3))
+        version: 0.0.3(preact@11.0.0-beta.2)(vite@8.0.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@22.19.17)(esbuild@0.27.3))
       preact:
-        specifier: ^10.26.9
-        version: 10.29.1
+        specifier: 11.0.0-beta.2
+        version: 11.0.0-beta.2(preact-render-to-string@6.7.0)
       preact-render-to-string:
-        specifier: ^6.5.13
-        version: 6.6.7(preact@10.29.1)
+        specifier: 6.7.0
+        version: 6.7.0(preact@11.0.0-beta.2)
       vite:
         specifier: ^8.0.0
         version: 8.0.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@22.19.17)(esbuild@0.27.3)
@@ -315,20 +319,20 @@ importers:
         specifier: ^1.0.0
         version: 1.1.0
       preact:
-        specifier: ^10.0.0
-        version: 10.29.1
+        specifier: 11.0.0-beta.2
+        version: 11.0.0-beta.2(preact-render-to-string@6.7.0)
       preact-render-to-string:
-        specifier: ^6.0.0
-        version: 6.6.7(preact@10.29.1)
+        specifier: 6.7.0
+        version: 6.7.0(preact@11.0.0-beta.2)
       preact-suspense:
         specifier: ^0.3.0
-        version: 0.3.0(preact@10.29.1)
+        version: 0.3.0(preact@11.0.0-beta.2)
 
   packages/image:
     dependencies:
       preact:
-        specifier: ^10.0.0
-        version: 10.29.1
+        specifier: 11.0.0-beta.2
+        version: 11.0.0-beta.2(preact-render-to-string@6.7.0)
     devDependencies:
       sharp:
         specifier: ^0.34.0
@@ -337,11 +341,11 @@ importers:
   packages/preact-ssr-precompile:
     dependencies:
       preact:
-        specifier: ^10.26.0
-        version: 10.29.1
+        specifier: 11.0.0-beta.2
+        version: 11.0.0-beta.2(preact-render-to-string@6.7.0)
       preact-render-to-string:
-        specifier: ^6.5.13
-        version: 6.6.7(preact@10.29.1)
+        specifier: 6.7.0
+        version: 6.7.0(preact@11.0.0-beta.2)
       rolldown:
         specifier: ^1.0.0-rc.12
         version: 1.0.0-rc.12(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
@@ -370,10 +374,10 @@ importers:
         version: link:../preact-ssr-precompile
       '@preact/preset-vite':
         specifier: ^2.10.5
-        version: 2.10.5(@babel/core@7.29.0)(preact@10.29.1)(rollup@4.60.1)(vite@8.0.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@22.19.17)(esbuild@0.27.3))
+        version: 2.10.5(@babel/core@7.29.0)(preact@11.0.0-beta.2)(rollup@4.60.1)(vite@8.0.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@22.19.17)(esbuild@0.27.3))
       '@prefresh/vite':
         specifier: ^2.0.0
-        version: 2.4.12(preact@10.29.1)(vite@8.0.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@22.19.17)(esbuild@0.27.3))
+        version: 2.4.12(preact@11.0.0-beta.2)(vite@8.0.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@22.19.17)(esbuild@0.27.3))
       vite:
         specifier: ^8.0.0
         version: 8.0.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@22.19.17)(esbuild@0.27.3)
@@ -1529,7 +1533,7 @@ packages:
   '@prefresh/core@1.5.9':
     resolution: {integrity: sha512-IKBKCPaz34OFVC+adiQ2qaTF5qdztO2/4ZPf4KsRTgjKosWqxVXmEbxCiUydYZRY8GVie+DQlKzQr9gt6HQ+EQ==}
     peerDependencies:
-      preact: ^10.0.0 || ^11.0.0-0
+      preact: 11.0.0-beta.2
 
   '@prefresh/utils@1.2.1':
     resolution: {integrity: sha512-vq/sIuN5nYfYzvyayXI4C2QkprfNaHUQ9ZX+3xLD8nL3rWyzpxOm1+K7RtMbhd+66QcaISViK7amjnheQ/4WZw==}
@@ -1537,7 +1541,7 @@ packages:
   '@prefresh/vite@2.4.12':
     resolution: {integrity: sha512-FY1fzXpUjiuosznMV0YM7XAOPZjB5FIdWS0W24+XnlxYkt9hNAwwsiKYn+cuTEoMtD/ZVazS5QVssBr9YhpCQA==}
     peerDependencies:
-      preact: ^10.4.0 || ^11.0.0-0
+      preact: 11.0.0-beta.2
       vite: '>=2.0.0'
 
   '@quansync/fs@1.0.0':
@@ -1908,7 +1912,7 @@ packages:
   '@tabler/icons-preact@3.41.1':
     resolution: {integrity: sha512-H27Fzpk3lgj/AC4waJ/YGFPrvrR5MXeLbPhl23V6GWWC8uJ27rU7DVVVNI6hFoKVjpl+KlkmH2SUPissy5LJ+w==}
     peerDependencies:
-      preact: ^10.5.13
+      preact: 11.0.0-beta.2
 
   '@tabler/icons@3.41.1':
     resolution: {integrity: sha512-OaRnVbRmH2nHtFeg+RmMJ/7m2oBIF9XCJAUD5gQnMrpK9f05ydj8MZrAf3NZQqOXyxGN1UBL0D5IKLLEUfr74Q==}
@@ -1919,7 +1923,7 @@ packages:
   '@tsrx/preact@0.0.3':
     resolution: {integrity: sha512-OgbypbFLbLm/WJwSaRyUgR3Ew/qJGKhwzru9YHu8lj1DZNUf/NNiboiWlmfOahrg/r8MijSnUQKJH0Ubw3IeSg==}
     peerDependencies:
-      preact: '>=10'
+      preact: 11.0.0-beta.2
 
   '@tsrx/vite-plugin-preact@0.0.3':
     resolution: {integrity: sha512-0b0FEAema2TqmgguF/foiv/1jsMpiajylyK7seq9q3QLf+4evepupR0eDtD+xQV9Zt/rJ5A3g50qbCiSVaW6zg==}
@@ -2871,18 +2875,23 @@ packages:
     resolution: {integrity: sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==}
     engines: {node: ^10 || ^12 || >=14}
 
-  preact-render-to-string@6.6.7:
-    resolution: {integrity: sha512-3XdbsX3+vn9dQW+jJI/FsI9rlkgl6dbeUpqLsChak6jp3j3auFqBCkno7VChbMFs5Q8ylBj6DrUkKRwtVN3nvw==}
+  preact-render-to-string@6.7.0:
+    resolution: {integrity: sha512-Z4WR8fmLMRpdYqJ9i7vrlXSsSrxVJydwrkEXHapexfARbWfGb7vGcnvNQnIzN0cXciMVOlz/XLoiMCi9gUsy9Q==}
     peerDependencies:
-      preact: '>=10 || >= 11.0.0-0'
+      preact: 11.0.0-beta.2
 
   preact-suspense@0.3.0:
     resolution: {integrity: sha512-mKcwdDwvpEtRQ8dG8eNN2//GRxP84bI6q+j4D+WVkF8fSc7Aikk3sAhCj6SpGG8gyFUxE+Nu5ej6vqzPFqe8dg==}
     peerDependencies:
-      preact: ^10.0.0
+      preact: 11.0.0-beta.2
 
-  preact@10.29.1:
-    resolution: {integrity: sha512-gQCLc/vWroE8lIpleXtdJhTFDogTdZG9AjMUpVkDf2iTCNwYNWA+u16dL41TqUDJO4gm2IgrcMv3uTpjd4Pwmg==}
+  preact@11.0.0-beta.2:
+    resolution: {integrity: sha512-7nIgtr4wtls48+fuazknYNuZ3tOuJoo9ZrT+dzXrMBWkcQH5xmOJiibJpmbU8sFmo2IKLFe3eMp84n0Lq0dCHg==}
+    peerDependencies:
+      preact-render-to-string: 6.7.0
+    peerDependenciesMeta:
+      preact-render-to-string:
+        optional: true
 
   prettier@2.8.8:
     resolution: {integrity: sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==}
@@ -4406,12 +4415,12 @@ snapshots:
 
   '@poppinss/exception@1.2.3': {}
 
-  '@preact/preset-vite@2.10.5(@babel/core@7.29.0)(preact@10.29.1)(rollup@4.60.1)(vite@8.0.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@22.19.17)(esbuild@0.27.3))':
+  '@preact/preset-vite@2.10.5(@babel/core@7.29.0)(preact@11.0.0-beta.2)(rollup@4.60.1)(vite@8.0.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@22.19.17)(esbuild@0.27.3))':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/plugin-transform-react-jsx': 7.28.6(@babel/core@7.29.0)
       '@babel/plugin-transform-react-jsx-development': 7.27.1(@babel/core@7.29.0)
-      '@prefresh/vite': 2.4.12(preact@10.29.1)(vite@8.0.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@22.19.17)(esbuild@0.27.3))
+      '@prefresh/vite': 2.4.12(preact@11.0.0-beta.2)(vite@8.0.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@22.19.17)(esbuild@0.27.3))
       '@rollup/pluginutils': 5.3.0(rollup@4.60.1)
       babel-plugin-transform-hook-names: 1.0.2(@babel/core@7.29.0)
       debug: 4.4.3
@@ -4427,20 +4436,20 @@ snapshots:
 
   '@prefresh/babel-plugin@0.5.3': {}
 
-  '@prefresh/core@1.5.9(preact@10.29.1)':
+  '@prefresh/core@1.5.9(preact@11.0.0-beta.2)':
     dependencies:
-      preact: 10.29.1
+      preact: 11.0.0-beta.2(preact-render-to-string@6.7.0)
 
   '@prefresh/utils@1.2.1': {}
 
-  '@prefresh/vite@2.4.12(preact@10.29.1)(vite@8.0.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@22.19.17)(esbuild@0.27.3))':
+  '@prefresh/vite@2.4.12(preact@11.0.0-beta.2)(vite@8.0.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@22.19.17)(esbuild@0.27.3))':
     dependencies:
       '@babel/core': 7.29.0
       '@prefresh/babel-plugin': 0.5.3
-      '@prefresh/core': 1.5.9(preact@10.29.1)
+      '@prefresh/core': 1.5.9(preact@11.0.0-beta.2)
       '@prefresh/utils': 1.2.1
       '@rollup/pluginutils': 4.2.1
-      preact: 10.29.1
+      preact: 11.0.0-beta.2(preact-render-to-string@6.7.0)
       vite: 8.0.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@22.19.17)(esbuild@0.27.3)
     transitivePeerDependencies:
       - supports-color
@@ -4650,10 +4659,10 @@ snapshots:
     dependencies:
       acorn: 8.16.0
 
-  '@tabler/icons-preact@3.41.1(preact@10.29.1)':
+  '@tabler/icons-preact@3.41.1(preact@11.0.0-beta.2)':
     dependencies:
       '@tabler/icons': 3.41.1
-      preact: 10.29.1
+      preact: 11.0.0-beta.2(preact-render-to-string@6.7.0)
 
   '@tabler/icons@3.41.1': {}
 
@@ -4671,18 +4680,18 @@ snapshots:
     transitivePeerDependencies:
       - '@typescript-eslint/types'
 
-  '@tsrx/preact@0.0.3(preact@10.29.1)':
+  '@tsrx/preact@0.0.3(preact@11.0.0-beta.2)':
     dependencies:
       '@tsrx/core': 0.0.8
       esrap: 2.2.5
-      preact: 10.29.1
+      preact: 11.0.0-beta.2(preact-render-to-string@6.7.0)
       zimmerframe: 1.1.4
     transitivePeerDependencies:
       - '@typescript-eslint/types'
 
-  '@tsrx/vite-plugin-preact@0.0.3(preact@10.29.1)(vite@8.0.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@22.19.17)(esbuild@0.27.3))':
+  '@tsrx/vite-plugin-preact@0.0.3(preact@11.0.0-beta.2)(vite@8.0.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@22.19.17)(esbuild@0.27.3))':
     dependencies:
-      '@tsrx/preact': 0.0.3(preact@10.29.1)
+      '@tsrx/preact': 0.0.3(preact@11.0.0-beta.2)
       vite: 8.0.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@22.19.17)(esbuild@0.27.3)
     transitivePeerDependencies:
       - '@typescript-eslint/types'
@@ -5626,15 +5635,17 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
-  preact-render-to-string@6.6.7(preact@10.29.1):
+  preact-render-to-string@6.7.0(preact@11.0.0-beta.2):
     dependencies:
-      preact: 10.29.1
+      preact: 11.0.0-beta.2(preact-render-to-string@6.7.0)
 
-  preact-suspense@0.3.0(preact@10.29.1):
+  preact-suspense@0.3.0(preact@11.0.0-beta.2):
     dependencies:
-      preact: 10.29.1
+      preact: 11.0.0-beta.2(preact-render-to-string@6.7.0)
 
-  preact@10.29.1: {}
+  preact@11.0.0-beta.2(preact-render-to-string@6.7.0):
+    optionalDependencies:
+      preact-render-to-string: 6.7.0(preact@11.0.0-beta.2)
 
   prettier@2.8.8: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,6 +4,10 @@ packages:
 
 minimumReleaseAge: 10080
 
+overrides:
+  preact: 11.0.0-beta.2
+  preact-render-to-string: 6.7.0
+
 blockExoticSubdeps: true
 
 allowBuilds:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -22,6 +22,10 @@ minimumReleaseAgeExclude:
   - "@changesets/types@7.0.0"
   - "@changesets/write@1.0.0"
 
+overrides:
+  preact: 11.0.0-beta.2
+  preact-render-to-string: 6.7.0
+
 blockExoticSubdeps: true
 
 allowBuilds:


### PR DESCRIPTION
## Summary

- Pin the workspace experiment to Preact 11 beta.2 and preact-render-to-string 6.7.0, with Playwright coverage for streamed Suspense races and Hydration 2.0 empty/multi-node boundaries.
- Make Pracht's public form, link, and image props compatible with Preact 11's JSX type organization, and document the experiment's production gaps.
- Related to #191.

## Testing

- [x] `pnpm e2e`
- [x] `pnpm format`
- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `pnpm typecheck`

## Checklist

- [x] Docs updated if needed
- [x] Skills updated if needed (N/A - no skill changes needed)
- [x] Changeset added if published packages changed
