### PR TITLE
fix: reload dev pages when a server-only module changes

### DIFF
--- a/.changeset/nervous-pugs-repeat.md
+++ b/.changeset/nervous-pugs-repeat.md
@@ -1,0 +1,11 @@
+---
+"@pracht/vite-plugin": patch
+---
+
+Reload the page in dev when a server-only module changes. Routes using
+`hydration: "islands"` or `hydration: "none"` are excluded from the client
+bundle, so their source files never enter the client module graph and Vite had
+no module to push an update through — editing them left the open page stale
+until a manual refresh. Files that exist only in the server graph now trigger a
+full reload, while anything with a client module (islands, full-hydration
+routes) keeps its granular HMR.

--- a/docs/ISLANDS.md
+++ b/docs/ISLANDS.md
@@ -181,6 +181,14 @@ Test tooling can wait for `html[data-pracht-islands-hydrated="true"]` (set
 after all `load` islands hydrate) and per-island `data-hydrated="true"`
 attributes.
 
+### Dev server updates
+
+Islands themselves hot-update in place like any client component. Everything
+else on an islands or `hydration: "none"` page — the route module, its shell,
+and the server-only components it imports — is not part of the client bundle,
+so there is no client module to patch: the dev server reloads the page instead.
+Either way, saving a file updates what you see without a manual refresh.
+
 ---
 
 ## Navigation

--- a/e2e/islands-dev.test.ts
+++ b/e2e/islands-dev.test.ts
@@ -1,4 +1,6 @@
 import { expect, test } from "@playwright/test";
+import { readFileSync, writeFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
 
 // Dev-server coverage for islands routes: the vite plugin serves the islands
 // bootstrap from /@pracht/islands.js and the dev SSR middleware renders the
@@ -58,4 +60,29 @@ test("hydration none routes render without islands bootstrap or state", async ({
   expect(html).not.toContain("/@pracht/islands.js");
   expect(html).not.toContain("/@pracht/client.js");
   await expect(page.locator("h1")).toHaveText("Fully static");
+});
+
+// Routes without full hydration are excluded from the client bundle, so their
+// source files never enter the client module graph and Vite has no module to
+// push an update through. The plugin has to reload the page itself, otherwise
+// editing a static route in dev does nothing at all.
+test("editing a hydration none route reloads the open page", async ({ page }) => {
+  test.setTimeout(30_000);
+
+  const routeFile = fileURLToPath(
+    new URL("../examples/islands/src/routes/static-page.tsx", import.meta.url),
+  );
+  const original = readFileSync(routeFile, "utf-8");
+
+  await page.goto("/static");
+  await expect(page.locator("h1")).toHaveText("Fully static");
+
+  try {
+    writeFileSync(routeFile, original.replace("Fully static", "Edited in dev"));
+    await expect(page.locator("h1")).toHaveText("Edited in dev", { timeout: 15_000 });
+  } finally {
+    writeFileSync(routeFile, original);
+  }
+
+  await expect(page.locator("h1")).toHaveText("Fully static", { timeout: 15_000 });
 });

--- a/packages/vite-plugin/src/hot-update-reload.ts
+++ b/packages/vite-plugin/src/hot-update-reload.ts
@@ -1,0 +1,60 @@
+/**
+ * Dev-server reload for files that only exist on the server.
+ *
+ * Routes rendered with `hydration: "islands"` or `hydration: "none"` are
+ * deliberately excluded from the client bundle (see
+ * `createNonFullHydrationExcludes`), so neither the route file nor the
+ * components it imports ever enter the client module graph. Vite only falls
+ * back to `full-reload` for a zero-module update when the changed file is
+ * HTML — for everything else it logs "no modules matched" and sends nothing.
+ * The dev SSR output changes, but the open page never hears about it and stays
+ * stale until a manual refresh.
+ *
+ * A file that is in the SSR graph and absent from the client graph can never be
+ * reached by client HMR, so a full reload is the only correct update for it.
+ * Files present in the client graph are left alone — their own HMR (route
+ * modules, islands, prefresh component updates) already handles them.
+ */
+
+interface ModuleGraphLike {
+  getModulesByFile(file: string): Set<unknown> | undefined;
+}
+
+interface EnvironmentLike {
+  moduleGraph: ModuleGraphLike;
+  hot?: { send(payload: { type: "full-reload" }): void };
+}
+
+export interface HotUpdateServerLike {
+  environments?: Record<string, EnvironmentLike | undefined>;
+}
+
+/**
+ * True when `file` participates in server rendering but has no counterpart in
+ * the client module graph, meaning client HMR can never deliver its change.
+ */
+export function isServerOnlyModuleFile(server: HotUpdateServerLike, file: string): boolean {
+  const environments = server.environments;
+  const client = environments?.client;
+  // Without the client environment there is no browser graph to compare
+  // against — leave the update to Vite's own handling.
+  if (!client) return false;
+  if (hasModules(client, file)) return false;
+
+  for (const [name, environment] of Object.entries(environments ?? {})) {
+    if (name === "client" || !environment) continue;
+    if (hasModules(environment, file)) return true;
+  }
+  return false;
+}
+
+/** Reload open pages when `file` can only reach them through the server. */
+export function sendServerOnlyFullReload(server: HotUpdateServerLike, file: string): boolean {
+  if (!isServerOnlyModuleFile(server, file)) return false;
+  server.environments?.client?.hot?.send({ type: "full-reload" });
+  return true;
+}
+
+function hasModules(environment: EnvironmentLike, file: string): boolean {
+  return (environment.moduleGraph.getModulesByFile(file)?.size ?? 0) > 0;
+}

--- a/packages/vite-plugin/src/index.ts
+++ b/packages/vite-plugin/src/index.ts
@@ -10,6 +10,7 @@ import {
 
 import type { RenderMode } from "@pracht/core";
 import { createEnvSafetyPlugin, PUBLIC_ENV_PREFIX, SERVER_ENV_MODULE_ID } from "./env-safety.ts";
+import { sendServerOnlyFullReload } from "./hot-update-reload.ts";
 import {
   PRACHT_CAPABILITIES_MODULE_ID,
   PRACHT_CLIENT_MODULE_ID,
@@ -286,6 +287,7 @@ export function pracht(options: PrachtPluginOptions = {}): Plugin[] {
       if (isPagesMode && relative.startsWith(resolved.pagesDir)) {
         clearPagesAppSourceCache();
         invalidateVirtualModules(server);
+        sendServerOnlyFullReload(server, file);
         return;
       }
 
@@ -333,6 +335,8 @@ export function pracht(options: PrachtPluginOptions = {}): Plugin[] {
           }
         }
       }
+
+      sendServerOnlyFullReload(server, file);
     },
   };
 

--- a/packages/vite-plugin/test/hot-update-reload.test.ts
+++ b/packages/vite-plugin/test/hot-update-reload.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  isServerOnlyModuleFile,
+  sendServerOnlyFullReload,
+  type HotUpdateServerLike,
+} from "../src/hot-update-reload.ts";
+
+function createServer(graphs: Record<string, string[]>): {
+  server: HotUpdateServerLike;
+  send: ReturnType<typeof vi.fn>;
+} {
+  const send = vi.fn();
+  const environments: Record<string, unknown> = {};
+  for (const [name, files] of Object.entries(graphs)) {
+    environments[name] = {
+      moduleGraph: {
+        getModulesByFile: (file: string) =>
+          files.includes(file) ? new Set([{ file }]) : undefined,
+      },
+      ...(name === "client" ? { hot: { send } } : {}),
+    };
+  }
+  return { server: { environments } as HotUpdateServerLike, send };
+}
+
+const ROUTE = "/app/src/routes/static-page.tsx";
+
+describe("isServerOnlyModuleFile", () => {
+  it("flags files that only the SSR environment knows about", () => {
+    const { server } = createServer({ client: [], ssr: [ROUTE] });
+    expect(isServerOnlyModuleFile(server, ROUTE)).toBe(true);
+  });
+
+  it("leaves files in the client graph to client HMR", () => {
+    const { server } = createServer({ client: [ROUTE], ssr: [ROUTE] });
+    expect(isServerOnlyModuleFile(server, ROUTE)).toBe(false);
+  });
+
+  it("ignores files no environment has loaded", () => {
+    const { server } = createServer({ client: [], ssr: [] });
+    expect(isServerOnlyModuleFile(server, ROUTE)).toBe(false);
+  });
+
+  it("checks every non-client environment, not just ssr", () => {
+    const { server } = createServer({ client: [], ssr: [], worker: [ROUTE] });
+    expect(isServerOnlyModuleFile(server, ROUTE)).toBe(true);
+  });
+
+  it("stays inert without a client environment", () => {
+    const { server } = createServer({ ssr: [ROUTE] });
+    expect(isServerOnlyModuleFile(server, ROUTE)).toBe(false);
+    expect(isServerOnlyModuleFile({}, ROUTE)).toBe(false);
+  });
+});
+
+describe("sendServerOnlyFullReload", () => {
+  it("reloads open pages for server-only files", () => {
+    const { server, send } = createServer({ client: [], ssr: [ROUTE] });
+    expect(sendServerOnlyFullReload(server, ROUTE)).toBe(true);
+    expect(send).toHaveBeenCalledWith({ type: "full-reload" });
+  });
+
+  it("sends nothing when the file has a client module", () => {
+    const { server, send } = createServer({ client: [ROUTE], ssr: [ROUTE] });
+    expect(sendServerOnlyFullReload(server, ROUTE)).toBe(false);
+    expect(send).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

- Fixes #248 — editing a route with `hydration: "islands"` or `hydration: "none"` did nothing in dev; the page stayed stale until a manual refresh.
- Root cause: `createNonFullHydrationExcludes` deliberately keeps those routes out of the client entry's `import.meta.glob`, so their files never enter Vite's client module graph. On change, Vite lands in the zero-modules branch of its HMR handling, which only falls back to `full-reload` for HTML files — for anything else it logs "no modules matched" and sends nothing. The dev SSR output *did* update; the browser was simply never told. (The reporter's note that `@vite/client` is still injected is correct and a red herring — the socket is connected and healthy, the server just never sends it anything.)
- Fix: new `hot-update-reload.ts`. A file that is in a server environment's module graph but absent from the client graph can never be reached by client HMR, so send an explicit `full-reload` for it. Wired into both exit paths of the plugin's `handleHotUpdate`. This also covers shells and components that are only reachable from a non-hydrating route, which had the same problem.
- Anything present in the client graph returns early, so islands, prefresh component updates, and full-hydration routes keep their existing granular HMR.

One deliberate non-change: the helper is called for its side effect and the hook still returns `undefined`. Returning `[]` would read more tidily, but Vite filters *both* environments' module lists by whatever `handleHotUpdate` returns, so an empty array would wipe the SSR module list and break the dev-SSR invalidation that already works.

### Verified against a real browser

Driving Chromium against `examples/islands`, editing files on disk and diffing patched vs. unpatched builds:

| edited file | before | after |
| --- | --- | --- |
| `routes/home.tsx` (`islands`) | nothing | reload + update |
| `routes/static-page.tsx` (`none`) | nothing | reload + update |
| `components/dead-button.tsx` (used by an islands route) | nothing | reload + update |
| `shells/site.tsx` (viewed from an islands route) | nothing | reload + update |
| `islands/Counter.tsx` | hot update, state preserved | **unchanged** |
| `routes/full.tsx` (full hydration) | reload | **unchanged** |

Prefresh was checked explicitly rather than assumed. With live state on the page (`Counter` incremented to 7; a temporary stateful component in `examples/basic` bumped to 3), both builds hot-updated in place with state preserved and no reload. The only rows that change are ones that previously did nothing at all.

Known trade-off: if a page has been server-rendered but the open tab never loaded its module client-side, editing a file used only by that page now reloads the tab where before it did nothing. An eager dev reload seemed clearly better than a silently stale page.

## Testing

- [x] `pnpm e2e` — 112 passed, run twice for stability. Includes a new test that rewrites a `hydration: "none"` route on disk and asserts the open page updates without a manual refresh.
- [x] `pnpm format`
- [x] `pnpm lint` — 0 warnings, 0 errors
- [x] `pnpm test` — 1305 passed, plus 7 new unit tests for the helper.

Two failures in `packages/cli/test/pracht-cli.test.js` (`pracht dev` typegen) are pre-existing and unrelated — verified by stashing this branch's changes and reproducing them on clean `origin/main`. Both are Windows-local flakes: an `EBUSY: resource busy` on temp-dir cleanup, and a dev server timing out on an occupied port 3000.

## Checklist

- [x] Docs updated if needed — a "Dev server updates" note under *How It Works* in `docs/ISLANDS.md`
- [x] Skills updated if needed — N/A, no skill covers dev-server update behaviour
- [x] Changeset added if published packages changed — patch bump for `@pracht/vite-plugin`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
