### PR TITLE
Improve create-pracht typecheck DX

### DIFF
--- a/.changeset/typecheck-starters.md
+++ b/.changeset/typecheck-starters.md
@@ -1,0 +1,5 @@
+---
+"create-pracht": patch
+---
+
+Add TypeScript and a `typecheck` script to generated starters so scaffolded apps can run `tsc --noEmit` immediately.

--- a/examples/docs/src/routes/docs/cli.md
+++ b/examples/docs/src/routes/docs/cli.md
@@ -10,6 +10,39 @@ next:
   title: Deployment
 ---
 
+## create-pracht
+
+`create-pracht` bootstraps a new application. It can run interactively, or fully non-interactively for agents and CI.
+
+```sh
+# Interactive
+pnpm create pracht my-app
+
+# Non-interactive manifest app for Node.js
+pnpm create pracht my-app --adapter=node --router=manifest --yes
+
+# Pages router, Cloudflare adapter, no install step
+pnpm create pracht my-app --adapter=cf --router=pages --skip-install --yes
+
+# Tailwind starter for Vercel
+pnpm create pracht my-app --adapter=vercel --template=tailwind --yes
+```
+
+Options:
+
+- `--adapter=node|cf|vercel` — choose Node.js, Cloudflare Workers, or Vercel output.
+- `--router=manifest|pages` — choose explicit `src/routes.ts` routing or file-system `src/pages/` routing.
+- `--template=minimal|tailwind`, `--tailwind`, `--no-tailwind` — control Tailwind setup.
+- `--agent-tools`, `--no-agent-tools` — seed or skip the pracht Claude Code skills and `.mcp.json`.
+- `--skip-install` — write files without installing dependencies.
+- `--no-git` — skip `git init` and the initial commit.
+- `--json` — print a machine-readable summary.
+- `--dry-run` — list files without writing them.
+
+Generated apps include `dev`, `build`, and `typecheck` scripts. Node and Cloudflare starters also include `preview`; Node starters include `start`; Cloudflare and Vercel starters include `deploy`.
+
+---
+
 ## pracht dev
 
 Starts the Vite dev server with SSR middleware, HMR, and instant feedback.
@@ -64,6 +97,8 @@ pracht generate middleware --name auth
 pracht generate route --path /dashboard --render ssr --shell app --middleware auth
 pracht generate api --path /health --methods GET,POST
 ```
+
+> On Windows Git Bash/MSYS shells, leading `/` arguments may be rewritten as absolute Windows paths before Node sees them. If `--path /dashboard` reports that it would write outside `src/routes`, use PowerShell/CMD or pass `MSYS_NO_PATHCONV=1` when invoking the `pracht` binary directly.
 
 - Manifest apps update `src/routes.ts` automatically for routes, shells, and middleware.
 - Pages-router apps scaffold route files into `src/pages/`.

--- a/examples/docs/src/routes/docs/getting-started.md
+++ b/examples/docs/src/routes/docs/getting-started.md
@@ -25,13 +25,29 @@ yarn create pracht my-app
 bunx create-pracht my-app
 ```
 
-The CLI will ask you to choose an adapter (Node.js, Cloudflare Workers, or Vercel). You can change this later in your `vite.config.ts`.
+The CLI will ask you to choose an adapter (Node.js, Cloudflare Workers, or Vercel), whether to use the explicit manifest router or the file-system pages router, whether to add Tailwind CSS, and whether to seed the agent tooling. You can change the adapter and router later in `vite.config.ts`.
+
+For reproducible setup in CI, demos, or agents, pass the same choices as flags:
+
+```sh
+pnpm create pracht my-app --adapter=node --router=manifest --template=tailwind --yes
+pnpm create pracht my-app --adapter=cf --router=pages --no-tailwind --no-agent-tools --yes
+pnpm create pracht my-app --adapter=vercel --skip-install --yes
+```
+
+Useful creation flags:
+
+- `--adapter=node|cf|vercel` chooses the deployment target.
+- `--router=manifest|pages` chooses explicit `src/routes.ts` routing or file-system `src/pages/` routing.
+- `--template=minimal|tailwind`, `--tailwind`, and `--no-tailwind` control styling setup.
+- `--agent-tools` and `--no-agent-tools` control `.claude/skills/` and `.mcp.json` setup.
+- `--skip-install`, `--no-git`, `--json`, and `--dry-run` are handy for automation.
 
 ---
 
 ## Project Structure
 
-After scaffolding, your project looks like this:
+A manifest-router scaffold looks like this:
 
 ```
 my-app/
@@ -43,6 +59,20 @@ my-app/
   vite.config.ts       # Vite + pracht plugin config
   package.json
 ```
+
+A pages-router scaffold uses `src/pages/` instead:
+
+```
+my-app/
+  src/
+    pages/_app.tsx     # App shell
+    pages/index.tsx    # First page component + loader
+    api/health.ts      # Sample API endpoint
+  vite.config.ts       # Vite + pracht plugin config
+  package.json
+```
+
+Depending on your choices, the starter can also include Tailwind's `src/styles/global.css`, adapter files such as `wrangler.jsonc` or `Dockerfile`, and agent files under `.claude/skills/` plus `.mcp.json`.
 
 ---
 

--- a/packages/start/README.md
+++ b/packages/start/README.md
@@ -17,7 +17,7 @@ npm run dev
 - Detects the active package manager from the current environment.
 - Lets the user choose between the Node.js, Cloudflare, and Vercel adapters.
 - Optionally wires up Tailwind CSS (`tailwindcss` + `@tailwindcss/vite`, a global stylesheet, and the shell import).
-- Scaffolds a minimal app with a route manifest or pages router, shell, home route, sample API route, runnable project README, and agent instructions.
+- Scaffolds a minimal app with a route manifest or pages router, shell, home route, sample API route, runnable project README, TypeScript typecheck script, and agent instructions.
 - Manifest scaffolds include a commented-out `constraints` example in `src/routes.ts`, ready for `pracht verify`.
 - The generated `.gitignore` keeps `.pracht/app-graph.json` committable, and the README and agent instructions cover the `pracht verify` / `pracht plan` / `pracht report` loop.
 - Seeds the pracht Claude Code skills into `.claude/skills/` and writes a `.mcp.json` registering the `pracht mcp` server (yes-default prompt; skipped with `--no-agent-tools`).
@@ -80,6 +80,7 @@ Cloudflare scaffolds also include:
 
 - `dev` -> `pracht dev`
 - `build` -> `pracht build`
+- `typecheck` -> `tsc --noEmit`
 
 Node starters also include:
 

--- a/packages/start/src/index.js
+++ b/packages/start/src/index.js
@@ -21,6 +21,7 @@ const FALLBACK_VERSION_RANGES = {
   "@pracht/vite-plugin": "^0.3.2",
   "@tailwindcss/vite": "^4.1.0",
   tailwindcss: "^4.1.0",
+  typescript: "^6.0.0",
   vercel: "^56.5.0",
 };
 
@@ -567,6 +568,7 @@ async function buildProjectFiles({
     "@pracht/vite-plugin",
     "@pracht/core",
     adapter.packageName,
+    "typescript",
   ];
   if (adapter.id === "vercel") {
     packagesToResolve.push("vercel");
@@ -664,6 +666,7 @@ function createPackageJson({ adapter, projectName, tailwind, versions }) {
   const scripts = {
     build: "pracht build",
     dev: "pracht dev",
+    typecheck: "tsc --noEmit",
   };
 
   if (adapter.id === "node") {
@@ -676,6 +679,7 @@ function createPackageJson({ adapter, projectName, tailwind, versions }) {
     "@pracht/vite-plugin": versions["@pracht/vite-plugin"],
     preact: "^10.26.9",
     "preact-render-to-string": "^6.5.13",
+    typescript: versions["typescript"],
     vite: "^8.0.0",
   };
 
@@ -1116,6 +1120,8 @@ function createReadme({ adapter, agentTools, packageManager, projectName, router
   const previewCommand = packageManager === "npm" ? "npm run preview" : `${packageManager} preview`;
   const startCommand = packageManager === "npm" ? "npm run start" : `${packageManager} start`;
   const deployCommand = packageManager === "npm" ? "npm run deploy" : `${packageManager} deploy`;
+  const typecheckCommand =
+    packageManager === "npm" ? "npm run typecheck" : `${packageManager} typecheck`;
 
   const lines = [
     `# ${projectName}`,
@@ -1126,6 +1132,7 @@ function createReadme({ adapter, agentTools, packageManager, projectName, router
     "",
     `- \`${installCommand}\``,
     `- \`${devCommand}\``,
+    `- \`${typecheckCommand}\``,
   ];
 
   if (adapter.id === "node") {

--- a/packages/start/test/index.test.js
+++ b/packages/start/test/index.test.js
@@ -56,6 +56,8 @@ describe("create-pracht", () => {
     expect(packageJson).toMatch(/"@pracht\/adapter-node": "\^\d+\.\d+\.\d+"/);
     expect(packageJson).toContain('"preview": "pracht preview"');
     expect(packageJson).toContain('"start": "node dist/server/server.js"');
+    expect(packageJson).toContain('"typecheck": "tsc --noEmit"');
+    expect(packageJson).toMatch(/"typescript": "\^\d+\.\d+\.\d+"/);
     expect(packageJson).not.toContain("wrangler");
     expect(gitignore).toContain(".env*");
     expect(gitignore).toContain("!.env.example");
@@ -79,6 +81,7 @@ describe("create-pracht", () => {
     expect(dockerignore).toContain("node_modules");
     expect(dockerignore).toContain(".env*");
     expect(readme).toContain("docker build");
+    expect(readme).toContain("pnpm typecheck");
     expect(readme).toContain("`pracht verify` validates routes and constraints.");
     expect(readme).toContain("`pracht plan --write`");
     expect(readme).toContain("`pracht report`");
@@ -152,6 +155,7 @@ describe("create-pracht", () => {
     expect(packageJson).toMatch(/"@pracht\/adapter-cloudflare": "\^\d+\.\d+\.\d+"/);
 
     expect(packageJson).toContain('"preview": "pracht preview"');
+    expect(packageJson).toContain('"typecheck": "tsc --noEmit"');
     expect(packageJson).toContain('"wrangler": "^4.81.0"');
     expect(packageJson).not.toContain('"@cloudflare/vite-plugin"');
     expect(wranglerConfig).toContain('"main": "dist/server/server.js"');
@@ -218,6 +222,7 @@ describe("create-pracht", () => {
     expect(packageJson).toMatch(/"vercel": "\^\d+\.\d+\.\d+"/);
 
     expect(packageJson).toContain('"deploy": "pracht build && vercel deploy --prebuilt"');
+    expect(packageJson).toContain('"typecheck": "tsc --noEmit"');
     expect(packageJson).not.toContain('"preview"');
     expect(readme).toContain("configured for Vercel");
     expect(readme).toContain("pnpm deploy");


### PR DESCRIPTION
## Summary

- Add TypeScript as a dev dependency in `create-pracht` starters.
- Add a generated `typecheck` script and document it in starter READMEs.
- Expand docs for `create-pracht` non-interactive flags and scaffold shapes, including the Windows Git Bash path conversion caveat discovered during dogfooding.

## Testing

- [x] `pnpm e2e`
- [x] `pnpm format`
- [x] `pnpm lint`

Additional targeted checks:

- [x] `pnpm exec vitest run packages/start/test/index.test.js`
- [x] `pnpm --filter @pracht/example-docs run build`
- [x] Scaffolded a fresh Node manifest app, then ran `pnpm install`, `pnpm run typecheck`, and `pnpm run build`.
- [x] `pnpm run format:check`

## Checklist

- [x] Docs updated if needed
- [x] Skills updated if needed — N/A
- [x] Changeset added if published packages changed
