### PR TITLE
Add opt-in OpenAPI 3.1 companion package

### DIFF
--- a/.changeset/openapi-companion-prototype.md
+++ b/.changeset/openapi-companion-prototype.md
@@ -7,4 +7,6 @@
 Add an opt-in OpenAPI 3.1 companion plugin with live JSON and optional
 Scalar/Swagger UI endpoints, matching static build artifacts for every adapter,
 typed operation descriptors, Standard JSON Schema conversion, and configurable
-completeness warnings.
+completeness warnings. Generated endpoint paths are canonicalized and checked
+for static output collisions, and request-body requiredness matches runtime
+schema validation.

--- a/.changeset/openapi-companion-prototype.md
+++ b/.changeset/openapi-companion-prototype.md
@@ -1,0 +1,10 @@
+---
+"@pracht/openapi": minor
+"@pracht/cli": minor
+"@pracht/vite-plugin": minor
+---
+
+Add an opt-in OpenAPI 3.1 companion plugin with live JSON and optional
+Scalar/Swagger UI endpoints, matching static build artifacts for every adapter,
+typed operation descriptors, Standard JSON Schema conversion, and configurable
+completeness warnings.

--- a/.changeset/openapi-companion-prototype.md
+++ b/.changeset/openapi-companion-prototype.md
@@ -9,4 +9,6 @@ Scalar/Swagger UI endpoints, matching static build artifacts for every adapter,
 typed operation descriptors, Standard JSON Schema conversion, and configurable
 completeness warnings. Generated endpoint paths are canonicalized and checked
 for static output collisions, and request-body requiredness matches runtime
-schema validation.
+schema validation. Compatible CLI and Vite plugin versions are enforced through
+peer dependencies, catch-all parameter schemas retain their constraints, and
+bodyless HTTP methods no longer advertise unreachable request bodies.

--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ The skills are distributed three ways (see the [catalog](skills/README.md)):
 - [docs/PERFORMANCE.md](docs/PERFORMANCE.md) — bundle analysis and per-route client JS budgets
 - [docs/DATA_LOADING.md](docs/DATA_LOADING.md) — loaders, forms, client hooks
 - [docs/API_VALIDATION.md](docs/API_VALIDATION.md) — Standard Schema validation for API routes, typed `apiFetch()`
+- [docs/OPENAPI.md](docs/OPENAPI.md) — optional OpenAPI 3.1 JSON/UI endpoints and build output
 - [docs/CAPABILITIES.md](docs/CAPABILITIES.md) — typed capabilities, HTTP projection, WebMCP page tools
 - [docs/REMOTE_MCP.md](docs/REMOTE_MCP.md) — serving capabilities as MCP tools over Streamable HTTP
 - [docs/AGENT_TRUST.md](docs/AGENT_TRUST.md) — Web Bot Auth, effect-class confirmation flow, audit hook, `pracht eval`

--- a/VISION_MVP.md
+++ b/VISION_MVP.md
@@ -119,6 +119,12 @@ Standalone server endpoints independent of the page rendering pipeline:
   `apiFetch()` client checks paths, methods, bodies, queries, and params at
   compile time and returns typed responses. See
   [docs/API_VALIDATION.md](docs/API_VALIDATION.md).
+- Optional OpenAPI 3.1 generation lives in the companion `@pracht/openapi`
+  package. Its sibling Vite plugin serves live JSON and optional Scalar/Swagger
+  UI endpoints in development and emits matching static build assets. Existing
+  `defineApi()` request schemas are inspected best-effort; complete
+  response/status documentation uses an explicit `defineOpenApi()` descriptor.
+  See [docs/OPENAPI.md](docs/OPENAPI.md).
 
 ### Capabilities (agent-ready operations)
 

--- a/docs/API_VALIDATION.md
+++ b/docs/API_VALIDATION.md
@@ -126,6 +126,16 @@ response from your own handlers or middleware.
 Plain handlers (`export function GET(args)`) keep working unchanged —
 `defineApi` is opt-in per export, and both styles can mix in one module.
 
+### Optional OpenAPI metadata
+
+OpenAPI documentation is deliberately separate from validation. Apps that
+need an OpenAPI 3.1 document can wrap a `defineApi()` handler with
+`defineOpenApi()` from the optional `@pracht/openapi` package. The wrapper
+preserves the handler and its `apiFetch()` inference while attaching explicit
+operation and response metadata. Its sibling Vite plugin can serve the
+generated document at `/openapi.json`, mount an optional Scalar or Swagger UI,
+and emit both as static production assets. See [OPENAPI.md](OPENAPI.md).
+
 ---
 
 ## Registered API Types with `pracht typegen`

--- a/docs/OPENAPI.md
+++ b/docs/OPENAPI.md
@@ -1,0 +1,247 @@
+# OpenAPI
+
+`@pracht/openapi` is an opt-in companion package for generating and serving an
+OpenAPI 3.1 document from Pracht API routes. Ordinary `defineApi()` routes keep
+their existing authoring, runtime behavior, and client inference.
+
+## Install and enable
+
+Add the companion plugin after `pracht()` so it can inspect the generated
+server graph:
+
+```ts
+// vite.config.ts
+import { defineConfig } from "vite";
+import { prachtOpenApi } from "@pracht/openapi/vite";
+import { pracht } from "@pracht/vite-plugin";
+
+export default defineConfig({
+  plugins: [
+    pracht(),
+    prachtOpenApi({
+      info: {
+        title: "Acme API",
+        version: "1.0.0",
+        description: "Public HTTP API for Acme.",
+      },
+      ui: "scalar",
+    }),
+  ],
+});
+```
+
+This reserves two paths while enabled:
+
+- `/openapi.json` — the OpenAPI 3.1 document;
+- `/docs` — the optional reference UI (`ui: false` is the default).
+
+Both paths are live in the normal Vite development server. `pracht build`
+writes the equivalent static files to `dist/client/openapi.json` and, when the
+UI is enabled, `dist/client/docs/index.html`. Node, Cloudflare, and Vercel then
+serve them through their existing static-asset paths.
+
+Paths are configurable:
+
+```ts
+prachtOpenApi({
+  info: { title: "Acme API", version: "1.0.0" },
+  documentPath: "/api/openapi.json",
+  ui: {
+    provider: "swagger",
+    path: "/api/reference",
+    title: "Acme API reference",
+  },
+});
+```
+
+The endpoints accept `GET` and `HEAD`. Other methods receive `405` in
+development. Development responses use `Cache-Control: no-store`; production
+cache policy belongs to the deployment's static-asset configuration. The
+document path must end in `.json` so every adapter's static host assigns the
+correct media type.
+
+Generated paths are reserved while the plugin is enabled. Development logs a
+warning when a Pracht route or `public/` file collides; production generation
+replaces a colliding public/build file and reports that replacement.
+
+## Document responses and operations
+
+Pracht can recover paths, methods, path parameters, and convertible request
+validators from existing routes. Response status codes and payloads cannot be
+inferred from arbitrary `Response` objects or erased TypeScript types. Attach
+that OpenAPI-only metadata with `defineOpenApi()`:
+
+```ts
+import { defineApi, json } from "@pracht/core";
+import { defineOpenApi } from "@pracht/openapi";
+
+export const POST = defineOpenApi(
+  defineApi({
+    body: createItemSchema,
+    handler: ({ body }) => json({ id: createItem(body) }, { status: 201 }),
+  }),
+  {
+    operationId: "createItem",
+    summary: "Create an item",
+    tags: ["items"],
+    responses: {
+      201: { description: "Item created", body: itemSchema },
+    },
+  },
+);
+```
+
+The wrapper mutates and returns the same handler. Pracht remains responsible
+for validation, dispatch, and `apiFetch()` type inference; the companion
+package owns only its descriptor.
+
+For each named method, generation:
+
+1. Converts Pracht `:param` paths to OpenAPI `{param}` paths.
+2. Reads path, query, and body validators from `defineApi()`.
+3. Uses Standard JSON Schema's input projection for wire request schemas.
+4. Adds framework-known 400 and 422 validation responses.
+5. Uses explicit response descriptors and their output schemas when present.
+6. Emits a valid undocumented `default` response and a scoped warning when
+   the response contract is unknown.
+
+Route module and schema conversion failures are warnings, so one unsupported
+handler does not erase the rest of the document. Set `failOnWarnings: true` to
+turn any warning into a failed development request and failed `pracht build`:
+
+```ts
+prachtOpenApi({
+  info: { title: "Acme API", version: "1.0.0" },
+  failOnWarnings: true,
+});
+```
+
+This is useful as a CI completeness gate once every public operation has an
+explicit response contract.
+
+### Servers, tags, and authentication
+
+Use `document` for OpenAPI metadata shared by the whole API. Security scheme
+names referenced by a `defineOpenApi({ security })` operation must exist in
+`document.components.securitySchemes`:
+
+```ts
+prachtOpenApi({
+  info: { title: "Acme API", version: "1.0.0" },
+  document: {
+    servers: [
+      { url: "https://api.example.com", description: "Production" },
+      { url: "http://localhost:3000", description: "Local development" },
+    ],
+    tags: [{ name: "items", description: "Item lifecycle" }],
+    components: {
+      securitySchemes: {
+        bearerAuth: {
+          type: "http",
+          scheme: "bearer",
+          bearerFormat: "JWT",
+        },
+      },
+    },
+    security: [{ bearerAuth: [] }],
+  },
+});
+```
+
+`document.security` applies globally. Set `security: []` on a documented
+operation to mark that operation public, or provide a different requirement.
+
+## UI guidance
+
+The JSON document is the stable integration point. The reference page is a
+small optional HTML shell, so switching UI providers does not affect API
+generation or route authoring.
+
+### Scalar
+
+Use `ui: "scalar"` for a modern reference with request examples and an API
+client.
+
+### Swagger UI
+
+Use `ui: "swagger"` for the widely supported Swagger UI renderer. Pracht
+enables deep links and disables Swagger's remote validator by default, so
+viewing an internal document does not send it to `validator.swagger.io`.
+
+### CDN, CSP, and self-hosting
+
+The built-in shells load pinned browser assets from jsDelivr:
+
+- Scalar `@scalar/api-reference@1.64.0`;
+- Swagger UI `swagger-ui-dist@5.32.12`.
+
+This keeps the companion package small, but production applications with
+offline requirements or a no-third-party-CDN policy should self-host those
+files and override their URLs:
+
+```ts
+prachtOpenApi({
+  info: { title: "Acme API", version: "1.0.0" },
+  ui: {
+    provider: "swagger",
+    scriptUrl: "/vendor/swagger-ui-bundle.js",
+    styleUrl: "/vendor/swagger-ui.css",
+  },
+});
+```
+
+`scriptUrl` is supported for both providers; `styleUrl` is Swagger-only. Copy
+the pinned distribution files into `public/vendor/` or provide your own HTML
+route if you need deeper UI customization.
+
+The generated shell also contains a small inline initialization script. A
+strict CSP must allow that exact script by hash (and the selected asset origin),
+or replace the shell with an app-owned page whose bootstrap follows the app's
+nonce policy. Self-hosting the provider bundle alone does not make the page
+compatible with a `script-src` policy that rejects every inline script.
+
+### Security and deployment
+
+- Treat the document and UI as public unless your hosting layer protects the
+  emitted static files. Do not put secrets, internal hostnames, or credentials
+  in descriptions or examples.
+- Keep the UI and JSON on the same origin. A cross-origin document needs CORS
+  headers, and browser restrictions still prevent tools from setting certain
+  headers such as `Cookie` directly.
+- “Try it out” sends real requests. Protect mutation endpoints with the same
+  authentication, authorization, CSRF, rate-limit, and confirmation policies
+  as every other client.
+- Never embed an OAuth client secret in UI configuration. Browser-delivered
+  configuration is observable by every visitor.
+- Set appropriate static caching for `/openapi.json`. Immutable asset caching
+  is usually wrong unless the URL is versioned or deployments purge it.
+
+## Programmatic generation
+
+`generateOpenApiDocument()` remains available for custom generators and tests.
+It accepts live resolved routes (methods are discovered from loaded modules) or
+serialized `AppGraphApiRoute` entries:
+
+```ts
+const { document, warnings } = await generateOpenApiDocument({
+  info: { title: "My API", version: "1.0.0" },
+  routes: apiRoutes,
+  loadModule: (file) => viteServer.ssrLoadModule(file),
+});
+```
+
+Raw JSON Schema response bodies work directly. Standard JSON Schema
+implementations use their output projection. Pass `resolveSchema` for
+libraries that require a separate converter.
+
+## Current boundaries
+
+- Default-export handlers are not expanded because their supported methods
+  cannot be inferred honestly.
+- Catch-all Pracht paths become a single `{path}` parameter and emit a warning
+  about slash encoding.
+- Request bodies default to `application/json`; other content types need
+  explicit request metadata in a future descriptor revision.
+- Capability HTTP projections are not included yet.
+- OpenAPI drift checking is expressed through deterministic build output and
+  `failOnWarnings`; a dedicated CLI diff/check command is not included yet.

--- a/docs/OPENAPI.md
+++ b/docs/OPENAPI.md
@@ -100,9 +100,11 @@ For each named method, generation:
 1. Converts Pracht `:param` paths to OpenAPI `{param}` paths.
 2. Reads path, query, and body validators from `defineApi()`.
 3. Uses Standard JSON Schema's input projection for wire request schemas.
-4. Adds framework-known 400 and 422 validation responses.
-5. Uses explicit response descriptors and their output schemas when present.
-6. Emits a valid undocumented `default` response and a scoped warning when
+4. Marks a request body optional when its validator accepts the same
+   `undefined` value that `defineApi()` passes for an empty body.
+5. Adds framework-known 400 and 422 validation responses.
+6. Uses explicit response descriptors and their output schemas when present.
+7. Emits a valid undocumented `default` response and a scoped warning when
    the response contract is unknown.
 
 Route module and schema conversion failures are warnings, so one unsupported

--- a/docs/WORKSPACE.md
+++ b/docs/WORKSPACE.md
@@ -8,6 +8,7 @@ described in `VISION_MVP.md`.
 | Path                          | Package                      | Current role                                                                                                 |
 | ----------------------------- | ---------------------------- | ------------------------------------------------------------------------------------------------------------ |
 | `packages/framework`          | `@pracht/core`               | Core manifest API, route resolution, API routes, SSR rendering, client runtime                               |
+| `packages/openapi`            | `@pracht/openapi`            | Opt-in OpenAPI 3.1 descriptors, live JSON/UI endpoints, and static build artifacts for API routes            |
 | `packages/vite-plugin`        | `@pracht/vite-plugin`        | Virtual modules, `import.meta.glob()` registries, API route auto-discovery, HMR, dev SSR middleware          |
 | `packages/preact-ssr-precompile` | `@pracht/preact-ssr-precompile` | Experimental Rolldown/Vite plugin that precompiles safe Preact JSX DOM subtrees into server-only `jsxTemplate()` calls |
 | `packages/adapter-node`       | `@pracht/adapter-node`       | Node `IncomingMessage`/`ServerResponse` bridge, ISG stale-while-revalidate, and webhook revalidation         |
@@ -62,6 +63,10 @@ described in `VISION_MVP.md`.
   `configureServer` hook adds SSR middleware to the Vite dev server. The
   `handleHotUpdate` hook invalidates virtual modules when route/shell/middleware/API files change and
   triggers full reload when the app manifest (`src/routes.ts`) changes.
+- **OpenAPI companion** — `prachtOpenApi()` augments the generated server graph
+  without changing core API authoring. It serves a live OpenAPI JSON document
+  and optional Scalar/Swagger page in development; `pracht build` writes the
+  same artifacts under `dist/client/` for every adapter.
 - **Client hydration** — The generated client module matches the current route,
   lazy-loads the route and shell modules via `import.meta.glob()`, and calls
   `hydrate()` from Preact.
@@ -79,7 +84,7 @@ described in `VISION_MVP.md`.
   from the resolved route graph for typed links and href helpers,
   `pracht generate route|shell|middleware|api` scaffolds framework-native
   files, and `pracht doctor` validates app wiring across the whole project.
-- **Package builds** — `tsdown` compiles `pracht`, `@pracht/vite-plugin`,
+- **Package builds** — `tsdown` compiles `pracht`, `@pracht/openapi`, `@pracht/vite-plugin`,
   `@pracht/preact-ssr-precompile`, `@pracht/adapter-node`,
   `@pracht/adapter-cloudflare`, `@pracht/adapter-vercel`, and `@pracht/image`
   from TypeScript to

--- a/e2e/cloudflare-build.test.ts
+++ b/e2e/cloudflare-build.test.ts
@@ -133,6 +133,19 @@ test("pracht build emits a deployable Cloudflare Worker setup", async () => {
     expect(llmsTxt.startsWith("# Pracht Cloudflare Example\n")).toBe(true);
     expect(llmsTxt).toContain("- [/pricing](/pricing)");
     expect(llmsTxt).not.toContain("/products/:id");
+
+    // OpenAPI JSON and its optional UI are regular static assets, so workerd
+    // serves them through the same ASSETS binding without runtime-only code.
+    const openApiPath = resolve(distDir, "client/openapi.json");
+    const openApiUiPath = resolve(distDir, "client/docs/index.html");
+    expect(existsSync(openApiPath)).toBe(true);
+    expect(existsSync(openApiUiPath)).toBe(true);
+    const openApi = JSON.parse(readFileSync(openApiPath, "utf-8"));
+    expect(openApi).toMatchObject({
+      openapi: "3.1.0",
+      info: { title: "Pracht Cloudflare Example API", version: "1.0.0" },
+    });
+    expect(readFileSync(openApiUiPath, "utf-8")).toContain('{"url":"/openapi.json"}');
   } finally {
     rmSync(tempDir, { force: true, recursive: true });
   }

--- a/e2e/node-build.test.ts
+++ b/e2e/node-build.test.ts
@@ -137,6 +137,26 @@ test("pracht build emits a deployable Node server entry", async () => {
     expect(llmsTxtResponse.headers.get("content-type")).toContain("text/plain");
     expect(await llmsTxtResponse.text()).toBe(llmsTxt);
 
+    const openApiPath = resolve(exampleDir, "dist/client/openapi.json");
+    const openApiUiPath = resolve(exampleDir, "dist/client/docs/index.html");
+    expect(existsSync(openApiPath)).toBe(true);
+    expect(existsSync(openApiUiPath)).toBe(true);
+    const openApi = JSON.parse(readFileSync(openApiPath, "utf-8"));
+    expect(openApi).toMatchObject({
+      openapi: "3.1.0",
+      info: { title: "Pracht Example API", version: "1.0.0" },
+    });
+    expect(openApi.paths["/api/health"].get).toBeDefined();
+    expect(readFileSync(openApiUiPath, "utf-8")).toContain('{"url":"/openapi.json"}');
+
+    const openApiResponse = await fetch(`http://127.0.0.1:${port}/openapi.json`);
+    expect(openApiResponse.status).toBe(200);
+    await expect(openApiResponse.json()).resolves.toEqual(openApi);
+
+    const openApiUiResponse = await fetch(`http://127.0.0.1:${port}/docs`);
+    expect(openApiUiResponse.status).toBe(200);
+    expect(await openApiUiResponse.text()).toContain("Scalar.createApiReference");
+
     const apiResponse = await fetch(`http://127.0.0.1:${port}/api/health`);
     expect(apiResponse.status).toBe(200);
     await expect(apiResponse.json()).resolves.toEqual({ status: "ok" });

--- a/e2e/openapi-cloudflare-dev.test.ts
+++ b/e2e/openapi-cloudflare-dev.test.ts
@@ -1,0 +1,23 @@
+import { expect, test } from "@playwright/test";
+
+test("Cloudflare dev serves OpenAPI without evaluating worker modules in Node", async ({
+  request,
+}) => {
+  const response = await request.get("/openapi.json");
+  expect(response.status()).toBe(200);
+  expect(response.headers()["content-type"]).toContain("application/json");
+
+  const document = await response.json();
+  expect(document).toMatchObject({
+    openapi: "3.1.0",
+    info: { title: "Pracht Cloudflare Example API", version: "1.0.0" },
+  });
+  expect(document.paths["/api/health"].get).toBeDefined();
+});
+
+test("Cloudflare dev serves the configured OpenAPI UI", async ({ request }) => {
+  const response = await request.get("/docs");
+  expect(response.status()).toBe(200);
+  expect(response.headers()["content-type"]).toContain("text/html");
+  expect(await response.text()).toContain('{"url":"/openapi.json"}');
+});

--- a/e2e/openapi-dev.test.ts
+++ b/e2e/openapi-dev.test.ts
@@ -1,0 +1,44 @@
+import { expect, test } from "@playwright/test";
+
+test("OpenAPI JSON is generated from the live API graph", async ({ request }) => {
+  const response = await request.get("/openapi.json");
+  expect(response.status()).toBe(200);
+  expect(response.headers()["content-type"]).toContain("application/json");
+  expect(response.headers()["cache-control"]).toBe("no-store");
+
+  const document = await response.json();
+  expect(document).toMatchObject({
+    openapi: "3.1.0",
+    info: { title: "Pracht Pages Example API", version: "1.0.0" },
+    paths: {
+      "/api/health": {
+        get: {
+          responses: {
+            default: { description: "Response contract is not documented." },
+          },
+        },
+      },
+    },
+  });
+});
+
+test("OpenAPI reference UI points at the generated JSON", async ({ request }) => {
+  const response = await request.get("/docs");
+  expect(response.status()).toBe(200);
+  expect(response.headers()["content-type"]).toContain("text/html");
+
+  const html = await response.text();
+  expect(html).toContain("Scalar.createApiReference");
+  expect(html).toContain('{"url":"/openapi.json"}');
+  expect(html).toContain("@scalar/api-reference@1.64.0");
+});
+
+test("OpenAPI endpoints allow only safe read methods", async ({ request }) => {
+  const head = await request.head("/openapi.json");
+  expect(head.status()).toBe(200);
+  expect(await head.body()).toEqual(Buffer.from([]));
+
+  const post = await request.post("/openapi.json");
+  expect(post.status()).toBe(405);
+  expect(post.headers().allow).toBe("GET, HEAD");
+});

--- a/e2e/vercel-build.test.ts
+++ b/e2e/vercel-build.test.ts
@@ -74,6 +74,17 @@ test("pracht build emits a deployable Vercel Build Output setup", async () => {
     expect(existsSync(staticLlmsTxtPath)).toBe(true);
     expect(readFileSync(staticLlmsTxtPath, "utf-8")).toContain("# Pracht Example");
 
+    const staticOpenApiPath = resolve(vercelDir, "static/openapi.json");
+    const staticOpenApiUiPath = resolve(vercelDir, "static/docs/index.html");
+    expect(existsSync(staticOpenApiPath)).toBe(true);
+    expect(existsSync(staticOpenApiUiPath)).toBe(true);
+    const openApi = JSON.parse(readFileSync(staticOpenApiPath, "utf-8"));
+    expect(openApi).toMatchObject({
+      openapi: "3.1.0",
+      info: { title: "Pracht Example API", version: "1.0.0" },
+    });
+    expect(readFileSync(staticOpenApiUiPath, "utf-8")).toContain('{"url":"/openapi.json"}');
+
     const config = JSON.parse(readFileSync(configPath, "utf-8"));
     expect(config.version).toBe(3);
     expect(config.routes).toEqual(
@@ -89,6 +100,7 @@ test("pracht build emits a deployable Vercel Build Output setup", async () => {
           dest: "/render",
         }),
         expect.objectContaining({ src: "^/$", dest: "/index.html" }),
+        expect.objectContaining({ src: "^/docs/?$", dest: "/docs/index.html" }),
         expect.objectContaining({ src: "^/pricing/?$", dest: "/pricing" }),
         expect.objectContaining({ handle: "filesystem" }),
         expect.objectContaining({ src: "/(.*)", dest: "/render" }),

--- a/examples/basic/package.json
+++ b/examples/basic/package.json
@@ -21,6 +21,7 @@
     "@pracht/capabilities": "workspace:*",
     "@pracht/core": "workspace:*",
     "@pracht/image": "workspace:*",
+    "@pracht/openapi": "workspace:*",
     "sharp": "^0.34.0"
   },
   "devDependencies": {

--- a/examples/basic/vite.config.ts
+++ b/examples/basic/vite.config.ts
@@ -1,4 +1,5 @@
 import { defineConfig } from "vite";
+import { prachtOpenApi } from "@pracht/openapi/vite";
 import { pracht } from "@pracht/vite-plugin";
 
 type DeployTarget = "cloudflare" | "node" | "vercel";
@@ -39,6 +40,14 @@ export default defineConfig(async () => {
           title: "Pracht Example",
           description: "Example app for the pracht framework.",
         },
+      }),
+      prachtOpenApi({
+        info: {
+          title: "Pracht Example API",
+          version: "1.0.0",
+          description: "HTTP endpoints exposed by the basic Pracht example.",
+        },
+        ui: "scalar",
       }),
     ],
   };

--- a/examples/cloudflare/package.json
+++ b/examples/cloudflare/package.json
@@ -8,7 +8,8 @@
   },
   "dependencies": {
     "@pracht/adapter-cloudflare": "workspace:*",
-    "@pracht/core": "workspace:*"
+    "@pracht/core": "workspace:*",
+    "@pracht/openapi": "workspace:*"
   },
   "devDependencies": {
     "@pracht/cli": "workspace:*",

--- a/examples/cloudflare/vite.config.ts
+++ b/examples/cloudflare/vite.config.ts
@@ -1,6 +1,7 @@
 import { defineConfig } from "vite";
 import { pracht } from "@pracht/vite-plugin";
 import { cloudflareAdapter } from "@pracht/adapter-cloudflare";
+import { prachtOpenApi } from "@pracht/openapi/vite";
 
 const e2eInspectorPort = process.env.PRACHT_E2E_INSPECTOR_PORT;
 
@@ -16,6 +17,10 @@ export default defineConfig({
         persistState: e2eInspectorPort ? false : undefined,
       }),
       llmsTxt: { title: "Pracht Cloudflare Example" },
+    }),
+    prachtOpenApi({
+      info: { title: "Pracht Cloudflare Example API", version: "1.0.0" },
+      ui: "scalar",
     }),
   ],
 });

--- a/examples/docs/src/routes.ts
+++ b/examples/docs/src/routes.ts
@@ -48,6 +48,10 @@ export const app = defineApp({
         id: "api-validation",
         render: "ssg",
       }),
+      route("/docs/openapi", () => import("./routes/docs/openapi.md"), {
+        id: "openapi",
+        render: "ssg",
+      }),
       route("/docs/middleware", () => import("./routes/docs/middleware.md"), {
         id: "middleware",
         render: "ssg",

--- a/examples/docs/src/routes/docs/api-validation.md
+++ b/examples/docs/src/routes/docs/api-validation.md
@@ -6,8 +6,8 @@ prev:
   href: /docs/api-routes
   title: API Routes
 next:
-  href: /docs/middleware
-  title: Middleware
+  href: /docs/openapi
+  title: OpenAPI
 ---
 
 ## Define a validated handler

--- a/examples/docs/src/routes/docs/middleware.md
+++ b/examples/docs/src/routes/docs/middleware.md
@@ -3,8 +3,8 @@ title: Middleware
 lead: Server-side request interceptors that run before loaders and API routes. Use them for authentication, redirects, request validation, and context enrichment.
 breadcrumb: Middleware
 prev:
-  href: /docs/api-validation
-  title: API Validation
+  href: /docs/openapi
+  title: OpenAPI
 next:
   href: /docs/shells
   title: Shells

--- a/examples/docs/src/routes/docs/openapi.md
+++ b/examples/docs/src/routes/docs/openapi.md
@@ -82,8 +82,10 @@ export const POST = defineOpenApi(
 );
 ```
 
-Standard JSON Schema request validators use their input projection. Response schemas use their
-output projection. Raw JSON Schema objects also work for response bodies.
+Standard JSON Schema request validators use their input projection. Request bodies are marked
+optional when their validator accepts the `undefined` value that `defineApi()` receives for an empty
+body. Response schemas use their output projection. Raw JSON Schema objects also work for response
+bodies.
 
 Pracht adds its known `400` body-parsing and `422` validation responses. A handler without an
 explicit response descriptor receives a valid undocumented `default` response and a scoped warning,

--- a/examples/docs/src/routes/docs/openapi.md
+++ b/examples/docs/src/routes/docs/openapi.md
@@ -1,0 +1,151 @@
+---
+title: OpenAPI
+lead: Generate an OpenAPI 3.1 document and optional Scalar or Swagger UI from Pracht API routes without changing ordinary route authoring.
+breadcrumb: OpenAPI
+prev:
+  href: /docs/api-validation
+  title: API Validation
+next:
+  href: /docs/middleware
+  title: Middleware
+---
+
+## Install the companion package
+
+OpenAPI support is opt-in through `@pracht/openapi`. Add its Vite plugin after `pracht()` so it can
+inspect Pracht's generated API graph:
+
+```ts [vite.config.ts]
+import { defineConfig } from "vite";
+import { prachtOpenApi } from "@pracht/openapi/vite";
+import { pracht } from "@pracht/vite-plugin";
+
+export default defineConfig({
+  plugins: [
+    pracht(),
+    prachtOpenApi({
+      info: {
+        title: "Acme API",
+        version: "1.0.0",
+        description: "Public HTTP API for Acme.",
+      },
+      ui: "scalar",
+    }),
+  ],
+});
+```
+
+The plugin serves `/openapi.json` during development. Enabling `ui: "scalar"` or `ui: "swagger"`
+also serves `/docs`. Both paths accept `GET` and `HEAD`; other methods receive `405`.
+
+During `pracht build`, the same resources become static files at
+`dist/client/openapi.json` and `dist/client/docs/index.html`. Node and Cloudflare serve them through
+their normal static-asset paths, while Vercel also receives an explicit route for the directory-index
+UI page.
+
+Use custom paths when these defaults overlap with app routes:
+
+```ts
+prachtOpenApi({
+  info: { title: "Acme API", version: "1.0.0" },
+  documentPath: "/api/openapi.json",
+  ui: { provider: "swagger", path: "/api/reference" },
+});
+```
+
+## Document response contracts
+
+Pracht can discover API paths, named HTTP methods, path parameters, and convertible `defineApi()`
+request schemas. Arbitrary `Response` objects and erased TypeScript types do not expose enough
+information to infer response statuses and payloads honestly.
+
+Wrap a validated handler with `defineOpenApi()` to attach that documentation without changing its
+runtime behavior or `apiFetch()` inference:
+
+```ts [src/api/items.ts]
+import { defineApi, json } from "@pracht/core";
+import { defineOpenApi } from "@pracht/openapi";
+
+export const POST = defineOpenApi(
+  defineApi({
+    body: createItemSchema,
+    handler: ({ body }) => json({ id: createItem(body) }, { status: 201 }),
+  }),
+  {
+    operationId: "createItem",
+    summary: "Create an item",
+    tags: ["items"],
+    responses: {
+      201: { description: "Item created", body: itemSchema },
+    },
+  },
+);
+```
+
+Standard JSON Schema request validators use their input projection. Response schemas use their
+output projection. Raw JSON Schema objects also work for response bodies.
+
+Pracht adds its known `400` body-parsing and `422` validation responses. A handler without an
+explicit response descriptor receives a valid undocumented `default` response and a scoped warning,
+so one incomplete route does not erase the rest of the document.
+
+Set `failOnWarnings: true` when documentation completeness should fail development requests and
+production builds:
+
+```ts
+prachtOpenApi({
+  info: { title: "Acme API", version: "1.0.0" },
+  failOnWarnings: true,
+});
+```
+
+## Add servers and authentication
+
+Use `document` for metadata shared across operations:
+
+```ts
+prachtOpenApi({
+  info: { title: "Acme API", version: "1.0.0" },
+  document: {
+    servers: [{ url: "https://api.example.com", description: "Production" }],
+    components: {
+      securitySchemes: {
+        bearerAuth: { type: "http", scheme: "bearer", bearerFormat: "JWT" },
+      },
+    },
+    security: [{ bearerAuth: [] }],
+  },
+});
+```
+
+Global security applies to every operation. Set `security: []` in a `defineOpenApi()` descriptor to
+mark one operation public, or provide another named security requirement.
+
+## Choose and deploy a reference UI
+
+The generated JSON document is the stable integration point. The optional UI is a small static HTML
+shell backed by that endpoint:
+
+- `ui: "scalar"` loads the pinned Scalar browser bundle.
+- `ui: "swagger"` loads pinned Swagger UI assets, enables deep links, and disables Swagger's remote
+  validator.
+- An options object can override `scriptUrl` for either provider and `styleUrl` for Swagger, allowing
+  the assets to be self-hosted from `public/`.
+
+The default bundles come from jsDelivr, and the shell contains a small inline initialization script.
+Strict Content Security Policy deployments must allow the selected asset origin and the inline
+script by hash, or use an app-owned UI page with the required nonce policy.
+
+Treat emitted OpenAPI files as public unless the hosting layer protects them. Avoid secrets and
+internal credentials in descriptions or examples, and remember that “Try it out” sends real requests
+to API handlers with their normal authentication, authorization, CSRF, rate-limit, and confirmation
+requirements.
+
+## Current boundaries
+
+- Default-export API handlers are omitted because their supported methods cannot be inferred.
+- Catch-all paths become a single `{path}` parameter and warn about slash encoding.
+- Request bodies currently default to `application/json`.
+- Capability HTTP projections are not included yet.
+- Drift enforcement uses deterministic build output and `failOnWarnings`; there is no dedicated diff
+  command yet.

--- a/examples/docs/src/shells/docs.tsx
+++ b/examples/docs/src/shells/docs.tsx
@@ -49,6 +49,7 @@ const NAV = [
       { href: "/docs/data-loading", Icon: IconServerBolt, title: "Data Loading" },
       { href: "/docs/api-routes", Icon: IconPlug, title: "API Routes" },
       { href: "/docs/api-validation", Icon: IconTestPipe, title: "API Validation" },
+      { href: "/docs/openapi", Icon: IconSitemap, title: "OpenAPI" },
       { href: "/docs/middleware", Icon: IconShield, title: "Middleware" },
       { href: "/docs/shells", Icon: IconLayout, title: "Shells" },
       { href: "/docs/styling", Icon: IconPalette, title: "Styling" },

--- a/examples/pages-router/package.json
+++ b/examples/pages-router/package.json
@@ -7,7 +7,8 @@
     "@pracht/adapter-cloudflare": "workspace:*",
     "@pracht/adapter-node": "workspace:*",
     "@pracht/adapter-vercel": "workspace:*",
-    "@pracht/core": "workspace:*"
+    "@pracht/core": "workspace:*",
+    "@pracht/openapi": "workspace:*"
   },
   "devDependencies": {
     "@pracht/cli": "workspace:*",

--- a/examples/pages-router/vite.config.ts
+++ b/examples/pages-router/vite.config.ts
@@ -1,4 +1,5 @@
 import { defineConfig } from "vite";
+import { prachtOpenApi } from "@pracht/openapi/vite";
 import { pracht } from "@pracht/vite-plugin";
 
 type DeployTarget = "cloudflare" | "node" | "vercel";
@@ -24,6 +25,10 @@ export default defineConfig(async () => {
         pagesDir: "/src/pages",
         adapter: await resolveAdapter(target),
         llmsTxt: { title: "Pracht Pages Example" },
+      }),
+      prachtOpenApi({
+        info: { title: "Pracht Pages Example API", version: "1.0.0" },
+        ui: "scalar",
       }),
     ],
   };

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "type": "module",
   "scripts": {
-    "build": "pnpm -r --filter @pracht/core --filter @pracht/capabilities --filter @pracht/vite-plugin --filter @pracht/preact-ssr-precompile --filter @pracht/adapter-node --filter @pracht/adapter-cloudflare --filter @pracht/adapter-vercel --filter @pracht/image --filter @pracht/cli --filter create-pracht run build",
+    "build": "pnpm -r --filter @pracht/core --filter @pracht/capabilities --filter @pracht/openapi --filter @pracht/vite-plugin --filter @pracht/preact-ssr-precompile --filter @pracht/adapter-node --filter @pracht/adapter-cloudflare --filter @pracht/adapter-vercel --filter @pracht/image --filter @pracht/cli --filter create-pracht run build",
     "check": "pnpm build && pnpm typecheck && pnpm test",
     "verify": "node ./scripts/verify.mjs",
     "typecheck": "tsc --noEmit && tsc --noEmit -p packages/cli/test/fixtures/cloudflare-runtime-import && tsc --noEmit -p examples/showcase",

--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -219,6 +219,57 @@ export async function runBuild(root: string, options: BuildOptions = {}): Promis
       log("\n  llms.txt → dist/client/llms.txt\n");
     }
 
+    const generatedStaticRoutes: string[] = [];
+
+    // Companion artifact generators can inspect the bundled server graph and
+    // return static files without coupling their authoring API to core. The
+    // OpenAPI plugin uses this for /openapi.json and its optional docs page.
+    if (typeof serverMod.generatePrachtOpenApiArtifacts === "function") {
+      const generated = await serverMod.generatePrachtOpenApiArtifacts();
+      const artifacts = Array.isArray(generated?.artifacts) ? generated.artifacts : [];
+      const seenOutputPaths = new Set<string>();
+      for (const artifact of artifacts) {
+        if (
+          !artifact ||
+          typeof artifact.outputPath !== "string" ||
+          typeof artifact.content !== "string"
+        ) {
+          throw new Error("OpenAPI generator returned an invalid build artifact.");
+        }
+        const filePath = resolveGeneratedArtifactOutputPath(clientDir, artifact.outputPath);
+        if (seenOutputPaths.has(filePath)) {
+          throw new Error(
+            `OpenAPI generator returned duplicate output path ${JSON.stringify(artifact.outputPath)}.`,
+          );
+        }
+        seenOutputPaths.add(filePath);
+        if (
+          typeof artifact.path === "string" &&
+          artifact.path.startsWith("/") &&
+          artifact.outputPath ===
+            (artifact.path === "/" ? "index.html" : `${artifact.path.slice(1)}/index.html`)
+        ) {
+          generatedStaticRoutes.push(artifact.path);
+        }
+        if (existsSync(filePath)) {
+          log(
+            `\n  Warning: OpenAPI artifact ${artifact.outputPath} replaces an existing public/build file.\n`,
+          );
+        }
+        mkdirSync(dirname(filePath), { recursive: true });
+        writeFileSync(filePath, artifact.content, "utf-8");
+        log(`\n  OpenAPI → dist/client/${artifact.outputPath}\n`);
+      }
+
+      const warnings = Array.isArray(generated?.warnings) ? generated.warnings : [];
+      for (const warning of warnings) {
+        const method = typeof warning?.method === "string" ? `${warning.method} ` : "";
+        const path = typeof warning?.path === "string" ? warning.path : "unknown route";
+        const message = typeof warning?.message === "string" ? warning.message : String(warning);
+        log(`  OpenAPI warning: ${method}${path}: ${message}\n`);
+      }
+    }
+
     if (Object.keys(headersManifest).length > 0) {
       const headersManifestJson = `${JSON.stringify(headersManifest, null, 2)}\n`;
       writeFileSync(
@@ -307,9 +358,12 @@ export async function runBuild(root: string, options: BuildOptions = {}): Promis
         markdownRoutes: Object.keys(markdownManifest),
         regions: serverMod.vercelRegions,
         root,
-        staticRoutes: pages
-          .map((page: { path: string }) => page.path)
-          .filter((path: string) => !(path in isgManifest)),
+        staticRoutes: [
+          ...pages
+            .map((page: { path: string }) => page.path)
+            .filter((path: string) => !(path in isgManifest)),
+          ...generatedStaticRoutes,
+        ],
       });
 
       log(`\n  Vercel build output → ${outputPath}\n`);
@@ -416,5 +470,33 @@ export function resolvePrerenderOutputPath(clientDir: string, routePath: string)
     );
   }
 
+  return filePath;
+}
+
+export function resolveGeneratedArtifactOutputPath(clientDir: string, outputPath: string): string {
+  if (
+    !outputPath ||
+    outputPath.includes("\0") ||
+    outputPath.includes("\\") ||
+    isAbsolute(outputPath)
+  ) {
+    throw new Error(
+      `Refusing to write generated artifact with unsafe output path ${JSON.stringify(outputPath)}.`,
+    );
+  }
+
+  const root = resolve(clientDir);
+  const filePath = resolve(root, outputPath);
+  const relativePath = relative(root, filePath);
+  if (
+    relativePath === "" ||
+    relativePath === ".." ||
+    relativePath.startsWith(`..${sep}`) ||
+    isAbsolute(relativePath)
+  ) {
+    throw new Error(
+      `Refusing to write generated artifact ${JSON.stringify(outputPath)} outside dist/client.`,
+    );
+  }
   return filePath;
 }

--- a/packages/cli/test/build-security.test.ts
+++ b/packages/cli/test/build-security.test.ts
@@ -2,11 +2,14 @@ import { resolve } from "node:path";
 
 import { describe, expect, it } from "vitest";
 
-import { resolvePrerenderOutputPath } from "../src/commands/build.ts";
+import {
+  resolveGeneratedArtifactOutputPath,
+  resolvePrerenderOutputPath,
+} from "../src/commands/build.ts";
+
+const clientDir = resolve("/tmp/pracht-app/dist/client");
 
 describe("resolvePrerenderOutputPath", () => {
-  const clientDir = resolve("/tmp/pracht-app/dist/client");
-
   it("resolves normal prerender routes inside dist/client", () => {
     expect(resolvePrerenderOutputPath(clientDir, "/products/1")).toBe(
       resolve(clientDir, "products/1/index.html"),
@@ -31,5 +34,25 @@ describe("resolvePrerenderOutputPath", () => {
 
   it("rejects NUL bytes before calling filesystem APIs", () => {
     expect(() => resolvePrerenderOutputPath(clientDir, "/safe\0evil")).toThrow(/NUL byte/);
+  });
+});
+
+describe("resolveGeneratedArtifactOutputPath", () => {
+  it("resolves nested static artifacts inside dist/client", () => {
+    expect(resolveGeneratedArtifactOutputPath(clientDir, "openapi.json")).toBe(
+      "/tmp/pracht-app/dist/client/openapi.json",
+    );
+    expect(resolveGeneratedArtifactOutputPath(clientDir, "docs/index.html")).toBe(
+      "/tmp/pracht-app/dist/client/docs/index.html",
+    );
+  });
+
+  it("rejects absolute paths and traversal", () => {
+    expect(() => resolveGeneratedArtifactOutputPath(clientDir, "/tmp/openapi.json")).toThrow(
+      /unsafe output path/,
+    );
+    expect(() => resolveGeneratedArtifactOutputPath(clientDir, "../openapi.json")).toThrow(
+      /outside dist\/client/,
+    );
   });
 });

--- a/packages/openapi/LICENSE
+++ b/packages/openapi/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Jovi De Croock
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/openapi/README.md
+++ b/packages/openapi/README.md
@@ -1,0 +1,67 @@
+# @pracht/openapi
+
+Opt-in OpenAPI 3.1 generation, development endpoints, static build output, and
+reference UI integration for Pracht API routes.
+
+```ts
+// vite.config.ts
+import { defineConfig } from "vite";
+import { prachtOpenApi } from "@pracht/openapi/vite";
+import { pracht } from "@pracht/vite-plugin";
+
+export default defineConfig({
+  plugins: [
+    pracht(),
+    prachtOpenApi({
+      info: { title: "My API", version: "1.0.0" },
+      ui: "scalar", // false (default), "scalar", or "swagger"
+    }),
+  ],
+});
+```
+
+During development, the plugin serves `/openapi.json` and optional `/docs`
+endpoints from the live app graph. `pracht build` emits the same resources to
+`dist/client/openapi.json` and `dist/client/docs/index.html`, so all Pracht
+adapters serve them as static assets.
+
+## Document a route
+
+Wrap `defineApi()` to add operation and response metadata without replacing
+its validation or inferred client contract:
+
+```ts
+import { defineApi, json } from "@pracht/core";
+import { defineOpenApi } from "@pracht/openapi";
+
+export const POST = defineOpenApi(
+  defineApi({
+    body: createItemSchema,
+    handler: ({ body }) => json({ id: createItem(body) }, { status: 201 }),
+  }),
+  {
+    summary: "Create an item",
+    tags: ["items"],
+    responses: {
+      201: { description: "Item created", body: itemSchema },
+    },
+  },
+);
+```
+
+Existing `defineApi()` handlers receive best-effort documentation. Unknown
+response contracts get a valid `default` response and a warning. Set
+`failOnWarnings: true` in `prachtOpenApi()` to require complete contracts in
+development and builds.
+
+Pass `document` to `prachtOpenApi()` for shared `servers`, `tags`,
+`components.securitySchemes`, reusable schemas, and global security
+requirements.
+
+The optional UI uses pinned Scalar or Swagger UI assets from jsDelivr. For an
+offline deployment, self-host the assets and configure `ui.scriptUrl` plus
+Swagger's `ui.styleUrl`. Strict CSP deployments must additionally allow the
+small initialization script by hash or use an app-owned UI page.
+
+See the complete [OpenAPI guide](../../docs/OPENAPI.md) for path configuration,
+custom generation, UI choices, deployment security, and current boundaries.

--- a/packages/openapi/package.json
+++ b/packages/openapi/package.json
@@ -1,0 +1,46 @@
+{
+  "name": "@pracht/openapi",
+  "version": "0.0.0",
+  "description": "Opt-in OpenAPI 3.1 document generation for Pracht API routes.",
+  "keywords": [
+    "pracht",
+    "openapi",
+    "api",
+    "standard-schema"
+  ],
+  "license": "MIT",
+  "homepage": "https://github.com/JoviDeCroock/pracht/tree/main/packages/openapi",
+  "bugs": {
+    "url": "https://github.com/JoviDeCroock/pracht/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/JoviDeCroock/pracht",
+    "directory": "packages/openapi"
+  },
+  "files": [
+    "dist"
+  ],
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.mts",
+      "default": "./dist/index.mjs"
+    },
+    "./vite": {
+      "types": "./dist/vite.d.mts",
+      "default": "./dist/vite.mjs"
+    }
+  },
+  "publishConfig": {
+    "provenance": true
+  },
+  "scripts": {
+    "build": "tsdown",
+    "prepublishOnly": "npm run build"
+  },
+  "peerDependencies": {
+    "@pracht/core": "workspace:*",
+    "vite": "^8.0.0"
+  }
+}

--- a/packages/openapi/package.json
+++ b/packages/openapi/package.json
@@ -40,7 +40,9 @@
     "prepublishOnly": "npm run build"
   },
   "peerDependencies": {
+    "@pracht/cli": "workspace:*",
     "@pracht/core": "workspace:*",
+    "@pracht/vite-plugin": "workspace:*",
     "vite": "^8.0.0"
   }
 }

--- a/packages/openapi/src/descriptor.ts
+++ b/packages/openapi/src/descriptor.ts
@@ -1,0 +1,65 @@
+import type { ApiRouteHandler } from "@pracht/core";
+
+import type { OpenApiOperationDescriptor } from "./types.ts";
+
+export const OPENAPI_OPERATION = Symbol.for("@pracht/openapi/operation");
+
+export type OpenApiDocumentedHandler<THandler extends ApiRouteHandler<any>> = THandler & {
+  readonly [OPENAPI_OPERATION]: OpenApiOperationDescriptor;
+};
+
+/**
+ * Attach OpenAPI-only metadata to a Pracht API handler without changing its
+ * runtime behavior or its `apiFetch()` request/response inference.
+ *
+ * Pass the result of `defineApi()` to retain Pracht's validation and types:
+ *
+ * ```ts
+ * export const POST = defineOpenApi(
+ *   defineApi({ body: createItemSchema, handler: createItem }),
+ *   { responses: { 201: { description: "Created", body: itemSchema } } },
+ * );
+ * ```
+ */
+export function defineOpenApi<THandler extends ApiRouteHandler<any>>(
+  handler: THandler,
+  descriptor: OpenApiOperationDescriptor,
+): OpenApiDocumentedHandler<THandler> {
+  assertDescriptor(descriptor);
+  return Object.assign(handler, {
+    [OPENAPI_OPERATION]: {
+      ...descriptor,
+      responses: { ...descriptor.responses },
+    },
+  });
+}
+
+export function getOpenApiDescriptor(value: unknown): OpenApiOperationDescriptor | undefined {
+  if (typeof value !== "function") return undefined;
+  return (value as { [OPENAPI_OPERATION]?: OpenApiOperationDescriptor })[OPENAPI_OPERATION];
+}
+
+function assertDescriptor(descriptor: OpenApiOperationDescriptor): void {
+  const responses = Object.entries(descriptor.responses);
+  if (responses.length === 0) {
+    throw new TypeError("defineOpenApi() requires at least one response.");
+  }
+
+  for (const [status, response] of responses) {
+    if (!/^(?:default|[1-5](?:\d{2}|XX))$/i.test(status)) {
+      throw new TypeError(
+        `defineOpenApi() response key ${JSON.stringify(status)} must be an HTTP status, range such as 2XX, or "default".`,
+      );
+    }
+    if (!response || typeof response.description !== "string" || !response.description.trim()) {
+      throw new TypeError(
+        `defineOpenApi() response ${JSON.stringify(status)} requires a non-empty description.`,
+      );
+    }
+    if (response.contentType !== undefined && !response.contentType.trim()) {
+      throw new TypeError(
+        `defineOpenApi() response ${JSON.stringify(status)} contentType must be non-empty.`,
+      );
+    }
+  }
+}

--- a/packages/openapi/src/generate.ts
+++ b/packages/openapi/src/generate.ts
@@ -1,0 +1,446 @@
+import type { ApiRouteSchemas } from "@pracht/core";
+
+import { getOpenApiDescriptor } from "./descriptor.ts";
+import type {
+  OpenApiDocument,
+  OpenApiDocumentOptions,
+  OpenApiInfo,
+  OpenApiOperationDescriptor,
+  OpenApiOperationObject,
+  OpenApiParameterObject,
+  OpenApiPathItemObject,
+  OpenApiResponseObject,
+  OpenApiSchema,
+  OpenApiSchemaDirection,
+  OpenApiSchemaResolver,
+  OpenApiWarning,
+  OpenApiWarningCode,
+} from "./types.ts";
+
+interface RuntimeApiHandler {
+  schemas?: ApiRouteSchemas;
+}
+
+const HTTP_METHODS = ["GET", "POST", "PUT", "PATCH", "DELETE", "HEAD", "OPTIONS"] as const;
+
+export interface GenerateOpenApiOptions {
+  info: OpenApiInfo;
+  /** Document-level servers, tags, security schemes, and reusable components. */
+  document?: OpenApiDocumentOptions;
+  /**
+   * Resolved Pracht API routes. `methods` and `hasDefaultHandler` may be
+   * omitted when `loadModule` can inspect the route module at generation time.
+   */
+  routes: readonly OpenApiRouteSource[];
+  loadModule: (file: string) => Promise<Record<string, unknown>>;
+  /** Optional converter for schema libraries that do not implement Standard JSON Schema directly. */
+  resolveSchema?: OpenApiSchemaResolver;
+  onWarning?: (warning: OpenApiWarning) => void;
+}
+
+export interface OpenApiRouteSource {
+  file: string;
+  path: string;
+  methods?: readonly string[];
+  hasDefaultHandler?: boolean;
+}
+
+export interface GenerateOpenApiResult {
+  document: OpenApiDocument;
+  warnings: OpenApiWarning[];
+}
+
+const VALIDATION_ERROR_SCHEMA: OpenApiSchema = {
+  type: "object",
+  required: ["error", "issues"],
+  properties: {
+    error: { const: "validation" },
+    issues: {
+      type: "array",
+      items: {
+        type: "object",
+        required: ["in", "message"],
+        properties: {
+          in: { enum: ["body", "query", "params"] },
+          message: { type: "string" },
+          path: {
+            type: "array",
+            items: { type: ["string", "number"] },
+          },
+        },
+      },
+    },
+  },
+};
+
+/** Generate an OpenAPI 3.1 document from Pracht's serialized API graph. */
+export async function generateOpenApiDocument(
+  options: GenerateOpenApiOptions,
+): Promise<GenerateOpenApiResult> {
+  const warnings: OpenApiWarning[] = [];
+  const document: OpenApiDocument = {
+    openapi: "3.1.0",
+    info: { ...options.info },
+    paths: {},
+    ...documentFields(options.document),
+  };
+
+  const warn = (
+    route: OpenApiRouteSource,
+    code: OpenApiWarningCode,
+    message: string,
+    method?: string,
+  ) => {
+    const warning: OpenApiWarning = {
+      code,
+      file: route.file,
+      message,
+      method,
+      path: route.path,
+    };
+    warnings.push(warning);
+    options.onWarning?.(warning);
+  };
+
+  for (const route of options.routes) {
+    let module: Record<string, unknown> = {};
+    try {
+      module = await options.loadModule(route.file);
+    } catch (error) {
+      warn(
+        route,
+        "route_module_load_failed",
+        `Could not load API route module: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+
+    const methods = route.methods ?? discoverMethods(module);
+    const hasDefaultHandler = route.hasDefaultHandler ?? typeof module.default === "function";
+    const openApiPath = toOpenApiPath(route.path);
+    if (route.path.includes("*")) {
+      warn(
+        route,
+        "catch_all_path",
+        `Catch-all route ${JSON.stringify(route.path)} is represented as a single {path} parameter; clients may need custom slash encoding.`,
+      );
+    }
+
+    const pathItem = (document.paths[openApiPath] ??= {});
+    for (const method of methods) {
+      const operation = buildOperation({
+        handler: module[method],
+        method,
+        options,
+        route,
+        warn,
+      });
+      pathItem[method.toLowerCase() as keyof OpenApiPathItemObject] = operation;
+    }
+
+    if (hasDefaultHandler) {
+      warn(
+        route,
+        "default_handler_omitted",
+        "The default handler can branch on any HTTP method, so it is omitted until methods are documented explicitly.",
+      );
+    }
+  }
+
+  return { document, warnings };
+}
+
+function documentFields(
+  options: OpenApiDocumentOptions | undefined,
+): Omit<OpenApiDocument, "info" | "openapi" | "paths"> {
+  if (!options) return {};
+  return {
+    ...(options.servers ? { servers: options.servers.map((server) => ({ ...server })) } : {}),
+    ...(options.tags ? { tags: options.tags.map((tag) => ({ ...tag })) } : {}),
+    ...(options.externalDocs ? { externalDocs: { ...options.externalDocs } } : {}),
+    ...(options.security
+      ? {
+          security: options.security.map((requirement) =>
+            Object.fromEntries(
+              Object.entries(requirement).map(([name, scopes]) => [name, [...scopes]]),
+            ),
+          ),
+        }
+      : {}),
+    ...(options.components ? { components: { ...options.components } } : {}),
+  };
+}
+
+function discoverMethods(module: Record<string, unknown>): string[] {
+  return HTTP_METHODS.filter((method) => typeof module[method] === "function");
+}
+
+function buildOperation({
+  handler,
+  method,
+  options,
+  route,
+  warn,
+}: {
+  handler: unknown;
+  method: string;
+  options: GenerateOpenApiOptions;
+  route: OpenApiRouteSource;
+  warn: (
+    route: OpenApiRouteSource,
+    code: OpenApiWarningCode,
+    message: string,
+    method?: string,
+  ) => void;
+}): OpenApiOperationObject {
+  const runtimeHandler = typeof handler === "function" ? (handler as RuntimeApiHandler) : undefined;
+  const schemas = runtimeHandler?.schemas;
+  const descriptor = getOpenApiDescriptor(handler);
+  const responses = buildResponses(descriptor, schemas, options, route, method, warn);
+  const operation: OpenApiOperationObject = {
+    ...descriptorOperationFields(descriptor),
+    responses,
+  };
+
+  const parameters = buildParameters(route, schemas, options, method, warn);
+  if (parameters.length > 0) operation.parameters = parameters;
+
+  if (schemas?.body) {
+    const schema = resolveSchema(schemas.body, "input", false, options, route, method, warn);
+    if (schema) {
+      operation.requestBody = {
+        required: true,
+        content: { "application/json": { schema } },
+      };
+    }
+  }
+
+  return operation;
+}
+
+function descriptorOperationFields(
+  descriptor: OpenApiOperationDescriptor | undefined,
+): Omit<OpenApiOperationObject, "parameters" | "requestBody" | "responses"> {
+  if (!descriptor) return {};
+  return {
+    ...(descriptor.tags ? { tags: [...descriptor.tags] } : {}),
+    ...(descriptor.summary ? { summary: descriptor.summary } : {}),
+    ...(descriptor.description ? { description: descriptor.description } : {}),
+    ...(descriptor.operationId ? { operationId: descriptor.operationId } : {}),
+    ...(descriptor.deprecated !== undefined ? { deprecated: descriptor.deprecated } : {}),
+    ...(descriptor.security
+      ? {
+          security: descriptor.security.map((requirement) =>
+            Object.fromEntries(
+              Object.entries(requirement).map(([name, scopes]) => [name, [...scopes]]),
+            ),
+          ),
+        }
+      : {}),
+  };
+}
+
+function buildResponses(
+  descriptor: OpenApiOperationDescriptor | undefined,
+  schemas: ApiRouteSchemas | undefined,
+  options: GenerateOpenApiOptions,
+  route: OpenApiRouteSource,
+  method: string,
+  warn: (
+    route: OpenApiRouteSource,
+    code: OpenApiWarningCode,
+    message: string,
+    method?: string,
+  ) => void,
+): Record<string, OpenApiResponseObject> {
+  const responses: Record<string, OpenApiResponseObject> = {};
+
+  if (schemas?.body) {
+    responses["400"] = validationResponse("Request body could not be parsed.");
+  }
+  if (schemas?.body || schemas?.query || schemas?.params) {
+    responses["422"] = validationResponse("Request validation failed.");
+  }
+
+  if (!descriptor) {
+    responses.default = { description: "Response contract is not documented." };
+    warn(
+      route,
+      "undocumented_response",
+      "No OpenAPI response descriptor is attached; emitted an explicit undocumented default response.",
+      method,
+    );
+    return responses;
+  }
+
+  for (const [rawStatus, response] of Object.entries(descriptor.responses)) {
+    const status = rawStatus.toUpperCase() === "DEFAULT" ? "default" : rawStatus.toUpperCase();
+    const generated: OpenApiResponseObject = { description: response.description };
+    if (response.body) {
+      const schema = resolveSchema(response.body, "output", true, options, route, method, warn);
+      if (schema) {
+        generated.content = {
+          [response.contentType ?? "application/json"]: { schema },
+        };
+      }
+    }
+    responses[status] = generated;
+  }
+
+  return responses;
+}
+
+function validationResponse(description: string): OpenApiResponseObject {
+  return {
+    description,
+    content: { "application/json": { schema: VALIDATION_ERROR_SCHEMA } },
+  };
+}
+
+function buildParameters(
+  route: OpenApiRouteSource,
+  schemas: ApiRouteSchemas | undefined,
+  options: GenerateOpenApiOptions,
+  method: string,
+  warn: (
+    route: OpenApiRouteSource,
+    code: OpenApiWarningCode,
+    message: string,
+    method?: string,
+  ) => void,
+): OpenApiParameterObject[] {
+  const parameters: OpenApiParameterObject[] = [];
+  const paramsSchema = schemas?.params
+    ? resolveSchema(schemas.params, "input", false, options, route, method, warn)
+    : undefined;
+  const paramProperties = objectProperties(paramsSchema);
+
+  for (const name of pathParameterNames(route.path)) {
+    parameters.push({
+      name,
+      in: "path",
+      required: true,
+      schema: paramProperties?.[name] ?? { type: "string" },
+    });
+  }
+
+  if (schemas?.query) {
+    const querySchema = resolveSchema(schemas.query, "input", false, options, route, method, warn);
+    const queryProperties = objectProperties(querySchema);
+    if (!queryProperties) {
+      if (querySchema) {
+        warn(
+          route,
+          "invalid_schema_shape",
+          "Query schema did not convert to an object with properties, so query parameters were omitted.",
+          method,
+        );
+      }
+    } else {
+      const required = new Set(
+        Array.isArray(querySchema?.required)
+          ? querySchema.required.filter((entry): entry is string => typeof entry === "string")
+          : [],
+      );
+      for (const [name, schema] of Object.entries(queryProperties)) {
+        parameters.push({ name, in: "query", required: required.has(name), schema });
+      }
+    }
+  }
+
+  return parameters;
+}
+
+function resolveSchema(
+  source: object,
+  direction: OpenApiSchemaDirection,
+  allowRawSchema: boolean,
+  options: GenerateOpenApiOptions,
+  route: OpenApiRouteSource,
+  method: string,
+  warn: (
+    route: OpenApiRouteSource,
+    code: OpenApiWarningCode,
+    message: string,
+    method?: string,
+  ) => void,
+): OpenApiSchema | undefined {
+  try {
+    const custom = options.resolveSchema?.(source, direction);
+    if (custom) return custom;
+
+    const converter = standardJsonSchemaConverter(source);
+    if (converter) {
+      return converter[direction]({ target: "draft-2020-12" });
+    }
+
+    if (allowRawSchema && isPlainObject(source) && !("~standard" in source)) {
+      return source;
+    }
+
+    warn(
+      route,
+      "schema_conversion_unavailable",
+      `The ${direction} schema does not implement Standard JSON Schema and no custom resolver converted it.`,
+      method,
+    );
+  } catch (error) {
+    warn(
+      route,
+      "schema_conversion_failed",
+      `The ${direction} schema conversion failed: ${error instanceof Error ? error.message : String(error)}`,
+      method,
+    );
+  }
+  return undefined;
+}
+
+function standardJsonSchemaConverter(source: object):
+  | {
+      input(options: { target: string }): OpenApiSchema;
+      output(options: { target: string }): OpenApiSchema;
+    }
+  | undefined {
+  const standard = (source as { "~standard"?: unknown })["~standard"];
+  if (!isPlainObject(standard)) return undefined;
+  const converter = standard.jsonSchema;
+  if (!isPlainObject(converter)) return undefined;
+  if (typeof converter.input !== "function" || typeof converter.output !== "function") {
+    return undefined;
+  }
+  return converter as ReturnType<typeof standardJsonSchemaConverter>;
+}
+
+function objectProperties(schema: OpenApiSchema | undefined): Record<string, OpenApiSchema> | null {
+  if (!schema || !isPlainObject(schema.properties)) return null;
+  const properties: Record<string, OpenApiSchema> = {};
+  for (const [name, value] of Object.entries(schema.properties)) {
+    if (isPlainObject(value)) properties[name] = value;
+  }
+  return properties;
+}
+
+function pathParameterNames(path: string): string[] {
+  const names: string[] = [];
+  for (const segment of path.split("/")) {
+    if (segment.startsWith(":")) names.push(segment.slice(1));
+    if (segment === "*") names.push("path");
+  }
+  return names;
+}
+
+function toOpenApiPath(path: string): string {
+  return path
+    .split("/")
+    .map((segment) => {
+      if (segment.startsWith(":")) return `{${segment.slice(1)}}`;
+      if (segment === "*") return "{path}";
+      return segment;
+    })
+    .join("/");
+}
+
+function isPlainObject(value: unknown): value is Record<string, any> {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) return false;
+  const prototype = Object.getPrototypeOf(value);
+  return prototype === Object.prototype || prototype === null;
+}

--- a/packages/openapi/src/generate.ts
+++ b/packages/openapi/src/generate.ts
@@ -22,6 +22,7 @@ interface RuntimeApiHandler {
 }
 
 const HTTP_METHODS = ["GET", "POST", "PUT", "PATCH", "DELETE", "HEAD", "OPTIONS"] as const;
+const BODYLESS_METHODS = new Set(["GET", "HEAD"]);
 
 export interface GenerateOpenApiOptions {
   info: OpenApiInfo;
@@ -204,7 +205,7 @@ async function buildOperation({
   const parameters = buildParameters(route, schemas, options, method, warn);
   if (parameters.length > 0) operation.parameters = parameters;
 
-  if (schemas?.body) {
+  if (schemas?.body && !BODYLESS_METHODS.has(method.toUpperCase())) {
     const schema = resolveSchema(schemas.body, "input", false, options, route, method, warn);
     if (schema) {
       operation.requestBody = {
@@ -265,7 +266,7 @@ function buildResponses(
 ): Record<string, OpenApiResponseObject> {
   const responses: Record<string, OpenApiResponseObject> = {};
 
-  if (schemas?.body) {
+  if (schemas?.body && !BODYLESS_METHODS.has(method.toUpperCase())) {
     responses["400"] = validationResponse("Request body could not be parsed.");
   }
   if (schemas?.body || schemas?.query || schemas?.params) {
@@ -325,12 +326,12 @@ function buildParameters(
     : undefined;
   const paramProperties = objectProperties(paramsSchema);
 
-  for (const name of pathParameterNames(route.path)) {
+  for (const { name, schemaName } of pathParameters(route.path)) {
     parameters.push({
       name,
       in: "path",
       required: true,
-      schema: paramProperties?.[name] ?? { type: "string" },
+      schema: paramProperties?.[schemaName] ?? { type: "string" },
     });
   }
 
@@ -430,13 +431,16 @@ function objectProperties(schema: OpenApiSchema | undefined): Record<string, Ope
   return properties;
 }
 
-function pathParameterNames(path: string): string[] {
-  const names: string[] = [];
+function pathParameters(path: string): Array<{ name: string; schemaName: string }> {
+  const parameters: Array<{ name: string; schemaName: string }> = [];
   for (const segment of path.split("/")) {
-    if (segment.startsWith(":")) names.push(segment.slice(1));
-    if (segment === "*") names.push("path");
+    if (segment.startsWith(":")) {
+      const name = segment.slice(1);
+      parameters.push({ name, schemaName: name });
+    }
+    if (segment === "*") parameters.push({ name: "path", schemaName: "*" });
   }
-  return names;
+  return parameters;
 }
 
 function toOpenApiPath(path: string): string {

--- a/packages/openapi/src/generate.ts
+++ b/packages/openapi/src/generate.ts
@@ -127,7 +127,7 @@ export async function generateOpenApiDocument(
 
     const pathItem = (document.paths[openApiPath] ??= {});
     for (const method of methods) {
-      const operation = buildOperation({
+      const operation = await buildOperation({
         handler: module[method],
         method,
         options,
@@ -174,7 +174,7 @@ function discoverMethods(module: Record<string, unknown>): string[] {
   return HTTP_METHODS.filter((method) => typeof module[method] === "function");
 }
 
-function buildOperation({
+async function buildOperation({
   handler,
   method,
   options,
@@ -191,7 +191,7 @@ function buildOperation({
     message: string,
     method?: string,
   ) => void;
-}): OpenApiOperationObject {
+}): Promise<OpenApiOperationObject> {
   const runtimeHandler = typeof handler === "function" ? (handler as RuntimeApiHandler) : undefined;
   const schemas = runtimeHandler?.schemas;
   const descriptor = getOpenApiDescriptor(handler);
@@ -208,13 +208,24 @@ function buildOperation({
     const schema = resolveSchema(schemas.body, "input", false, options, route, method, warn);
     if (schema) {
       operation.requestBody = {
-        required: true,
+        required: await bodySchemaRequiresValue(schemas.body),
         content: { "application/json": { schema } },
       };
     }
   }
 
   return operation;
+}
+
+async function bodySchemaRequiresValue(
+  schema: NonNullable<ApiRouteSchemas["body"]>,
+): Promise<boolean> {
+  try {
+    const result = await schema["~standard"].validate(undefined);
+    return result.issues !== undefined;
+  } catch {
+    return true;
+  }
 }
 
 function descriptorOperationFields(

--- a/packages/openapi/src/index.ts
+++ b/packages/openapi/src/index.ts
@@ -1,0 +1,34 @@
+export { defineOpenApi, getOpenApiDescriptor, OPENAPI_OPERATION } from "./descriptor.ts";
+export type { OpenApiDocumentedHandler } from "./descriptor.ts";
+export { generateOpenApiDocument } from "./generate.ts";
+export type {
+  GenerateOpenApiOptions,
+  GenerateOpenApiResult,
+  OpenApiRouteSource,
+} from "./generate.ts";
+export { createOpenApiUiHtml } from "./ui.ts";
+export type { CreateOpenApiUiHtmlOptions, OpenApiUiProvider } from "./ui.ts";
+export type {
+  OpenApiDocument,
+  OpenApiDocumentOptions,
+  OpenApiComponentsObject,
+  OpenApiExternalDocumentationObject,
+  OpenApiInfo,
+  OpenApiMediaTypeObject,
+  OpenApiOperationDescriptor,
+  OpenApiOperationObject,
+  OpenApiParameterObject,
+  OpenApiPathItemObject,
+  OpenApiRequestBodyObject,
+  OpenApiResponseDescriptor,
+  OpenApiResponseObject,
+  OpenApiSchema,
+  OpenApiSchemaDirection,
+  OpenApiSchemaResolver,
+  OpenApiSchemaSource,
+  OpenApiSecuritySchemeObject,
+  OpenApiServerObject,
+  OpenApiTagObject,
+  OpenApiWarning,
+  OpenApiWarningCode,
+} from "./types.ts";

--- a/packages/openapi/src/types.ts
+++ b/packages/openapi/src/types.ts
@@ -1,0 +1,162 @@
+export type OpenApiSchema = Record<string, unknown>;
+
+export interface OpenApiInfo {
+  title: string;
+  version: string;
+  summary?: string;
+  description?: string;
+  termsOfService?: string;
+  contact?: {
+    name?: string;
+    url?: string;
+    email?: string;
+  };
+  license?: {
+    name: string;
+    identifier?: string;
+    url?: string;
+  };
+}
+
+export interface OpenApiServerObject {
+  url: string;
+  description?: string;
+  variables?: Record<
+    string,
+    {
+      default: string;
+      description?: string;
+      enum?: string[];
+    }
+  >;
+}
+
+export interface OpenApiTagObject {
+  name: string;
+  description?: string;
+  externalDocs?: OpenApiExternalDocumentationObject;
+}
+
+export interface OpenApiExternalDocumentationObject {
+  url: string;
+  description?: string;
+}
+
+export interface OpenApiSecuritySchemeObject extends Record<string, unknown> {
+  type: "apiKey" | "http" | "mutualTLS" | "oauth2" | "openIdConnect" | string;
+  description?: string;
+}
+
+export interface OpenApiComponentsObject {
+  schemas?: Record<string, OpenApiSchema>;
+  securitySchemes?: Record<string, OpenApiSecuritySchemeObject>;
+  [componentType: string]: Record<string, unknown> | undefined;
+}
+
+export interface OpenApiDocumentOptions {
+  servers?: readonly OpenApiServerObject[];
+  tags?: readonly OpenApiTagObject[];
+  externalDocs?: OpenApiExternalDocumentationObject;
+  security?: readonly Record<string, readonly string[]>[];
+  components?: OpenApiComponentsObject;
+}
+
+export interface OpenApiMediaTypeObject {
+  schema?: OpenApiSchema;
+}
+
+export interface OpenApiResponseObject {
+  description: string;
+  content?: Record<string, OpenApiMediaTypeObject>;
+}
+
+export interface OpenApiParameterObject {
+  name: string;
+  in: "path" | "query";
+  required?: boolean;
+  description?: string;
+  schema: OpenApiSchema;
+}
+
+export interface OpenApiRequestBodyObject {
+  required?: boolean;
+  content: Record<string, OpenApiMediaTypeObject>;
+}
+
+export interface OpenApiOperationObject {
+  tags?: string[];
+  summary?: string;
+  description?: string;
+  operationId?: string;
+  deprecated?: boolean;
+  security?: Record<string, string[]>[];
+  parameters?: OpenApiParameterObject[];
+  requestBody?: OpenApiRequestBodyObject;
+  responses: Record<string, OpenApiResponseObject>;
+}
+
+export interface OpenApiPathItemObject {
+  get?: OpenApiOperationObject;
+  post?: OpenApiOperationObject;
+  put?: OpenApiOperationObject;
+  patch?: OpenApiOperationObject;
+  delete?: OpenApiOperationObject;
+  head?: OpenApiOperationObject;
+  options?: OpenApiOperationObject;
+}
+
+export interface OpenApiDocument {
+  openapi: "3.1.0";
+  info: OpenApiInfo;
+  paths: Record<string, OpenApiPathItemObject>;
+  servers?: OpenApiServerObject[];
+  tags?: OpenApiTagObject[];
+  externalDocs?: OpenApiExternalDocumentationObject;
+  security?: Record<string, string[]>[];
+  components?: OpenApiComponentsObject;
+}
+
+/** A raw JSON Schema or an object implementing Standard JSON Schema. */
+export type OpenApiSchemaSource = object;
+
+export interface OpenApiResponseDescriptor {
+  description: string;
+  /** Response payload schema. Standard JSON Schema converters use their output projection. */
+  body?: OpenApiSchemaSource;
+  /** Defaults to `application/json` when `body` is present. */
+  contentType?: string;
+}
+
+export interface OpenApiOperationDescriptor {
+  tags?: readonly string[];
+  summary?: string;
+  description?: string;
+  operationId?: string;
+  deprecated?: boolean;
+  security?: readonly Record<string, readonly string[]>[];
+  responses: Readonly<Record<string | number, OpenApiResponseDescriptor>>;
+}
+
+export type OpenApiWarningCode =
+  | "catch_all_path"
+  | "default_handler_omitted"
+  | "invalid_schema_shape"
+  | "route_module_load_failed"
+  | "schema_conversion_failed"
+  | "schema_conversion_unavailable"
+  | "undocumented_response";
+
+export interface OpenApiWarning {
+  code: OpenApiWarningCode;
+  file: string;
+  message: string;
+  method?: string;
+  path: string;
+}
+
+export type OpenApiSchemaDirection = "input" | "output";
+
+export type OpenApiSchemaResolver = (
+  schema: object,
+  direction: OpenApiSchemaDirection,
+) => OpenApiSchema | null | undefined;

--- a/packages/openapi/src/ui.ts
+++ b/packages/openapi/src/ui.ts
@@ -1,0 +1,107 @@
+export type OpenApiUiProvider = "scalar" | "swagger";
+
+export interface CreateOpenApiUiHtmlOptions {
+  provider: OpenApiUiProvider;
+  documentUrl: string;
+  title?: string;
+  /**
+   * Override the browser bundle URL. Pin this in production when the default
+   * CDN delivery is acceptable, or self-host the corresponding bundle.
+   */
+  scriptUrl?: string;
+  /** Swagger UI only. Override the stylesheet URL to self-host its assets. */
+  styleUrl?: string;
+}
+
+const DEFAULT_SCALAR_SCRIPT =
+  "https://cdn.jsdelivr.net/npm/@scalar/api-reference@1.64.0/dist/browser/standalone.js";
+const DEFAULT_SWAGGER_SCRIPT =
+  "https://cdn.jsdelivr.net/npm/swagger-ui-dist@5.32.12/swagger-ui-bundle.js";
+const DEFAULT_SWAGGER_STYLE = "https://cdn.jsdelivr.net/npm/swagger-ui-dist@5.32.12/swagger-ui.css";
+
+/** Create a small, static HTML shell that reads the generated OpenAPI JSON endpoint. */
+export function createOpenApiUiHtml(options: CreateOpenApiUiHtmlOptions): string {
+  assertAbsolutePath(options.documentUrl, "documentUrl");
+  const title = escapeHtml(options.title?.trim() || "API reference");
+
+  if (options.provider === "scalar") {
+    const scriptUrl = escapeHtml(options.scriptUrl ?? DEFAULT_SCALAR_SCRIPT);
+    const configuration = scriptJson({ url: options.documentUrl });
+    return `<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>${title}</title>
+  </head>
+  <body>
+    <div id="api-reference"></div>
+    <script src="${scriptUrl}"></script>
+    <script>
+      Scalar.createApiReference("#api-reference", ${configuration});
+    </script>
+  </body>
+</html>
+`;
+  }
+
+  const scriptUrl = escapeHtml(options.scriptUrl ?? DEFAULT_SWAGGER_SCRIPT);
+  const styleUrl = escapeHtml(options.styleUrl ?? DEFAULT_SWAGGER_STYLE);
+  const configuration = scriptJson({
+    deepLinking: true,
+    dom_id: "#swagger-ui",
+    url: options.documentUrl,
+    validatorUrl: null,
+  });
+  return `<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>${title}</title>
+    <link rel="stylesheet" href="${styleUrl}" />
+  </head>
+  <body>
+    <div id="swagger-ui"></div>
+    <script src="${scriptUrl}" crossorigin></script>
+    <script>
+      SwaggerUIBundle(${configuration});
+    </script>
+  </body>
+</html>
+`;
+}
+
+function assertAbsolutePath(value: string, name: string): void {
+  if (
+    !value.startsWith("/") ||
+    value.startsWith("//") ||
+    value.includes("\\") ||
+    hasControlCharacter(value)
+  ) {
+    throw new TypeError(`createOpenApiUiHtml() ${name} must be a root-relative URL path.`);
+  }
+}
+
+function hasControlCharacter(value: string): boolean {
+  for (const character of value) {
+    const codePoint = character.codePointAt(0);
+    if (codePoint !== undefined && (codePoint <= 0x1f || codePoint === 0x7f)) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+function escapeHtml(value: string): string {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;");
+}
+
+function scriptJson(value: unknown): string {
+  return JSON.stringify(value).replaceAll("<", "\\u003c");
+}

--- a/packages/openapi/src/vite.ts
+++ b/packages/openapi/src/vite.ts
@@ -1,0 +1,347 @@
+import type { IncomingMessage, ServerResponse } from "node:http";
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+import type { Connect, Plugin, ViteDevServer } from "vite";
+
+import type { OpenApiDocumentOptions, OpenApiInfo } from "./types.ts";
+import type { OpenApiUiProvider } from "./ui.ts";
+
+const PRACHT_SERVER_MODULE_ID = "virtual:pracht/server";
+const PRACHT_DEV_MODULE_ID = "virtual:pracht/dev-metadata";
+
+export interface PrachtOpenApiUiOptions {
+  provider: OpenApiUiProvider;
+  /** URL path for the reference page. Defaults to `/docs`. */
+  path?: string;
+  title?: string;
+  /** Override the provider's pinned jsDelivr browser bundle. */
+  scriptUrl?: string;
+  /** Swagger UI only. Override the provider's pinned jsDelivr stylesheet. */
+  styleUrl?: string;
+}
+
+export interface PrachtOpenApiOptions {
+  info: OpenApiInfo;
+  /** Document-level servers, tags, security schemes, and reusable components. */
+  document?: OpenApiDocumentOptions;
+  /** JSON endpoint and emitted asset path. Defaults to `/openapi.json`. */
+  documentPath?: string;
+  /** Opt into a static Scalar or Swagger UI page backed by the JSON endpoint. */
+  ui?: false | OpenApiUiProvider | PrachtOpenApiUiOptions;
+  /** Turn best-effort generation warnings into build/dev request failures. */
+  failOnWarnings?: boolean;
+}
+
+interface ResolvedPrachtOpenApiOptions {
+  documentPath: string;
+  document: OpenApiDocumentOptions;
+  failOnWarnings: boolean;
+  info: OpenApiInfo;
+  ui:
+    | (Required<Pick<PrachtOpenApiUiOptions, "path" | "provider">> &
+        Omit<PrachtOpenApiUiOptions, "path" | "provider">)
+    | null;
+}
+
+export interface PrachtOpenApiArtifact {
+  content: string;
+  contentType: string;
+  outputPath: string;
+  path: string;
+}
+
+export interface PrachtOpenApiArtifacts {
+  artifacts: PrachtOpenApiArtifact[];
+  warnings: Array<{ code: string; file: string; message: string; method?: string; path: string }>;
+}
+
+/**
+ * Add live OpenAPI JSON/reference endpoints and matching static build assets
+ * without changing ordinary Pracht route authoring.
+ */
+export function prachtOpenApi(options: PrachtOpenApiOptions): Plugin {
+  const resolved = resolvePrachtOpenApiOptions(options);
+  const warned = new Set<string>();
+
+  return {
+    name: "pracht:openapi",
+
+    configureServer(server) {
+      warnPublicArtifactCollisions(server, resolved);
+      server.middlewares.use(createOpenApiDevMiddleware(server, resolved, warned));
+    },
+
+    transform(code, id) {
+      if (!isPrachtGraphModule(id)) return null;
+      return {
+        code: `${code}\n${createOpenApiServerModuleSource(resolved)}`,
+        map: null,
+      };
+    },
+  };
+}
+
+export function resolvePrachtOpenApiOptions(
+  options: PrachtOpenApiOptions,
+): ResolvedPrachtOpenApiOptions {
+  if (!options || typeof options !== "object") {
+    throw new TypeError("prachtOpenApi() expects an options object.");
+  }
+  if (!options.info || typeof options.info.title !== "string" || !options.info.title.trim()) {
+    throw new TypeError("prachtOpenApi() info.title must be a non-empty string.");
+  }
+  if (typeof options.info.version !== "string" || !options.info.version.trim()) {
+    throw new TypeError("prachtOpenApi() info.version must be a non-empty string.");
+  }
+
+  const documentPath = normalizeEndpointPath(
+    options.documentPath ?? "/openapi.json",
+    "documentPath",
+  );
+  if (!documentPath.endsWith(".json")) {
+    throw new TypeError(
+      "prachtOpenApi() documentPath must end in .json so static hosts send the correct media type.",
+    );
+  }
+  const ui = resolveUiOptions(options.ui);
+  if (
+    ui?.path === documentPath ||
+    (ui && documentPath.slice(1) === `${ui.path.slice(1)}/index.html`)
+  ) {
+    throw new TypeError("prachtOpenApi() UI and document paths must be different.");
+  }
+
+  return {
+    documentPath,
+    document: options.document ? { ...options.document } : {},
+    failOnWarnings: options.failOnWarnings ?? false,
+    info: { ...options.info },
+    ui,
+  };
+}
+
+function resolveUiOptions(value: PrachtOpenApiOptions["ui"]): ResolvedPrachtOpenApiOptions["ui"] {
+  if (value === undefined || value === false) return null;
+  if (value === "scalar" || value === "swagger") {
+    return { path: "/docs", provider: value };
+  }
+  if (!value || typeof value !== "object") {
+    throw new TypeError(
+      'prachtOpenApi() ui must be false, "scalar", "swagger", or an options object.',
+    );
+  }
+  if (value.provider !== "scalar" && value.provider !== "swagger") {
+    throw new TypeError('prachtOpenApi() ui.provider must be "scalar" or "swagger".');
+  }
+  if (value.provider === "scalar" && value.styleUrl !== undefined) {
+    throw new TypeError("prachtOpenApi() ui.styleUrl is only supported by Swagger UI.");
+  }
+  return {
+    ...value,
+    path: normalizeEndpointPath(value.path ?? "/docs", "ui.path"),
+  };
+}
+
+function normalizeEndpointPath(path: string, name: string): string {
+  if (
+    typeof path !== "string" ||
+    !path.startsWith("/") ||
+    path.startsWith("//") ||
+    path.includes("\\") ||
+    path.includes("?") ||
+    path.includes("#") ||
+    pathHasUnsafeSegment(path)
+  ) {
+    throw new TypeError(`prachtOpenApi() ${name} must be a safe root-relative URL path.`);
+  }
+  const normalized = path.length > 1 ? path.replace(/\/+$/, "") : path;
+  if (normalized === "/") {
+    throw new TypeError(`prachtOpenApi() ${name} must not replace the app root.`);
+  }
+  return normalized;
+}
+
+function pathHasUnsafeSegment(path: string): boolean {
+  try {
+    return path.split("/").some((segment) => {
+      const decoded = decodeURIComponent(segment);
+      return (
+        decoded === "." ||
+        decoded === ".." ||
+        decoded.includes("/") ||
+        decoded.includes("\\") ||
+        hasControlCharacter(decoded)
+      );
+    });
+  } catch {
+    return true;
+  }
+}
+
+function hasControlCharacter(value: string): boolean {
+  for (const character of value) {
+    const codePoint = character.codePointAt(0);
+    if (codePoint !== undefined && (codePoint <= 0x1f || codePoint === 0x7f)) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+function isPrachtGraphModule(id: string): boolean {
+  const normalized = (id.charCodeAt(0) === 0 ? id.slice(1) : id).split("?")[0];
+  return normalized === PRACHT_SERVER_MODULE_ID || normalized === PRACHT_DEV_MODULE_ID;
+}
+
+function createOpenApiServerModuleSource(options: ResolvedPrachtOpenApiOptions): string {
+  const serializable = {
+    documentPath: options.documentPath,
+    document: options.document,
+    failOnWarnings: options.failOnWarnings,
+    info: options.info,
+    ui: options.ui,
+  };
+  return [
+    '// Generated by the opt-in "@pracht/openapi/vite" companion plugin.',
+    'import { createOpenApiUiHtml as __prachtCreateOpenApiUiHtml, generateOpenApiDocument as __prachtGenerateOpenApiDocument } from "@pracht/openapi";',
+    `const __prachtOpenApiConfig = ${JSON.stringify(serializable)};`,
+    "async function __prachtLoadOpenApiRoute(file) {",
+    "  const load = apiModules[file];",
+    '  if (typeof load !== "function") {',
+    "    throw new Error(`No API module importer exists for ${JSON.stringify(file)}.`);",
+    "  }",
+    "  return load();",
+    "}",
+    "export async function generatePrachtOpenApiArtifacts() {",
+    "  const result = await __prachtGenerateOpenApiDocument({",
+    "    info: __prachtOpenApiConfig.info,",
+    "    document: __prachtOpenApiConfig.document,",
+    "    routes: apiRoutes,",
+    "    loadModule: __prachtLoadOpenApiRoute,",
+    "  });",
+    "  if (__prachtOpenApiConfig.failOnWarnings && result.warnings.length > 0) {",
+    '    const summary = result.warnings.map((warning) => `${warning.method ? warning.method + " " : ""}${warning.path}: ${warning.message}`).join("\\n");',
+    "    throw new Error(`OpenAPI generation produced ${result.warnings.length} warning(s):\\n${summary}`);",
+    "  }",
+    "  const artifacts = [{",
+    "    path: __prachtOpenApiConfig.documentPath,",
+    "    outputPath: __prachtOpenApiConfig.documentPath.slice(1),",
+    '    contentType: "application/json; charset=utf-8",',
+    '    content: JSON.stringify(result.document, null, 2) + "\\n",',
+    "  }];",
+    "  if (__prachtOpenApiConfig.ui) {",
+    "    artifacts.push({",
+    "      path: __prachtOpenApiConfig.ui.path,",
+    '      outputPath: __prachtOpenApiConfig.ui.path.slice(1) + "/index.html",',
+    '      contentType: "text/html; charset=utf-8",',
+    "      content: __prachtCreateOpenApiUiHtml({",
+    "        ...__prachtOpenApiConfig.ui,",
+    "        documentUrl: __prachtOpenApiConfig.documentPath,",
+    '        title: __prachtOpenApiConfig.ui.title ?? __prachtOpenApiConfig.info.title + " API reference",',
+    "      }),",
+    "    });",
+    "  }",
+    "  return { artifacts, warnings: result.warnings };",
+    "}",
+    "",
+  ].join("\n");
+}
+
+function createOpenApiDevMiddleware(
+  server: ViteDevServer,
+  options: ResolvedPrachtOpenApiOptions,
+  warned: Set<string>,
+): Connect.NextHandleFunction {
+  const endpointPaths = new Set([
+    options.documentPath,
+    ...(options.ui ? [options.ui.path, `${options.ui.path}/`] : []),
+  ]);
+
+  return async (req: IncomingMessage, res: ServerResponse, next: Connect.NextFunction) => {
+    const requestUrl = new URL(req.url ?? "/", "http://localhost");
+    if (!endpointPaths.has(requestUrl.pathname)) return next();
+
+    const method = (req.method ?? "GET").toUpperCase();
+    if (method !== "GET" && method !== "HEAD") {
+      res.statusCode = 405;
+      res.setHeader("allow", "GET, HEAD");
+      res.setHeader("content-type", "text/plain; charset=utf-8");
+      res.end("Method Not Allowed");
+      return;
+    }
+
+    try {
+      const [framework, serverModule] = await Promise.all([
+        server.ssrLoadModule("@pracht/core/server"),
+        server.ssrLoadModule(PRACHT_DEV_MODULE_ID),
+      ]);
+      const collisionKey = `route:${requestUrl.pathname}`;
+      if (
+        !warned.has(collisionKey) &&
+        (framework.matchAppRoute?.(serverModule.resolvedApp, requestUrl.pathname) ||
+          framework.matchApiRoute?.(serverModule.apiRoutes, requestUrl.pathname))
+      ) {
+        warned.add(collisionKey);
+        server.config.logger.warn(
+          `[pracht:openapi] An app route matches reserved path ${requestUrl.pathname}. ` +
+            "The OpenAPI endpoint wins while the companion plugin is enabled.",
+        );
+      }
+      const generate = serverModule.generatePrachtOpenApiArtifacts;
+      if (typeof generate !== "function") {
+        throw new Error(
+          "OpenAPI graph hook is missing. Place prachtOpenApi() after pracht() in vite.config.ts.",
+        );
+      }
+      const result = (await generate()) as PrachtOpenApiArtifacts;
+      for (const warning of result.warnings) {
+        const key = JSON.stringify(warning);
+        if (warned.has(key)) continue;
+        warned.add(key);
+        server.config.logger.warn(
+          `[pracht:openapi] ${warning.method ? `${warning.method} ` : ""}${warning.path}: ${warning.message}`,
+        );
+      }
+
+      const canonicalPath = requestUrl.pathname.endsWith("/")
+        ? requestUrl.pathname.slice(0, -1)
+        : requestUrl.pathname;
+      const artifact = result.artifacts.find((candidate) => candidate.path === canonicalPath);
+      if (!artifact) return next();
+
+      res.statusCode = 200;
+      res.setHeader("cache-control", "no-store");
+      res.setHeader("content-type", artifact.contentType);
+      res.setHeader("x-content-type-options", "nosniff");
+      res.end(method === "HEAD" ? undefined : artifact.content);
+    } catch (error) {
+      if (error instanceof Error) server.ssrFixStacktrace(error);
+      server.config.logger.error(
+        `[pracht:openapi] ${error instanceof Error ? (error.stack ?? error.message) : String(error)}`,
+      );
+      res.statusCode = 500;
+      res.setHeader("cache-control", "no-store");
+      res.setHeader("content-type", "text/plain; charset=utf-8");
+      res.end("OpenAPI generation failed");
+    }
+  };
+}
+
+function warnPublicArtifactCollisions(
+  server: ViteDevServer,
+  options: ResolvedPrachtOpenApiOptions,
+): void {
+  if (typeof server.config.publicDir !== "string") return;
+  const outputPaths = [
+    options.documentPath.slice(1),
+    ...(options.ui ? [`${options.ui.path.slice(1)}/index.html`] : []),
+  ];
+  for (const outputPath of outputPaths) {
+    if (!existsSync(join(server.config.publicDir, outputPath))) continue;
+    server.config.logger.warn(
+      `[pracht:openapi] public/${outputPath} collides with a generated OpenAPI artifact. ` +
+        "The companion endpoint wins in development and pracht build replaces the public file.",
+    );
+  }
+}

--- a/packages/openapi/src/vite.ts
+++ b/packages/openapi/src/vite.ts
@@ -104,11 +104,14 @@ export function resolvePrachtOpenApiOptions(
     );
   }
   const ui = resolveUiOptions(options.ui);
-  if (
-    ui?.path === documentPath ||
-    (ui && documentPath.slice(1) === `${ui.path.slice(1)}/index.html`)
-  ) {
-    throw new TypeError("prachtOpenApi() UI and document paths must be different.");
+  if (ui) {
+    const documentOutputPath = documentPath.slice(1);
+    const uiOutputPath = `${ui.path.slice(1)}/index.html`;
+    if (outputPathsOverlap(documentOutputPath, uiOutputPath)) {
+      throw new TypeError(
+        "prachtOpenApi() UI and document paths must not overlap in static build output.",
+      );
+    }
   }
 
   return {
@@ -154,11 +157,16 @@ function normalizeEndpointPath(path: string, name: string): string {
   ) {
     throw new TypeError(`prachtOpenApi() ${name} must be a safe root-relative URL path.`);
   }
-  const normalized = path.length > 1 ? path.replace(/\/+$/, "") : path;
+  const canonicalPath = new URL(path, "http://pracht.local").pathname.replace(/\/{2,}/g, "/");
+  const normalized = canonicalPath.length > 1 ? canonicalPath.replace(/\/+$/, "") : canonicalPath;
   if (normalized === "/") {
     throw new TypeError(`prachtOpenApi() ${name} must not replace the app root.`);
   }
   return normalized;
+}
+
+function outputPathsOverlap(left: string, right: string): boolean {
+  return left === right || left.startsWith(`${right}/`) || right.startsWith(`${left}/`);
 }
 
 function pathHasUnsafeSegment(path: string): boolean {

--- a/packages/openapi/test/openapi.test.ts
+++ b/packages/openapi/test/openapi.test.ts
@@ -9,12 +9,18 @@ import {
   getOpenApiDescriptor,
 } from "../src/index.ts";
 
-function standardSchema(jsonSchema: Record<string, unknown>) {
+function standardSchema(
+  jsonSchema: Record<string, unknown>,
+  options: { acceptsUndefined?: boolean } = {},
+) {
   return {
     "~standard": {
       version: 1 as const,
       vendor: "pracht-openapi-test",
-      validate: (value: unknown) => ({ value }),
+      validate: (value: unknown) =>
+        value === undefined && !options.acceptsUndefined
+          ? { issues: [{ message: "Required" }] }
+          : { value },
       jsonSchema: {
         input: () => jsonSchema,
         output: () => jsonSchema,
@@ -200,6 +206,20 @@ describe("generateOpenApiDocument", () => {
         schema: { type: "string", enum: ["yes", "no"] },
       },
     ]);
+  });
+
+  it("keeps request bodies optional when the runtime validator accepts undefined", async () => {
+    const body = standardSchema({ type: "object", properties: {} }, { acceptsUndefined: true });
+    const handler = defineApi({ body, handler: () => ({ ok: true }) });
+    const result = await generateOpenApiDocument({
+      info: { title: "Example", version: "1.0.0" },
+      routes: [graphRoute()],
+      loadModule: async () => ({ POST: handler }),
+    });
+
+    expect(result.document.paths["/api/items/{id}"]?.post?.requestBody).toMatchObject({
+      required: false,
+    });
   });
 
   it("emits an honest fallback and warnings for undocumented or unloadable handlers", async () => {

--- a/packages/openapi/test/openapi.test.ts
+++ b/packages/openapi/test/openapi.test.ts
@@ -1,0 +1,308 @@
+import { describe, expect, expectTypeOf, it, vi } from "vitest";
+
+import { defineApi, json, type ApiHandlerTypes } from "../../framework/src/api-validation.ts";
+import type { AppGraphApiRoute } from "../../framework/src/app-graph.ts";
+import {
+  createOpenApiUiHtml,
+  defineOpenApi,
+  generateOpenApiDocument,
+  getOpenApiDescriptor,
+} from "../src/index.ts";
+
+function standardSchema(jsonSchema: Record<string, unknown>) {
+  return {
+    "~standard": {
+      version: 1 as const,
+      vendor: "pracht-openapi-test",
+      validate: (value: unknown) => ({ value }),
+      jsonSchema: {
+        input: () => jsonSchema,
+        output: () => jsonSchema,
+      },
+    },
+  };
+}
+
+function graphRoute(overrides: Partial<AppGraphApiRoute> = {}): AppGraphApiRoute {
+  return {
+    file: "/src/api/items/[id].ts",
+    hasDefaultHandler: false,
+    methods: ["POST"],
+    path: "/api/items/:id",
+    ...overrides,
+  };
+}
+
+describe("defineOpenApi", () => {
+  it("attaches a validated descriptor without replacing the handler", () => {
+    const handler = defineApi({ handler: () => ({ ok: true }) });
+    const documented = defineOpenApi(handler, {
+      summary: "Create an item",
+      responses: { 200: { description: "Created" } },
+    });
+
+    expect(documented).toBe(handler);
+    expectTypeOf<ApiHandlerTypes<typeof documented>>().toEqualTypeOf<
+      ApiHandlerTypes<typeof handler>
+    >();
+    expect(getOpenApiDescriptor(documented)).toEqual({
+      summary: "Create an item",
+      responses: { 200: { description: "Created" } },
+    });
+  });
+
+  it("rejects missing response descriptions and invalid response keys", () => {
+    const handler = defineApi({ handler: () => ({ ok: true }) });
+
+    expect(() =>
+      defineOpenApi(handler, {
+        responses: { 200: { description: "" } },
+      }),
+    ).toThrow("requires a non-empty description");
+    expect(() =>
+      defineOpenApi(handler, {
+        responses: { success: { description: "Nope" } },
+      }),
+    ).toThrow("must be an HTTP status");
+  });
+});
+
+describe("generateOpenApiDocument", () => {
+  it("preserves document-level servers, tags, components, and security", async () => {
+    const result = await generateOpenApiDocument({
+      info: { title: "Example", version: "1.0.0" },
+      document: {
+        servers: [{ url: "https://api.example.com", description: "Production" }],
+        tags: [{ name: "health", description: "Service status" }],
+        components: {
+          securitySchemes: {
+            bearerAuth: { type: "http", scheme: "bearer", bearerFormat: "JWT" },
+          },
+        },
+        security: [{ bearerAuth: [] }],
+      },
+      routes: [],
+      loadModule: async () => ({}),
+    });
+
+    expect(result.document).toMatchObject({
+      servers: [{ url: "https://api.example.com", description: "Production" }],
+      tags: [{ name: "health", description: "Service status" }],
+      components: {
+        securitySchemes: {
+          bearerAuth: { type: "http", scheme: "bearer", bearerFormat: "JWT" },
+        },
+      },
+      security: [{ bearerAuth: [] }],
+    });
+  });
+
+  it("discovers named methods when given live resolved routes", async () => {
+    const result = await generateOpenApiDocument({
+      info: { title: "Example", version: "1.0.0" },
+      routes: [{ file: "/src/api/health.ts", path: "/api/health" }],
+      loadModule: async () => ({ GET: () => Response.json({ ok: true }) }),
+    });
+
+    expect(result.document.paths["/api/health"]?.get).toMatchObject({
+      responses: { default: { description: "Response contract is not documented." } },
+    });
+    expect(result.warnings.map((warning) => warning.code)).toEqual(["undocumented_response"]);
+  });
+
+  it("combines graph paths, Standard JSON Schema requests, and explicit responses", async () => {
+    const body = standardSchema({
+      type: "object",
+      required: ["name"],
+      properties: { name: { type: "string" } },
+    });
+    const params = standardSchema({
+      type: "object",
+      properties: { id: { type: "string", format: "uuid" } },
+    });
+    const query = standardSchema({
+      type: "object",
+      required: ["notify"],
+      properties: { notify: { type: "string", enum: ["yes", "no"] } },
+    });
+    const handler = defineOpenApi(
+      defineApi({
+        body,
+        params,
+        query,
+        handler: () => json({ id: "42" }, { status: 201 }),
+      }),
+      {
+        operationId: "updateItem",
+        summary: "Update an item",
+        tags: ["items"],
+        responses: {
+          201: {
+            description: "Item updated",
+            body: {
+              type: "object",
+              required: ["id"],
+              properties: { id: { type: "string" } },
+            },
+          },
+        },
+      },
+    );
+
+    const result = await generateOpenApiDocument({
+      info: { title: "Example", version: "1.0.0" },
+      routes: [graphRoute()],
+      loadModule: async () => ({ POST: handler }),
+    });
+
+    expect(result.warnings).toEqual([]);
+    expect(result.document.openapi).toBe("3.1.0");
+    const operation = result.document.paths["/api/items/{id}"]?.post;
+    expect(operation).toMatchObject({
+      operationId: "updateItem",
+      summary: "Update an item",
+      tags: ["items"],
+      requestBody: {
+        required: true,
+        content: {
+          "application/json": {
+            schema: {
+              type: "object",
+              required: ["name"],
+            },
+          },
+        },
+      },
+      responses: {
+        201: {
+          description: "Item updated",
+          content: {
+            "application/json": {
+              schema: { type: "object", required: ["id"] },
+            },
+          },
+        },
+        400: { description: "Request body could not be parsed." },
+        422: { description: "Request validation failed." },
+      },
+    });
+    expect(operation?.parameters).toEqual([
+      {
+        name: "id",
+        in: "path",
+        required: true,
+        schema: { type: "string", format: "uuid" },
+      },
+      {
+        name: "notify",
+        in: "query",
+        required: true,
+        schema: { type: "string", enum: ["yes", "no"] },
+      },
+    ]);
+  });
+
+  it("emits an honest fallback and warnings for undocumented or unloadable handlers", async () => {
+    const onWarning = vi.fn();
+    const result = await generateOpenApiDocument({
+      info: { title: "Example", version: "1.0.0" },
+      routes: [
+        graphRoute({
+          file: "/src/api/files/[...path].ts",
+          hasDefaultHandler: true,
+          methods: ["GET"],
+          path: "/api/files/*",
+        }),
+      ],
+      loadModule: async () => {
+        throw new Error("database unavailable");
+      },
+      onWarning,
+    });
+
+    expect(result.document.paths["/api/files/{path}"]?.get).toMatchObject({
+      parameters: [{ name: "path", in: "path", required: true, schema: { type: "string" } }],
+      responses: { default: { description: "Response contract is not documented." } },
+    });
+    expect(result.warnings.map((warning) => warning.code)).toEqual([
+      "route_module_load_failed",
+      "catch_all_path",
+      "undocumented_response",
+      "default_handler_omitted",
+    ]);
+    expect(onWarning).toHaveBeenCalledTimes(4);
+  });
+
+  it("supports external schema-library resolvers without treating validators as raw schemas", async () => {
+    const schema = {
+      "~standard": {
+        version: 1 as const,
+        vendor: "custom",
+        validate: (value: unknown) => ({ value }),
+      },
+    };
+    const handler = defineApi({ query: schema, handler: () => ({ ok: true }) });
+    const result = await generateOpenApiDocument({
+      info: { title: "Example", version: "1.0.0" },
+      routes: [graphRoute({ methods: ["GET"] })],
+      loadModule: async () => ({ GET: handler }),
+      resolveSchema: (value) =>
+        value === schema
+          ? { type: "object", properties: { search: { type: "string" } } }
+          : undefined,
+    });
+
+    expect(result.document.paths["/api/items/{id}"]?.get?.parameters).toContainEqual({
+      name: "search",
+      in: "query",
+      required: false,
+      schema: { type: "string" },
+    });
+    expect(result.warnings.map((warning) => warning.code)).toEqual(["undocumented_response"]);
+  });
+});
+
+describe("createOpenApiUiHtml", () => {
+  it("creates a pinned Scalar shell backed by the JSON endpoint", () => {
+    const html = createOpenApiUiHtml({
+      provider: "scalar",
+      documentUrl: "/openapi.json",
+      title: "Example API",
+    });
+
+    expect(html).toContain("@scalar/api-reference@1.64.0");
+    expect(html).toContain('Scalar.createApiReference("#api-reference"');
+    expect(html).toContain('{"url":"/openapi.json"}');
+  });
+
+  it("creates a privacy-conscious Swagger UI shell and escapes configuration", () => {
+    const html = createOpenApiUiHtml({
+      provider: "swagger",
+      documentUrl: "/openapi.json",
+      title: "</title><script>alert(1)</script>",
+    });
+
+    expect(html).toContain("swagger-ui-dist@5.32.12");
+    expect(html).toContain('"validatorUrl":null');
+    expect(html).not.toContain("<script>alert(1)</script>");
+    expect(html).toContain("&lt;/title&gt;");
+  });
+
+  it("rejects cross-origin document URLs", () => {
+    expect(() =>
+      createOpenApiUiHtml({
+        provider: "scalar",
+        documentUrl: "https://example.com/openapi.json",
+      }),
+    ).toThrow(/root-relative/);
+  });
+
+  it("rejects backslash URLs that browsers resolve cross-origin", () => {
+    expect(() =>
+      createOpenApiUiHtml({
+        provider: "scalar",
+        documentUrl: "/\\evil.example/openapi.json",
+      }),
+    ).toThrow(/root-relative/);
+  });
+});

--- a/packages/openapi/test/openapi.test.ts
+++ b/packages/openapi/test/openapi.test.ts
@@ -222,6 +222,55 @@ describe("generateOpenApiDocument", () => {
     });
   });
 
+  it("does not document request bodies or parse errors for bodyless methods", async () => {
+    const body = standardSchema({ type: "object", properties: { value: { type: "string" } } });
+    const handler = defineOpenApi(defineApi({ body, handler: () => ({ ok: true }) }), {
+      responses: { 200: { description: "Success" } },
+    });
+    const result = await generateOpenApiDocument({
+      info: { title: "Example", version: "1.0.0" },
+      routes: [graphRoute({ methods: ["GET"] })],
+      loadModule: async () => ({ GET: handler }),
+    });
+
+    const operation = result.document.paths["/api/items/{id}"]?.get;
+    expect(operation?.requestBody).toBeUndefined();
+    expect(operation?.responses["400"]).toBeUndefined();
+    expect(operation?.responses["422"]).toEqual(
+      expect.objectContaining({ description: "Request validation failed." }),
+    );
+  });
+
+  it("preserves catch-all parameter schema constraints from the runtime wildcard key", async () => {
+    const params = standardSchema({
+      type: "object",
+      properties: { "*": { type: "string", pattern: "^docs/" } },
+    });
+    const handler = defineOpenApi(defineApi({ params, handler: () => ({ ok: true }) }), {
+      responses: { 200: { description: "Success" } },
+    });
+    const result = await generateOpenApiDocument({
+      info: { title: "Example", version: "1.0.0" },
+      routes: [
+        graphRoute({
+          file: "/src/api/files/[...path].ts",
+          methods: ["GET"],
+          path: "/api/files/*",
+        }),
+      ],
+      loadModule: async () => ({ GET: handler }),
+    });
+
+    expect(result.document.paths["/api/files/{path}"]?.get?.parameters).toEqual([
+      {
+        name: "path",
+        in: "path",
+        required: true,
+        schema: { type: "string", pattern: "^docs/" },
+      },
+    ]);
+  });
+
   it("emits an honest fallback and warnings for undocumented or unloadable handlers", async () => {
     const onWarning = vi.fn();
     const result = await generateOpenApiDocument({

--- a/packages/openapi/test/vite.test.ts
+++ b/packages/openapi/test/vite.test.ts
@@ -33,6 +33,19 @@ describe("prachtOpenApi options", () => {
     });
   });
 
+  it("canonicalizes endpoint paths for browser requests and static output", () => {
+    expect(
+      resolvePrachtOpenApiOptions({
+        documentPath: "/schéma//openapi.json",
+        info: { title: "Example", version: "1.0.0" },
+        ui: { path: "/référence", provider: "scalar" },
+      }),
+    ).toMatchObject({
+      documentPath: "/sch%C3%A9ma/openapi.json",
+      ui: { path: "/r%C3%A9f%C3%A9rence", provider: "scalar" },
+    });
+  });
+
   it("rejects unsafe and colliding paths", () => {
     expect(() =>
       resolvePrachtOpenApiOptions({
@@ -64,7 +77,21 @@ describe("prachtOpenApi options", () => {
         info: { title: "Example", version: "1.0.0" },
         ui: { path: "/docs.json", provider: "swagger" },
       }),
-    ).toThrow(/must be different/);
+    ).toThrow(/must not overlap/);
+    expect(() =>
+      resolvePrachtOpenApiOptions({
+        documentPath: "/docs/index.html/openapi.json",
+        info: { title: "Example", version: "1.0.0" },
+        ui: "scalar",
+      }),
+    ).toThrow(/must not overlap/);
+    expect(() =>
+      resolvePrachtOpenApiOptions({
+        documentPath: "/docs/openapi.json",
+        info: { title: "Example", version: "1.0.0" },
+        ui: { path: "/docs/openapi.json/reference", provider: "scalar" },
+      }),
+    ).toThrow(/must not overlap/);
   });
 });
 

--- a/packages/openapi/test/vite.test.ts
+++ b/packages/openapi/test/vite.test.ts
@@ -1,0 +1,177 @@
+import type { IncomingMessage, ServerResponse } from "node:http";
+import type { Connect, ViteDevServer } from "vite";
+import { describe, expect, it, vi } from "vitest";
+
+import { prachtOpenApi, resolvePrachtOpenApiOptions } from "../src/vite.ts";
+
+function hookHandler<T extends (...args: any[]) => any>(hook: T | { handler: T } | undefined): T {
+  if (!hook) throw new Error("Expected Vite hook");
+  return typeof hook === "function" ? hook : hook.handler;
+}
+
+describe("prachtOpenApi options", () => {
+  it("defaults to JSON-only endpoints", () => {
+    expect(resolvePrachtOpenApiOptions({ info: { title: "Example", version: "1.0.0" } })).toEqual({
+      document: {},
+      documentPath: "/openapi.json",
+      failOnWarnings: false,
+      info: { title: "Example", version: "1.0.0" },
+      ui: null,
+    });
+  });
+
+  it("normalizes shorthand UI options", () => {
+    expect(
+      resolvePrachtOpenApiOptions({
+        documentPath: "/schema.json/",
+        info: { title: "Example", version: "1.0.0" },
+        ui: "scalar",
+      }),
+    ).toMatchObject({
+      documentPath: "/schema.json",
+      ui: { path: "/docs", provider: "scalar" },
+    });
+  });
+
+  it("rejects unsafe and colliding paths", () => {
+    expect(() =>
+      resolvePrachtOpenApiOptions({
+        documentPath: "/../openapi.json",
+        info: { title: "Example", version: "1.0.0" },
+      }),
+    ).toThrow(/safe root-relative/);
+    expect(() =>
+      resolvePrachtOpenApiOptions({
+        documentPath: "/%2e%2e/openapi.json",
+        info: { title: "Example", version: "1.0.0" },
+      }),
+    ).toThrow(/safe root-relative/);
+    expect(() =>
+      resolvePrachtOpenApiOptions({
+        documentPath: "/openapi.json\n",
+        info: { title: "Example", version: "1.0.0" },
+      }),
+    ).toThrow(/safe root-relative/);
+    expect(() =>
+      resolvePrachtOpenApiOptions({
+        documentPath: "/openapi",
+        info: { title: "Example", version: "1.0.0" },
+      }),
+    ).toThrow(/must end in \.json/);
+    expect(() =>
+      resolvePrachtOpenApiOptions({
+        documentPath: "/docs.json",
+        info: { title: "Example", version: "1.0.0" },
+        ui: { path: "/docs.json", provider: "swagger" },
+      }),
+    ).toThrow(/must be different/);
+  });
+});
+
+describe("prachtOpenApi Vite integration", () => {
+  it("augments only the Pracht server module with an artifact generator", async () => {
+    const plugin = prachtOpenApi({
+      info: { title: "Example", version: "1.0.0" },
+      ui: { provider: "swagger", path: "/reference" },
+    });
+    const transform = hookHandler(plugin.transform);
+    const context = {} as never;
+    const source = "const apiModules = {}; const apiRoutes = [];";
+
+    const result = await transform.call(context, source, "\0virtual:pracht/server");
+    const code = typeof result === "string" ? result : result?.code;
+    expect(code).toContain('from "@pracht/openapi"');
+    expect(code).toContain("export async function generatePrachtOpenApiArtifacts()");
+    expect(code).toContain('"path":"/reference"');
+    const devResult = await transform.call(context, source, "\0virtual:pracht/dev-metadata");
+    const devCode = typeof devResult === "string" ? devResult : devResult?.code;
+    expect(devCode).toContain("generatePrachtOpenApiArtifacts");
+    expect(await transform.call(context, source, "/src/app.ts")).toBeNull();
+  });
+
+  it("serves generated JSON, UI, HEAD, and method errors in dev", async () => {
+    const artifacts = {
+      artifacts: [
+        {
+          content: '{"openapi":"3.1.0"}\n',
+          contentType: "application/json; charset=utf-8",
+          outputPath: "openapi.json",
+          path: "/openapi.json",
+        },
+        {
+          content: "<!doctype html><title>Docs</title>",
+          contentType: "text/html; charset=utf-8",
+          outputPath: "docs/index.html",
+          path: "/docs",
+        },
+      ],
+      warnings: [
+        {
+          code: "undocumented_response",
+          file: "/src/api/health.ts",
+          message: "Missing response metadata.",
+          method: "GET",
+          path: "/api/health",
+        },
+      ],
+    };
+    let middleware: Connect.NextHandleFunction | undefined;
+    const warn = vi.fn();
+    const server = {
+      config: { logger: { error: vi.fn(), warn } },
+      middlewares: { use: (handler: Connect.NextHandleFunction) => (middleware = handler) },
+      ssrFixStacktrace: vi.fn(),
+      ssrLoadModule: vi.fn(async (id: string) =>
+        id === "@pracht/core/server"
+          ? { matchApiRoute: () => undefined, matchAppRoute: () => undefined }
+          : { generatePrachtOpenApiArtifacts: async () => artifacts },
+      ),
+    } as unknown as ViteDevServer;
+    const plugin = prachtOpenApi({
+      info: { title: "Example", version: "1.0.0" },
+      ui: "scalar",
+    });
+    hookHandler(plugin.configureServer).call({} as never, server);
+    if (!middleware) throw new Error("Expected middleware registration");
+
+    const json = await runMiddleware(middleware, "/openapi.json", "GET");
+    expect(json.status).toBe(200);
+    expect(json.headers["content-type"]).toContain("application/json");
+    expect(json.body).toContain('"openapi"');
+
+    const ui = await runMiddleware(middleware, "/docs/", "GET");
+    expect(ui.status).toBe(200);
+    expect(ui.headers["content-type"]).toContain("text/html");
+
+    const head = await runMiddleware(middleware, "/openapi.json", "HEAD");
+    expect(head.status).toBe(200);
+    expect(head.body).toBe("");
+
+    const post = await runMiddleware(middleware, "/openapi.json", "POST");
+    expect(post.status).toBe(405);
+    expect(post.headers.allow).toBe("GET, HEAD");
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(server.ssrLoadModule).toHaveBeenCalledWith("virtual:pracht/dev-metadata");
+  });
+});
+
+async function runMiddleware(
+  middleware: Connect.NextHandleFunction,
+  url: string,
+  method: string,
+): Promise<{ body: string; headers: Record<string, string>; status: number }> {
+  const request = { method, url } as IncomingMessage;
+  const headers: Record<string, string> = {};
+  let body = "";
+  const response = {
+    end(value?: unknown) {
+      body = value === undefined ? "" : String(value);
+    },
+    setHeader(name: string, value: unknown) {
+      headers[name.toLowerCase()] = String(value);
+    },
+    statusCode: 200,
+  } as unknown as ServerResponse;
+  await middleware(request, response, vi.fn());
+  return { body, headers, status: response.statusCode };
+}

--- a/packages/openapi/tsdown.config.ts
+++ b/packages/openapi/tsdown.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "tsdown";
+
+export default defineConfig({
+  clean: true,
+  entry: ["src/index.ts", "src/vite.ts"],
+  format: "esm",
+  dts: true,
+  external: ["@pracht/core", "vite", /^node:/],
+});

--- a/packages/vite-plugin/test/plugin-options.test.ts
+++ b/packages/vite-plugin/test/plugin-options.test.ts
@@ -1,7 +1,10 @@
 import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
 
-import { createPrachtServerModuleSource } from "../src/plugin-codegen.ts";
+import {
+  createPrachtDevModuleSource,
+  createPrachtServerModuleSource,
+} from "../src/plugin-codegen.ts";
 import { resolveOptions } from "../src/plugin-options.ts";
 
 describe("resolveOptions budgets", () => {
@@ -84,6 +87,16 @@ describe("createPrachtServerModuleSource llmsTxt export", () => {
     const packageRoot = fileURLToPath(new URL("..", import.meta.url));
     const source = createPrachtServerModuleSource({ llmsTxt: {} }, { root: packageRoot });
     expect(source).toContain('"title":"@pracht/vite-plugin"');
+  });
+});
+
+describe("createPrachtDevModuleSource API graph", () => {
+  it("exports adapter-neutral resolved API routes for companion tooling", () => {
+    const source = createPrachtDevModuleSource({ apiDir: "/src/http" });
+    expect(source).toContain('import { resolveApp, resolveApiRoutes } from "@pracht/core/server";');
+    expect(source).toContain(
+      'export const apiRoutes = resolveApiRoutes(Object.keys(apiModules), "/src/http");',
+    );
   });
 });
 

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -43,14 +43,15 @@ export default defineConfig({
     {
       name: "basic",
       testMatch:
-        /basic\.test\.ts|navigation\.test\.ts|node-build\.test\.ts|cloudflare-build\.test\.ts|vercel-build\.test\.ts|pages-isg-build\.test\.ts|client-bundle-strip\.test\.ts|tsrx-build\.test\.ts|islands-build\.test\.ts|env-safety\.test\.ts|not-found\.test\.ts/,
+        /basic\.test\.ts|navigation\.test\.ts|node-build\.test\.ts|cloudflare-build\.test\.ts|vercel-build\.test\.ts|pages-isg-build\.test\.ts|client-bundle-strip\.test\.ts|tsrx-build\.test\.ts|islands-build\.test\.ts|env-safety\.test\.ts|not-found\.test\.ts|openapi-cloudflare-dev\.test\.ts/,
       use: {
         baseURL: e2eUrls.basic,
       },
     },
     {
       name: "pages-router",
-      testMatch: /pages-router\.test\.ts|dev-404\.test\.ts|llms-txt-dev\.test\.ts/,
+      testMatch:
+        /pages-router\.test\.ts|dev-404\.test\.ts|llms-txt-dev\.test\.ts|openapi-dev\.test\.ts/,
       use: {
         baseURL: e2eUrls.pagesRouter,
       },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -354,9 +354,15 @@ importers:
 
   packages/openapi:
     dependencies:
+      '@pracht/cli':
+        specifier: workspace:*
+        version: link:../cli
       '@pracht/core':
         specifier: workspace:*
         version: link:../framework
+      '@pracht/vite-plugin':
+        specifier: workspace:*
+        version: link:../vite-plugin
       vite:
         specifier: ^8.0.0
         version: 8.0.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@22.19.17)(esbuild@0.27.3)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -71,6 +71,9 @@ importers:
       '@pracht/image':
         specifier: workspace:*
         version: link:../../packages/image
+      '@pracht/openapi':
+        specifier: workspace:*
+        version: link:../../packages/openapi
       sharp:
         specifier: ^0.34.0
         version: 0.34.5
@@ -102,6 +105,9 @@ importers:
       '@pracht/core':
         specifier: workspace:*
         version: link:../../packages/framework
+      '@pracht/openapi':
+        specifier: workspace:*
+        version: link:../../packages/openapi
     devDependencies:
       '@pracht/cli':
         specifier: workspace:*
@@ -195,6 +201,9 @@ importers:
       '@pracht/core':
         specifier: workspace:*
         version: link:../../packages/framework
+      '@pracht/openapi':
+        specifier: workspace:*
+        version: link:../../packages/openapi
     devDependencies:
       '@pracht/cli':
         specifier: workspace:*
@@ -342,6 +351,15 @@ importers:
       sharp:
         specifier: ^0.34.0
         version: 0.34.5
+
+  packages/openapi:
+    dependencies:
+      '@pracht/core':
+        specifier: workspace:*
+        version: link:../framework
+      vite:
+        specifier: ^8.0.0
+        version: 8.0.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@22.19.17)(esbuild@0.27.3)
 
   packages/preact-ssr-precompile:
     dependencies:

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -24,6 +24,8 @@
       "@pracht/core/server": ["./packages/framework/src/server.ts"],
       "@pracht/core/islands-client": ["./packages/framework/src/islands-client.ts"],
       "@pracht/capabilities": ["./packages/capabilities/src/index.ts"],
+      "@pracht/openapi": ["./packages/openapi/src/index.ts"],
+      "@pracht/openapi/vite": ["./packages/openapi/src/vite.ts"],
       "@pracht/vite-plugin": ["./packages/vite-plugin/src/index.ts"],
       "@pracht/preact-ssr-precompile": ["./packages/preact-ssr-precompile/src/index.ts"],
       "@pracht/adapter-node": ["./packages/adapter-node/src/index.ts"],


### PR DESCRIPTION
## Summary

- Add the opt-in `@pracht/openapi` companion package with OpenAPI 3.1 generation, explicit operation descriptors, and optional Scalar or Swagger UI endpoints.
- Integrate live development generation and static Node, Cloudflare, and Vercel build artifacts, with path hardening, deployment routing, examples, and documentation.
- Closes #256.

## Testing

- [x] `pnpm e2e`
- [x] `pnpm format`
- [x] `pnpm lint`
- [x] `pnpm test`

## Checklist

- [x] Docs updated if needed
- [x] Skills updated if needed
- [x] Changeset added if published packages changed
