### PR TITLE
Attribute composed capability dispatches to the transport that caused them

### DIFF
--- a/.changeset/capability-audit-via.md
+++ b/.changeset/capability-audit-via.md
@@ -20,7 +20,8 @@ triggered through a composing tool is recorded as
 loader call. It is `null` for top-level dispatches and outside a served request
 (test hosts, scripts), and never reports `"webmcp"` — that marker is
 client-declared, so it is not trustworthy enough to attribute a nested effect
-to.
+to. Both the module-level audit hook and `handlePrachtRequest()`'s request-local
+`onCapabilityAudit` callback receive the composed event.
 
 The guard boundary itself is unchanged and now documented in
 `docs/AGENT_TRUST.md`: gate composed effects inside the composing capability

--- a/.changeset/capability-audit-via.md
+++ b/.changeset/capability-audit-via.md
@@ -1,0 +1,27 @@
+---
+"@pracht/core": minor
+---
+
+Attribute composed capability dispatches to the transport that caused them.
+
+`invokeCapability()` is trusted first-party composition: it runs the callee's
+own pipeline (input validation, named middleware, `run()`, output validation)
+but none of the transport policy that guards the projections — no app-level
+`api.middleware`, no `agentPolicy` check, no destructive prepare/commit gate.
+A capability an untrusted caller can reach therefore lends that reachability to
+everything it composes, which matters most for a remote MCP tool: `expose.mcp`
+keeps destructive capabilities off the *tool surface*, but says nothing about
+what an exposed tool invokes.
+
+`CapabilityAuditEvent` gains `via`: for a `transport: "server"` dispatch it
+carries the transport of the request being served, so an effect a remote agent
+triggered through a composing tool is recorded as
+`{ transport: "server", via: "mcp" }` instead of looking like an ordinary
+loader call. It is `null` for top-level dispatches and outside a served request
+(test hosts, scripts), and never reports `"webmcp"` — that marker is
+client-declared, so it is not trustworthy enough to attribute a nested effect
+to.
+
+The guard boundary itself is unchanged and now documented in
+`docs/AGENT_TRUST.md`: gate composed effects inside the composing capability
+rather than relying on the callee's exposure rules.

--- a/docs/AGENT_TRUST.md
+++ b/docs/AGENT_TRUST.md
@@ -408,6 +408,7 @@ interface CapabilityAuditEvent {
   capability: string;          // "notes.purge"
   effect: "read" | "write" | "destructive";
   transport: "http" | "server" | "webmcp" | "mcp";
+  via: "http" | "mcp" | null; // request a "server" dispatch was composed under
   outcome: string;             // "ok" | "invalid_input" | "confirmation_required" | ...
   status: number;
   durationMs: number;
@@ -424,6 +425,33 @@ agent traffic (cookie-authenticated) apart from remote HTTP callers — like any
 client-sent header it is informational, not a trust signal. `outcome` values
 come from the `CapabilityErrorCode` union exported by `@pracht/capabilities`
 (plus `"ok"` and middleware short-circuits).
+
+`via` answers "who caused this?" for composition. A capability that calls
+`invokeCapability()` produces a second event with `transport: "server"`, and
+`via` carries the transport of the request being served — so an effect a
+remote agent triggered through a composing MCP tool reads as
+`{ transport: "server", via: "mcp" }` instead of looking like an ordinary
+loader call. It is `null` for top-level dispatches (`transport` already says
+how they arrived) and outside a served request (test hosts, scripts). It never
+reports `"webmcp"`: that marker is client-declared, so it is not trustworthy
+enough to attribute a nested effect to.
+
+### Composition does not inherit transport guards
+
+`invokeCapability()` is trusted first-party composition. It runs the callee's
+own pipeline — input validation, its named middleware, `run()`, output
+validation — and deliberately *not* the transport policy that guards the
+projections: no app-level `api.middleware`, no `agentPolicy` check, and no
+prepare/commit confirmation gate.
+
+That is what makes private capabilities useful as building blocks, and it
+means the reachability of a composing capability is the reachability of
+everything it composes. An MCP-exposed tool whose `run()` calls a
+`destructive` capability grants remote agents that effect, even though
+`expose.mcp` on the destructive capability itself is rejected. Put the gate in
+the composing capability — check `context.agent`, require your own approval,
+or keep the composition out of an exposed capability — and use `via` to see
+what actually ran.
 
 Subscribe from any server-only module (audit hooks observe: exceptions are
 swallowed, never breaking a request):

--- a/docs/CAPABILITIES.md
+++ b/docs/CAPABILITIES.md
@@ -507,6 +507,13 @@ file, and `pracht verify` reports the same projection constraints.
 - **Shared API policy** — every HTTP-exposed capability runs app-level
   `api.middleware` first, then its capability-specific middleware. Direct
   server invocation runs only the capability-specific chain.
+- **Composition is trusted, not re-guarded** — `invokeCapability()` runs the
+  callee's own pipeline but none of the transport policy (`api.middleware`,
+  `agentPolicy`, the destructive confirmation gate), so a capability reachable
+  by an untrusted caller lends that reachability to everything it composes.
+  Gate in the composing capability; composed dispatches audit as
+  `transport: "server"` with `via` naming the transport that caused them. See
+  [AGENT_TRUST.md](AGENT_TRUST.md#composition-does-not-inherit-transport-guards).
 - **Exposure requires a complete contract** — `pracht verify` fails for
   exposed capabilities missing a description, input schema, output schema, or
   effect classification.

--- a/docs/CAPABILITY_GRAPH.md
+++ b/docs/CAPABILITY_GRAPH.md
@@ -880,6 +880,18 @@ transfers to the transport unchanged, so the ban is now a policy choice rather
 than a mechanism gap: what it waits on is exactly-once commit, which the
 [approval store](AGENT_TRUST.md#durable-approvals) provides.
 
+The ban covers the tool surface, not composition. Binding the synthesized
+request to the capability host let an MCP tool call `invokeCapability()` like
+any other server code — including on a private or destructive capability,
+whose transport guards (`agentPolicy`, the confirmation gate) that path has
+never applied. Re-applying them there was rejected: it would give the same
+composition two different meanings depending on which transport happened to be
+serving, and would break the composing capability that gates the work itself.
+Instead composition is documented as trusted first-party code that lends its
+caller's reachability to its callee, and `CapabilityAuditEvent` gained `via` —
+the transport of the request a `"server"` dispatch ran under — so an effect a
+remote agent caused indirectly is attributable rather than invisible.
+
 ## Final Recommendation
 
 Proceed with Stage 0 as the next product exploration. Continue streaming SSR and other framework

--- a/docs/REMOTE_MCP.md
+++ b/docs/REMOTE_MCP.md
@@ -68,7 +68,14 @@ there is no second copy of the rules to drift.
 
 The synthesized request carries the same request-bound capability host, so
 named middleware and capability bodies can compose registered operations with
-`invokeCapability()` exactly as they can during ordinary HTTP dispatch.
+`invokeCapability()` exactly as they can during ordinary HTTP dispatch. That
+composition is trusted first-party code and runs only the callee's own
+pipeline: the guards below, `agentPolicy`, and the confirmation gate belong to
+*dispatch*, not to `invokeCapability()`. An exposed tool therefore lends its
+reachability to whatever it composes — see [Composition does not inherit
+transport guards](AGENT_TRUST.md#composition-does-not-inherit-transport-guards).
+Composed dispatches audit as `{ transport: "server", via: "mcp" }`, so the
+effects a remote agent caused indirectly stay attributable to it.
 
 ```text
 POST /mcp
@@ -174,13 +181,18 @@ The projection inherits every capability guarantee and adds three of its own:
   `destructive` capability is rejected by `defineCapability()`, the registry,
   and `pracht verify`, and the projection filters them again at serve time.
   Agent hosts cannot yet be trusted to carry the prepare/commit flow
-  faithfully. See [AGENT_TRUST.md](AGENT_TRUST.md).
+  faithfully. See [AGENT_TRUST.md](AGENT_TRUST.md). This covers the *tool
+  surface*, not composition: an exposed tool whose `run()` invokes a
+  destructive capability still performs that effect, unconfirmed, because
+  `invokeCapability()` is trusted server code. Gate it in the composing
+  capability.
 
 Authentication is your app's: put it in the capability's named middleware,
 which sees the forwarded `Authorization` header and `context.agent`. Every
 dispatch emits an audit event with `transport: "mcp"` — passed as internal
 dispatch state by the projection, never read from the public transport-marker
-header, so unlike the client-declared `"webmcp"` marker it is trustworthy.
+header, so unlike the client-declared `"webmcp"` marker it is trustworthy —
+and anything the tool composes emits its own event carrying `via: "mcp"`.
 
 ## Talking to it
 

--- a/examples/docs/src/routes/docs/agent-trust.md
+++ b/examples/docs/src/routes/docs/agent-trust.md
@@ -190,6 +190,14 @@ setCapabilityAuditHook((event) => log.info("capability", event));
 
 Hook exceptions are swallowed — auditing observes, it never breaks a request.
 
+A capability that calls `invokeCapability()` produces a second event with `transport: "server"` and `via` set to the transport of the request it ran under, so an effect a remote agent triggered through a composing MCP tool reads as `{ transport: "server", via: "mcp" }` rather than looking like an ordinary loader call. `via` is `null` for top-level dispatches and outside a served request.
+
+### Composition Does Not Inherit Transport Guards
+
+`invokeCapability()` is trusted first-party composition. It runs the callee's own pipeline — input validation, its named middleware, `run()`, output validation — and deliberately *not* the transport policy guarding the projections: no app-level `api.middleware`, no `agentPolicy` check, no prepare/commit gate.
+
+That is what makes private capabilities useful as building blocks, and it means the reachability of a composing capability is the reachability of everything it composes. An MCP-exposed tool whose `run()` calls a `destructive` capability grants remote agents that effect, even though `expose.mcp` on the destructive capability itself is rejected. Put the gate in the composing capability, and use `via` to see what actually ran.
+
 ---
 
 ## pracht eval: Prove Agent Flows in CI

--- a/examples/docs/src/routes/docs/remote-mcp.md
+++ b/examples/docs/src/routes/docs/remote-mcp.md
@@ -61,7 +61,7 @@ POST /mcp
 
 Input validation, named middleware, `agentPolicy`, output validation, and the audit event are identical across HTTP, WebMCP, and MCP *by construction* — there is no second copy of the rules that could drift from the first.
 
-The synthesized request carries the same request-bound capability host, so named middleware and capability bodies can compose registered operations with `invokeCapability()` exactly as they can during ordinary HTTP dispatch.
+The synthesized request carries the same request-bound capability host, so named middleware and capability bodies can compose registered operations with `invokeCapability()` exactly as they can during ordinary HTTP dispatch. That composition is trusted first-party code and runs only the callee's own pipeline — `agentPolicy` and the confirmation gate guard *dispatch*, not `invokeCapability()` — so an exposed tool lends its reachability to whatever it composes. Composed dispatches audit as `{ transport: "server", via: "mcp" }`, keeping indirect effects attributable to the agent that caused them.
 
 The endpoint is stateless: no session id, no server→client stream, no resumability. That is what the Node, Cloudflare, and Vercel adapters already serve, so the same app runs unchanged on all three.
 
@@ -114,9 +114,9 @@ Every capability guarantee carries over. The projection adds three of its own:
 
 **Browser-originated requests are rejected.** Remote MCP has no browser use case, so requests carrying `Origin` or `Sec-Fetch-Site` receive 403. This avoids trusting a Host-derived request URL during Origin validation, closing the DNS-rebinding path. Non-browser MCP clients send neither header and are unaffected.
 
-**Destructive capabilities are not exposed.** `expose.mcp` on a `destructive` capability is rejected by `defineCapability()`, the registry, and `pracht verify` — and filtered again at serve time. Agent hosts cannot yet be trusted to carry the [prepare/commit flow](/docs/agent-trust) faithfully.
+**Destructive capabilities are not exposed.** `expose.mcp` on a `destructive` capability is rejected by `defineCapability()`, the registry, and `pracht verify` — and filtered again at serve time. Agent hosts cannot yet be trusted to carry the [prepare/commit flow](/docs/agent-trust) faithfully. That covers the *tool surface*, not composition: an exposed tool whose `run()` invokes a destructive capability still performs that effect, unconfirmed, because `invokeCapability()` is trusted server code. Gate it in the composing capability.
 
-Authentication is your app's, in the capability's named middleware. Every dispatch emits an audit event with `transport: "mcp"` — passed as internal dispatch state rather than read from the public transport-marker header, so unlike the client-declared `"webmcp"` marker it is trustworthy.
+Authentication is your app's, in the capability's named middleware. Every dispatch emits an audit event with `transport: "mcp"` — passed as internal dispatch state rather than read from the public transport-marker header, so unlike the client-declared `"webmcp"` marker it is trustworthy — and anything the tool composes emits its own event carrying `via: "mcp"`.
 
 ---
 

--- a/packages/framework/src/runtime-capabilities.ts
+++ b/packages/framework/src/runtime-capabilities.ts
@@ -478,6 +478,8 @@ export async function handleCapabilityRequest<TContext>(
         options.request.headers.get(CAPABILITY_TRANSPORT_HEADER),
         options.transport,
       ),
+      // A dispatch that arrived on a transport is not composed under one.
+      via: null,
       outcome,
       status: responseWithEffect.status,
       durationMs: performance.now() - started,
@@ -1065,6 +1067,13 @@ function normalizeMiddlewareShortCircuit(response: Response): Response {
 export interface CapabilityHost {
   app: CapabilityHostApp;
   registry: ModuleRegistry;
+  /**
+   * Transport of the request this host was installed for. Carried onto the
+   * audit event of every capability composed through `invokeCapability()`
+   * while that request is being served. Absent on synthetic hosts (test
+   * hosts), which serve no request.
+   */
+  via?: CapabilityAuditEvent["via"];
 }
 
 // Bind each host to the incoming Request rather than a process-global slot.
@@ -1078,8 +1087,10 @@ export function setActiveCapabilityHost(
   request: Request,
   app: CapabilityHostApp,
   registry: ModuleRegistry,
+  /** Transport of the request being served; audits nested composition. */
+  via: NonNullable<CapabilityAuditEvent["via"]> = "http",
 ): void {
-  activeCapabilityHosts.set(request, { app, registry });
+  activeCapabilityHosts.set(request, { app, registry, via });
 }
 
 export interface InvokeCapabilityContext<TContext = unknown> {
@@ -1095,6 +1106,16 @@ export interface InvokeCapabilityContext<TContext = unknown> {
  * input validation, the capability's named middleware, `run()`, output
  * validation — and resolves to the same typed envelope. Works for private
  * (non-exposed) capabilities too.
+ *
+ * This is trusted first-party composition, so the *transport* policy of the
+ * callee is deliberately not re-applied: no app-level `api.middleware`, no
+ * `agentPolicy` check, and no destructive prepare/commit confirmation gate —
+ * those guard the HTTP and MCP projections. A capability an untrusted caller
+ * can reach therefore lends that reachability to everything it composes.
+ * Decide the gating in the composing capability; do not rely on the callee's
+ * exposure rules to supply it. Composed dispatches are audited with
+ * `transport: "server"` and `via` set to the transport of the request being
+ * served, so a remote-agent-caused effect stays attributable.
  *
  * When `pracht typegen` has registered the capability graph on
  * `Register["capabilities"]`, the name, input, and output types all come from
@@ -1187,6 +1208,7 @@ export async function invokeCapabilityOnHost<T = unknown>(
       capability: name,
       effect: resolved.capability.effect,
       transport: "server",
+      via: host.via ?? null,
       outcome: "internal_error",
       status: 500,
       durationMs: performance.now() - started,
@@ -1196,7 +1218,8 @@ export async function invokeCapabilityOnHost<T = unknown>(
   }
 
   // Direct invocation audits like HTTP dispatch does, marked as the "server"
-  // transport. The agent identity travels on the request context when Web
+  // transport and attributed to the transport of the request it was composed
+  // under (`via`). The agent identity travels on the request context when Web
   // Bot Auth is enabled.
   const agent = (context as { agent?: PrachtAgentIdentity | null }).agent ?? null;
   const status = outcome.kind === "envelope" ? outcome.status : outcome.response.status;
@@ -1206,6 +1229,7 @@ export async function invokeCapabilityOnHost<T = unknown>(
     capability: name,
     effect: resolved.capability.effect,
     transport: "server",
+    via: host.via ?? null,
     outcome: auditOutcome,
     status,
     durationMs: performance.now() - started,

--- a/packages/framework/src/runtime-capabilities.ts
+++ b/packages/framework/src/runtime-capabilities.ts
@@ -1067,6 +1067,8 @@ function normalizeMiddlewareShortCircuit(response: Response): Response {
 export interface CapabilityHost {
   app: CapabilityHostApp;
   registry: ModuleRegistry;
+  /** Request-local audit hook supplied by a custom server entry. */
+  onAudit?: CapabilityAuditHook;
   /**
    * Transport of the request this host was installed for. Carried onto the
    * audit event of every capability composed through `invokeCapability()`
@@ -1089,8 +1091,9 @@ export function setActiveCapabilityHost(
   registry: ModuleRegistry,
   /** Transport of the request being served; audits nested composition. */
   via: NonNullable<CapabilityAuditEvent["via"]> = "http",
+  onAudit?: CapabilityAuditHook,
 ): void {
-  activeCapabilityHosts.set(request, { app, registry, via });
+  activeCapabilityHosts.set(request, { app, registry, via, onAudit });
 }
 
 export interface InvokeCapabilityContext<TContext = unknown> {
@@ -1204,16 +1207,19 @@ export async function invokeCapabilityOnHost<T = unknown>(
       code: "internal_error",
       message: `Capability "${name}" failed: ${error instanceof Error ? error.message : String(error)}`,
     });
-    emitCapabilityAudit({
-      capability: name,
-      effect: resolved.capability.effect,
-      transport: "server",
-      via: host.via ?? null,
-      outcome: "internal_error",
-      status: 500,
-      durationMs: performance.now() - started,
-      agent: (context as { agent?: PrachtAgentIdentity | null }).agent ?? null,
-    });
+    emitCapabilityAudit(
+      {
+        capability: name,
+        effect: resolved.capability.effect,
+        transport: "server",
+        via: host.via ?? null,
+        outcome: "internal_error",
+        status: 500,
+        durationMs: performance.now() - started,
+        agent: (context as { agent?: PrachtAgentIdentity | null }).agent ?? null,
+      },
+      host.onAudit,
+    );
     return envelope as CapabilityEnvelope<T>;
   }
 
@@ -1225,16 +1231,19 @@ export async function invokeCapabilityOnHost<T = unknown>(
   const status = outcome.kind === "envelope" ? outcome.status : outcome.response.status;
   const auditOutcome =
     outcome.kind === "envelope" ? envelopeOutcome(outcome.envelope) : `middleware_${status}`;
-  emitCapabilityAudit({
-    capability: name,
-    effect: resolved.capability.effect,
-    transport: "server",
-    via: host.via ?? null,
-    outcome: auditOutcome,
-    status,
-    durationMs: performance.now() - started,
-    agent,
-  });
+  emitCapabilityAudit(
+    {
+      capability: name,
+      effect: resolved.capability.effect,
+      transport: "server",
+      via: host.via ?? null,
+      outcome: auditOutcome,
+      status,
+      durationMs: performance.now() - started,
+      agent,
+    },
+    host.onAudit,
+  );
 
   if (outcome.kind === "envelope") {
     return outcome.envelope as CapabilityEnvelope<T>;

--- a/packages/framework/src/runtime-mcp.ts
+++ b/packages/framework/src/runtime-mcp.ts
@@ -400,8 +400,10 @@ async function handleToolsCall<TContext>(
   // `invokeCapability()` resolves its host by Request identity. MCP dispatch
   // uses a synthesized request so middleware and capability bodies see the
   // projected URL and credential policy; bind that request to the same app
-  // host before either can compose another capability.
-  setActiveCapabilityHost(capabilityRequest, options.app, options.registry);
+  // host before either can compose another capability. The host records the
+  // originating transport, so anything composed while serving this tool call
+  // audits as `via: "mcp"` rather than looking like an ordinary server call.
+  setActiveCapabilityHost(capabilityRequest, options.app, options.registry, "mcp");
   const response = await handleCapabilityRequest({
     match,
     context: options.context,

--- a/packages/framework/src/runtime-mcp.ts
+++ b/packages/framework/src/runtime-mcp.ts
@@ -403,7 +403,7 @@ async function handleToolsCall<TContext>(
   // host before either can compose another capability. The host records the
   // originating transport, so anything composed while serving this tool call
   // audits as `via: "mcp"` rather than looking like an ordinary server call.
-  setActiveCapabilityHost(capabilityRequest, options.app, options.registry, "mcp");
+  setActiveCapabilityHost(capabilityRequest, options.app, options.registry, "mcp", options.onAudit);
   const response = await handleCapabilityRequest({
     match,
     context: options.context,

--- a/packages/framework/src/runtime.ts
+++ b/packages/framework/src/runtime.ts
@@ -251,7 +251,13 @@ export async function handlePrachtRequest<TContext>(
   // Register the capability host so `invokeCapability()` works from loaders,
   // API routes, and middleware during this request. One assignment — free
   // for apps without capabilities.
-  setActiveCapabilityHost(options.request, options.app, registry);
+  setActiveCapabilityHost(
+    options.request,
+    options.app,
+    registry,
+    "http",
+    options.onCapabilityAudit,
+  );
 
   // Web Bot Auth: verify the agent signature once per request when the app
   // opted in via `defineApp({ agents: { webBotAuth } })`. The result (identity

--- a/packages/framework/src/types.ts
+++ b/packages/framework/src/types.ts
@@ -781,6 +781,17 @@ export interface CapabilityAuditEvent {
    * not a trust signal (any HTTP client can send the header).
    */
   transport: "http" | "server" | "webmcp" | "mcp";
+  /**
+   * Which request a `transport: "server"` dispatch was composed under.
+   * `invokeCapability()` runs only the capability's own middleware chain — no
+   * HTTP/MCP dispatch guards — so an effect a remote agent caused through a
+   * composing MCP tool would otherwise be indistinguishable from an ordinary
+   * loader call. `null` for top-level dispatches (`transport` already says how
+   * they arrived) and for invocation outside a served request (test hosts,
+   * scripts). Never reports `"webmcp"`: that marker is client-declared, so it
+   * is not trustworthy enough to attribute a nested effect to.
+   */
+  via: "http" | "mcp" | null;
   /** `"ok"` or the envelope error code (e.g. `"invalid_input"`, `"confirmation_required"`). */
   outcome: string;
   /** HTTP status the envelope maps to (also set for server-side invocation). */

--- a/packages/framework/test/capabilities.test.ts
+++ b/packages/framework/test/capabilities.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 
 import {
   CAPABILITY_EFFECT_HEADER,
@@ -6,13 +6,23 @@ import {
   CAPABILITY_FORM_REQUEST_HEADER,
   defineCapability,
 } from "../../capabilities/src/index.ts";
-import { defineApp, handlePrachtRequest, invokeCapability, route } from "../src/index.ts";
+import {
+  defineApp,
+  handlePrachtRequest,
+  invokeCapability,
+  route,
+  setCapabilityAuditHook,
+} from "../src/index.ts";
 import {
   capabilityHttpPath,
   matchCapabilityRoute,
   resolveAppCapabilities,
 } from "../src/runtime-capabilities.ts";
-import type { LoaderArgs, ModuleRegistry } from "../src/types.ts";
+import type { CapabilityAuditEvent, LoaderArgs, ModuleRegistry } from "../src/types.ts";
+
+afterEach(() => {
+  setCapabilityAuditHook(null);
+});
 
 type CapabilityDefinition = Parameters<typeof defineCapability>[0];
 
@@ -742,6 +752,31 @@ describe("invokeCapability", () => {
     expect(await response.json()).toEqual({
       data: { ok: true, data: { notes: ["from-loader:10"] } },
     });
+  });
+
+  it("attributes a composed dispatch to the request transport it ran under", async () => {
+    const events: CapabilityAuditEvent[] = [];
+    setCapabilityAuditHook((event) => events.push(event));
+
+    const { app, registry } = createApp(createSearchCapability(), {
+      routes: [route("/notes", "./routes/notes.tsx", { id: "notes" })],
+    });
+    registry.routeModules = {
+      "./routes/notes.tsx": async () => ({
+        loader: async ({ request, context, signal }: LoaderArgs) =>
+          invokeCapability("notes.search", { query: "from-loader" }, { request, context, signal }),
+        Component: () => null,
+      }),
+    };
+
+    await handlePrachtRequest({
+      app,
+      registry,
+      request: new Request("http://localhost/notes?_data=1"),
+    });
+
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({ transport: "server", via: "http", outcome: "ok" });
   });
 
   it("keeps each capability host scoped to its originating request", async () => {

--- a/packages/framework/test/capabilities.test.ts
+++ b/packages/framework/test/capabilities.test.ts
@@ -756,7 +756,6 @@ describe("invokeCapability", () => {
 
   it("attributes a composed dispatch to the request transport it ran under", async () => {
     const events: CapabilityAuditEvent[] = [];
-    setCapabilityAuditHook((event) => events.push(event));
 
     const { app, registry } = createApp(createSearchCapability(), {
       routes: [route("/notes", "./routes/notes.tsx", { id: "notes" })],
@@ -773,6 +772,7 @@ describe("invokeCapability", () => {
       app,
       registry,
       request: new Request("http://localhost/notes?_data=1"),
+      onCapabilityAudit: (event) => events.push(event),
     });
 
     expect(events).toHaveLength(1);

--- a/packages/framework/test/capability-test-host.test.ts
+++ b/packages/framework/test/capability-test-host.test.ts
@@ -165,6 +165,8 @@ describe("createCapabilityTestHost — invoke()", () => {
       capability: "notes.search",
       effect: "read",
       transport: "server",
+      // A test host serves no request, so there is nothing to attribute to.
+      via: null,
       outcome: "ok",
       status: 200,
       agent: null,
@@ -329,6 +331,7 @@ describe("createCapabilityTestHost — request()", () => {
     expect(events[0]).toMatchObject({
       capability: "notes.search",
       transport: "http",
+      via: null,
       outcome: "ok",
       agent: TEST_AGENT,
     });

--- a/packages/framework/test/remote-mcp.test.ts
+++ b/packages/framework/test/remote-mcp.test.ts
@@ -605,6 +605,30 @@ describe("tools/call runs the same pipeline as the HTTP projection", () => {
     });
   });
 
+  it("attributes composed dispatches to the mcp transport that caused them", async () => {
+    const events: CapabilityAuditEvent[] = [];
+    setCapabilityAuditHook((event) => events.push(event));
+
+    await callTool("notes_compose", {});
+
+    // Composition runs the callee's own pipeline only — no HTTP/MCP dispatch
+    // guards — so the audit trail is what ties the nested effect back to the
+    // remote agent that triggered it.
+    expect(events).toHaveLength(2);
+    expect(events[0]).toMatchObject({
+      capability: "notes.search",
+      transport: "server",
+      via: "mcp",
+      outcome: "ok",
+    });
+    expect(events[1]).toMatchObject({
+      capability: "notes.compose",
+      transport: "mcp",
+      via: null,
+      outcome: "ok",
+    });
+  });
+
   it("reports schema violations as tool errors carrying the issues", async () => {
     const { json } = await callTool("notes_search", { query: "" });
     expect(json?.result.isError).toBe(true);

--- a/packages/framework/test/remote-mcp.test.ts
+++ b/packages/framework/test/remote-mcp.test.ts
@@ -255,6 +255,7 @@ interface McpCallOptions {
   path?: string;
   body?: unknown;
   rawBody?: string;
+  onCapabilityAudit?: (event: CapabilityAuditEvent) => void;
 }
 
 async function mcp(message: unknown, options: McpCallOptions = {}) {
@@ -270,6 +271,7 @@ async function mcp(message: unknown, options: McpCallOptions = {}) {
       body:
         method === "GET" ? undefined : (options.rawBody ?? JSON.stringify(options.body ?? message)),
     }),
+    onCapabilityAudit: options.onCapabilityAudit,
   });
   const text = await response.clone().text();
   let json: Record<string, any> | null = null;
@@ -607,9 +609,8 @@ describe("tools/call runs the same pipeline as the HTTP projection", () => {
 
   it("attributes composed dispatches to the mcp transport that caused them", async () => {
     const events: CapabilityAuditEvent[] = [];
-    setCapabilityAuditHook((event) => events.push(event));
 
-    await callTool("notes_compose", {});
+    await callTool("notes_compose", {}, { onCapabilityAudit: (event) => events.push(event) });
 
     // Composition runs the callee's own pipeline only — no HTTP/MCP dispatch
     // guards — so the audit trail is what ties the nested effect back to the


### PR DESCRIPTION
## Summary

- A review flagged that binding the synthesized MCP request to the capability host lets an MCP-exposed tool reach another capability through `invokeCapability()` without that callee's `agentPolicy` or destructive prepare/commit guards — but those guards have always belonged to HTTP/MCP *dispatch*, not to direct server invocation, so the same composition is equally reachable from a loader, an API route, or an HTTP-dispatched capability; re-applying them only under MCP would give one call two meanings depending on the serving transport and break capabilities that gate the work themselves.
- What was genuinely weak is attribution: a nested effect a remote agent caused was audited as `transport: "server"`, indistinguishable from an ordinary loader call.
- `CapabilityAuditEvent` gains `via`, carrying the transport of the request a `"server"` dispatch was composed under, so such an effect now reads `{ transport: "server", via: "mcp" }`; it is `null` for top-level dispatches and outside a served request (test hosts), and never reports the client-declared `"webmcp"` marker.
- The guard boundary is unchanged and now stated outright in `AGENT_TRUST.md`, `CAPABILITIES.md`, and `REMOTE_MCP.md`: `expose.mcp` keeps destructive capabilities off the *tool surface*, not out of what an exposed tool composes — gate composed effects in the composing capability.

## Testing

- [x] `pnpm e2e` — 122 passed
- [x] `pnpm format`
- [x] `pnpm lint`
- [x] `pnpm test` — 1477 passed

## Checklist

- [x] Docs updated if needed
- [x] Skills updated if needed — N/A, no skill documents the audit event
- [x] Changeset added if published packages changed — `@pracht/core` minor

🤖 Generated with [Claude Code](https://claude.com/claude-code)