### PR TITLE
feat(start): scaffold a not-found page

### DIFF
--- a/.changeset/scaffold-not-found-page.md
+++ b/.changeset/scaffold-not-found-page.md
@@ -1,5 +1,6 @@
 ---
 "create-pracht": minor
+"@pracht/cli": patch
 ---
 
 Scaffold a not-found page. New manifest apps get `src/routes/not-found.tsx` wired
@@ -7,3 +8,6 @@ through `defineApp({ notFound })`; pages-router apps get `src/pages/404.tsx`,
 which pracht wires automatically. Previously the manifest only carried a
 commented-out `notFound:` hint pointing at a file that was never generated, which
 made `pracht doctor` report a missing module reference on a fresh scaffold.
+
+Pages-router verification now reports `pages/404.tsx` as the automatically
+wired not-found page instead of counting it as a route.

--- a/.changeset/scaffold-not-found-page.md
+++ b/.changeset/scaffold-not-found-page.md
@@ -10,4 +10,5 @@ commented-out `notFound:` hint pointing at a file that was never generated, whic
 made `pracht doctor` report a missing module reference on a fresh scaffold.
 
 Pages-router verification now reports `pages/404.tsx` as the automatically
-wired not-found page instead of counting it as a route.
+wired not-found page instead of counting it as a route, and rejects ambiguous
+projects where multiple files resolve to the not-found page.

--- a/.changeset/scaffold-not-found-page.md
+++ b/.changeset/scaffold-not-found-page.md
@@ -1,0 +1,9 @@
+---
+"create-pracht": minor
+---
+
+Scaffold a not-found page. New manifest apps get `src/routes/not-found.tsx` wired
+through `defineApp({ notFound })`; pages-router apps get `src/pages/404.tsx`,
+which pracht wires automatically. Previously the manifest only carried a
+commented-out `notFound:` hint pointing at a file that was never generated, which
+made `pracht doctor` report a missing module reference on a fresh scaffold.

--- a/docs/ROUTING.md
+++ b/docs/ROUTING.md
@@ -198,6 +198,10 @@ export const app = defineApp({
 });
 ```
 
+New apps ship with this wired already: `create-pracht` generates
+`src/routes/not-found.tsx` and the matching `notFound` entry (or
+`src/pages/404.tsx` in pages mode). Edit or delete it like any other page.
+
 The shorthand `notFound: () => import("./routes/not-found.tsx")` takes the
 module ref directly. The full form accepts:
 

--- a/examples/docs/src/routes/docs/getting-started.md
+++ b/examples/docs/src/routes/docs/getting-started.md
@@ -54,6 +54,7 @@ my-app/
   src/
     routes.ts          # Route manifest (the central wiring file)
     routes/home.tsx    # First page component + loader
+    routes/not-found.tsx # Not-found page, wired from the manifest
     shells/public.tsx  # Layout wrapper
     api/health.ts      # Sample API endpoint
   vite.config.ts       # Vite + pracht plugin config
@@ -67,6 +68,7 @@ my-app/
   src/
     pages/_app.tsx     # App shell
     pages/index.tsx    # First page component + loader
+    pages/404.tsx      # Not-found page, wired automatically
     api/health.ts      # Sample API endpoint
   vite.config.ts       # Vite + pracht plugin config
   package.json

--- a/examples/docs/src/routes/docs/routing.md
+++ b/examples/docs/src/routes/docs/routing.md
@@ -124,6 +124,8 @@ export const app = defineApp({
 });
 ```
 
+New apps ship with this wired already: `create-pracht` generates `src/routes/not-found.tsx` and the matching `notFound` entry, or `src/pages/404.tsx` in pages mode. Edit or delete it like any other page.
+
 The shorthand `notFound: () => import("./routes/not-found.tsx")` takes the module ref directly; the full form also accepts `loader`, `middleware`, and `hydration`. The module is a normal route module — `Component`, `loader`, `head`, `headers` — and the page hydrates like any other.
 
 It is deliberately **not** a route. A trailing catch-all (`route("/*", ...)`) matches every URL, so it shadows static assets and paths you add later, and it shows up in typed routes, prefetching, speculation rules, and SSG path enumeration. `notFound` sits outside the route table: it runs only after matching fails, and after the adapter has already tried static assets.

--- a/packages/cli/src/verification-checks.ts
+++ b/packages/cli/src/verification-checks.ts
@@ -196,6 +196,7 @@ export function collectPagesVerification(
 
   const pages = scanPagesDirectory(pagesDir);
   const routes = pages.filter((page) => page.kind === "route");
+  const notFoundPages = pages.filter((page) => page.kind === "not-found");
   const duplicates = collectDuplicateRoutePaths(routes as PagesRoute[]).map((entry) => ({
     ...entry,
     files: entry.files.map((file) => displayPath(project.root, file)),
@@ -219,11 +220,22 @@ export function collectPagesVerification(
       checks.push(createCheck("ok", "Found a pages-router `_app` shell."));
     }
 
-    if (pages.some((page) => page.kind === "not-found")) {
+    if (notFoundPages.length === 1) {
       checks.push(createCheck("ok", "Found a pages-router not-found page."));
     }
   } else {
     collectChangedPagesChecks(project, checks, pagesDir, changedFiles);
+  }
+
+  if (notFoundPages.length > 1) {
+    checks.push(
+      createCheck(
+        "error",
+        `Pages router resolves multiple not-found pages: ${notFoundPages
+          .map((page) => JSON.stringify(displayPath(project.root, page.file)))
+          .join(", ")}. Only one file may resolve to "/404".`,
+      ),
+    );
   }
 
   if (duplicates.length > 0) {

--- a/packages/cli/src/verification-checks.ts
+++ b/packages/cli/src/verification-checks.ts
@@ -218,6 +218,10 @@ export function collectPagesVerification(
     } else {
       checks.push(createCheck("ok", "Found a pages-router `_app` shell."));
     }
+
+    if (pages.some((page) => page.kind === "not-found")) {
+      checks.push(createCheck("ok", "Found a pages-router not-found page."));
+    }
   } else {
     collectChangedPagesChecks(project, checks, pagesDir, changedFiles);
   }
@@ -281,6 +285,16 @@ function collectChangedPagesChecks(
         createCheck(
           "warning",
           `Changed pages file ${JSON.stringify(display)} is ignored by the pages router.`,
+        ),
+      );
+      continue;
+    }
+
+    if (page.kind === "not-found") {
+      checks.push(
+        createCheck(
+          "ok",
+          `Changed pages not-found file ${JSON.stringify(display)} is wired automatically.`,
         ),
       );
       continue;

--- a/packages/cli/src/verification-pages.ts
+++ b/packages/cli/src/verification-pages.ts
@@ -5,6 +5,7 @@ import { normalizeRoutePath, PAGE_SOURCE_RE } from "./verification-helpers.js";
 
 export type PagesFile =
   | { file: string; kind: "shell" }
+  | { file: string; kind: "not-found" }
   | { file: string; kind: "ignored" }
   | PagesRoute;
 
@@ -31,6 +32,10 @@ export function describePagesFile(pagesDir: string, file: string): PagesFile {
 
   if (name.startsWith("_")) {
     return { file, kind: "ignored" };
+  }
+
+  if (routePath === "404") {
+    return { file, kind: "not-found" };
   }
 
   if (routePath === "index") {

--- a/packages/cli/src/verification-pages.ts
+++ b/packages/cli/src/verification-pages.ts
@@ -34,7 +34,8 @@ export function describePagesFile(pagesDir: string, file: string): PagesFile {
     return { file, kind: "ignored" };
   }
 
-  if (routePath === "404") {
+  const withoutIndex = routePath.replace(/\/index$/, "");
+  if (withoutIndex === "404") {
     return { file, kind: "not-found" };
   }
 
@@ -42,7 +43,6 @@ export function describePagesFile(pagesDir: string, file: string): PagesFile {
     return { file, kind: "route", routePath: "/" };
   }
 
-  const withoutIndex = routePath.replace(/\/index$/, "");
   const normalized = withoutIndex
     .replace(/\[\.\.\.([^\]]+)\]/g, "*")
     .replace(/\[([^\].]+)\]/g, ":$1");

--- a/packages/cli/test/pracht-cli.test.js
+++ b/packages/cli/test/pracht-cli.test.js
@@ -196,6 +196,24 @@ export const app = defineApp({
     expect(report.checks.some((check) => check.message.includes("missing files"))).toBe(true);
   });
 
+  it("reports a pages-router 404 as the not-found page instead of a route", () => {
+    const appDir = createTempDir("pracht-cli-doctor-pages-not-found-");
+    writePagesApp(appDir);
+    writeProjectFile(appDir, "src/pages/_app.tsx", "export function Shell() { return null; }");
+    writeProjectFile(appDir, "src/pages/index.tsx", "export function Component() { return null; }");
+    writeProjectFile(appDir, "src/pages/404.tsx", "export function Component() { return null; }");
+
+    const result = runCli(["doctor", "--json"], { cwd: appDir });
+    const report = JSON.parse(result.stdout);
+
+    expect(report.ok).toBe(true);
+    expect(report.checks.some((check) => check.message === "Found 1 page route.")).toBe(true);
+    expect(
+      report.checks.some((check) => check.message === "Found a pages-router not-found page."),
+    ).toBe(true);
+    expect(report.checks.some((check) => check.message === "Found 2 page routes.")).toBe(false);
+  });
+
   it("reports a healthy manifest app in verify json output", () => {
     const appDir = createTempDir("pracht-cli-verify-ok-");
     writeManifestApp(appDir, {

--- a/packages/cli/test/pracht-cli.test.js
+++ b/packages/cli/test/pracht-cli.test.js
@@ -196,23 +196,34 @@ export const app = defineApp({
     expect(report.checks.some((check) => check.message.includes("missing files"))).toBe(true);
   });
 
-  it("reports a pages-router 404 as the not-found page instead of a route", () => {
-    const appDir = createTempDir("pracht-cli-doctor-pages-not-found-");
-    writePagesApp(appDir);
-    writeProjectFile(appDir, "src/pages/_app.tsx", "export function Shell() { return null; }");
-    writeProjectFile(appDir, "src/pages/index.tsx", "export function Component() { return null; }");
-    writeProjectFile(appDir, "src/pages/404.tsx", "export function Component() { return null; }");
+  it.each(["404.tsx", "404/index.tsx"])(
+    "reports a pages-router %s as the not-found page instead of a route",
+    (notFoundFile) => {
+      const appDir = createTempDir("pracht-cli-doctor-pages-not-found-");
+      writePagesApp(appDir);
+      writeProjectFile(appDir, "src/pages/_app.tsx", "export function Shell() { return null; }");
+      writeProjectFile(
+        appDir,
+        "src/pages/index.tsx",
+        "export function Component() { return null; }",
+      );
+      writeProjectFile(
+        appDir,
+        `src/pages/${notFoundFile}`,
+        "export function Component() { return null; }",
+      );
 
-    const result = runCli(["doctor", "--json"], { cwd: appDir });
-    const report = JSON.parse(result.stdout);
+      const result = runCli(["doctor", "--json"], { cwd: appDir });
+      const report = JSON.parse(result.stdout);
 
-    expect(report.ok).toBe(true);
-    expect(report.checks.some((check) => check.message === "Found 1 page route.")).toBe(true);
-    expect(
-      report.checks.some((check) => check.message === "Found a pages-router not-found page."),
-    ).toBe(true);
-    expect(report.checks.some((check) => check.message === "Found 2 page routes.")).toBe(false);
-  });
+      expect(report.ok).toBe(true);
+      expect(report.checks.some((check) => check.message === "Found 1 page route.")).toBe(true);
+      expect(
+        report.checks.some((check) => check.message === "Found a pages-router not-found page."),
+      ).toBe(true);
+      expect(report.checks.some((check) => check.message === "Found 2 page routes.")).toBe(false);
+    },
+  );
 
   it("reports a healthy manifest app in verify json output", () => {
     const appDir = createTempDir("pracht-cli-verify-ok-");

--- a/packages/cli/test/pracht-cli.test.js
+++ b/packages/cli/test/pracht-cli.test.js
@@ -225,6 +225,51 @@ export const app = defineApp({
     },
   );
 
+  it("rejects multiple pages-router not-found files", () => {
+    const appDir = createTempDir("pracht-cli-doctor-pages-not-found-duplicate-");
+    writePagesApp(appDir);
+    writeProjectFile(appDir, "src/pages/index.tsx", "export function Component() { return null; }");
+    writeProjectFile(appDir, "src/pages/404.tsx", "export function Component() { return null; }");
+    writeProjectFile(
+      appDir,
+      "src/pages/404/index.tsx",
+      "export function Component() { return null; }",
+    );
+
+    const result = runCliStatus(["doctor", "--json"], { cwd: appDir });
+    expect(result.status).toBe(1);
+
+    const report = JSON.parse(result.stdout);
+    expect(report.ok).toBe(false);
+    expect(report.checks.some((check) => check.message.includes("multiple not-found pages"))).toBe(
+      true,
+    );
+  });
+
+  it("rejects a second pages-router not-found file in changed verification", () => {
+    const appDir = createTempDir("pracht-cli-verify-pages-not-found-duplicate-");
+    writePagesApp(appDir);
+    writeProjectFile(appDir, "src/pages/index.tsx", "export function Component() { return null; }");
+    writeProjectFile(appDir, "src/pages/404.tsx", "export function Component() { return null; }");
+    initializeGitRepo(appDir);
+    writeProjectFile(
+      appDir,
+      "src/pages/404/index.tsx",
+      "export function Component() { return null; }",
+    );
+
+    const result = runCliStatus(["verify", "--changed", "--json"], { cwd: appDir });
+    expect(result.status).toBe(1);
+
+    const report = JSON.parse(result.stdout);
+    expect(report.ok).toBe(false);
+    expect(report.scope).toBe("changed");
+    expect(report.frameworkFiles).toContain("src/pages/404/index.tsx");
+    expect(report.checks.some((check) => check.message.includes("multiple not-found pages"))).toBe(
+      true,
+    );
+  });
+
   it("reports a healthy manifest app in verify json output", () => {
     const appDir = createTempDir("pracht-cli-verify-ok-");
     writeManifestApp(appDir, {

--- a/packages/start/README.md
+++ b/packages/start/README.md
@@ -17,7 +17,7 @@ npm run dev
 - Detects the active package manager from the current environment.
 - Lets the user choose between the Node.js, Cloudflare, and Vercel adapters.
 - Optionally wires up Tailwind CSS (`tailwindcss` + `@tailwindcss/vite`, a global stylesheet, and the shell import).
-- Scaffolds a minimal app with a route manifest or pages router, shell, home route, sample API route, runnable project README, TypeScript typecheck script, and agent instructions.
+- Scaffolds a minimal app with a route manifest or pages router, shell, home route, not-found page, sample API route, runnable project README, TypeScript typecheck script, and agent instructions.
 - Manifest scaffolds include a commented-out `constraints` example in `src/routes.ts`, ready for `pracht verify`.
 - The generated `.gitignore` keeps `.pracht/app-graph.json` committable, and the README and agent instructions cover the `pracht verify` / `pracht plan` / `pracht report` loop.
 - Seeds the pracht Claude Code skills into `.claude/skills/` and writes a `.mcp.json` registering the `pracht mcp` server (yes-default prompt; skipped with `--no-agent-tools`).
@@ -53,6 +53,7 @@ node ./packages/start/bin/create-pracht.js my-app --adapter=node --no-tailwind -
 - `vite.config.ts`
 - `src/routes.ts`
 - `src/routes/home.tsx`
+- `src/routes/not-found.tsx` — the app's 404 page, wired via `notFound` in the manifest (pages scaffolds get `src/pages/404.tsx`, which pracht wires automatically)
 - `src/shells/public.tsx`
 - `src/api/health.ts`
 - `.gitignore`

--- a/packages/start/src/index.js
+++ b/packages/start/src/index.js
@@ -13,12 +13,12 @@ export class ValidationError extends Error {
 }
 
 const FALLBACK_VERSION_RANGES = {
-  "@pracht/adapter-cloudflare": "^0.2.2",
-  "@pracht/adapter-node": "^0.1.11",
-  "@pracht/adapter-vercel": "^0.0.13",
-  "@pracht/cli": "^1.3.1",
-  "@pracht/core": "^0.5.0",
-  "@pracht/vite-plugin": "^0.3.2",
+  "@pracht/adapter-cloudflare": "^0.5.8",
+  "@pracht/adapter-node": "^0.3.8",
+  "@pracht/adapter-vercel": "^0.2.8",
+  "@pracht/cli": "^1.9.0",
+  "@pracht/core": "^0.12.0",
+  "@pracht/vite-plugin": "^0.7.6",
   "@tailwindcss/vite": "^4.1.0",
   tailwindcss: "^4.1.0",
   typescript: "^6.0.0",

--- a/packages/start/src/index.js
+++ b/packages/start/src/index.js
@@ -600,9 +600,11 @@ async function buildProjectFiles({
   if (router === "pages") {
     files["src/pages/_app.tsx"] = createShellFile(projectName, tailwind);
     files["src/pages/index.tsx"] = createPagesHomeRoute(adapter);
+    files["src/pages/404.tsx"] = createNotFoundRoute();
   } else {
     files["src/routes.ts"] = createRoutesFile();
     files["src/routes/home.tsx"] = createHomeRoute(adapter);
+    files["src/routes/not-found.tsx"] = createNotFoundRoute();
     files["src/shells/public.tsx"] = createShellFile(projectName, tailwind);
   }
 
@@ -761,8 +763,12 @@ function createRoutesFile() {
     "  routes: [",
     '    route("/", "./routes/home.tsx", { id: "home", render: "ssg", shell: "public" }),',
     "  ],",
-    "  // Custom 404 page — any module in ./routes, rendered when nothing matches:",
-    '  // notFound: "./routes/not-found.tsx",',
+    "  // Rendered with a 404 status when nothing matches. Not a route: it never",
+    "  // matches a URL, so it cannot shadow static assets or later pages.",
+    "  notFound: {",
+    '    component: "./routes/not-found.tsx",',
+    '    shell: "public",',
+    "  },",
     "  // Declarative invariants enforced by `pracht verify` — uncomment to use",
     "  // (add the helpers to the @pracht/core import):",
     "  // constraints: [",
@@ -836,6 +842,33 @@ function createHomeRoute(adapter) {
     '      <p style={{ marginTop: "24px" }}>',
     "        Check <code>/api/health</code> for a simple API route.",
     "      </p>",
+    "    </section>",
+    "  );",
+    "}",
+    "",
+  ].join("\n");
+}
+
+function createNotFoundRoute() {
+  return [
+    "export function head() {",
+    "  return {",
+    '    title: "Page not found",',
+    '    meta: [{ content: "noindex", name: "robots" }],',
+    "  };",
+    "}",
+    "",
+    "export function Component() {",
+    "  return (",
+    "    <section>",
+    '      <p style={{ color: "#555", marginBottom: "8px" }}>404</p>',
+    '      <h1 style={{ fontSize: "2.5rem", lineHeight: 1.1, margin: "0 0 16px" }}>Page not found.</h1>',
+    '      <p style={{ fontSize: "1.1rem", lineHeight: 1.6, marginBottom: "24px" }}>',
+    "        The page you asked for does not exist. It may have moved, or the link may be wrong.",
+    "      </p>",
+    "      {/* A plain anchor keeps this page independent of the route table.",
+    '          Use <Link route="home"> once you want client-side navigation. */}',
+    '      <a href="/">Back to home</a>',
     "    </section>",
     "  );",
     "}",
@@ -1073,11 +1106,17 @@ function createAgentInstructions({ adapter, agentTools, packageManager, router, 
     lines.push("");
     lines.push("- `src/pages/` — file-system routes (each file becomes a route)");
     lines.push("- `src/pages/_app.tsx` — app shell (layout and head)");
+    lines.push(
+      "- `src/pages/404.tsx` — not-found page, wired automatically (never a URL of its own)",
+    );
   } else {
     lines.push("This app uses **manifest routing**.");
     lines.push("");
     lines.push("- `src/routes.ts` — route manifest (defines all routes and shells)");
     lines.push("- `src/routes/` — route components and loaders");
+    lines.push(
+      "- `src/routes/not-found.tsx` — not-found page, wired via `notFound` in the manifest",
+    );
     lines.push("- `src/shells/` — shell components (layouts)");
   }
 
@@ -1163,9 +1202,11 @@ function createReadme({ adapter, agentTools, packageManager, projectName, router
     lines.push("- `src/pages/` contains your file-system routes.");
     lines.push("- `src/pages/_app.tsx` is the app shell.");
     lines.push("- `src/pages/index.tsx` is the home page.");
+    lines.push("- `src/pages/404.tsx` is the not-found page; pracht wires it automatically.");
   } else {
     lines.push("- `src/routes.ts` defines your app manifest.");
     lines.push("- `src/routes/home.tsx` is the first page.");
+    lines.push("- `src/routes/not-found.tsx` is the not-found page, wired via `notFound`.");
   }
 
   lines.push("- `src/api/health.ts` is a sample API route.");

--- a/packages/start/src/index.js
+++ b/packages/start/src/index.js
@@ -867,7 +867,7 @@ function createNotFoundRoute() {
     "        The page you asked for does not exist. It may have moved, or the link may be wrong.",
     "      </p>",
     "      {/* A plain anchor keeps this page independent of the route table.",
-    '          Use <Link route="home"> once you want client-side navigation. */}',
+    "          Use a typed <Link> once you want client-side navigation. */}",
     '      <a href="/">Back to home</a>',
     "    </section>",
     "  );",

--- a/packages/start/test/index.test.js
+++ b/packages/start/test/index.test.js
@@ -49,11 +49,20 @@ describe("create-pracht", () => {
     });
 
     const packageJson = await readFile(join(targetDir, "package.json"), "utf-8");
+    const parsedPackageJson = JSON.parse(packageJson);
     const gitignore = await readFile(join(targetDir, ".gitignore"), "utf-8");
     const routes = await readFile(join(targetDir, "src/routes.ts"), "utf-8");
 
     expect(packageJson).toMatch(/"@pracht\/cli": "\^\d+\.\d+\.\d+"/);
     expect(packageJson).toMatch(/"@pracht\/adapter-node": "\^\d+\.\d+\.\d+"/);
+    expect(parsedPackageJson.dependencies).toMatchObject({
+      "@pracht/adapter-node": "^0.3.8",
+      "@pracht/core": "^0.12.0",
+    });
+    expect(parsedPackageJson.devDependencies).toMatchObject({
+      "@pracht/cli": "^1.9.0",
+      "@pracht/vite-plugin": "^0.7.6",
+    });
     expect(packageJson).toContain('"preview": "pracht preview"');
     expect(packageJson).toContain('"start": "node dist/server/server.js"');
     expect(packageJson).toContain('"typecheck": "tsc --noEmit"');

--- a/packages/start/test/index.test.js
+++ b/packages/start/test/index.test.js
@@ -65,7 +65,14 @@ describe("create-pracht", () => {
     expect(gitignore).not.toContain("\n.pracht\n");
     expect(gitignore).toContain("Keep .pracht/app-graph.json committed");
     expect(routes).toContain('route("/", "./routes/home.tsx"');
-    expect(routes).toContain('// notFound: "./routes/not-found.tsx",');
+    expect(routes).toContain('component: "./routes/not-found.tsx",');
+    expect(routes).toContain('shell: "public",');
+    expect(routes).not.toContain("// notFound:");
+
+    const notFound = await readFile(join(targetDir, "src/routes/not-found.tsx"), "utf-8");
+    expect(notFound).toContain("Page not found.");
+    expect(notFound).toContain('<a href="/">Back to home</a>');
+    expect(notFound).toContain('content: "noindex", name: "robots"');
     expect(routes).toContain("// constraints: [");
     expect(routes).toContain('//   requireHead("**"),');
     expect(existsSync(join(targetDir, "wrangler.jsonc"))).toBe(false);
@@ -281,6 +288,8 @@ describe("create-pracht", () => {
     expect(viteConfig).toContain('pagesDir: "/src/pages"');
     expect(existsSync(join(targetDir, "src/pages/index.tsx"))).toBe(true);
     expect(existsSync(join(targetDir, "src/pages/_app.tsx"))).toBe(true);
+    expect(existsSync(join(targetDir, "src/pages/404.tsx"))).toBe(true);
+    expect(existsSync(join(targetDir, "src/routes/not-found.tsx"))).toBe(false);
     expect(existsSync(join(targetDir, "src/routes.ts"))).toBe(false);
     expect(readme).toContain("src/pages/");
 

--- a/packages/start/test/index.test.js
+++ b/packages/start/test/index.test.js
@@ -73,6 +73,8 @@ describe("create-pracht", () => {
     expect(notFound).toContain("Page not found.");
     expect(notFound).toContain('<a href="/">Back to home</a>');
     expect(notFound).toContain('content: "noindex", name: "robots"');
+    expect(notFound).toContain("Use a typed <Link>");
+    expect(notFound).not.toContain('route="home"');
     expect(routes).toContain("// constraints: [");
     expect(routes).toContain('//   requireHead("**"),');
     expect(existsSync(join(targetDir, "wrangler.jsonc"))).toBe(false);


### PR DESCRIPTION
## Summary

- `create-pracht` now generates a not-found page. Manifest scaffolds get `src/routes/not-found.tsx` wired through `defineApp({ notFound })`; pages scaffolds get `src/pages/404.tsx`, which pracht wires automatically.
- Previously the generated manifest carried only a commented-out `notFound: "./routes/not-found.tsx"` hint pointing at a file that was never created. `pracht doctor` reads the manifest source without skipping comments, so **every fresh scaffold failed doctor** with `ERROR Manifest references missing files: "./routes/not-found.tsx"`. Generating the file makes the reference real and doctor green.
- The generated page is a plain route module — `head()` with a title and `noindex`, a 404 heading, and an anchor home. It deliberately uses `<a href="/">` rather than `<Link>` so it carries no dependency on the app's route ids; a comment points at `<Link route="home">` for client-side navigation.
- Docs: `docs/ROUTING.md` notes that new apps ship with this wired, and the `create-pracht` README lists the new file.
- No linked issue — found while dogfooding a fresh scaffold.

Note: doctor's manifest scan still treats commented-out module refs as real references. That is a separate bug and is not addressed here.

### Verification

Scaffolded both routers against the local packages:

| | manifest | pages |
| --- | --- | --- |
| `pracht doctor` | no blocking issues (was 1 error) | n/a |
| `tsc --noEmit` | clean | clean |
| dev, unknown URL | 404 + `<title>Page not found</title>` | 404 + `<title>Page not found</title>` |
| `pracht build` + `preview` | `/` 200, `/nope` 404, `/api/health` 200 | — |
| `/404` as a URL | n/a | 404 (not a route of its own) |

## Testing

- [x] `pnpm e2e`
- [x] `pnpm format`
- [x] `pnpm lint`
- [x] `pnpm test`

## Checklist

- [x] Docs updated if needed
- [x] Skills updated if needed — N/A (`pracht-scaffold` covers `pracht generate`, not `create-pracht` output)
- [x] Changeset added if published packages changed — `create-pracht` minor

🤖 Generated with [Claude Code](https://claude.com/claude-code)