### PR TITLE
Fix Cloudflare app graph inspection with worker exports

### DIFF
--- a/.changeset/dev-metadata-graph-module.md
+++ b/.changeset/dev-metadata-graph-module.md
@@ -1,0 +1,13 @@
+---
+"@pracht/vite-plugin": patch
+"@pracht/cli": patch
+---
+
+Stop evaluating the adapter's server entry when reading the app graph. `pracht
+dev`'s startup banner, `pracht inspect`, `pracht plan`, and `pracht verify` now
+load the adapter-neutral `virtual:pracht/dev-metadata` module (which gained
+`apiRoutes` and `buildTarget` exports) instead of `virtual:pracht/server`. On
+Cloudflare apps using `workerExportsFrom`, loading the server entry in Vite's
+Node SSR environment logged `Cannot find module 'cloudflare:workers'` on every
+`pracht dev` start and swallowed the route/API banner. Metadata evaluation
+errors remain intact instead of falling back to that runtime-specific entry.

--- a/docs/ADAPTERS.md
+++ b/docs/ADAPTERS.md
@@ -845,6 +845,14 @@ The generated server entry module has access to `resolvedApp`, `registry`,
 `apiRoutes`, `clientEntryUrl`, `cssManifest`, and `jsManifest` -- your
 `createServerEntryModule()` code can reference these directly.
 
+The entry may import modules that only resolve inside the target runtime (the
+Cloudflare adapter re-exports Durable Objects that import `cloudflare:workers`).
+Graph-reading tooling -- the `pracht dev` banner, `pracht inspect`, `pracht plan`,
+`pracht verify`, and dev-time CSS discovery -- therefore never evaluates
+`virtual:pracht/server`. It reads `virtual:pracht/dev-metadata`, an
+adapter-neutral module exporting `resolvedApp`, `apiRoutes`, `registry`, and
+`buildTarget`, so an adapter is free to emit runtime-only imports.
+
 At the runtime level, an adapter also typically needs to:
 
 1. **Accept a platform request** and convert it to a Web `Request` object

--- a/packages/cli/src/app-graph.ts
+++ b/packages/cli/src/app-graph.ts
@@ -61,6 +61,38 @@ interface ApiRouteEntry {
   path: string;
 }
 
+const PRACHT_DEV_METADATA_MODULE_ID = "virtual:pracht/dev-metadata";
+
+/**
+ * Adapter-neutral app metadata (`resolvedApp`, `apiRoutes`, `registry`,
+ * `buildTarget`) for graph-reading commands. It comes from a dedicated virtual
+ * module rather than the adapter's server entry because that entry can pull in
+ * imports Vite's Node SSR environment cannot resolve — Cloudflare Durable
+ * Objects re-exported through `workerExportsFrom` import `cloudflare:workers`,
+ * which only exists inside workerd.
+ */
+export async function loadAppMetadataModule(server: ViteDevServer): Promise<Record<string, any>> {
+  try {
+    return await server.ssrLoadModule(PRACHT_DEV_METADATA_MODULE_ID);
+  } catch (error) {
+    if (!isMissingDevMetadataModule(error)) throw error;
+
+    // Apps on a @pracht/vite-plugin older than the dev-metadata module.
+    return server.ssrLoadModule("virtual:pracht/server");
+  }
+}
+
+function isMissingDevMetadataModule(error: unknown): boolean {
+  return (
+    error instanceof Error &&
+    "code" in error &&
+    error.code === "ERR_LOAD_URL" &&
+    error.message.includes(
+      `Failed to load url ${PRACHT_DEV_METADATA_MODULE_ID} (resolved id: ${PRACHT_DEV_METADATA_MODULE_ID})`,
+    )
+  );
+}
+
 /**
  * Load the resolved app graph (page routes + API routes) from a running Vite
  * dev server. Shared by `pracht inspect` and the `pracht dev` startup banner.
@@ -70,7 +102,7 @@ export async function collectAppGraph(
   root: string,
   options: { executeApiModules?: boolean } = {},
 ): Promise<AppGraph> {
-  const serverModule = await server.ssrLoadModule("virtual:pracht/server");
+  const serverModule = await loadAppMetadataModule(server);
   const notFound = serverModule.resolvedApp.notFound;
   return {
     api: await collectApiRoutes(server, root, serverModule.apiRoutes, options),

--- a/packages/cli/src/app-server.ts
+++ b/packages/cli/src/app-server.ts
@@ -2,6 +2,7 @@ import { existsSync } from "node:fs";
 
 import { createServer, type ViteDevServer } from "vite";
 
+import { loadAppMetadataModule } from "./app-graph.js";
 import { readProjectConfig, resolveProjectPath, type ProjectConfig } from "./project.js";
 
 export interface AppServerContext {
@@ -12,7 +13,7 @@ export interface AppServerContext {
 
 /**
  * Boot a silent middleware-mode Vite server for the app at `root`, load the
- * `virtual:pracht/server` module, run `fn`, and always close the server.
+ * app's resolved graph metadata, run `fn`, and always close the server.
  * Shared by `pracht inspect`, `pracht plan`, and graph-aware verification so
  * they all observe the exact same resolved app graph.
  */
@@ -46,7 +47,7 @@ export async function withAppServer<T>(
   });
 
   try {
-    const serverModule = await server.ssrLoadModule("virtual:pracht/server");
+    const serverModule = await loadAppMetadataModule(server);
     return await fn({ project, server, serverModule });
   } finally {
     await server.close();

--- a/packages/cli/test/app-metadata-module.test.ts
+++ b/packages/cli/test/app-metadata-module.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it, vi } from "vitest";
+import type { ViteDevServer } from "vite";
+
+import { loadAppMetadataModule } from "../src/app-graph.ts";
+
+function fakeServer(modules: Record<string, unknown>): ViteDevServer {
+  return {
+    ssrLoadModule: vi.fn(async (id: string) => {
+      if (!(id in modules)) {
+        const error = new Error(
+          `Failed to load url ${id} (resolved id: ${id}). Does the file exist?`,
+        );
+        Object.assign(error, { code: "ERR_LOAD_URL" });
+        throw error;
+      }
+      if (modules[id] instanceof Error) throw modules[id];
+      return modules[id] as Record<string, unknown>;
+    }),
+  } as unknown as ViteDevServer;
+}
+
+describe("loadAppMetadataModule", () => {
+  // The Cloudflare adapter re-exports Durable Objects (which import
+  // `cloudflare:workers`) from the server entry — unresolvable in Vite's Node
+  // SSR environment, so graph-reading commands must not touch that entry.
+  it("reads the adapter-neutral dev metadata module", async () => {
+    const server = fakeServer({
+      "virtual:pracht/dev-metadata": { buildTarget: "cloudflare" },
+      "virtual:pracht/server": { buildTarget: "should-not-be-read" },
+    });
+
+    await expect(loadAppMetadataModule(server)).resolves.toMatchObject({
+      buildTarget: "cloudflare",
+    });
+    expect(server.ssrLoadModule).toHaveBeenCalledTimes(1);
+  });
+
+  it("falls back to the server entry for older vite-plugin versions", async () => {
+    const server = fakeServer({ "virtual:pracht/server": { buildTarget: "node" } });
+
+    await expect(loadAppMetadataModule(server)).resolves.toMatchObject({
+      buildTarget: "node",
+    });
+  });
+
+  it("does not mask an app error from the metadata module", async () => {
+    const server = fakeServer({
+      "virtual:pracht/dev-metadata": new Error('Unknown middleware "atu" for route "/".'),
+      "virtual:pracht/server": new Error("Cannot find module 'cloudflare:workers'"),
+    });
+
+    await expect(loadAppMetadataModule(server)).rejects.toThrow(
+      'Unknown middleware "atu" for route "/".',
+    );
+    expect(server.ssrLoadModule).toHaveBeenCalledTimes(1);
+  });
+
+  it("surfaces the app's own load error when neither module loads", async () => {
+    await expect(loadAppMetadataModule(fakeServer({}))).rejects.toThrow(
+      "Failed to load url virtual:pracht/server",
+    );
+  });
+});

--- a/packages/vite-plugin/src/plugin-codegen.ts
+++ b/packages/vite-plugin/src/plugin-codegen.ts
@@ -385,12 +385,14 @@ export function createPrachtDevModuleSource(
     : `import { app } from ${JSON.stringify(resolved.appFile)};`;
 
   return [
-    'import { resolveApp } from "@pracht/core/server";',
+    'import { resolveApp, resolveApiRoutes } from "@pracht/core/server";',
     appImport,
     "",
     createPrachtRegistryModuleSource(resolved),
     "",
     "export const resolvedApp = resolveApp(app);",
+    `export const apiRoutes = resolveApiRoutes(Object.keys(apiModules), ${JSON.stringify(resolved.apiDir)});`,
+    `export const buildTarget = ${JSON.stringify(resolved.adapter?.id ?? "node")};`,
     "",
   ].join("\n");
 }

--- a/packages/vite-plugin/test/pages-router.test.ts
+++ b/packages/vite-plugin/test/pages-router.test.ts
@@ -234,4 +234,31 @@ describe("createPrachtRegistryModuleSource", () => {
     expect(source).toContain("export const registry = {");
     expect(source).not.toContain("createCloudflareFetchHandler");
   });
+
+  // The dev banner, `pracht inspect`, and the graph snapshot read the whole
+  // app graph from this module, so it carries the adapter-neutral exports the
+  // server entry has — without the adapter's runtime-only imports.
+  it("exposes the app graph the CLI reads without the adapter entry", () => {
+    const source = createPrachtDevModuleSource({
+      adapter: {
+        id: "cloudflare",
+        serverImports: 'import { x } from "@pracht/adapter-cloudflare/runtime";',
+        createServerEntryModule: () => 'export * from "/src/cloudflare.ts";',
+      },
+      appFile: "/src/routes.ts",
+    });
+
+    expect(source).toContain(
+      'export const apiRoutes = resolveApiRoutes(Object.keys(apiModules), "/src/api");',
+    );
+    expect(source).toContain('export const buildTarget = "cloudflare";');
+    expect(source).not.toContain("/src/cloudflare.ts");
+    expect(source).not.toContain("@pracht/adapter-cloudflare/runtime");
+  });
+
+  it("reports the node build target when no adapter is configured", () => {
+    expect(createPrachtDevModuleSource({ appFile: "/src/routes.ts" })).toContain(
+      'export const buildTarget = "node";',
+    );
+  });
 });


### PR DESCRIPTION
## Summary

- Load graph-reading CLI commands from adapter-neutral metadata so Cloudflare `workerExportsFrom` imports no longer break the dev banner, inspect, plan, or verify.
- Preserve original app errors, retain compatibility with older Vite plugins, document the adapter contract, and add patch changesets for `@pracht/cli` and `@pracht/vite-plugin`.
- Issue: N/A.

## Testing

- [x] `pnpm e2e`
- [x] `pnpm format`
- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `pnpm run typecheck`

## Checklist

- [x] Docs updated if needed
- [x] Skills updated if needed (N/A — no skill workflow changed)
- [x] Changeset added if published packages changed
