### PR TITLE
Fix dev reloads for CSS-scanned islands routes

### DIFF
--- a/.changeset/fuzzy-otters-reload.md
+++ b/.changeset/fuzzy-otters-reload.md
@@ -1,0 +1,10 @@
+---
+"@pracht/vite-plugin": patch
+---
+
+Keep dev pages with `hydration: "islands"` or `hydration: "none"` live when CSS
+content scanners register their server-only source files as watched assets.
+
+File-only asset graph entries no longer suppress the full-page reload required
+for changed server-rendered modules, while real client JavaScript and CSS
+modules continue to use their existing hot-update paths.

--- a/docs/ISLANDS.md
+++ b/docs/ISLANDS.md
@@ -187,6 +187,11 @@ Islands themselves hot-update in place like any client component. Everything
 else on an islands or `hydration: "none"` page — the route module, its shell,
 and the server-only components it imports — is not part of the client bundle,
 so there is no client module to patch: the dev server reloads the page instead.
+A plugin that watches source files from a CSS transform — any content scanner,
+Tailwind and UnoCSS among them — makes Vite record those sources as file-only
+asset entries in the client graph. Those entries are watch dependencies rather
+than browser modules, so they do not suppress this reload. CSS updates still
+hot-update normally alongside it.
 Either way, saving a file updates what you see without a manual refresh.
 
 ---

--- a/e2e/islands-dev.test.ts
+++ b/e2e/islands-dev.test.ts
@@ -62,10 +62,33 @@ test("hydration none routes render without islands bootstrap or state", async ({
   await expect(page.locator("h1")).toHaveText("Fully static");
 });
 
-// Routes without full hydration are excluded from the client bundle, so their
-// source files never enter the client module graph and Vite has no module to
-// push an update through. The plugin has to reload the page itself, otherwise
-// editing a static route in dev does nothing at all.
+// Routes without full hydration are excluded from the client bundle. Content
+// scanners such as Tailwind still register their source files as file-only
+// assets in Vite's client graph, but those watch entries cannot update the
+// rendered HTML. The plugin has to reload the page itself.
+test("editing a hydration islands route reloads the open page with CSS scanning active", async ({
+  page,
+}) => {
+  test.setTimeout(30_000);
+
+  const routeFile = fileURLToPath(
+    new URL("../examples/islands/src/routes/home.tsx", import.meta.url),
+  );
+  const original = readFileSync(routeFile, "utf-8");
+
+  await page.goto("/");
+  await expect(page.locator("h1")).toHaveText("Islands architecture");
+
+  try {
+    writeFileSync(routeFile, original.replace("Islands architecture", "Edited islands in dev"));
+    await expect(page.locator("h1")).toHaveText("Edited islands in dev", { timeout: 15_000 });
+  } finally {
+    writeFileSync(routeFile, original);
+  }
+
+  await expect(page.locator("h1")).toHaveText("Islands architecture", { timeout: 15_000 });
+});
+
 test("editing a hydration none route reloads the open page", async ({ page }) => {
   test.setTimeout(30_000);
 
@@ -85,4 +108,33 @@ test("editing a hydration none route reloads the open page", async ({ page }) =>
   }
 
   await expect(page.locator("h1")).toHaveText("Fully static", { timeout: 15_000 });
+});
+
+test("editing an island keeps client state while file-only asset entries exist", async ({
+  page,
+}) => {
+  test.setTimeout(30_000);
+
+  const islandFile = fileURLToPath(
+    new URL("../examples/islands/src/islands/Counter.tsx", import.meta.url),
+  );
+  const original = readFileSync(islandFile, "utf-8");
+
+  await page.goto("/");
+  await page.waitForSelector('html[data-pracht-islands-hydrated="true"]');
+  await page.getByTestId("increment").click();
+  await expect(page.getByTestId("count")).toHaveText("Count: 6");
+
+  try {
+    writeFileSync(islandFile, original.replace("Increment", "Increment updated"));
+    await expect(page.getByTestId("increment")).toHaveText("Increment updated", {
+      timeout: 15_000,
+    });
+    await expect(page.getByTestId("count")).toHaveText("Count: 6");
+  } finally {
+    writeFileSync(islandFile, original);
+  }
+
+  await expect(page.getByTestId("increment")).toHaveText("Increment", { timeout: 15_000 });
+  await expect(page.getByTestId("count")).toHaveText("Count: 6");
 });

--- a/examples/islands/src/islands/Counter.tsx
+++ b/examples/islands/src/islands/Counter.tsx
@@ -1,5 +1,6 @@
 import { useState } from "preact/hooks";
 import type { IslandProps } from "@pracht/core";
+import "../styles.css";
 
 interface CounterProps {
   start?: number;

--- a/examples/islands/src/styles.css
+++ b/examples/islands/src/styles.css
@@ -1,0 +1,3 @@
+.site-shell {
+  display: block;
+}

--- a/examples/islands/vite.config.ts
+++ b/examples/islands/vite.config.ts
@@ -1,7 +1,28 @@
-import { defineConfig } from "vite";
+import { defineConfig, type Plugin } from "vite";
 import { pracht } from "@pracht/vite-plugin";
 import { nodeAdapter } from "@pracht/adapter-node";
+import { fileURLToPath } from "node:url";
+
+// Content scanners such as Tailwind register every source they inspect as a
+// file-only asset dependency of their CSS module. Model that through Vite's
+// public addWatchFile hook so this example covers the same graph state without
+// coupling the monorepo's Vite installation to optional peer dependencies.
+function contentScannerFixture(): Plugin {
+  const sourceFiles = ["./src/routes/home.tsx", "./src/routes/static-page.tsx"].map((path) =>
+    fileURLToPath(new URL(path, import.meta.url)),
+  );
+
+  return {
+    name: "pracht:e2e-content-scanner",
+    transform(_, id) {
+      if (!id.endsWith("/src/styles.css")) return;
+      for (const file of sourceFiles) {
+        this.addWatchFile(file);
+      }
+    },
+  };
+}
 
 export default defineConfig({
-  plugins: [pracht({ adapter: nodeAdapter() })],
+  plugins: [contentScannerFixture(), pracht({ adapter: nodeAdapter() })],
 });

--- a/packages/vite-plugin/src/hot-update-reload.ts
+++ b/packages/vite-plugin/src/hot-update-reload.ts
@@ -16,8 +16,12 @@
  * modules, islands, prefresh component updates) already handles them.
  */
 
+interface ModuleNodeLike {
+  type?: "js" | "css" | "asset";
+}
+
 interface ModuleGraphLike {
-  getModulesByFile(file: string): Set<unknown> | undefined;
+  getModulesByFile(file: string): Set<ModuleNodeLike> | undefined;
 }
 
 interface EnvironmentLike {
@@ -30,8 +34,10 @@ export interface HotUpdateServerLike {
 }
 
 /**
- * True when `file` participates in server rendering but has no counterpart in
- * the client module graph, meaning client HMR can never deliver its change.
+ * True when `file` participates in server rendering but has no runtime
+ * counterpart in the client module graph, meaning client HMR can never deliver
+ * its change. File-only asset entries created by content scanners are watchers,
+ * not browser modules, so they do not make an update client-reachable.
  */
 export function isServerOnlyModuleFile(server: HotUpdateServerLike, file: string): boolean {
   const environments = server.environments;
@@ -39,11 +45,11 @@ export function isServerOnlyModuleFile(server: HotUpdateServerLike, file: string
   // Without the client environment there is no browser graph to compare
   // against — leave the update to Vite's own handling.
   if (!client) return false;
-  if (hasModules(client, file)) return false;
+  if (hasRuntimeModules(client, file)) return false;
 
   for (const [name, environment] of Object.entries(environments ?? {})) {
     if (name === "client" || !environment) continue;
-    if (hasModules(environment, file)) return true;
+    if (hasRuntimeModules(environment, file)) return true;
   }
   return false;
 }
@@ -55,6 +61,9 @@ export function sendServerOnlyFullReload(server: HotUpdateServerLike, file: stri
   return true;
 }
 
-function hasModules(environment: EnvironmentLike, file: string): boolean {
-  return (environment.moduleGraph.getModulesByFile(file)?.size ?? 0) > 0;
+function hasRuntimeModules(environment: EnvironmentLike, file: string): boolean {
+  for (const module of environment.moduleGraph.getModulesByFile(file) ?? []) {
+    if (module.type !== "asset") return true;
+  }
+  return false;
 }

--- a/packages/vite-plugin/test/hot-update-reload.test.ts
+++ b/packages/vite-plugin/test/hot-update-reload.test.ts
@@ -5,17 +5,35 @@ import {
   type HotUpdateServerLike,
 } from "../src/hot-update-reload.ts";
 
-function createServer(graphs: Record<string, string[]>): {
+interface GraphEntry {
+  file: string;
+  type?: "js" | "css" | "asset";
+}
+
+// Vite never resolves or transforms the file-only entries it creates for plugin
+// watch dependencies, so they carry an `/@fs/`-prefixed url and a null id. Real
+// modules always carry a resolved id. Mirror both shapes so the fixture matches
+// what the dev server actually hands `handleHotUpdate`.
+function createModuleNode(entry: string | GraphEntry) {
+  const { file, type = "js" } = typeof entry === "string" ? { file: entry } : entry;
+  return type === "asset"
+    ? { file, id: null, type, url: `/@fs/${file}` }
+    : { file, id: file, type, url: file };
+}
+
+function createServer(graphs: Record<string, Array<string | GraphEntry>>): {
   server: HotUpdateServerLike;
   send: ReturnType<typeof vi.fn>;
 } {
   const send = vi.fn();
   const environments: Record<string, unknown> = {};
-  for (const [name, files] of Object.entries(graphs)) {
+  for (const [name, entries] of Object.entries(graphs)) {
     environments[name] = {
       moduleGraph: {
-        getModulesByFile: (file: string) =>
-          files.includes(file) ? new Set([{ file }]) : undefined,
+        getModulesByFile: (file: string) => {
+          const modules = entries.map(createModuleNode).filter((module) => module.file === file);
+          return modules.length > 0 ? new Set(modules) : undefined;
+        },
       },
       ...(name === "client" ? { hot: { send } } : {}),
     };
@@ -36,8 +54,32 @@ describe("isServerOnlyModuleFile", () => {
     expect(isServerOnlyModuleFile(server, ROUTE)).toBe(false);
   });
 
+  it("ignores client file-only asset entries created by content scanners", () => {
+    const { server } = createServer({
+      client: [{ file: ROUTE, type: "asset" }],
+      ssr: [ROUTE, { file: ROUTE, type: "asset" }],
+    });
+    expect(isServerOnlyModuleFile(server, ROUTE)).toBe(true);
+  });
+
+  it("leaves real client CSS modules to client HMR", () => {
+    const { server } = createServer({
+      client: [{ file: ROUTE, type: "css" }],
+      ssr: [ROUTE],
+    });
+    expect(isServerOnlyModuleFile(server, ROUTE)).toBe(false);
+  });
+
   it("ignores files no environment has loaded", () => {
     const { server } = createServer({ client: [], ssr: [] });
+    expect(isServerOnlyModuleFile(server, ROUTE)).toBe(false);
+  });
+
+  it("ignores files represented only by file-only assets in every graph", () => {
+    const { server } = createServer({
+      client: [{ file: ROUTE, type: "asset" }],
+      ssr: [{ file: ROUTE, type: "asset" }],
+    });
     expect(isServerOnlyModuleFile(server, ROUTE)).toBe(false);
   });
 


### PR DESCRIPTION
## Summary

- Treat Vite file-only asset entries created by CSS content scanners as watch dependencies rather than client runtime modules.
- Restore full-page reloads when server-rendered files change on `hydration: "islands"` and `hydration: "none"` routes while preserving JavaScript and CSS HMR.
- Add unit and browser regression coverage, document the behavior, and include a patch changeset for `@pracht/vite-plugin`.
- Fixes #248.

## Testing

- [x] `pnpm e2e`
- [x] `pnpm format`
- [x] `pnpm lint`
- [x] `pnpm test`

Additionally reproduced the failure locally with Tailwind 4.3.3 against the 0.7.3 implementation, then verified both islands and none routes reload with this fix while island HMR preserves client state.

## Checklist

- [x] Docs updated if needed
- [x] Skills updated if needed — N/A, no skill changes required
- [x] Changeset added if published packages changed
