### PR TITLE
Make @pracht/core exports tree-shakeable

### DIFF
--- a/.changeset/tiny-framework-imports.md
+++ b/.changeset/tiny-framework-imports.md
@@ -1,0 +1,5 @@
+---
+"@pracht/core": patch
+---
+
+Publish the core package as unbundled ESM so downstream bundlers can tree-shake unused public APIs instead of retaining unrelated framework modules.

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -4,6 +4,24 @@ Pracht's core promise is shipping less JavaScript. Two built-in tools keep that
 promise honest as an app grows: `pracht build --analyze` (visibility) and
 per-route client-JS budgets (enforcement).
 
+## Tree-shaking framework imports
+
+`@pracht/core` is published as unbundled ESM so downstream bundlers can follow
+the dependency graph for each named export. Import the public API you need from
+the package normally; Vite can remove unrelated framework modules from the
+client bundle:
+
+```ts
+import { createHref } from "@pracht/core";
+```
+
+Type-only imports disappear entirely. Browser components and hooks such as
+`Form` and `useLocation` still bring their required Preact and router runtime,
+while small helpers such as `createHref`, `publicEnv`, and `apiFetch` do not pull
+in unrelated client features. The dedicated `@pracht/core/client`, `/manifest`,
+`/env`, `/env/server`, and `/server` entry points remain available for generated
+framework code and explicit environment separation.
+
 ## `pracht build --analyze`
 
 After a successful production build, `--analyze` prints a per-route report of

--- a/docs/WORKSPACE.md
+++ b/docs/WORKSPACE.md
@@ -83,11 +83,14 @@ described in `VISION_MVP.md`.
   `@pracht/preact-ssr-precompile`, `@pracht/adapter-node`,
   `@pracht/adapter-cloudflare`, `@pracht/adapter-vercel`, and `@pracht/image`
   from TypeScript to
-  ESM (`dist/index.mjs` + `.d.mts`). `@pracht/core` also publishes browser,
-  client, manifest, and server subpath entries so the Vite plugin can keep
-  server-only runtime code and route-only browser helpers out of the critical
-  client bootstrap graph while generated server modules avoid the browser export
-  condition. The CLI remains plain JS.
+  ESM (`dist/index.mjs` + `.d.mts`). `@pracht/core` preserves its source-module
+  boundaries in the published ESM so downstream builds can tree-shake named
+  public imports. Its prerender module remains explicitly side-effectful because
+  edge bundlers must retain its module initialization. The package also publishes
+  browser, client, manifest, and server subpath entries so the Vite plugin can
+  keep server-only runtime code and route-only browser helpers out of the
+  critical client bootstrap graph while generated server modules avoid the
+  browser export condition. The CLI remains plain JS.
 - **Node adapter** — Translates Node requests to Web `Request` objects, calls
   `handlePrachtRequest()`, and implements ISG stale-while-revalidate plus
   webhook regeneration of on-disk HTML.

--- a/packages/framework/package.json
+++ b/packages/framework/package.json
@@ -27,6 +27,9 @@
   "files": [
     "dist"
   ],
+  "sideEffects": [
+    "./dist/prerender.mjs"
+  ],
   "type": "module",
   "exports": {
     ".": {

--- a/packages/framework/test/package-tree-shaking.test.ts
+++ b/packages/framework/test/package-tree-shaking.test.ts
@@ -1,0 +1,98 @@
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { gzipSync } from "node:zlib";
+
+import { build } from "vite";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+const frameworkRoot = fileURLToPath(new URL("..", import.meta.url));
+const tempRoot = mkdtempSync(join(tmpdir(), "pracht-tree-shaking-"));
+const outputDir = join(tempRoot, "dist");
+const browserEntry = join(outputDir, "browser.mjs");
+
+type FrameworkPackage = {
+  sideEffects?: boolean | string[];
+};
+
+const packageJson = JSON.parse(
+  readFileSync(join(frameworkRoot, "package.json"), "utf-8"),
+) as FrameworkPackage;
+
+beforeAll(() => {
+  writeFileSync(
+    join(tempRoot, "package.json"),
+    JSON.stringify({ type: "module", sideEffects: packageJson.sideEffects }),
+    "utf-8",
+  );
+
+  execFileSync("pnpm", ["exec", "tsdown", "--config", "tsdown.config.ts", "--out-dir", outputDir], {
+    cwd: frameworkRoot,
+    stdio: "pipe",
+  });
+}, 30_000);
+
+afterAll(() => {
+  rmSync(tempRoot, { force: true, recursive: true });
+});
+
+async function bundleExport(exportName: string): Promise<number> {
+  const publicId = "virtual:pracht-tree-shaking-entry";
+  const resolvedId = `\0${publicId}`;
+  const result = await build({
+    configFile: false,
+    logLevel: "silent",
+    define: {
+      __PRACHT_PUBLIC_ENV__: "{}",
+    },
+    plugins: [
+      {
+        name: "pracht-tree-shaking-test",
+        resolveId(id) {
+          if (id === publicId) return resolvedId;
+        },
+        load(id) {
+          if (id !== resolvedId) return;
+          return `export { ${exportName} } from ${JSON.stringify(pathToFileURL(browserEntry).href)};`;
+        },
+      },
+    ],
+    build: {
+      minify: "esbuild",
+      rollupOptions: {
+        external: [/^@pracht\//, "@standard-schema/spec", "preact", /^preact\//, "preact-suspense"],
+        input: publicId,
+      },
+      write: false,
+    },
+  });
+
+  if ("on" in result) throw new Error("Unexpected Vite watcher result");
+  const outputs = Array.isArray(result) ? result : [result];
+  return outputs
+    .flatMap((output) => output.output)
+    .filter((item) => item.type === "chunk")
+    .reduce((total, chunk) => total + gzipSync(Buffer.from(chunk.code)).byteLength, 0);
+}
+
+describe("published package tree shaking", () => {
+  it("keeps prerender initialization while marking other modules as side-effect-free", () => {
+    expect(packageJson.sideEffects).toEqual(["./dist/prerender.mjs"]);
+  });
+
+  it("emits source modules instead of shared cross-entry chunks", () => {
+    expect(readFileSync(browserEntry, "utf-8")).toContain('from "./href.mjs"');
+    expect(readFileSync(join(outputDir, "href.mjs"), "utf-8")).toContain("createHref");
+  });
+
+  it.each([
+    ["publicEnv", 350],
+    ["createHref", 1_400],
+    ["apiFetch", 2_200],
+    ["PrachtHttpError", 350],
+  ])("keeps a named %s import below %i gzip bytes", async (exportName, maxGzipBytes) => {
+    expect(await bundleExport(exportName)).toBeLessThanOrEqual(maxGzipBytes);
+  });
+});

--- a/packages/framework/tsdown.config.ts
+++ b/packages/framework/tsdown.config.ts
@@ -18,5 +18,6 @@ export default defineConfig({
   ],
   format: "esm",
   dts: true,
+  unbundle: true,
   external: ["preact", "preact/hooks", "preact-render-to-string"],
 });


### PR DESCRIPTION
## Summary

- Publish `@pracht/core` as unbundled ESM so downstream bundlers can remove unrelated framework modules from named imports.
- Mark only `dist/prerender.mjs` as side-effectful, preserving required module initialization in Cloudflare and Vercel edge builds.
- Add an isolated package-build + Vite regression suite with gzip ceilings for `publicEnv`, `createHref`, `apiFetch`, and `PrachtHttpError`.
- Document package-level tree shaking and add a patch changeset.
- Link issue if relevant: N/A

## Measurements

Local production gzip measurements for isolated imports:

| Named import | Before | After |
| --- | ---: | ---: |
| `publicEnv` | 5.58 KB | 0.19 KB |
| `createHref` | 6.34 KB | 0.91 KB |
| `apiFetch` | 6.94 KB | 1.54 KB |
| `PrachtHttpError` | 4.76 KB | 0.13 KB |

A real `createHref` route fixture dropped from 17.01 KB to 15.20 KB gzip, while the existing basic, minimal, notes, dashboard, islands, and hydration-none example builds remained flat or improved.

## Testing

- [x] `pnpm run e2e` (114 passed)
- [x] `pnpm run format`
- [x] `pnpm run lint` (0 findings)
- [x] `pnpm run test` (81 files, 1,330 passed)
- [x] `pnpm run typecheck`
- [x] `pnpm run build`
- [x] `npm pack --dry-run --json` for `@pracht/core`

## Checklist

- [x] Docs updated if needed
- [x] Skills reviewed; update not needed for this package-internal change
- [x] Changeset added if published packages changed
