### PR TITLE
perf(framework): group form and query fields in a single pass

### DIFF
--- a/.changeset/api-validation-record-single-pass.md
+++ b/.changeset/api-validation-record-single-pass.md
@@ -1,0 +1,12 @@
+---
+"@pracht/framework": patch
+---
+
+Group form and query fields in a single pass. `formDataToRecord()` and
+`searchParamsToRecord()` walked the unique keys and called `getAll()` for each
+one; because `getAll()` rescans the entire entry list, the cost grew
+quadratically with the number of distinct fields, so requests carrying many
+fields spent a disproportionate amount of time in validation before the handler
+ran. Both helpers now build the record in one pass over the entries. Behaviour
+is unchanged: a field that appears once maps to its value, a repeated field maps
+to an array in submission order, and the record keeps its null prototype.

--- a/docs/API_VALIDATION.md
+++ b/docs/API_VALIDATION.md
@@ -317,3 +317,7 @@ The docs use zod in examples for familiarity; nothing in pracht assumes it.
   middleware short-circuit still prevents body parsing.
 - `formDataToRecord`, `searchParamsToRecord`, and `validateStandardSchema`
   are exported for reuse in custom handlers or middleware.
+- Both record helpers group entries in a single pass, so their cost is linear
+  in the number of fields. A field that appears once maps to its value, a
+  repeated field maps to an array in submission order, and the returned record
+  has a null prototype so a `__proto__` field stays an ordinary own property.

--- a/packages/framework/src/api-validation.ts
+++ b/packages/framework/src/api-validation.ts
@@ -437,12 +437,7 @@ async function runSchema(
 export function searchParamsToRecord(
   searchParams: URLSearchParams,
 ): Record<string, string | string[]> {
-  const record = Object.create(null) as Record<string, string | string[]>;
-  for (const key of new Set(searchParams.keys())) {
-    const values = searchParams.getAll(key);
-    record[key] = values.length === 1 ? values[0] : values;
-  }
-  return record;
+  return groupEntriesByKey(searchParams);
 }
 
 /**
@@ -452,11 +447,36 @@ export function searchParamsToRecord(
 export function formDataToRecord(
   formData: FormData,
 ): Record<string, FormDataEntryValue | FormDataEntryValue[]> {
-  const record = Object.create(null) as Record<string, FormDataEntryValue | FormDataEntryValue[]>;
-  for (const key of new Set(formData.keys())) {
-    const values = formData.getAll(key);
-    record[key] = values.length === 1 ? values[0] : values;
+  return groupEntriesByKey(formData);
+}
+
+/**
+ * Group `[key, value]` pairs into one record: the value itself for a key that
+ * appears once, an array for a key that repeats.
+ *
+ * Deliberately a single pass. Iterating unique keys and calling `getAll(key)`
+ * per key reads as the obvious implementation, but `getAll` rescans the whole
+ * entry list, making the cost O(n²) in the number of distinct keys — bodies and
+ * query strings with many fields get slow fast. The record stays null-prototype
+ * so a `__proto__` field remains an ordinary own property.
+ */
+function groupEntriesByKey<TValue>(
+  entries: Iterable<[string, TValue]>,
+): Record<string, TValue | TValue[]> {
+  const record = Object.create(null) as Record<string, TValue | TValue[]>;
+  const repeated = new Set<string>();
+
+  for (const [key, value] of entries) {
+    if (!(key in record)) {
+      record[key] = value;
+    } else if (repeated.has(key)) {
+      (record[key] as TValue[]).push(value);
+    } else {
+      repeated.add(key);
+      record[key] = [record[key] as TValue, value];
+    }
   }
+
   return record;
 }
 

--- a/packages/framework/test/api-validation.test.ts
+++ b/packages/framework/test/api-validation.test.ts
@@ -341,6 +341,44 @@ describe("record helpers", () => {
     expect(formDataToRecord(formData)).toEqual({ a: "1", b: ["2", "3"] });
   });
 
+  it("keeps every value, in order, when a key repeats more than twice", () => {
+    const formData = new FormData();
+    for (const value of ["1", "2", "3", "4"]) {
+      formData.append("tag", value);
+    }
+
+    expect(formDataToRecord(formData)).toEqual({ tag: ["1", "2", "3", "4"] });
+    expect(searchParamsToRecord(new URLSearchParams("tag=1&tag=2&tag=3&tag=4"))).toEqual({
+      tag: ["1", "2", "3", "4"],
+    });
+  });
+
+  it("groups many distinct keys in a single pass", () => {
+    // Grouping by re-reading every entry per unique key is quadratic: at this
+    // size it costs tens of seconds, so the budget below fails loudly if the
+    // per-key rescan ever comes back. A single pass lands in ~20ms.
+    const COUNT = 100_000;
+    const formData = new FormData();
+    const pairs: string[] = [];
+    for (let index = 0; index < COUNT; index++) {
+      const key = index.toString(36);
+      formData.append(key, "");
+      pairs.push(`${key}=`);
+    }
+    const searchParams = new URLSearchParams(pairs.join("&"));
+
+    const started = performance.now();
+    const form = formDataToRecord(formData);
+    const query = searchParamsToRecord(searchParams);
+    const elapsed = performance.now() - started;
+
+    expect(Object.keys(form)).toHaveLength(COUNT);
+    expect(Object.keys(query)).toHaveLength(COUNT);
+    expect(form[(COUNT - 1).toString(36)]).toBe("");
+    expect(query[(COUNT - 1).toString(36)]).toBe("");
+    expect(elapsed).toBeLessThan(5_000);
+  });
+
   it("preserves special field names without changing the record prototype", () => {
     const query = searchParamsToRecord(new URLSearchParams("__proto__=query&constructor=value"));
     const formData = new FormData();


### PR DESCRIPTION
## Summary

- `formDataToRecord()` and `searchParamsToRecord()` built their record by iterating the unique keys and calling `getAll()` for each one. `getAll()` rescans the entire entry list, so grouping cost grew quadratically with the number of *distinct* fields — a request with many fields spent a disproportionate amount of time in validation before the handler ever ran.
- Both helpers now share a single linear pass over the entries (`groupEntriesByKey`). Measured on the `defineApi` path, a form body with 250k distinct fields goes from minutes of CPU to ~90ms.
- Behaviour is unchanged: a field that appears once maps to its value, a repeated field maps to an array in submission order, and the record keeps its null prototype so a `__proto__` field stays an ordinary own property.
- Swept the repo for the same shape; these were the only two occurrences. `coerceFormInput()` in `@pracht/capabilities` already groups in one pass with a `Map`.
- No linked issue.

## Testing

- [x] `pnpm e2e` — 114 passed
- [x] `pnpm format`
- [x] `pnpm lint` — 0 warnings, 0 errors
- [x] `pnpm test` — 1332 passed (81 files)

Also ran `pnpm typecheck` (clean). New tests cover the previously untested 3+ repeat grouping path and assert the helpers stay linear at 100k distinct fields — that test alone took ~35s under the old implementation and now runs in well under a second.

## Checklist

- [x] Docs updated if needed — noted the linear grouping and record semantics in `docs/API_VALIDATION.md`
- [ ] Skills updated if needed — N/A
- [x] Changeset added if published packages changed — `.changeset/api-validation-record-single-pass.md` (patch, `@pracht/framework`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)