### PR TITLE
fix(capabilities): one shared projection extractor, cross-checked by typegen

### DIFF
--- a/.changeset/capability-projection-consistency.md
+++ b/.changeset/capability-projection-consistency.md
@@ -1,0 +1,19 @@
+---
+"@pracht/capabilities": patch
+"@pracht/vite-plugin": patch
+"@pracht/cli": patch
+---
+
+Give the capability projection rules one home, and cross-check them in typegen.
+
+The HTTP path, effect, WebMCP exposure, and input schema of a capability were
+derived twice: once by the Vite plugin's static analysis (capability modules
+must never enter the client graph, so it cannot execute them) and once by the
+app graph, which loads the modules. Both now share
+`extractCapabilityProjection` from `@pracht/capabilities/static`.
+
+`pracht typegen` cross-checks the executed graph against that static pass and
+fails when they disagree — including when static analysis cannot read an exposed
+capability at all, which is what a computed `expose` or `effect` looks like.
+Without the check, generated types could describe an endpoint the client bundle
+never registers.

--- a/packages/capabilities/src/static.ts
+++ b/packages/capabilities/src/static.ts
@@ -1,15 +1,135 @@
 /**
  * Static analysis of capability sources — shared by the Vite plugin (client
- * projection codegen) and the CLI (`pracht verify`). Both consumers parse the
- * same `defineCapability({ ... })` call sites without executing application
- * code, so keeping the parser here guarantees the build and verification can
- * never disagree about what is statically analyzable.
+ * projection codegen) and the CLI (`pracht verify`, `pracht typegen`). Every
+ * consumer parses the same `defineCapability({ ... })` call sites without
+ * executing application code, so keeping the parser here guarantees the build,
+ * verification, and type generation can never disagree about what is
+ * statically analyzable.
  *
  * Constraint this imposes on capability authors: values the tools need
  * (`expose`, `effect`, `input`, string fields) must be inline literals — no
  * imported constants or spreads. `evaluateLiteral()` parses the literal text
  * as data and returns `undefined` for anything else.
  */
+
+import { capabilityHttpPath, isValidCapabilityHttpPath } from "./protocol.ts";
+
+/**
+ * The parts of a capability contract that decide what gets projected to the
+ * browser: whether it has an HTTP endpoint, its effect class, whether it
+ * registers a WebMCP page tool, and the input schema that tool advertises.
+ */
+export interface CapabilityProjection {
+  description: string;
+  effect: string | null;
+  httpPath: string | null;
+  webmcp: boolean;
+  inputSchema: Record<string, unknown> | null;
+}
+
+/**
+ * Derive a capability's projection from its source, without executing it.
+ *
+ * This is the single implementation behind three consumers that must agree:
+ * the Vite plugin builds the browser endpoint table from it, `pracht verify`
+ * checks the contract against it, and `pracht typegen` cross-checks it against
+ * the executed graph. If they disagreed, generated types could promise an
+ * endpoint the client bundle never registered.
+ *
+ * `name` supplies the default HTTP path; `describe` wraps error messages so
+ * each caller can phrase them its own way (the plugin fails the build, the CLI
+ * fails a check).
+ */
+export function extractCapabilityProjection(
+  name: string,
+  source: string,
+  describe: (detail: string) => string,
+): CapabilityProjection {
+  const args = extractDefineCapabilityArgs(source);
+  if (!args) {
+    throw new Error(
+      describe("does not contain a defineCapability({ ... }) call the build can analyze."),
+    );
+  }
+
+  const properties = scanTopLevelProperties(args);
+  const exposeText = properties.get("expose");
+  if (!exposeText) {
+    // Private capability: server-only, nothing to project to the client.
+    return { description: "", effect: null, httpPath: null, webmcp: false, inputSchema: null };
+  }
+
+  const expose = evaluateLiteral(exposeText);
+  if (!isPlainObject(expose)) {
+    throw new Error(
+      describe(
+        '"expose" must be an inline object literal so the client projection can be generated at build time.',
+      ),
+    );
+  }
+
+  const http = expose.http;
+  let httpPath: string | null = null;
+  if (http === true) {
+    httpPath = capabilityHttpPath(name);
+  } else if (isPlainObject(http)) {
+    httpPath = typeof http.path === "string" ? http.path : capabilityHttpPath(name);
+  }
+  if (httpPath && !isValidCapabilityHttpPath(httpPath)) {
+    throw new Error(
+      describe('HTTP exposure "path" must be an exact same-origin pathname starting with "/".'),
+    );
+  }
+
+  const webmcp = expose.webmcp === true;
+  if (webmcp && !httpPath) {
+    throw new Error(describe("expose.webmcp requires expose.http."));
+  }
+
+  let description = "";
+  const descriptionText = properties.get("description");
+  if (descriptionText) {
+    const value = evaluateLiteral(descriptionText);
+    if (typeof value === "string") description = value;
+  }
+
+  let effect: string | null = null;
+  const effectText = properties.get("effect");
+  if (effectText) {
+    const value = evaluateLiteral(effectText);
+    if (typeof value === "string") effect = value;
+  }
+  if (httpPath && effect !== "read" && effect !== "write" && effect !== "destructive") {
+    throw new Error(
+      describe(
+        'is exposed via HTTP, but its "effect" could not be extracted at build time. ' +
+          'HTTP-exposed capabilities must declare "effect" as an inline "read", "write", or ' +
+          '"destructive" string literal.',
+      ),
+    );
+  }
+
+  let inputSchema: Record<string, unknown> | null = null;
+  if (webmcp) {
+    const inputText = properties.get("input");
+    const value = inputText ? evaluateLiteral(inputText) : undefined;
+    if (!isPlainObject(value)) {
+      throw new Error(
+        describe(
+          'is exposed via WebMCP, but its "input" schema could not be extracted at build time. ' +
+            "WebMCP-exposed capabilities must declare their input schema as an inline object literal.",
+        ),
+      );
+    }
+    inputSchema = value;
+  }
+
+  return { description, effect, httpPath, webmcp, inputSchema };
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
 
 /**
  * Extract the argument object text of the *default-exported*

--- a/packages/cli/src/capability-consistency.ts
+++ b/packages/cli/src/capability-consistency.ts
@@ -1,0 +1,140 @@
+/**
+ * Cross-check the two ways pracht reads a capability's exposure.
+ *
+ * `pracht typegen` gets its metadata from the resolved app graph, which loads
+ * capability modules and reads the objects `defineCapability()` returned. The
+ * Vite plugin cannot do that — capability modules are server-only and must
+ * never enter the client graph — so it builds the browser endpoint table from
+ * static analysis of the same sources instead.
+ *
+ * Both feed the type layer: the graph decides what `Register["capabilities"]`
+ * marks as http-exposed, and the static pass decides which endpoints the
+ * generated client actually dispatches. If they disagreed, the generated types
+ * would promise a capability the browser bundle has no endpoint for — a
+ * compile-time green light for a call that 404s. Typegen is the moment those
+ * types are minted, so it is the right place to prove the two agree.
+ */
+
+import { existsSync, readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+
+import {
+  extractCapabilityProjection,
+  type CapabilityProjection,
+} from "@pracht/capabilities/static";
+
+import { resolveProjectPath, type ProjectConfig } from "./project.js";
+
+/** The subset of the app-graph capability entry this check compares. */
+export interface GraphCapabilityExposure {
+  effect: string | null;
+  httpPath: string | null;
+  name: string;
+  source: string;
+  transports: string[];
+}
+
+/**
+ * Throw when the executed graph and the static analyzer disagree about a
+ * capability's HTTP path, effect class, or WebMCP exposure — including when
+ * static analysis cannot read an exposed capability at all, which is the most
+ * common way the two diverge (a computed `expose`, a hoisted constant).
+ *
+ * Capabilities whose source file is missing are skipped: the manifest check
+ * reports those, and duplicating it here would turn one problem into two.
+ */
+export function assertCapabilityProjectionsAgree(
+  project: ProjectConfig,
+  capabilities: GraphCapabilityExposure[],
+): void {
+  if (capabilities.length === 0) return;
+
+  const manifestPath = resolveProjectPath(project.root, project.appFile);
+  if (!existsSync(manifestPath)) return;
+  const manifestDir = dirname(manifestPath);
+
+  const drift: string[] = [];
+  for (const capability of capabilities) {
+    // Root-relative refs resolve against the project root, matching the runtime
+    // registry and the Vite plugin; everything else is manifest-relative.
+    const filePath = capability.source.startsWith("/")
+      ? resolveProjectPath(project.root, capability.source)
+      : resolve(manifestDir, capability.source);
+    if (!existsSync(filePath)) continue;
+
+    let projection: CapabilityProjection;
+    try {
+      projection = extractCapabilityProjection(
+        capability.name,
+        readFileSync(filePath, "utf-8"),
+        (detail) => detail,
+      );
+    } catch (error) {
+      // Extraction failing *is* the drift, not a reason to skip: the graph read
+      // this capability by executing it, the client projection could not read
+      // it at all, and the emitted types would describe an endpoint the browser
+      // bundle never registers. Only report it for capabilities the graph
+      // believes are exposed — a private one has no client projection to differ
+      // from, and the build raises its own error for genuinely broken sources.
+      if (capability.httpPath !== null || capability.transports.length > 0) {
+        drift.push(
+          `  ${capability.name} (${capability.source}): the app graph exposes it over ` +
+            `${describe(capability.httpPath)}, but static analysis cannot read its projection — ` +
+            `${error instanceof Error ? error.message : String(error)}`,
+        );
+      }
+      continue;
+    }
+
+    for (const difference of compare(capability, projection)) {
+      drift.push(`  ${capability.name} (${capability.source}): ${difference}`);
+    }
+  }
+
+  if (drift.length > 0) {
+    throw new Error(
+      "Capability exposure differs between the resolved app graph and build-time static " +
+        "analysis, so generated types would not match the endpoints the browser bundle " +
+        `registers:\n${drift.join("\n")}\n` +
+        "This happens when `expose` or `effect` is computed rather than written as an inline " +
+        "literal. Declare them inline so both readers see the same contract.",
+    );
+  }
+}
+
+function compare(graph: GraphCapabilityExposure, statically: CapabilityProjection): string[] {
+  const differences: string[] = [];
+
+  if (graph.httpPath !== statically.httpPath) {
+    differences.push(
+      `HTTP endpoint is ${describe(graph.httpPath)} in the app graph but ` +
+        `${describe(statically.httpPath)} in static analysis`,
+    );
+  }
+
+  // Effect only matters where it is projected. The static pass reads it only
+  // for http-exposed capabilities (a private one has no client projection to
+  // annotate), so comparing it elsewhere would report drift that cannot exist.
+  // A null graph effect means the module failed to load — a broken
+  // registration other checks already report, not exposure drift.
+  if (statically.httpPath !== null && graph.effect !== null && graph.effect !== statically.effect) {
+    differences.push(
+      `effect is ${describe(graph.effect)} in the app graph but ` +
+        `${describe(statically.effect)} in static analysis`,
+    );
+  }
+
+  const graphWebmcp = graph.transports.includes("webmcp");
+  if (graphWebmcp !== statically.webmcp) {
+    differences.push(
+      `WebMCP exposure is ${graphWebmcp ? "on" : "off"} in the app graph but ` +
+        `${statically.webmcp ? "on" : "off"} in static analysis`,
+    );
+  }
+
+  return differences;
+}
+
+function describe(value: string | null): string {
+  return value === null ? "none" : JSON.stringify(value);
+}

--- a/packages/cli/src/commands/typegen.ts
+++ b/packages/cli/src/commands/typegen.ts
@@ -5,6 +5,7 @@ import { defineCommand } from "citty";
 
 import { displayPath, readProjectConfig, resolveProjectPath } from "../project.js";
 import { schemaToTypeText } from "@pracht/capabilities";
+import { assertCapabilityProjectionsAgree } from "../capability-consistency.js";
 import { ensureTrailingNewline, handleCliError } from "../utils.js";
 import { runInspect, type InspectReport } from "./inspect.js";
 
@@ -115,6 +116,10 @@ export async function runTypegen(options: TypegenOptions): Promise<TypegenResult
   validateApiRoutes(apiRoutes);
 
   const project = readProjectConfig(options.root);
+  // Generated types claim which capabilities the browser can reach; the client
+  // bundle's endpoint table comes from a separate static pass. Prove they agree
+  // before writing types that would otherwise green-light a call that 404s.
+  assertCapabilityProjectionsAgree(project, capabilities);
   const declarationPath = resolveOutputPath(options.root, options.declarationOut);
   const runtimePath = resolveOutputPath(options.root, options.runtimeOut);
   const capabilitiesPath = resolveOutputPath(options.root, options.capabilitiesOut);

--- a/packages/cli/test/capability-consistency.test.ts
+++ b/packages/cli/test/capability-consistency.test.ts
@@ -1,0 +1,141 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  assertCapabilityProjectionsAgree,
+  type GraphCapabilityExposure,
+} from "../src/capability-consistency.ts";
+import type { ProjectConfig } from "../src/project.ts";
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    rmSync(dir, { force: true, recursive: true });
+  }
+});
+
+function createApp(capabilitySources: Record<string, string>): ProjectConfig {
+  const root = mkdtempSync(join(tmpdir(), "pracht-capability-consistency-"));
+  tempDirs.push(root);
+  mkdirSync(join(root, "src/capabilities"), { recursive: true });
+  writeFileSync(join(root, "src/routes.ts"), "export const app = {};\n", "utf-8");
+  for (const [file, source] of Object.entries(capabilitySources)) {
+    writeFileSync(join(root, "src/capabilities", file), source, "utf-8");
+  }
+  // Project paths are root-relative with a leading slash (resolveProjectPath
+  // resolves them as "./<path>"), matching PROJECT_DEFAULTS.
+  return { appFile: "/src/routes.ts", root } as ProjectConfig;
+}
+
+/** `expose: null` omits the property entirely — how a private capability reads. */
+function capabilitySource({
+  effect = '"read"',
+  expose = "{ http: true }",
+}: { effect?: string; expose?: string | null } = {}): string {
+  return `import { defineCapability } from "@pracht/capabilities";
+
+export default defineCapability({
+  title: "Search notes",
+  description: "Find notes.",
+  input: { type: "object", properties: {}, additionalProperties: false },
+  output: { type: "object", properties: {}, additionalProperties: false },
+  effect: ${effect},
+${expose === null ? "" : `  expose: ${expose},\n`}  async run() {
+    return {};
+  },
+});
+`;
+}
+
+function graphEntry(overrides: Partial<GraphCapabilityExposure> = {}): GraphCapabilityExposure {
+  return {
+    effect: "read",
+    httpPath: "/api/capabilities/notes/search",
+    name: "notes.search",
+    source: "./capabilities/notes-search.ts",
+    transports: ["http"],
+    ...overrides,
+  };
+}
+
+describe("assertCapabilityProjectionsAgree", () => {
+  it("passes when the executed graph and static analysis match", () => {
+    const project = createApp({ "notes-search.ts": capabilitySource() });
+
+    expect(() => assertCapabilityProjectionsAgree(project, [graphEntry()])).not.toThrow();
+  });
+
+  it("passes for private capabilities, whose effect static analysis never reads", () => {
+    const project = createApp({
+      "notes-search.ts": capabilitySource({ effect: '"write"', expose: null }),
+    });
+
+    expect(() =>
+      assertCapabilityProjectionsAgree(project, [
+        graphEntry({ effect: "write", httpPath: null, transports: [] }),
+      ]),
+    ).not.toThrow();
+  });
+
+  it("reports an endpoint the browser bundle would never register", () => {
+    // The graph says http-exposed (so generated types would allow a browser
+    // call); the source says private (so the client has no endpoint for it).
+    const project = createApp({
+      "notes-search.ts": capabilitySource({ expose: null }),
+    });
+
+    expect(() => assertCapabilityProjectionsAgree(project, [graphEntry()])).toThrow(
+      /HTTP endpoint is "\/api\/capabilities\/notes\/search" in the app graph but none in static analysis/,
+    );
+  });
+
+  it("reports a mismatched effect class on an exposed capability", () => {
+    const project = createApp({ "notes-search.ts": capabilitySource({ effect: '"write"' }) });
+
+    expect(() =>
+      assertCapabilityProjectionsAgree(project, [graphEntry({ effect: "destructive" })]),
+    ).toThrow(/effect is "destructive" in the app graph but "write" in static analysis/);
+  });
+
+  it("reports mismatched WebMCP exposure", () => {
+    const project = createApp({ "notes-search.ts": capabilitySource() });
+
+    expect(() =>
+      assertCapabilityProjectionsAgree(project, [graphEntry({ transports: ["http", "webmcp"] })]),
+    ).toThrow(/WebMCP exposure is on in the app graph but off in static analysis/);
+  });
+
+  it("reports an exposed capability whose projection static analysis cannot read", () => {
+    // The most common real divergence: `expose` computed from a hoisted const.
+    // The graph read it by executing the module, the client projection cannot
+    // read it at all, so the emitted types would describe an endpoint the
+    // browser bundle never registers. Staying quiet here would leave this check
+    // contributing nothing in the exact case it exists for.
+    const project = createApp({
+      "notes-search.ts": capabilitySource({ expose: "EXPOSE_CONFIG" }),
+    });
+
+    expect(() => assertCapabilityProjectionsAgree(project, [graphEntry()])).toThrow(
+      /static analysis cannot read its projection/,
+    );
+  });
+
+  it("stays quiet when an unreadable capability is private in the graph too", () => {
+    // Nothing is projected to the client, so there is no divergence to report;
+    // the build raises its own error for a genuinely broken source.
+    const project = createApp({ "notes-search.ts": "export default {};\n" });
+
+    expect(() =>
+      assertCapabilityProjectionsAgree(project, [graphEntry({ httpPath: null, transports: [] })]),
+    ).not.toThrow();
+  });
+
+  it("ignores capabilities whose source file is missing", () => {
+    const project = createApp({});
+
+    expect(() => assertCapabilityProjectionsAgree(project, [graphEntry()])).not.toThrow();
+  });
+});

--- a/packages/vite-plugin/src/plugin-capabilities.ts
+++ b/packages/vite-plugin/src/plugin-capabilities.ts
@@ -24,15 +24,11 @@ import { dirname, resolve } from "node:path";
 import {
   CAPABILITY_SETTLED_EVENT,
   CAPABILITY_TRANSPORT_HEADER,
-  capabilityHttpPath,
   CONFIRMATION_HEADER,
-  isValidCapabilityHttpPath,
 } from "@pracht/capabilities";
 import {
-  evaluateLiteral,
+  extractCapabilityProjection,
   extractCapabilityRegistrations,
-  extractDefineCapabilityArgs,
-  scanTopLevelProperties,
 } from "@pracht/capabilities/static";
 import { resolveOptions, type PrachtPluginOptions } from "./plugin-options.ts";
 
@@ -97,92 +93,14 @@ function extractCapabilityMetadata(
   file: string,
   source: string,
 ): ExtractedCapability {
-  const args = extractDefineCapabilityArgs(source);
-  if (!args) {
-    throw new Error(
-      `[pracht] Capability "${name}" (${file}) does not contain a ` +
-        "defineCapability({ ... }) call the build can analyze.",
-    );
-  }
-
-  const properties = scanTopLevelProperties(args);
-  const exposeText = properties.get("expose");
-  if (!exposeText) {
-    // Private capability: server-only, nothing to project to the client.
-    return {
-      name,
-      file,
-      description: "",
-      effect: null,
-      httpPath: null,
-      webmcp: false,
-      inputSchema: null,
-    };
-  }
-
-  const expose = evaluateLiteral(exposeText);
-  if (!isPlainObject(expose)) {
-    throw new Error(
-      `[pracht] Capability "${name}" (${file}): "expose" must be an inline object ` +
-        "literal so the client projection can be generated at build time.",
-    );
-  }
-
-  const http = expose.http;
-  let httpPath: string | null = null;
-  if (http === true) {
-    httpPath = capabilityHttpPath(name);
-  } else if (isPlainObject(http)) {
-    httpPath = typeof http.path === "string" ? http.path : capabilityHttpPath(name);
-  }
-  if (httpPath && !isValidCapabilityHttpPath(httpPath)) {
-    throw new Error(
-      `[pracht] Capability "${name}" (${file}): HTTP exposure "path" must be an exact ` +
-        'same-origin pathname starting with "/".',
-    );
-  }
-
-  const webmcp = expose.webmcp === true;
-  if (webmcp && !httpPath) {
-    throw new Error(`[pracht] Capability "${name}" (${file}): expose.webmcp requires expose.http.`);
-  }
-
-  let description = "";
-  const descriptionText = properties.get("description");
-  if (descriptionText) {
-    const value = evaluateLiteral(descriptionText);
-    if (typeof value === "string") description = value;
-  }
-
-  let effect: string | null = null;
-  const effectText = properties.get("effect");
-  if (effectText) {
-    const value = evaluateLiteral(effectText);
-    if (typeof value === "string") effect = value;
-  }
-  if (httpPath && effect !== "read" && effect !== "write" && effect !== "destructive") {
-    throw new Error(
-      `[pracht] Capability "${name}" (${file}) is exposed via HTTP, but its "effect" ` +
-        'could not be extracted at build time. HTTP-exposed capabilities must declare "effect" ' +
-        'as an inline "read", "write", or "destructive" string literal.',
-    );
-  }
-
-  let inputSchema: Record<string, unknown> | null = null;
-  if (webmcp) {
-    const inputText = properties.get("input");
-    const value = inputText ? evaluateLiteral(inputText) : undefined;
-    if (!isPlainObject(value)) {
-      throw new Error(
-        `[pracht] Capability "${name}" (${file}) is exposed via WebMCP, but its "input" ` +
-          "schema could not be extracted at build time. WebMCP-exposed capabilities must " +
-          "declare their input schema as an inline object literal.",
-      );
-    }
-    inputSchema = value;
-  }
-
-  return { name, file, description, effect, httpPath, webmcp, inputSchema };
+  // The projection rules live in @pracht/capabilities so the build, `pracht
+  // verify`, and `pracht typegen` cannot drift on what a capability exposes.
+  const projection = extractCapabilityProjection(
+    name,
+    source,
+    (detail) => `[pracht] Capability ${JSON.stringify(name)} (${file}) ${detail}`,
+  );
+  return { name, file, ...projection };
 }
 
 /**
@@ -382,8 +300,4 @@ export function hasWebmcpCapabilities(
     // Extraction errors surface when the virtual modules are generated.
     return true;
   }
-}
-
-function isPlainObject(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
 }


### PR DESCRIPTION
## Summary

- Pracht reads a capability's exposure two ways. The app graph (`pracht inspect`, `pracht typegen`) gets it by **loading** capability modules; the Vite plugin cannot do that — capability modules must never enter the client graph — so it builds the browser endpoint table from **static analysis** of the same sources.
- Those two readers had separate implementations of the same rules (HTTP path, effect, WebMCP exposure, input schema). Moved the rules into `@pracht/capabilities/static` as one `extractCapabilityProjection`, which the plugin now delegates to. This is the same consolidation the capability-graph decision log already applied to `capabilityHttpPath` and the extractor itself, for the same reason: two copies drift.
- `pracht typegen` now cross-checks the executed graph against that static pass and fails when they disagree. Typegen is the moment the types are minted, so it is the right place to prove the two agree — otherwise a generated type can green-light a browser call the client bundle has no endpoint for.

The check reports the divergence that actually happens in practice: an `expose` or `effect` computed from a hoisted constant rather than written inline. Static analysis cannot read it, the graph can, and the emitted types would describe an endpoint that never gets registered. It stays quiet for private capabilities (nothing is projected, so nothing can differ) and for missing files (the manifest check reports those).

## Testing

- [x] `pnpm e2e`
- [x] `pnpm format`
- [x] `pnpm lint`
- [x] `pnpm test`

New coverage: `packages/cli/test/capability-consistency.test.ts` — 8 tests covering agreement, a graph-exposed capability the source says is private, a mismatched effect, mismatched WebMCP exposure, an exposed capability static analysis cannot read at all, and the two deliberate silences.

Note: `pracht dev explains how to enable generated route types` and `pracht dev keeps generated route types in sync with route files` fail on this machine (Windows `EBUSY` on rmdir, and a dev-server watch timeout). Both fail identically at `main` with this branch stashed — pre-existing and unrelated.

## Checklist

- [ ] Docs updated if needed — N/A (behaviour is a build-time check; the developer-facing rule is unchanged)
- [ ] Skills updated if needed — N/A
- [x] Changeset added if published packages changed
