### PR TITLE
fix(vercel): deploy ISG routes as serverless functions

### DIFF
--- a/.changeset/vercel-isg-serverless.md
+++ b/.changeset/vercel-isg-serverless.md
@@ -1,0 +1,15 @@
+---
+"@pracht/adapter-vercel": patch
+"@pracht/cli": patch
+---
+
+Fix `vercel deploy --prebuilt` failing with `Unexpected function type "EdgeFunction"` for ISG routes.
+
+Vercel only supports ISR on Serverless Functions, but the build paired each
+`<route>.prerender-config.json` with the edge function, so any app with an ISG
+route produced an output Vercel refused to deploy. ISG routes are now emitted as
+Node Serverless Functions while the main handler stays on the edge; both load
+the same Web-API-only server bundle. Generated Vercel entries export a
+`nodeListener` (`createVercelNodeListener(handle)`) for those functions to use,
+and a custom server entry that omits it now fails the build with a descriptive
+error instead of at request time.

--- a/.changeset/vercel-isg-serverless.md
+++ b/.changeset/vercel-isg-serverless.md
@@ -12,4 +12,6 @@ Node Serverless Functions while the main handler stays on the edge; both load
 the same Web-API-only server bundle. Generated Vercel entries export a
 `nodeListener` (`createVercelNodeListener(handle)`) for those functions to use,
 and a custom server entry that omits it now fails the build with a descriptive
-error instead of at request time.
+error instead of at request time. The Node listener exposes a compatible
+`waitUntil()` context, and Edge's `regions: "all"` sentinel is omitted from Node
+function configs so they use the project's default Serverless region.

--- a/docs/ADAPTERS.md
+++ b/docs/ADAPTERS.md
@@ -663,7 +663,14 @@ export default {
   `x-pracht-route-state-request: 1` and `?_data=1`, so route-state requests go
   to the edge function before any static SSG rewrite can serve cached HTML.
 - **Native ISR**: ISG routes are emitted as Build Output API prerender functions
-  with `.prerender-config.json` files. Time policies become Vercel
+  with `.prerender-config.json` files. Vercel only supports ISR on Serverless
+  Functions — a `.prerender-config.json` next to an Edge Function fails the
+  deployment with `Unexpected function type "EdgeFunction"` — so these run on
+  Node (`nodejs22.x`) while the main handler stays on the edge. Both load the
+  same server bundle: it is built against Web APIs only, which Node provides
+  natively. The first ISG route materializes the function directory and the
+  rest are symlinks to it, so N ISG paths don't duplicate the bundle. Time
+  policies become Vercel
   `expiration` values, build-time HTML becomes the prerender fallback, and
   `PRACHT_REVALIDATE_TOKEN` is used as the `bypassToken` when present at build
   time. If the env var is absent during build, Pracht writes a random bypass
@@ -682,6 +689,10 @@ export default {
   function. ISG document requests are handled by route-named prerender functions,
   while route-state requests still bypass static/prerender output and reach the
   edge function.
+- **Node launcher**: generated entries also export `nodeListener`
+  (`createVercelNodeListener(handle)`), which the ISG functions re-export as
+  their handler. A custom server entry that omits it fails the build with a
+  descriptive error rather than at request time in production.
 - **Static security headers**: the generated `config.json` includes a `headers`
   section that applies the same baseline security headers to all responses,
   including static assets served by Vercel's CDN. Static prerendered routes also
@@ -727,6 +738,9 @@ export default async function handle(request, context) {
   });
   return handler(request, context);
 }
+
+// Entry point of the Node serverless functions emitted for ISG routes.
+export const nodeListener = createVercelNodeListener(handle);
 ```
 
 ---

--- a/docs/ADAPTERS.md
+++ b/docs/ADAPTERS.md
@@ -692,7 +692,10 @@ export default {
 - **Node launcher**: generated entries also export `nodeListener`
   (`createVercelNodeListener(handle)`), which the ISG functions re-export as
   their handler. A custom server entry that omits it fails the build with a
-  descriptive error rather than at request time in production.
+  descriptive error rather than at request time in production. The listener
+  supplies a `waitUntil()`-compatible context and drains registered work after
+  ending the response; other Edge-only context fields are unavailable on Node
+  ISG invocations.
 - **Static security headers**: the generated `config.json` includes a `headers`
   section that applies the same baseline security headers to all responses,
   including static assets served by Vercel's CDN. Static prerendered routes also
@@ -713,14 +716,18 @@ vercelAdapter({
 });
 ```
 
-The context module must export `createContext(args)`. Vercel passes `{ request, context }`.
+The context module must export `createContext(args)`. Edge invocations receive
+Vercel's execution context; Node ISG invocations receive the compatibility
+context described above. `regions: "all"` keeps the Edge function global and
+leaves Node ISG functions on the project's default Serverless region because
+`all` is not a Node region identifier.
 
 ### Entry module
 
 ```javascript
 // virtual:pracht/server (generated in vercel mode)
 import { resolveApp, resolveApiRoutes } from "@pracht/core/server";
-import { createVercelEdgeHandler } from "@pracht/adapter-vercel";
+import { createVercelEdgeHandler, createVercelNodeListener } from "@pracht/adapter-vercel";
 import { app } from "./src/routes.ts";
 
 const resolvedApp = resolveApp(app);

--- a/docs/RENDERING_MODES.md
+++ b/docs/RENDERING_MODES.md
@@ -108,7 +108,8 @@ import { timeRevalidate } from "@pracht/core";
 Node checks the file's mtime against the revalidation window. Cloudflare checks
 the generated timestamp stored in the Cache API entry and falls back to the
 build-time asset timestamp. Vercel writes native `.prerender-config.json` files
-with `expiration` set from the time policy.
+with `expiration` set from the time policy, next to a Node Serverless Function
+per ISG route — Vercel does not accept ISR on an Edge Function.
 
 > **Cloudflare Workers Caching:** with `cloudflareAdapter({ cache: true })`
 > (plus `"cache": { "enabled": true }` in wrangler config), time-revalidated

--- a/e2e/vercel-build.test.ts
+++ b/e2e/vercel-build.test.ts
@@ -1,7 +1,7 @@
 import { execFileSync } from "node:child_process";
 import { existsSync, readFileSync, rmSync } from "node:fs";
 import { resolve } from "node:path";
-import { fileURLToPath } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 
 import { expect, test } from "@playwright/test";
 
@@ -15,7 +15,9 @@ test("pracht build emits a deployable Vercel Build Output setup", async () => {
   const configPath = resolve(vercelDir, "config.json");
   const functionConfigPath = resolve(vercelDir, "functions/render.func/.vc-config.json");
   const serverEntryPath = resolve(vercelDir, "functions/render.func/server.js");
-  const pricingFunctionConfigPath = resolve(vercelDir, "functions/pricing.func/.vc-config.json");
+  const pricingFunctionDir = resolve(vercelDir, "functions/pricing.func");
+  const pricingFunctionConfigPath = resolve(pricingFunctionDir, ".vc-config.json");
+  const pricingFunctionEntryPath = resolve(pricingFunctionDir, "_pracht-node-entry.cjs");
   const pricingPrerenderConfigPath = resolve(vercelDir, "functions/pricing.prerender-config.json");
   const pricingFallbackPath = resolve(vercelDir, "functions/pricing.prerender-fallback.html");
   const staticIndexPath = resolve(vercelDir, "static/index.html");
@@ -91,8 +93,20 @@ test("pracht build emits a deployable Vercel Build Output setup", async () => {
     runtime: "edge",
     entrypoint: "server.js",
   });
+
+  // Vercel rejects a deployment that pairs `.prerender-config.json` with an
+  // edge function ('Unexpected function type "EdgeFunction"'), so ISG routes
+  // must be emitted as Node serverless functions.
   const pricingFunctionConfig = JSON.parse(readFileSync(pricingFunctionConfigPath, "utf-8"));
-  expect(pricingFunctionConfig).toMatchObject(functionConfig);
+  expect(pricingFunctionConfig).toMatchObject({
+    handler: "_pracht-node-entry.cjs",
+    launcherType: "Nodejs",
+    runtime: expect.stringMatching(/^nodejs\d+\.x$/),
+  });
+  expect(JSON.parse(readFileSync(resolve(pricingFunctionDir, "package.json"), "utf-8"))).toEqual({
+    type: "module",
+  });
+  expect(existsSync(resolve(pricingFunctionDir, "server.js"))).toBe(true);
 
   const pricingPrerenderConfig = JSON.parse(readFileSync(pricingPrerenderConfigPath, "utf-8"));
   expect(pricingPrerenderConfig).toMatchObject({
@@ -108,4 +122,35 @@ test("pracht build emits a deployable Vercel Build Output setup", async () => {
   expect(functionSource).toContain('buildTarget = "vercel"');
   expect(functionSource).toContain("createVercelEdgeHandler");
   expect(functionSource).toContain("async function handle(request, context)");
+  expect(functionSource).toContain("createVercelNodeListener");
+
+  // The prerender function runs on Node with the same Web-API-only bundle the
+  // edge function uses — drive its launcher the way Vercel's Node launcher
+  // does to prove the emitted function boots and renders.
+  const { default: nodeListener } = await import(pathToFileURL(pricingFunctionEntryPath).href);
+  const chunks: Buffer[] = [];
+  const responseHeaders: Record<string, string | string[]> = {};
+  const res = {
+    statusCode: 0,
+    setHeader(key: string, value: string | string[]) {
+      responseHeaders[key] = value;
+    },
+    write(chunk: Uint8Array) {
+      chunks.push(Buffer.from(chunk));
+    },
+    end() {},
+  };
+  await nodeListener(
+    {
+      headers: { host: "example.com", "x-forwarded-proto": "https" },
+      method: "GET",
+      url: "/pricing",
+      async *[Symbol.asyncIterator]() {},
+    },
+    res,
+  );
+
+  expect(res.statusCode).toBe(200);
+  expect(responseHeaders["content-type"]).toContain("text/html");
+  expect(Buffer.concat(chunks).toString("utf-8")).toContain("MVP plan");
 });

--- a/examples/docs/src/routes/docs/adapters.md
+++ b/examples/docs/src/routes/docs/adapters.md
@@ -186,6 +186,8 @@ pracht({ adapter: vercelAdapter() })
 
 Static prerendered routes receive document headers through the generated Build Output `headers` config.
 
+If `vercelAdapter({ regions: "all" })` is configured, the Edge function remains global while Node ISG functions use the project's default Serverless region. Node functions require concrete region identifiers and cannot use Edge's `all` sentinel.
+
 ### Build output
 
 ```
@@ -280,7 +282,8 @@ export function createContext({ request }: { request: Request }) {
 }
 
 // Cloudflare receives { request, env, executionContext }.
-// Vercel receives { request, context }.
+// Vercel Edge receives { request, context }. Node ISG provides a
+// waitUntil-compatible context, without other Edge-only fields.
 ```
 
 The context object is available as `args.context` in every loader, middleware, and API route handler.

--- a/examples/docs/src/routes/docs/adapters.md
+++ b/examples/docs/src/routes/docs/adapters.md
@@ -171,7 +171,7 @@ npx wrangler deploy
 
 ## Vercel Edge Functions
 
-Deploy using Vercel's Build Output API v3. SSG pages are served from the static file system; SSR and ISG routes go through the Edge Function.
+Deploy using Vercel's Build Output API v3. SSG pages are served from the static file system and SSR/API routes go through the Edge Function. ISG routes get one Serverless Function each — Vercel only supports ISR (`.prerender-config.json`) on serverless, and rejects a deployment that pairs it with an Edge Function.
 
 ### Setup
 
@@ -195,7 +195,7 @@ Static prerendered routes receive document headers through the generated Build O
     static/        // SSG pages served from the filesystem
     functions/
       render.func/ // Edge Function for SSR/API routes and webhook bridge
-      pricing.func/
+      pricing.func/ // Serverless Function for one ISG route
       pricing.prerender-config.json
 ```
 

--- a/examples/showcase/README.md
+++ b/examples/showcase/README.md
@@ -10,7 +10,7 @@ Deployed at https://showcase-ten-eosin.vercel.app
 |---|---|---|
 | `/` | **SSG** | Marketing page. Pre-built at deploy, served from CDN, zero server cost. |
 | `/blog/:slug` | **SSG** | Blog posts with `getStaticPaths`. Static content, great SEO. |
-| `/pricing` | **ISG** | Revalidates every hour. Fast like static, fresh when plans change. |
+| `/pricing` | **SSG** | Plans are hard-coded here, so there is nothing to revalidate. Add `revalidate` and it becomes ISG. |
 | `/app` | **SSR** | Dashboard with per-request data. Personalized, always current. |
 | `/app/projects/:id` | **SSR** | Project detail. Needs request context for auth + live data. |
 | `/app/settings` | **SPA** | Client-only interactive UI. Shell paints instantly, no SEO needed. |

--- a/examples/showcase/src/routes.ts
+++ b/examples/showcase/src/routes.ts
@@ -1,4 +1,4 @@
-import { defineApp, group, route, timeRevalidate } from "@pracht/core";
+import { defineApp, group, route } from "@pracht/core";
 
 export const app = defineApp({
   shells: {
@@ -20,11 +20,12 @@ export const app = defineApp({
         render: "ssg",
       }),
 
-      // Pricing changes when plans update — ISG keeps it fast AND fresh
+      // Plans are hard-coded in this demo, so there is nothing to revalidate:
+      // SSG keeps the whole marketing shell on the CDN with no function
+      // invocation. examples/basic covers the ISG build path.
       route("/pricing", () => import("./routes/pricing.tsx"), {
         id: "pricing",
-        render: "isg",
-        revalidate: timeRevalidate(3600),
+        render: "ssg",
       }),
       route("/agents", () => import("./routes/agents.tsx"), {
         id: "agents",

--- a/examples/showcase/src/routes/agents.tsx
+++ b/examples/showcase/src/routes/agents.tsx
@@ -23,7 +23,7 @@ const STRENGTHS = [
 
 const AGENT_TASKS = [
   "Find every authenticated route",
-  "Convert pricing from SSR to ISG",
+  "Convert pricing from SSG to ISG",
   "Add a public docs page with SSG",
   "Audit loaders for secret leakage",
   "Generate a sitemap from the manifest",
@@ -45,7 +45,7 @@ This page is the agent-readable briefing for the Pracht showcase.
 ## Demo tasks
 
 1. Find every route protected by auth middleware.
-2. Explain why /pricing uses ISG instead of SSR.
+2. Explain why /pricing uses SSG instead of SSR.
 3. Add a new SSG docs route without changing layout folders.
 4. Audit all loaders and confirm they run server-side.
 5. Produce a deployment note for Node, Cloudflare, and Vercel.

--- a/examples/showcase/src/routes/home.tsx
+++ b/examples/showcase/src/routes/home.tsx
@@ -10,7 +10,8 @@ const MODES = [
   {
     tag: "isg",
     title: "Pricing & catalogs",
-    description: "Our pricing page revalidates hourly. Fast like static, fresh like dynamic.",
+    description:
+      "Add a revalidate policy and the page rebuilds on a timer. Fast like static, fresh like dynamic.",
   },
   {
     tag: "ssr",
@@ -60,7 +61,7 @@ export function Component({ data }: RouteComponentProps<typeof loader>) {
         </h1>
 
         <p class="hero-sub">
-          Static marketing. Dynamic dashboards. Revalidating pricing. Client-only settings. One
+          Static marketing. Dynamic dashboards. Timed revalidation. Client-only settings. One
           codebase, one manifest, one build.
         </p>
 
@@ -101,9 +102,9 @@ export function Component({ data }: RouteComponentProps<typeof loader>) {
               {", ...  { "}
               <span class="prop">render</span>
               {": "}
-              <span class="str">"isg"</span>
+              <span class="str">"ssg"</span>
               {" })  "}
-              <span class="cmt">// revalidates hourly</span>
+              <span class="cmt">// prerendered</span>
               {"\n"}
               <span class="kw">route</span>
               {"("}

--- a/examples/showcase/src/routes/pricing.tsx
+++ b/examples/showcase/src/routes/pricing.tsx
@@ -52,11 +52,12 @@ export function head() {
 export function Component({ data }: RouteComponentProps<typeof loader>) {
   return (
     <section class="pricing">
-      <span class="pricing-badge">ISG — revalidates every hour</span>
+      <span class="pricing-badge">SSG — prerendered at build</span>
       <h1>Simple pricing</h1>
       <p class="pricing-sub">
-        This page uses <strong>Incremental Static Generation</strong>. Pre-rendered at build, served
-        instantly from the CDN, and refreshed in the background every hour.
+        This page uses <strong>Static Site Generation</strong>: rendered once at build time and
+        served straight from the CDN. Swap <code>render</code> to <code>"isg"</code> and add{" "}
+        <code>revalidate</code> to refresh it in the background instead.
       </p>
       <div class="pricing-grid">
         {data.plans.map((plan) => (

--- a/packages/adapter-vercel/README.md
+++ b/packages/adapter-vercel/README.md
@@ -1,6 +1,6 @@
 # @pracht/adapter-vercel
 
-Vercel Edge adapter for pracht. Emits Vercel Build Output API v3 output with an Edge Function entry.
+Vercel adapter for pracht. Emits Vercel Build Output API v3 output with an Edge Function entry for SSR/API routes and Node Serverless Functions for ISG routes.
 
 ## Install
 
@@ -26,6 +26,7 @@ pracht build && vercel deploy --prebuilt
 
 - Build Output API v3 integration
 - Edge Function runtime support
+- Native ISR through Node Serverless prerender functions
 - Static SSG rewrites with route-state bypasses for client navigation
 
 ## Context factory
@@ -41,3 +42,10 @@ pracht({
 ```
 
 `/src/server/context.ts` should export `createContext({ request, context })`.
+Edge invocations receive Vercel's execution context. Node ISG invocations
+receive a compatibility context with `waitUntil()`; other Edge-only fields are
+unavailable.
+
+`vercelAdapter({ regions: "all" })` keeps the Edge function global and leaves
+Node ISG functions on the project's default Serverless region. Configure one or
+more concrete region identifiers to place both runtimes explicitly.

--- a/packages/adapter-vercel/src/index.ts
+++ b/packages/adapter-vercel/src/index.ts
@@ -45,6 +45,27 @@ export interface VercelServerEntryModuleOptions {
   createContextFrom?: string;
 }
 
+/**
+ * Structural subset of Node's `IncomingMessage` used by the serverless
+ * launcher. Typed inline so this edge-targeted package keeps no dependency on
+ * `@types/node`.
+ */
+export interface VercelNodeRequest {
+  headers: Record<string, string | string[] | undefined>;
+  method?: string;
+  url?: string;
+  [Symbol.asyncIterator](): AsyncIterator<Uint8Array | string>;
+}
+
+/** Structural subset of Node's `ServerResponse` used by the serverless launcher. */
+export interface VercelNodeResponse {
+  statusCode: number;
+  statusMessage?: string;
+  setHeader(name: string, value: string | string[]): unknown;
+  write(chunk: Uint8Array): unknown;
+  end(): unknown;
+}
+
 export function createVercelEdgeHandler<
   TVercelContext extends VercelExecutionContext = VercelExecutionContext,
   TContext = TVercelContext,
@@ -69,6 +90,108 @@ export function createVercelEdgeHandler<
       jsManifest: options.jsManifest,
     } satisfies HandlePrachtRequestOptions<TContext>);
   };
+}
+
+/**
+ * Wrap a `fetch`-style handler as a Node request listener.
+ *
+ * Vercel only supports ISR (`.prerender-config.json`) on Serverless Functions,
+ * so ISG routes are deployed as Node functions even though the main handler
+ * stays on the edge. Both share the same server bundle: it is built against Web
+ * APIs only, which Node provides natively.
+ *
+ * Only web globals are used here — pulling in `node:http`/`node:stream` would
+ * break the webworker-targeted bundle the edge function is built from.
+ */
+export function createVercelNodeListener(
+  handler: (request: Request, context: VercelExecutionContext) => Promise<Response>,
+): (req: VercelNodeRequest, res: VercelNodeResponse) => Promise<void> {
+  return async (req, res) => {
+    const response = await handler(await createNodeWebRequest(req), {});
+    await writeNodeResponse(res, response);
+  };
+}
+
+const BODYLESS_METHODS = new Set(["GET", "HEAD"]);
+
+async function createNodeWebRequest(req: VercelNodeRequest): Promise<Request> {
+  const headers = new Headers();
+  for (const [key, value] of Object.entries(req.headers)) {
+    if (value === undefined) continue;
+    if (Array.isArray(value)) {
+      for (const entry of value) headers.append(key, entry);
+      continue;
+    }
+    headers.set(key, value);
+  }
+
+  // Vercel terminates TLS in front of the function and always sets the
+  // forwarded headers itself, so there is no untrusted hop to distrust here.
+  const protocol = headers.get("x-forwarded-proto") ?? "https";
+  const host = headers.get("x-forwarded-host") ?? headers.get("host") ?? "localhost";
+  const url = new URL(req.url ?? "/", `${protocol}://${host}`);
+  const method = req.method ?? "GET";
+  const init: RequestInit = { headers, method };
+
+  if (!BODYLESS_METHODS.has(method.toUpperCase())) {
+    const body = await readNodeRequestBody(req);
+    if (body.byteLength > 0) init.body = body;
+  }
+
+  return new Request(url, init);
+}
+
+async function readNodeRequestBody(req: VercelNodeRequest): Promise<ArrayBuffer> {
+  const chunks: Uint8Array[] = [];
+  let size = 0;
+
+  for await (const chunk of req) {
+    const bytes = typeof chunk === "string" ? new TextEncoder().encode(chunk) : chunk;
+    chunks.push(bytes);
+    size += bytes.byteLength;
+  }
+
+  const body = new ArrayBuffer(size);
+  const view = new Uint8Array(body);
+  let offset = 0;
+  for (const chunk of chunks) {
+    view.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+
+  return body;
+}
+
+async function writeNodeResponse(res: VercelNodeResponse, response: Response): Promise<void> {
+  res.statusCode = response.status;
+  if (response.statusText) res.statusMessage = response.statusText;
+
+  const setCookie =
+    (response.headers as Headers & { getSetCookie?: () => string[] }).getSetCookie?.call(
+      response.headers,
+    ) ?? [];
+  response.headers.forEach((value, key) => {
+    if (key.toLowerCase() === "set-cookie" && setCookie.length > 0) return;
+    res.setHeader(key, value);
+  });
+  if (setCookie.length > 0) res.setHeader("set-cookie", setCookie);
+
+  if (!response.body) {
+    res.end();
+    return;
+  }
+
+  const reader = response.body.getReader();
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      if (value) res.write(value);
+    }
+  } finally {
+    reader.releaseLock();
+    res.end();
+  }
 }
 
 export function createVercelServerEntryModule(
@@ -97,6 +220,10 @@ export function createVercelServerEntryModule(
     "  });",
     "  return handler(request, context);",
     "}",
+    "",
+    "// Entry point of the Node serverless functions emitted for ISG routes;",
+    "// Vercel rejects `.prerender-config.json` next to an edge function.",
+    "export const nodeListener = createVercelNodeListener(handle);",
     "",
   ].join("\n");
 }
@@ -190,7 +317,7 @@ export function vercelAdapter(options: VercelServerEntryModuleOptions = {}): Pra
     id: "vercel",
     edge: true,
     serverImports:
-      'import { resolveApp, resolveApiRoutes } from "@pracht/core/server";\nimport { createVercelEdgeHandler } from "@pracht/adapter-vercel";',
+      'import { resolveApp, resolveApiRoutes } from "@pracht/core/server";\nimport { createVercelEdgeHandler, createVercelNodeListener } from "@pracht/adapter-vercel";',
     createServerEntryModule() {
       return createVercelServerEntryModule(options);
     },

--- a/packages/adapter-vercel/src/index.ts
+++ b/packages/adapter-vercel/src/index.ts
@@ -107,9 +107,34 @@ export function createVercelNodeListener(
   handler: (request: Request, context: VercelExecutionContext) => Promise<Response>,
 ): (req: VercelNodeRequest, res: VercelNodeResponse) => Promise<void> {
   return async (req, res) => {
-    const response = await handler(await createNodeWebRequest(req), {});
-    await writeNodeResponse(res, response);
+    const waitUntilTasks: Promise<unknown>[] = [];
+    const context: VercelExecutionContext = {
+      waitUntil(promise) {
+        const task = Promise.resolve(promise);
+        // Attach a rejection handler immediately so a task that rejects while
+        // the response is streaming is not reported as unhandled. The drain
+        // below still observes the original promise's final state.
+        void task.catch(() => {});
+        waitUntilTasks.push(task);
+      },
+    };
+
+    try {
+      const response = await handler(await createNodeWebRequest(req), context);
+      await writeNodeResponse(res, response);
+    } finally {
+      await drainWaitUntilTasks(waitUntilTasks);
+    }
   };
+}
+
+async function drainWaitUntilTasks(tasks: Promise<unknown>[]): Promise<void> {
+  let drained = 0;
+  while (drained < tasks.length) {
+    const batch = tasks.slice(drained);
+    drained = tasks.length;
+    await Promise.allSettled(batch);
+  }
 }
 
 const BODYLESS_METHODS = new Set(["GET", "HEAD"]);

--- a/packages/adapter-vercel/test/index.test.ts
+++ b/packages/adapter-vercel/test/index.test.ts
@@ -2,7 +2,11 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { defineApp, route, timeRevalidate, webhookRevalidate } from "@pracht/core";
 
-import { createVercelEdgeHandler, createVercelServerEntryModule } from "../src/index.ts";
+import {
+  createVercelEdgeHandler,
+  createVercelNodeListener,
+  createVercelServerEntryModule,
+} from "../src/index.ts";
 
 describe("createVercelServerEntryModule", () => {
   it("imports an app createContext module when configured", () => {
@@ -18,6 +22,50 @@ describe("createVercelServerEntryModule", () => {
     expect(source).toContain("createContext: createPrachtContext");
     expect(source).toContain("createVercelEdgeHandler");
     expect(source).toContain('export const vercelFunctionName = "app";');
+  });
+});
+
+describe("createVercelNodeListener", () => {
+  it("provides waitUntil and drains registered work", async () => {
+    let releaseTask: (() => void) | undefined;
+    const backgroundTask = new Promise<void>((resolve) => {
+      releaseTask = resolve;
+    });
+    let receivedWaitUntil = false;
+    let listenerSettled = false;
+    const chunks: Uint8Array[] = [];
+    const listener = createVercelNodeListener(async (_request, context) => {
+      receivedWaitUntil = typeof context.waitUntil === "function";
+      context.waitUntil?.(backgroundTask);
+      return new Response("ok");
+    });
+
+    const invocation = listener(
+      {
+        headers: { host: "example.com" },
+        method: "GET",
+        url: "/pricing",
+        async *[Symbol.asyncIterator]() {},
+      },
+      {
+        statusCode: 0,
+        setHeader() {},
+        write(chunk) {
+          chunks.push(chunk);
+        },
+        end() {},
+      },
+    ).then(() => {
+      listenerSettled = true;
+    });
+
+    await vi.waitFor(() => expect(receivedWaitUntil).toBe(true));
+    expect(listenerSettled).toBe(false);
+    releaseTask?.();
+    await invocation;
+
+    expect(listenerSettled).toBe(true);
+    expect(new TextDecoder().decode(chunks[0])).toBe("ok");
   });
 });
 

--- a/packages/cli/src/build-shared.ts
+++ b/packages/cli/src/build-shared.ts
@@ -7,6 +7,29 @@ import { VERSION } from "./constants.js";
 
 const ROUTE_STATE_REQUEST_HEADER = "x-pracht-route-state-request";
 
+/**
+ * Vercel only accepts `.prerender-config.json` (ISR) next to a Serverless
+ * Function — pairing one with an Edge Function fails the deployment with
+ * `Unexpected function type "EdgeFunction"`. ISG routes therefore run on Node
+ * while the main handler stays on the edge; both load the same Web-API-only
+ * server bundle.
+ */
+const VERCEL_NODE_RUNTIME = "nodejs22.x";
+/**
+ * Named so it cannot collide with a chunk emitted into `dist/server`. It is
+ * CommonJS (like Next.js' `___next_launcher.cjs`) so Vercel's Node launcher can
+ * require it without relying on ES module interop; the ESM server bundle is
+ * pulled in through a dynamic import.
+ */
+const VERCEL_NODE_ENTRY_FILE = "_pracht-node-entry.cjs";
+const VERCEL_NODE_ENTRY_SOURCE = `let listener;
+
+module.exports = async (req, res) => {
+  listener ??= (await import("./server.js")).nodeListener;
+  return listener(req, res);
+};
+`;
+
 interface VercelBuildOutputOptions {
   functionName?: string;
   headersManifest?: Record<string, Record<string, string>>;
@@ -53,6 +76,7 @@ export function writeVercelBuildOutput({
     functionsDir,
     headersManifest,
     isgManifest,
+    regions,
     revalidateToken,
     staticDir,
   });
@@ -102,6 +126,7 @@ function writeVercelPrerenderFunctions({
   functionsDir,
   headersManifest,
   isgManifest,
+  regions,
   revalidateToken,
   staticDir,
 }: {
@@ -109,23 +134,22 @@ function writeVercelPrerenderFunctions({
   functionsDir: string;
   headersManifest: Record<string, Record<string, string>>;
   isgManifest: Record<string, ISGManifestEntry>;
+  regions?: string[];
   revalidateToken: string;
   staticDir: string;
 }): void {
+  // The first ISG route materializes the Node function; the rest symlink to it
+  // so that N ISG paths don't each duplicate the server bundle.
+  let sharedNodeFunctionDir: string | undefined;
+
   for (const [route, entry] of Object.entries(isgManifest)) {
     const prerenderName = routeToPrerenderFunctionName(route);
     const routeFunctionDir = join(functionsDir, `${prerenderName}.func`);
-    if (routeFunctionDir !== functionDir) {
-      mkdirSync(dirname(routeFunctionDir), { recursive: true });
-      // Symlink rather than copy so that N ISG routes don't each duplicate the
-      // full server bundle. Vercel resolves symlinked `.func` directories; fall
-      // back to a copy where symlinks aren't available (e.g. Windows without
-      // the required privileges).
-      try {
-        symlinkSync(relative(dirname(routeFunctionDir), functionDir), routeFunctionDir, "dir");
-      } catch {
-        cpSync(functionDir, routeFunctionDir, { recursive: true });
-      }
+    if (sharedNodeFunctionDir) {
+      linkVercelPrerenderFunction({ routeFunctionDir, sharedNodeFunctionDir });
+    } else {
+      writeVercelPrerenderFunction({ functionDir, regions, routeFunctionDir });
+      sharedNodeFunctionDir = routeFunctionDir;
     }
 
     const configPath = join(functionsDir, `${prerenderName}.prerender-config.json`);
@@ -154,6 +178,61 @@ function writeVercelPrerenderFunctions({
       )}\n`,
       "utf-8",
     );
+  }
+}
+
+/**
+ * Emit the Serverless Function ISG routes render through. It gets its own copy
+ * of the server bundle rather than linking to the edge function's: Node
+ * resolves a symlinked module at its real path, so a linked `server.js` would
+ * be typed by the edge function directory — which carries no ESM
+ * `package.json` — and fail to parse as CommonJS.
+ */
+function writeVercelPrerenderFunction({
+  functionDir,
+  regions,
+  routeFunctionDir,
+}: {
+  functionDir: string;
+  regions?: string[];
+  routeFunctionDir: string;
+}): void {
+  mkdirSync(dirname(routeFunctionDir), { recursive: true });
+  cpSync(functionDir, routeFunctionDir, { recursive: true });
+
+  // The bundle is ESM and Vite emits no `package.json` beside it, so without
+  // this Node would load `server.js` as CommonJS and fail to parse it.
+  writeFileSync(
+    join(routeFunctionDir, "package.json"),
+    `${JSON.stringify({ type: "module" }, null, 2)}\n`,
+    "utf-8",
+  );
+  writeFileSync(join(routeFunctionDir, VERCEL_NODE_ENTRY_FILE), VERCEL_NODE_ENTRY_SOURCE, "utf-8");
+  writeFileSync(
+    join(routeFunctionDir, ".vc-config.json"),
+    `${JSON.stringify(createVercelNodeFunctionConfig({ regions }), null, 2)}\n`,
+    "utf-8",
+  );
+}
+
+function linkVercelPrerenderFunction({
+  routeFunctionDir,
+  sharedNodeFunctionDir,
+}: {
+  routeFunctionDir: string;
+  sharedNodeFunctionDir: string;
+}): void {
+  mkdirSync(dirname(routeFunctionDir), { recursive: true });
+  // Vercel resolves symlinked `.func` directories; fall back to a copy where
+  // symlinks aren't available (e.g. Windows without the required privileges).
+  try {
+    symlinkSync(
+      relative(dirname(routeFunctionDir), sharedNodeFunctionDir),
+      routeFunctionDir,
+      "dir",
+    );
+  } catch {
+    cpSync(sharedNodeFunctionDir, routeFunctionDir, { recursive: true });
   }
 }
 
@@ -238,6 +317,25 @@ function createVercelFunctionConfig({ regions }: { regions?: string[] }): Record
   const config: Record<string, unknown> = {
     entrypoint: "server.js",
     runtime: "edge",
+  };
+
+  if (regions) {
+    config.regions = regions;
+  }
+
+  return config;
+}
+
+function createVercelNodeFunctionConfig({
+  regions,
+}: {
+  regions?: string[];
+}): Record<string, unknown> {
+  const config: Record<string, unknown> = {
+    handler: VERCEL_NODE_ENTRY_FILE,
+    launcherType: "Nodejs",
+    runtime: VERCEL_NODE_RUNTIME,
+    shouldAddHelpers: false,
   };
 
   if (regions) {

--- a/packages/cli/src/build-shared.ts
+++ b/packages/cli/src/build-shared.ts
@@ -30,12 +30,14 @@ module.exports = async (req, res) => {
 };
 `;
 
+type VercelRegions = string | string[];
+
 interface VercelBuildOutputOptions {
   functionName?: string;
   headersManifest?: Record<string, Record<string, string>>;
   isgManifest: Record<string, ISGManifestEntry>;
   revalidateToken?: string;
-  regions?: string[];
+  regions?: VercelRegions;
   root: string;
   staticRoutes: string[];
 }
@@ -134,7 +136,7 @@ function writeVercelPrerenderFunctions({
   functionsDir: string;
   headersManifest: Record<string, Record<string, string>>;
   isgManifest: Record<string, ISGManifestEntry>;
-  regions?: string[];
+  regions?: VercelRegions;
   revalidateToken: string;
   staticDir: string;
 }): void {
@@ -194,7 +196,7 @@ function writeVercelPrerenderFunction({
   routeFunctionDir,
 }: {
   functionDir: string;
-  regions?: string[];
+  regions?: VercelRegions;
   routeFunctionDir: string;
 }): void {
   mkdirSync(dirname(routeFunctionDir), { recursive: true });
@@ -313,7 +315,11 @@ function createVercelOutputConfig({
   };
 }
 
-function createVercelFunctionConfig({ regions }: { regions?: string[] }): Record<string, unknown> {
+function createVercelFunctionConfig({
+  regions,
+}: {
+  regions?: VercelRegions;
+}): Record<string, unknown> {
   const config: Record<string, unknown> = {
     entrypoint: "server.js",
     runtime: "edge",
@@ -329,7 +335,7 @@ function createVercelFunctionConfig({ regions }: { regions?: string[] }): Record
 function createVercelNodeFunctionConfig({
   regions,
 }: {
-  regions?: string[];
+  regions?: VercelRegions;
 }): Record<string, unknown> {
   const config: Record<string, unknown> = {
     handler: VERCEL_NODE_ENTRY_FILE,
@@ -339,7 +345,7 @@ function createVercelNodeFunctionConfig({
   };
 
   if (regions) {
-    config.regions = regions;
+    config.regions = Array.isArray(regions) ? regions : [regions];
   }
 
   return config;

--- a/packages/cli/src/build-shared.ts
+++ b/packages/cli/src/build-shared.ts
@@ -344,7 +344,9 @@ function createVercelNodeFunctionConfig({
     shouldAddHelpers: false,
   };
 
-  if (regions) {
+  // `all` is an Edge-only sentinel. Node functions must name concrete regions;
+  // omitting the field lets the project-level Serverless default apply.
+  if (regions && regions !== "all") {
     config.regions = Array.isArray(regions) ? regions : [regions];
   }
 

--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -269,6 +269,17 @@ export async function runBuild(root: string, options: BuildOptions = {}): Promis
     }
 
     if (serverMod.buildTarget === "vercel") {
+      // ISG routes deploy as Node serverless functions that re-export
+      // `nodeListener` from the bundle; catch a custom server entry that
+      // doesn't provide it here instead of at request time in production.
+      if (Object.keys(isgManifest).length > 0 && typeof serverMod.nodeListener !== "function") {
+        throw new Error(
+          "The Vercel server entry does not export `nodeListener`, which the ISG routes' " +
+            "serverless functions import. Generate the entry with `vercelAdapter()` or export " +
+            "`createVercelNodeListener(handle)` from your custom entry module.",
+        );
+      }
+
       const outputPath = writeVercelBuildOutput({
         functionName: serverMod.vercelFunctionName,
         isgManifest,

--- a/packages/cli/test/vercel-build-output.test.ts
+++ b/packages/cli/test/vercel-build-output.test.ts
@@ -1,4 +1,12 @@
-import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import {
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -24,6 +32,64 @@ describe("writeVercelBuildOutput", () => {
     writeFileSync(join(root, "dist/server/server.js"), "export default {}\n", "utf-8");
     return root;
   }
+
+  it("emits ISG routes as Node serverless functions", () => {
+    const root = createBuildRoot();
+
+    writeVercelBuildOutput({
+      isgManifest: { "/pricing": { revalidate: timeRevalidate(60) } },
+      root,
+      staticRoutes: ["/"],
+    });
+
+    const functionDir = join(root, ".vercel/output/functions/pricing.func");
+    // Vercel fails the deployment when a `.prerender-config.json` sits next to
+    // an edge function, so this one has to be a serverless function.
+    expect(JSON.parse(readFileSync(join(functionDir, ".vc-config.json"), "utf-8"))).toEqual({
+      handler: "_pracht-node-entry.cjs",
+      launcherType: "Nodejs",
+      runtime: expect.stringMatching(/^nodejs\d+\.x$/),
+      shouldAddHelpers: false,
+    });
+    expect(readFileSync(join(functionDir, "_pracht-node-entry.cjs"), "utf-8")).toContain(
+      'await import("./server.js")).nodeListener',
+    );
+    // Node types a module by its real path, so the bundle has to live inside
+    // the function directory next to a `package.json` marking it as ESM.
+    expect(lstatSync(join(functionDir, "server.js")).isFile()).toBe(true);
+    expect(JSON.parse(readFileSync(join(functionDir, "package.json"), "utf-8"))).toEqual({
+      type: "module",
+    });
+    expect(existsSync(join(root, ".vercel/output/functions/pricing.prerender-config.json"))).toBe(
+      true,
+    );
+    // The main handler stays on the edge.
+    expect(
+      JSON.parse(
+        readFileSync(join(root, ".vercel/output/functions/render.func/.vc-config.json"), "utf-8"),
+      ),
+    ).toMatchObject({ runtime: "edge" });
+  });
+
+  it("shares one serverless bundle across ISG routes", () => {
+    const root = createBuildRoot();
+
+    writeVercelBuildOutput({
+      isgManifest: {
+        "/pricing": { revalidate: timeRevalidate(60) },
+        "/products/1": { revalidate: timeRevalidate(60) },
+      },
+      root,
+      staticRoutes: [],
+    });
+
+    const functionsDir = join(root, ".vercel/output/functions");
+    expect(lstatSync(join(functionsDir, "products/1.func")).isSymbolicLink()).toBe(true);
+    expect(
+      JSON.parse(readFileSync(join(functionsDir, "products/1.func/.vc-config.json"), "utf-8")),
+    ).toMatchObject({ launcherType: "Nodejs" });
+    expect(existsSync(join(functionsDir, "products/1.prerender-config.json"))).toBe(true);
+  });
 
   it("rejects an ISG route that collides with the default edge function", () => {
     const root = createBuildRoot();

--- a/packages/cli/test/vercel-build-output.test.ts
+++ b/packages/cli/test/vercel-build-output.test.ts
@@ -71,6 +71,22 @@ describe("writeVercelBuildOutput", () => {
     ).toMatchObject({ runtime: "edge" });
   });
 
+  it("normalizes a scalar region for ISG serverless functions", () => {
+    const root = createBuildRoot();
+
+    writeVercelBuildOutput({
+      isgManifest: { "/pricing": { revalidate: timeRevalidate(60) } },
+      regions: "iad1",
+      root,
+      staticRoutes: [],
+    });
+
+    const functionConfig = JSON.parse(
+      readFileSync(join(root, ".vercel/output/functions/pricing.func/.vc-config.json"), "utf-8"),
+    );
+    expect(functionConfig.regions).toEqual(["iad1"]);
+  });
+
   it("shares one serverless bundle across ISG routes", () => {
     const root = createBuildRoot();
 

--- a/packages/cli/test/vercel-build-output.test.ts
+++ b/packages/cli/test/vercel-build-output.test.ts
@@ -87,6 +87,27 @@ describe("writeVercelBuildOutput", () => {
     expect(functionConfig.regions).toEqual(["iad1"]);
   });
 
+  it("keeps the all sentinel on edge and uses the project default for ISG", () => {
+    const root = createBuildRoot();
+
+    writeVercelBuildOutput({
+      isgManifest: { "/pricing": { revalidate: timeRevalidate(60) } },
+      regions: "all",
+      root,
+      staticRoutes: [],
+    });
+
+    const functionsDir = join(root, ".vercel/output/functions");
+    const edgeConfig = JSON.parse(
+      readFileSync(join(functionsDir, "render.func/.vc-config.json"), "utf-8"),
+    );
+    const nodeConfig = JSON.parse(
+      readFileSync(join(functionsDir, "pricing.func/.vc-config.json"), "utf-8"),
+    );
+    expect(edgeConfig.regions).toBe("all");
+    expect(nodeConfig).not.toHaveProperty("regions");
+  });
+
   it("shares one serverless bundle across ISG routes", () => {
     const root = createBuildRoot();
 

--- a/skills/configure-isg/SKILL.md
+++ b/skills/configure-isg/SKILL.md
@@ -100,7 +100,7 @@ curl -X POST https://example.com/__pracht/revalidate \
 | Node | File mtime vs window; serves stale, refreshes in background | Regenerates the on-disk HTML synchronously |
 | Cloudflare (default) | Worker-managed Cache API timestamp, `env.ASSETS` fallback — **per colo** | Overwrites the Cache API entry in the receiving colo only |
 | Cloudflare (`cache: true`) | Edge-tier Workers Caching in front of the Worker for time-revalidated routes | Webhook-only routes keep the worker-managed path; time+webhook routes also get their edge entry purged |
-| Vercel | Build Output prerender functions: `.prerender-config.json` with `expiration` from the time policy and build HTML as fallback | `x-vercel-cache`-verified bypass; `PRACHT_REVALIDATE_TOKEN` becomes the `bypassToken` and **must be set at build time** (runtime-only setting → webhook paths report `failed` until you rebuild) |
+| Vercel | Build Output prerender functions: `.prerender-config.json` with `expiration` from the time policy and build HTML as fallback, next to a Node Serverless Function per ISG route (Vercel rejects ISR on an Edge Function) | `x-vercel-cache`-verified bypass; `PRACHT_REVALIDATE_TOKEN` becomes the `bypassToken` and **must be set at build time** (runtime-only setting → webhook paths report `failed` until you rebuild) |
 
 Cloudflare specifics (`docs/ADAPTERS.md#isg-via-workers-caching-cache`):
 

--- a/skills/pre-deploy/SKILL.md
+++ b/skills/pre-deploy/SKILL.md
@@ -143,6 +143,10 @@ a markdown summary (graph diff + verify + budgets) worth attaching to it.
   **Serverless** `<route>.func` (`.vc-config.json` with `launcherType:
   "Nodejs"`). Vercel rejects a prerender config paired with an edge function:
   `Unexpected function type "EdgeFunction" at path "<route>"`.
+- Region configuration: `vercelAdapter({ regions: "all" })` is valid for the
+  Edge render function, but generated Node ISG function configs must omit
+  `regions` so the project's default Serverless region applies. Node configs
+  may only contain arrays of concrete region identifiers.
 - An API route importing `@pracht/image/node` is an error for the Vercel Edge
   function. Require `vercelLoader` (with aligned allowed sizes) or
   `passthroughLoader` instead.

--- a/skills/pre-deploy/SKILL.md
+++ b/skills/pre-deploy/SKILL.md
@@ -134,11 +134,15 @@ a markdown summary (graph diff + verify + budgets) worth attaching to it.
 - Required env vars are configured in the Vercel project (cannot verify from
   CLI without `vercel env pull` — run that and diff against `process.env.*`
   references).
-- Edge runtime constraints: pracht **always** writes the function's
-  `.vc-config.json` with `runtime: "edge"` — there is no Node runtime
-  variant, so run the same Node-only API check as Cloudflare
-  **unconditionally** for Vercel builds. Do not skip it based on a runtime
-  probe.
+- Edge runtime constraints: the render function's `.vc-config.json` is
+  **always** written with `runtime: "edge"`, so run the same Node-only API
+  check as Cloudflare **unconditionally** for Vercel builds. Do not skip it
+  based on a runtime probe — ISG routes run the same bundle on Node, but any
+  Node-only API still breaks the edge function.
+- ISG functions: every `<route>.prerender-config.json` must sit next to a
+  **Serverless** `<route>.func` (`.vc-config.json` with `launcherType:
+  "Nodejs"`). Vercel rejects a prerender config paired with an edge function:
+  `Unexpected function type "EdgeFunction" at path "<route>"`.
 - An API route importing `@pracht/image/node` is an error for the Vercel Edge
   function. Require `vercelLoader` (with aligned allowed sizes) or
   `passthroughLoader` instead.

--- a/skills/tune-render-mode/SKILL.md
+++ b/skills/tune-render-mode/SKILL.md
@@ -159,7 +159,7 @@ Apply the edits only after the user confirms.
    | ---------- | -------------------------------------------------------------- | ----- |
    | Node       | Filesystem: `isg-manifest.json` + file-mtime revalidation      | Serves stale immediately, refreshes in place. |
    | Cloudflare | Worker-managed Workers Cache API, **per colo** — works without any extra config | `cloudflareAdapter({ cache: true })` + `"cache": { "enabled": true }` in wrangler config is an **optional upgrade** that moves time-revalidated routes to an edge-tier cache in front of the Worker; webhook-only routes stay worker-managed. Webhook invalidation on the default path is per-colo, not a global purge. |
-   | Vercel     | Native ISR: Build Output API prerender functions with `expiration` from the time policy; `PRACHT_REVALIDATE_TOKEN` becomes the `bypassToken` (must be set at build time) | See docs/ADAPTERS.md. |
+   | Vercel     | Native ISR: Build Output API prerender functions with `expiration` from the time policy; `PRACHT_REVALIDATE_TOKEN` becomes the `bypassToken` (must be set at build time) | ISG routes deploy as Node Serverless Functions (Vercel rejects ISR on an Edge Function) while SSR stays on the edge. See docs/ADAPTERS.md. |
 
 4. For dynamic SSG/ISG routes, ensure `getStaticPaths` exists. Flag if missing.
 5. Use `pracht inspect routes --json` rather than reading `src/routes.ts`


### PR DESCRIPTION
## Summary

- `vercel deploy --prebuilt` failed with `Unexpected function type "EdgeFunction" at path "pricing"` because the build paired every `<route>.prerender-config.json` with the edge function, and Vercel only accepts ISR on Serverless Functions — so any app with an ISG route emitted output that could not deploy.
- ISG routes now emit Node serverless functions (CJS launcher + `{"type":"module"}` + the bundle, with extra routes symlinked to the first) while the main handler stays on the edge; both load the same Web-API-only server bundle, and `@pracht/adapter-vercel` gained `createVercelNodeListener()` whose `nodeListener` export the launcher calls.
- `e2e/vercel-build.test.ts` asserted the broken shape, so it never caught this: it now asserts the serverless shape and drives the emitted launcher the way Vercel's Node launcher does, proving the function boots and renders.
- Showcase `/pricing` moves to SSG with a comment explaining why (its plans are hard-coded, so there is nothing to revalidate) and the copy claiming it revalidates hourly was corrected; `examples/basic` keeps the ISG build coverage.
- Docs, the `configure-isg` / `tune-render-mode` / `pre-deploy` skills, and a changeset are updated to match.

## Testing

- [x] `pnpm e2e`
- [x] `pnpm format`
- [x] `pnpm lint`
- [x] `pnpm test`

Not verified: an actual `vercel deploy --prebuilt` against the new output.

## Checklist

- [x] Docs updated if needed
- [x] Skills updated if needed
- [x] Changeset added if published packages changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)