### PR TITLE
fix capability boundary checks across canonical paths

### DIFF
--- a/.changeset/canonical-capability-guards.md
+++ b/.changeset/canonical-capability-guards.md
@@ -1,0 +1,16 @@
+---
+"@pracht/cli": patch
+"@pracht/vite-plugin": patch
+---
+
+Harden capability boundary checks across canonical file paths and module-load
+failures.
+
+The Vite plugin now compares canonical paths for app manifests, route module
+directories, registered capability modules, and client imports, so symlinked
+modules and path aliases cannot bypass manifest rewriting or server-only
+client guards.
+
+Type generation now leaves capability module-load failures to the existing
+wiring checks instead of misreporting their null graph metadata as exposure
+drift with an unrelated inline-literal remediation.

--- a/packages/cli/src/capability-consistency.ts
+++ b/packages/cli/src/capability-consistency.ts
@@ -62,6 +62,13 @@ export function assertCapabilityProjectionsAgree(
       : resolve(manifestDir, capability.source);
     if (!existsSync(filePath)) continue;
 
+    // serializeCapabilities() uses a null effect to retain a graph entry when
+    // its module failed to load. That is a wiring failure for verify/doctor to
+    // report, not projection drift; comparing its other null fallback fields
+    // against valid source text would hide the real cause behind an unrelated
+    // instruction to inline expose/effect.
+    if (capability.effect === null) continue;
+
     let projection: CapabilityProjection;
     try {
       projection = extractCapabilityProjection(

--- a/packages/cli/test/capability-consistency.test.ts
+++ b/packages/cli/test/capability-consistency.test.ts
@@ -80,6 +80,20 @@ describe("assertCapabilityProjectionsAgree", () => {
     ).not.toThrow();
   });
 
+  it("leaves module-load failures to the wiring checks", () => {
+    const project = createApp({ "notes-search.ts": capabilitySource() });
+
+    // serializeCapabilities() retains a null-metadata graph entry when the
+    // module fails to load. Its source can still be perfectly analyzable, so
+    // comparing the fallback null endpoint would misdiagnose the load failure
+    // as a computed expose/effect value.
+    expect(() =>
+      assertCapabilityProjectionsAgree(project, [
+        graphEntry({ effect: null, httpPath: null, transports: [] }),
+      ]),
+    ).not.toThrow();
+  });
+
   it("reports an endpoint the browser bundle would never register", () => {
     // The graph says http-exposed (so generated types would allow a browser
     // call); the source says private (so the client has no endpoint for it).

--- a/packages/vite-plugin/src/index.ts
+++ b/packages/vite-plugin/src/index.ts
@@ -1,5 +1,6 @@
 import { preactSsrPrecompile } from "@pracht/preact-ssr-precompile";
 import preact from "@preact/preset-vite";
+import { existsSync, realpathSync } from "node:fs";
 import { createRequire } from "node:module";
 import { join, resolve } from "node:path";
 import { loadEnv, type Plugin, type UserConfig } from "vite";
@@ -37,7 +38,6 @@ import {
   createPrachtIslandsClientModuleSource,
   createPrachtServerModuleSource,
 } from "./plugin-codegen.ts";
-import { existsSync } from "node:fs";
 import {
   createDevCssInjectionMiddleware,
   createDevSSRMiddleware,
@@ -179,7 +179,7 @@ export function pracht(options: PrachtPluginOptions = {}): Plugin[] {
       isBuild = config.command === "build";
       routeFileDirs = computeRouteFileDirs(root, resolved);
       capabilityModulePaths = new Set(
-        resolveCapabilityModulePaths(resolved, root).map((path) => toPosixPath(path)),
+        resolveCapabilityModulePaths(resolved, root).map(canonicalFilePath),
       );
     },
 
@@ -237,8 +237,8 @@ export function pracht(options: PrachtPluginOptions = {}): Plugin[] {
       // Transform () => import("./path") to "./path" in the app manifest file.
       // This lets users write import() for IDE click-to-navigate while keeping
       // the framework's string-based file resolution intact.
-      const appFileAbs = resolveConfigPath(root, resolved.appFile);
-      const normalizedId = toPosixPath(id.split("?")[0]);
+      const appFileAbs = canonicalFilePath(resolveConfigPath(root, resolved.appFile));
+      const normalizedId = canonicalFilePath(id.split("?")[0]);
       if (normalizedId !== appFileAbs) return null;
 
       const withStringModuleRefs = code.replace(
@@ -569,7 +569,7 @@ const ROUTE_FILE_EXTENSIONS = new Set([".ts", ".tsx", ".js", ".jsx", ".md", ".md
 
 function computeRouteFileDirs(root: string, resolved: ResolvedPrachtPluginOptions): string[] {
   const dirs = resolved.pagesDir ? [resolved.pagesDir] : [resolved.routesDir, resolved.shellsDir];
-  return dirs.map((dir) => resolveConfigPath(root, dir)).map(withTrailingSep);
+  return dirs.map((dir) => canonicalFilePath(resolveConfigPath(root, dir))).map(withTrailingSep);
 }
 
 /**
@@ -584,7 +584,21 @@ function isCapabilityModule(id: string, capabilityModulePaths: Set<string>): boo
   const queryStart = id.indexOf("?");
   const path = queryStart === -1 ? id : id.slice(0, queryStart);
   if (path.startsWith("\0") || path.startsWith("virtual:")) return false;
-  return capabilityModulePaths.has(toPosixPath(path));
+  return capabilityModulePaths.has(canonicalFilePath(path));
+}
+
+/**
+ * Match Vite's canonical module ids even when the manifest path crosses a
+ * symlink (including macOS' /var -> /private/var alias). Missing paths keep
+ * their lexical identity so the projection code can raise its precise missing
+ * capability error later.
+ */
+function canonicalFilePath(path: string): string {
+  try {
+    return toPosixPath(realpathSync.native(path));
+  } catch {
+    return toPosixPath(path);
+  }
 }
 
 function isRouteOrShellFile(id: string, dirs: string[]): boolean {

--- a/packages/vite-plugin/test/client-module-transform.test.ts
+++ b/packages/vite-plugin/test/client-module-transform.test.ts
@@ -1,4 +1,13 @@
-import { mkdtempSync, mkdirSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import {
+  mkdtempSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  renameSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -615,6 +624,63 @@ export function Component() {
       /Capability module .* was imported by client code/,
     );
   });
+
+  it.runIf(process.platform !== "win32")(
+    "guards a registered capability whose manifest path is a symlink",
+    async () => {
+      // Vite resolves symlinks before passing module ids to transforms. The
+      // registered path must use the same canonical identity or the equality
+      // check misses the module and ships its server implementation.
+      const root = makeTempProject();
+      writeCapabilityManifestProject(root);
+      const registeredPath = join(root, "src", "capabilities", "notes-search.ts");
+      const realPath = join(root, "src", "server", "notes-search.ts");
+      renameSync(registeredPath, realPath);
+      symlinkSync(realPath, registeredPath);
+      writeFileSync(
+        join(root, "src", "routes", "home.tsx"),
+        `
+import capability from "../capabilities/notes-search";
+
+export function Component() {
+  return <main>{capability.title}</main>;
+}
+`,
+      );
+
+      await expect(buildTempProject(root, MANIFEST_PLUGIN_OPTIONS)).rejects.toThrow(
+        /Capability module .* was imported by client code/,
+      );
+    },
+  );
+
+  it.runIf(process.platform !== "win32")(
+    "rewrites capability registrations through a symlinked project root",
+    async () => {
+      // If the app-manifest transform compares the lexical root with Vite's
+      // real module id, its lazy capability import survives as client code and
+      // either ships the server module or triggers the capability guard even
+      // though no component imported it.
+      const parent = makeTempProject();
+      const realRoot = join(parent, "real-project");
+      const linkedRoot = join(parent, "linked-project");
+      mkdirSync(realRoot);
+      symlinkSync(realRoot, linkedRoot);
+      writeCapabilityManifestProject(linkedRoot);
+      writeFileSync(
+        join(linkedRoot, "src", "routes", "home.tsx"),
+        `
+export function Component() {
+  return <main>Symlinked root</main>;
+}
+`,
+      );
+
+      await buildTempProject(linkedRoot, MANIFEST_PLUGIN_OPTIONS);
+
+      expect(readBuiltJs(linkedRoot)).not.toContain("CAPABILITY_SERVER_SECRET_MARKER");
+    },
+  );
 
   it("lets client code import a non-capability file that lives beside capabilities", async () => {
     // The guard matches the manifest's registered capability modules, not a


### PR DESCRIPTION
## Summary

- Canonicalize app-manifest, route-directory, registered-capability, and transformed module paths before Vite compares them, preventing symlink and path-alias bypasses of manifest rewriting and the capability client-import guard.
- Leave capability module-load failures to the existing wiring diagnostics instead of misreporting their null app-graph metadata as projection drift.
- Add build-level regressions for a symlinked capability and project root, plus CLI coverage for the module-load sentinel. This addresses the follow-up findings from #252 and #253.

## Testing

- [x] `pnpm e2e`
- [x] `pnpm format`
- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `pnpm typecheck`
- [x] Focused Vite plugin and capability-consistency tests

## Checklist

- [x] Docs updated if needed — N/A; the documented capability boundary and typegen behavior are unchanged, and this restores them.
- [x] Skills updated if needed — N/A; no authoring workflow or skill contract changed.
- [x] Changeset added if published packages changed
