### PR TITLE
fix(vite-plugin): reject capability modules imported from client code

### DIFF
--- a/.changeset/capability-client-import-guard.md
+++ b/.changeset/capability-client-import-guard.md
@@ -1,0 +1,17 @@
+---
+"@pracht/vite-plugin": patch
+---
+
+Fail the build when client code imports a capability module.
+
+Capability modules are server-only, but nothing stripped them the way route
+loaders are stripped, so a component importing one directly bundled `run()` and
+everything it imports — database clients, secrets — for every visitor. The build
+now rejects it and points at the browser projection instead: `callCapability` /
+`capabilities` from `virtual:pracht/capabilities`, or `invokeCapability` from
+`@pracht/core/server`.
+
+The check matches the capability modules the manifest registers rather than a
+`capabilitiesDir` prefix, so a capability registered from anywhere else in the
+project is still caught, and ordinary files that merely sit beside capabilities
+(shared constants, types) stay importable.

--- a/docs/CAPABILITIES.md
+++ b/docs/CAPABILITIES.md
@@ -199,9 +199,28 @@ const result = await callCapability<{ note: Note }>("notes.create", { title });
 
 `virtual:pracht/capabilities` is generated at build time from the manifest and
 contains only http-exposed capability names, endpoints, and effect classes —
-capability modules themselves are server-only and never enter the client graph
-(guarded by e2e bundle assertions). Apps without capabilities ship zero extra
-bytes.
+capability modules themselves are server-only and never enter the client graph.
+Apps without capabilities ship zero extra bytes.
+
+Importing a capability module from client code is a build error. Nothing strips
+one the way a route loader is stripped, so the import would bundle `run()` and
+everything it pulls in — a database client, an API key — for every visitor. Call
+the capability instead.
+
+What crosses to the browser is deliberately narrow, and guarded in both
+directions by tests:
+
+| Stays server-side | Reaches the browser |
+| --- | --- |
+| `run()` bodies and anything they import | capability name |
+| input/output JSON Schemas | HTTP endpoint path and method |
+| `title` and `description` prose | effect class (it drives revalidation) |
+| private capabilities — not even their names | — |
+
+The one exception is `expose.webmcp`: an in-page agent cannot call a tool
+without its schema, so webmcp-exposed capabilities ship their description and
+input schema in the separate `virtual:pracht/webmcp` chunk, which only loads
+when the browser exposes the WebMCP API. Nothing else does.
 
 Options: `{ headers, signal, confirm, revalidate }`. `confirm` sets the
 confirmation header when committing a destructive call (take the token from

--- a/e2e/client-bundle-strip.test.ts
+++ b/e2e/client-bundle-strip.test.ts
@@ -118,6 +118,21 @@ test("server-only route exports and their imports are stripped from client bundl
     // stay out of every client asset while remaining in the server bundle.
     expect(clientJs).not.toContain(CAPABILITY_SERVER_MARKER);
     expect(serverJs).toContain(CAPABILITY_SERVER_MARKER);
+
+    // The generated browser client (`callCapability` and the nested
+    // `capabilities` object) carries only names, endpoints, and effects.
+    // Contract prose and input schemas are server-side detail, and reach the
+    // browser for WebMCP-exposed capabilities only — an in-page agent needs
+    // the tool schema. notes.purge is destructive and never webmcp-exposed, so
+    // neither its description nor its schema may appear in any client asset.
+    expect(clientJs).not.toContain("Permanently delete every note whose title");
+    expect(clientJs).not.toContain("titlePrefix");
+    expect(serverJs).toContain("titlePrefix");
+
+    // notes.search *is* webmcp-exposed, so its schema is expected in the
+    // client — proof the assertions above test exposure, not merely that
+    // capability text never ships.
+    expect(clientJs).toContain("Find notes whose title or body matches the query.");
   } finally {
     rmSync(tempDir, { force: true, recursive: true });
   }

--- a/packages/vite-plugin/src/index.ts
+++ b/packages/vite-plugin/src/index.ts
@@ -27,6 +27,7 @@ import {
 import {
   createPrachtCapabilitiesClientModuleSource,
   createPrachtWebmcpModuleSource,
+  resolveCapabilityModulePaths,
 } from "./plugin-capabilities.ts";
 import {
   clearPagesAppSourceCache,
@@ -87,6 +88,7 @@ export function pracht(options: PrachtPluginOptions = {}): Plugin[] {
   const isPagesMode = !!resolved.pagesDir;
   let root = process.cwd();
   let routeFileDirs: string[] = [];
+  let capabilityModulePaths = new Set<string>();
 
   if (isPagesMode && options.appFile) {
     console.warn(
@@ -175,6 +177,9 @@ export function pracht(options: PrachtPluginOptions = {}): Plugin[] {
       root = config.root;
       isBuild = config.command === "build";
       routeFileDirs = computeRouteFileDirs(root, resolved);
+      capabilityModulePaths = new Set(
+        resolveCapabilityModulePaths(resolved, root).map((path) => toPosixPath(path)),
+      );
     },
 
     resolveId(id, importer, resolveIdOptions) {
@@ -341,6 +346,22 @@ export function pracht(options: PrachtPluginOptions = {}): Plugin[] {
     enforce: "post",
 
     transform(code, id, transformOptions) {
+      // Capability modules are server-only: they hold `run()` and everything it
+      // imports (database clients, secrets, internal stores). Nothing strips
+      // them the way route loaders are stripped, so a component importing one
+      // directly would ship the whole contract and its dependencies to every
+      // visitor. The generated browser projection exists precisely so that
+      // never has to happen — fail the build and point at it.
+      if (!transformOptions?.ssr && isCapabilityModule(id, capabilityModulePaths)) {
+        throw new Error(
+          `[pracht] Capability module ${JSON.stringify(toPosixPath(id))} was imported by client ` +
+            "code. Capability modules are server-only — their run() implementation and its " +
+            "imports would be bundled for every visitor. Call the capability instead: " +
+            '`callCapability`/`capabilities` from "virtual:pracht/capabilities" in the browser, ' +
+            'or `invokeCapability` from "@pracht/core/server" in loaders, middleware, and API routes.',
+        );
+      }
+
       const shouldStrip =
         isPrachtClientModuleId(id) ||
         (!transformOptions?.ssr && isRouteOrShellFile(id, routeFileDirs));
@@ -545,6 +566,21 @@ const ROUTE_FILE_EXTENSIONS = new Set([".ts", ".tsx", ".js", ".jsx", ".md", ".md
 function computeRouteFileDirs(root: string, resolved: ResolvedPrachtPluginOptions): string[] {
   const dirs = resolved.pagesDir ? [resolved.pagesDir] : [resolved.routesDir, resolved.shellsDir];
   return dirs.map((dir) => resolveConfigPath(root, dir)).map(withTrailingSep);
+}
+
+/**
+ * Whether `id` is one of the capability modules the manifest registers.
+ * Matching the registered set rather than a directory keeps ordinary files that
+ * merely live beside capabilities importable, and still catches a capability
+ * registered from anywhere else in the project. Extension-agnostic, because the
+ * comparison is against paths the manifest already resolved.
+ */
+function isCapabilityModule(id: string, capabilityModulePaths: Set<string>): boolean {
+  if (capabilityModulePaths.size === 0) return false;
+  const queryStart = id.indexOf("?");
+  const path = queryStart === -1 ? id : id.slice(0, queryStart);
+  if (path.startsWith("\0") || path.startsWith("virtual:")) return false;
+  return capabilityModulePaths.has(toPosixPath(path));
 }
 
 function isRouteOrShellFile(id: string, dirs: string[]): boolean {

--- a/packages/vite-plugin/src/plugin-capabilities.ts
+++ b/packages/vite-plugin/src/plugin-capabilities.ts
@@ -92,6 +92,40 @@ export function extractCapabilities(
   });
 }
 
+/**
+ * Absolute paths of the capability modules the manifest registers.
+ *
+ * The client-import guard uses this rather than a `capabilitiesDir` prefix
+ * test: registration is what makes a module server-only, and the manifest may
+ * point anywhere. A directory test both misses capabilities registered from
+ * elsewhere and wrongly rejects ordinary co-located files (shared constants,
+ * types) that happen to sit in the capability folder.
+ *
+ * Returns an empty list when the manifest cannot be read or parsed — the
+ * virtual-module generation raises its own precise error for those, and
+ * guessing here would turn one clear failure into two confusing ones.
+ */
+export function resolveCapabilityModulePaths(
+  options: PrachtPluginOptions = {},
+  root: string = process.cwd(),
+): string[] {
+  const resolved = resolveOptions(options);
+  if (resolved.pagesDir) return [];
+
+  const appFileAbs = resolve(root, resolved.appFile.replace(/^\//, ""));
+  let manifestSource: string;
+  try {
+    manifestSource = readFileSync(appFileAbs, "utf-8");
+  } catch {
+    return [];
+  }
+
+  const appDir = dirname(appFileAbs);
+  return extractCapabilityRegistrations(manifestSource).map(({ file }) =>
+    file.startsWith("/") ? resolve(root, file.replace(/^\//, "")) : resolve(appDir, file),
+  );
+}
+
 function extractCapabilityMetadata(
   name: string,
   file: string,

--- a/packages/vite-plugin/test/client-module-transform.test.ts
+++ b/packages/vite-plugin/test/client-module-transform.test.ts
@@ -21,6 +21,59 @@ function makeTempProject(): string {
   return dir;
 }
 
+const MANIFEST_PLUGIN_OPTIONS = { appFile: "/src/routes.ts" } as const;
+
+/**
+ * Scaffold a manifest-mode project with one registered capability. Capabilities
+ * only exist in manifest mode, so the pages-router fixture cannot exercise them.
+ * `capabilityPath` is the manifest-relative module ref, which may point outside
+ * the conventional capabilities directory.
+ */
+function writeCapabilityManifestProject(
+  root: string,
+  { capabilityPath = "./capabilities/notes-search.ts" } = {},
+): void {
+  mkdirSync(join(root, "src", "routes"), { recursive: true });
+  mkdirSync(join(root, "src", "capabilities"), { recursive: true });
+  mkdirSync(join(root, "src", "server"), { recursive: true });
+
+  writeFileSync(
+    join(root, "src", capabilityPath.replace(/^\.\//, "")),
+    // A local `defineCapability` keeps the module statically analyzable without
+    // pulling @pracht/capabilities into this fixture's resolver. No `expose`,
+    // so it stays private and needs no client projection.
+    `function defineCapability(definition) {
+  return { kind: "capability", ...definition };
+}
+
+const SERVER_SECRET = "CAPABILITY_SERVER_SECRET_MARKER";
+
+export default defineCapability({
+  title: "Search notes",
+  description: "Find notes.",
+  input: { type: "object" },
+  output: { type: "object" },
+  effect: "read",
+  run() {
+    return { secret: SERVER_SECRET };
+  },
+});
+`,
+  );
+  writeFileSync(
+    join(root, "src", "routes.ts"),
+    `import { defineApp, route } from "@pracht/core";
+
+export const app = defineApp({
+  capabilities: {
+    "notes.search": () => import(${JSON.stringify(capabilityPath)}),
+  },
+  routes: [route("/", () => import("./routes/home.tsx"), { id: "home" })],
+});
+`,
+  );
+}
+
 function readBuiltJs(root: string): string {
   const assetsDir = join(root, "dist", "assets");
   return readdirSync(assetsDir)
@@ -33,12 +86,17 @@ function expectValidModuleSource(code: string): void {
   expect(() => parseAst(code, { lang: "tsx" })).not.toThrow();
 }
 
-async function buildTempProject(root: string): Promise<void> {
+async function buildTempProject(
+  root: string,
+  // Capabilities are manifest-mode only, so tests that involve them must build
+  // with an `appFile` rather than the default pages-router fixture.
+  pluginOptions: Parameters<typeof pracht>[0] = { pagesDir: "/src/pages" },
+): Promise<void> {
   await build({
     root,
     configFile: false,
     logLevel: "silent",
-    plugins: pracht({ pagesDir: "/src/pages" }),
+    plugins: pracht(pluginOptions),
     resolve: {
       alias: [
         {
@@ -511,6 +569,78 @@ describe("client route module build", () => {
     expect(clientSource).toContain('"/src/routes/about.tsx":false');
     expect(serverSource).toContain('"./routes/index.tsx":true');
     expect(serverSource).toContain('"./routes/about.tsx":false');
+  });
+
+  it("fails the build when client code imports a capability module directly", async () => {
+    // Nothing strips a capability module the way a route loader is stripped, so
+    // importing one from a component would bundle run() and everything it
+    // imports — a database client, an API key — for every visitor. The browser
+    // projection exists so that never has to happen; the build must say so
+    // rather than quietly shipping it.
+    const root = makeTempProject();
+    writeCapabilityManifestProject(root);
+    writeFileSync(
+      join(root, "src", "routes", "home.tsx"),
+      `
+import capability from "../capabilities/notes-search";
+
+export function Component() {
+  return <main>{capability.title}</main>;
+}
+`,
+    );
+
+    await expect(buildTempProject(root, MANIFEST_PLUGIN_OPTIONS)).rejects.toThrow(
+      /Capability module .* was imported by client code/,
+    );
+  });
+
+  it("guards capability modules registered outside the capabilities directory", async () => {
+    // Registration is what makes a module server-only, not where it sits. A
+    // directory-based guard would miss this one entirely.
+    const root = makeTempProject();
+    writeCapabilityManifestProject(root, { capabilityPath: "./server/elsewhere.ts" });
+    writeFileSync(
+      join(root, "src", "routes", "home.tsx"),
+      `
+import capability from "../server/elsewhere";
+
+export function Component() {
+  return <main>{capability.title}</main>;
+}
+`,
+    );
+
+    await expect(buildTempProject(root, MANIFEST_PLUGIN_OPTIONS)).rejects.toThrow(
+      /Capability module .* was imported by client code/,
+    );
+  });
+
+  it("lets client code import a non-capability file that lives beside capabilities", async () => {
+    // The guard matches the manifest's registered capability modules, not a
+    // directory. Shared constants and types co-located with capabilities are
+    // ordinary modules and must stay importable — rejecting them would fail the
+    // build with advice ("call the capability instead") that makes no sense.
+    const root = makeTempProject();
+    writeCapabilityManifestProject(root);
+    writeFileSync(
+      join(root, "src", "capabilities", "labels.ts"),
+      'export const LABEL = "CO_LOCATED_CONSTANT_MARKER";\n',
+    );
+    writeFileSync(
+      join(root, "src", "routes", "home.tsx"),
+      `
+import { LABEL } from "../capabilities/labels";
+
+export function Component() {
+  return <main>{LABEL}</main>;
+}
+`,
+    );
+
+    await buildTempProject(root, MANIFEST_PLUGIN_OPTIONS);
+
+    expect(readBuiltJs(root)).toContain("CO_LOCATED_CONSTANT_MARKER");
   });
 
   it("excludes imports used only by typed inline loaders from browser bundles", async () => {


### PR DESCRIPTION
## Summary

- Capability modules are server-only, but nothing stopped client code from importing one. A component doing `import notesSearch from "../capabilities/notes-search.ts"` built successfully and shipped the whole module to the browser — `run()`, its schemas, and everything it imports, which in a real app means the database client and whatever secrets it closes over.
- The build now rejects that import, pointing at the browser projection that exists precisely so it never has to happen: `callCapability` / `capabilities` from `virtual:pracht/capabilities`, or `invokeCapability` from `@pracht/core/server`. This mirrors the existing guard for the server-only env entry.
- The check matches the capability modules the **manifest registers**, not a `capabilitiesDir` prefix. Registration is what makes a module server-only, and the manifest may point anywhere: a directory test both misses capabilities registered elsewhere and wrongly rejects ordinary co-located files (shared constants, types).

Reproduced against `examples/basic` before the fix: the build exited 0 and the server-store marker was present in `dist/client/assets/`. After the fix the build exits 1 and the marker is absent.

What legitimately still crosses to the browser is unchanged and now documented in `docs/CAPABILITIES.md`: capability name, endpoint path/method, and effect class — plus, for `expose.webmcp` capabilities only, the description and input schema an in-page agent needs to call the tool.

## Testing

- [x] `pnpm e2e`
- [x] `pnpm format`
- [x] `pnpm lint`
- [x] `pnpm test`

New coverage:
- `packages/vite-plugin/test/client-module-transform.test.ts` — build-level tests that the guard fires for a capability in the conventional directory, fires for one registered outside it, and does **not** fire for a non-capability file co-located with capabilities.
- `e2e/client-bundle-strip.test.ts` — over a real build, asserts a destructive non-WebMCP capability's description and input schema never reach any client asset, with a positive control asserting the WebMCP-exposed one's description does (so the test proves it checks exposure, not merely that capability text never ships).

Note: `pracht dev explains how to enable generated route types` and `pracht dev keeps generated route types in sync with route files` fail on this machine (Windows `EBUSY` on rmdir, and a dev-server watch timeout). Both fail identically at `main` with this branch stashed — pre-existing and unrelated.

## Checklist

- [x] Docs updated if needed
- [ ] Skills updated if needed — N/A
- [x] Changeset added if published packages changed
