### PR TITLE
fix: sanitize shared-cache ISG renders on Vercel and Cloudflare

### DIFF
--- a/.changeset/vercel-isg-sanitized-request.md
+++ b/.changeset/vercel-isg-sanitized-request.md
@@ -1,0 +1,30 @@
+---
+"@pracht/adapter-vercel": patch
+"@pracht/adapter-cloudflare": patch
+"@pracht/core": patch
+---
+
+Render Vercel and Cloudflare Workers Caching ISG routes on a sanitized request so a cache miss cannot store a personalized page.
+
+Vercel's prerender functions were invoked with a faithful copy of the visitor's
+request, so loaders saw that visitor's `Cookie` and `Authorization` headers while
+producing HTML that Vercel stores in the ISR cache (keyed on the path alone) and
+replays to everyone else. `createVercelNodeListener` now renders on the same
+sanitized ISG request the Node and Cloudflare regeneration paths use — `GET`,
+`Accept: text/html`, path only, no query string or body — and strips credential
+headers (`Set-Cookie`, `Authorization`, `WWW-Authenticate`, `Proxy-Authenticate`,
+secret-shaped `x-*`) from the response before Vercel caches it, matching what
+build-time prerendering already refuses to emit. Responses that mark themselves
+uncacheable are logged, since Vercel's prerender cache stores them regardless.
+
+Cloudflare Workers Caching cold and stale renders now use the same sanitized
+request as the worker-managed Cache API regeneration path before calling
+`createContext`, middleware, or loaders. Query strings still participate in the
+edge cache key, but they cannot influence the shared response that application
+code renders; markdown-capable routes retain a canonical `text/markdown`
+variant without forwarding the visitor's raw `Accept` value.
+
+`createISGRegenerationRequest(pathname, base)` now accepts a `URL` or absolute
+URL string as its base in addition to a `Request`, and `@pracht/core` exports
+`isDangerousPrerenderHeader` plus the server-side `prefersMarkdown` negotiation
+helper for adapters that write into a shared cache.

--- a/docs/ADAPTERS.md
+++ b/docs/ADAPTERS.md
@@ -327,6 +327,11 @@ With the option on:
   time. The first request after a deploy renders fresh (Workers Caching
   partitions the cache per Worker version, so deploys always start cold).
   Webhook-only ISG routes keep their snapshots and the worker-managed path.
+- Cold and stale Workers Caching renders use a sanitized `GET` request with the
+  pathname only and a canonical representation header (`Accept: text/html`, or
+  `text/markdown` for that cache variant). Cookies, authorization, query
+  parameters, and the request body never reach `createContext`, middleware, or
+  loaders while producing a shared response.
 - Routes with both a time and a webhook policy are edge-cached, and
   `POST /__pracht/revalidate` purges their edge entries after regenerating
   the worker-managed copy.
@@ -382,9 +387,9 @@ enabling Workers Caching, keep ISG query shapes bounded and canonical:
 - If query parameters do not affect the page, have that gateway call a cached
   entrypoint with a pathname-only `cf.cacheKey`. This adds a gateway invocation
   but collapses tracking and attacker-chosen values onto one cache entry.
-- If a route genuinely renders different content for an unbounded query space,
-  opt it out with a route `Cache-Control: private, no-store` header or do not
-  enable Workers Caching for that deployment.
+- If query parameters must affect the rendered page, use SSR or opt the route
+  out with `Cache-Control: private, no-store`; sanitized ISG renders never pass
+  the query string to application code.
 
 Cloudflare compares request-header values named by `Vary` verbatim. Pracht
 therefore adds `Vary: Accept` only to routes that actually export `markdown`,
@@ -696,6 +701,19 @@ export default {
   supplies a `waitUntil()`-compatible context and drains registered work after
   ending the response; other Edge-only context fields are unavailable on Node
   ISG invocations.
+- **Sanitized ISG renders**: Vercel keys the prerender cache on the path alone
+  (`allowQuery: []`) and replays the stored response to every later visitor, so
+  the launcher renders on the same sanitized ISG request the Node and Cloudflare
+  regeneration paths use — `GET`, `Accept: text/html`, path only. The triggering
+  visitor's `Cookie`/`Authorization` headers, query string, and body never reach
+  loaders, middleware, or `createContext`, so a cache miss cannot materialize a
+  personalized page into shared cache. On the way out, credential headers
+  (`Set-Cookie`, `Authorization`, `WWW-Authenticate`, `Proxy-Authenticate`,
+  secret-shaped `x-*`) are stripped with a logged error — the same set
+  build-time prerendering refuses outright — and a response that marks itself
+  uncacheable (`Cache-Control: private`/`no-store`, `Vary: Cookie`/
+  `Authorization`) is logged as a warning, because Vercel's prerender cache
+  stores it regardless. Render such routes as `ssr` instead.
 - **Static security headers**: the generated `config.json` includes a `headers`
   section that applies the same baseline security headers to all responses,
   including static assets served by Vercel's CDN. Static prerendered routes also

--- a/docs/RENDERING_MODES.md
+++ b/docs/RENDERING_MODES.md
@@ -95,6 +95,12 @@ authenticated webhook. Node and Cloudflare serve stale HTML immediately while a
 new version is generated in the background for time-based revalidation. Vercel
 uses Build Output API prerender functions and the platform ISR cache.
 
+Every HTML regeneration — on any adapter — renders on a sanitized request
+(`GET`, `Accept: text/html`, path only). The visitor whose request triggered it
+never lends their cookies or credentials to the render, because the resulting
+HTML is served to everyone who asks for that path afterwards. Cloudflare Workers
+Caching applies the same isolation to its `text/markdown` cache variant.
+
 ### Time-based revalidation
 
 ```typescript

--- a/examples/docs/src/routes/docs/adapters.md
+++ b/examples/docs/src/routes/docs/adapters.md
@@ -70,6 +70,8 @@ dist/
 
 Prerendered HTML receives document headers from the generated `_pracht/headers.json` asset.
 
+Every shared-cache ISG render, including a cold render with `cloudflareAdapter({ cache: true })`, uses a sanitized request: path only, a canonical HTML or markdown `Accept` header, and no cookies, credentials, query string, or body. This prevents the visitor who triggers the render from personalizing the stored response.
+
 Keep your `wrangler.jsonc` in the project root so you can add bindings without the build overwriting them.
 
 ### Exporting Durable Objects and other primitives
@@ -185,6 +187,8 @@ pracht({ adapter: vercelAdapter() })
 ```
 
 Static prerendered routes receive document headers through the generated Build Output `headers` config.
+
+ISG Serverless invocations render on a sanitized request — path only, `Accept: text/html`, no cookies, credentials, query string, or body — because Vercel keys the prerender cache on the path alone and replays the stored response to every visitor. Credential headers on the rendered response (`Set-Cookie`, `Authorization`, secret-shaped `x-*`) are stripped before Vercel stores it.
 
 If `vercelAdapter({ regions: "all" })` is configured, the Edge function remains global while Node ISG functions use the project's default Serverless region. Node functions require concrete region identifiers and cannot use Edge's `all` sentinel.
 

--- a/packages/adapter-cloudflare/src/runtime.ts
+++ b/packages/adapter-cloudflare/src/runtime.ts
@@ -10,6 +10,7 @@ import {
   isCacheableISGResponse,
   jsonResponse,
   type ModuleRegistry,
+  prefersMarkdown,
   PRACHT_REVALIDATE_ENDPOINT,
   PRACHT_REVALIDATE_TOKEN_ENV,
   type ResolvedApiRoute,
@@ -165,14 +166,15 @@ export function createCloudflareFetchHandler<
       }
     }
 
+    const renderRequest = cacheRoute ? createWorkersCacheRenderRequest(request) : request;
     const context = options.createContext
-      ? await options.createContext({ request, env, executionContext })
+      ? await options.createContext({ request: renderRequest, env, executionContext })
       : ({ env, executionContext } as TContext);
 
     const response = await handlePrachtRequest({
       app: options.app,
       registry: options.registry,
-      request,
+      request: renderRequest,
       context,
       apiRoutes: options.apiRoutes,
       clientEntryUrl: options.clientEntryUrl,
@@ -193,6 +195,17 @@ export function createCloudflareFetchHandler<
     // `"cache": { "enabled": true }` in wrangler config is independent.
     return preventHeuristicCaching(request, finalResponse);
   };
+}
+
+function createWorkersCacheRenderRequest(originalRequest: Request): Request {
+  const request = createISGRegenerationRequest(
+    new URL(originalRequest.url).pathname,
+    originalRequest,
+  );
+  if (prefersMarkdown(originalRequest.headers.get("accept"))) {
+    request.headers.set("accept", "text/markdown");
+  }
+  return request;
 }
 
 async function maybeServeAsset(

--- a/packages/adapter-cloudflare/test/runtime.test.ts
+++ b/packages/adapter-cloudflare/test/runtime.test.ts
@@ -288,6 +288,106 @@ describe("createCloudflareFetchHandler ISG", () => {
     expect(body).not.toContain("cached");
     expect(body).toContain("fresh-content");
   });
+
+  it("sanitizes cold Workers Caching renders before they reach app code", async () => {
+    const { executionContext } = createExecutionContext();
+    let contextRequest: Request | undefined;
+    let loaderRequest: Request | undefined;
+    const app = defineApp({
+      routes: [
+        route("/pricing", "./routes/pricing.tsx", {
+          render: "isg",
+          revalidate: timeRevalidate(60),
+        }),
+      ],
+    });
+    const registry: ModuleRegistry = {
+      routeModules: {
+        "./routes/pricing.tsx": async () => ({
+          Component: () => "anonymous pricing",
+          loader: ({ request }) => {
+            loaderRequest = request;
+            return null;
+          },
+        }),
+      },
+    };
+    const handler = createCloudflareFetchHandler({
+      app,
+      cache: true,
+      createContext({ request }) {
+        contextRequest = request;
+        return {};
+      },
+      registry,
+    });
+
+    const response = await handler(
+      new Request("https://cache.example/pricing?campaign=visitor", {
+        headers: {
+          authorization: "Bearer visitor-token",
+          cookie: "session=visitor-session",
+        },
+      }),
+      { ASSETS: create404Assets() },
+      executionContext,
+    );
+
+    for (const request of [contextRequest, loaderRequest]) {
+      expect(request?.url).toBe("https://cache.example/pricing");
+      expect(request?.method).toBe("GET");
+      expect(Object.fromEntries(request?.headers ?? new Headers())).toEqual({
+        accept: "text/html",
+      });
+    }
+    expect(response.headers.get("cloudflare-cdn-cache-control")).toContain("max-age=60");
+    await expect(response.text()).resolves.toContain("anonymous pricing");
+  });
+
+  it("preserves the canonical markdown cache variant while sanitizing it", async () => {
+    const { executionContext } = createExecutionContext();
+    let loaderRequest: Request | undefined;
+    const app = defineApp({
+      routes: [
+        route("/pricing", "./routes/pricing.tsx", {
+          render: "isg",
+          revalidate: timeRevalidate(60),
+        }),
+      ],
+    });
+    const registry: ModuleRegistry = {
+      routeModules: {
+        "./routes/pricing.tsx": async () => ({
+          Component: () => "html pricing",
+          loader: ({ request }) => {
+            loaderRequest = request;
+            return null;
+          },
+          markdown: "# Markdown pricing",
+        }),
+      },
+    };
+    const handler = createCloudflareFetchHandler({ app, cache: true, registry });
+
+    const response = await handler(
+      new Request("https://cache.example/pricing?campaign=visitor", {
+        headers: {
+          accept: "text/html;q=0.5, text/markdown;q=0.9",
+          cookie: "session=visitor-session",
+        },
+      }),
+      { ASSETS: create404Assets() },
+      executionContext,
+    );
+
+    expect(loaderRequest?.url).toBe("https://cache.example/pricing");
+    expect(Object.fromEntries(loaderRequest?.headers ?? new Headers())).toEqual({
+      accept: "text/markdown",
+    });
+    expect(response.headers.get("content-type")).toContain("text/markdown");
+    expect(response.headers.get("cloudflare-cdn-cache-control")).toContain("max-age=60");
+    await expect(response.text()).resolves.toBe("# Markdown pricing");
+  });
 });
 
 describe("createCloudflareFetchHandler webhook revalidation", () => {

--- a/packages/adapter-vercel/src/index.ts
+++ b/packages/adapter-vercel/src/index.ts
@@ -1,8 +1,11 @@
 import type { PrachtAdapter } from "@pracht/vite-plugin";
 import {
+  createISGRegenerationRequest,
   handlePrachtRequest,
   hasWebhookRevalidate,
   type HandlePrachtRequestOptions,
+  isCacheableISGResponse,
+  isDangerousPrerenderHeader,
   jsonResponse,
   matchAppRoute,
   type ModuleRegistry,
@@ -54,7 +57,6 @@ export interface VercelNodeRequest {
   headers: Record<string, string | string[] | undefined>;
   method?: string;
   url?: string;
-  [Symbol.asyncIterator](): AsyncIterator<Uint8Array | string>;
 }
 
 /** Structural subset of Node's `ServerResponse` used by the serverless launcher. */
@@ -93,12 +95,21 @@ export function createVercelEdgeHandler<
 }
 
 /**
- * Wrap a `fetch`-style handler as a Node request listener.
+ * Wrap a `fetch`-style handler as the Node request listener the ISG prerender
+ * functions run on.
  *
  * Vercel only supports ISR (`.prerender-config.json`) on Serverless Functions,
  * so ISG routes are deployed as Node functions even though the main handler
  * stays on the edge. Both share the same server bundle: it is built against Web
  * APIs only, which Node provides natively.
+ *
+ * Every invocation here renders into Vercel's prerender cache, which is keyed
+ * on the path alone (`allowQuery: []`) and replayed to every later visitor. The
+ * listener therefore renders on a sanitized ISG request rather than the
+ * visitor's own — the triggering visitor's `Cookie`/`Authorization` headers,
+ * query string, and body never reach loaders, so a cache miss cannot
+ * materialize a personalized page into shared cache. This mirrors the Node and
+ * Cloudflare adapters' regeneration path.
  *
  * Only web globals are used here — pulling in `node:http`/`node:stream` would
  * break the webworker-targeted bundle the edge function is built from.
@@ -120,8 +131,9 @@ export function createVercelNodeListener(
     };
 
     try {
-      const response = await handler(await createNodeWebRequest(req), context);
-      await writeNodeResponse(res, response);
+      const request = createNodeISGRequest(req);
+      const response = await handler(request, context);
+      await writeNodeResponse(res, prepareVercelISGResponse(request, response));
     } finally {
       await drainWaitUntilTasks(waitUntilTasks);
     }
@@ -137,54 +149,64 @@ async function drainWaitUntilTasks(tasks: Promise<unknown>[]): Promise<void> {
   }
 }
 
-const BODYLESS_METHODS = new Set(["GET", "HEAD"]);
-
-async function createNodeWebRequest(req: VercelNodeRequest): Promise<Request> {
-  const headers = new Headers();
-  for (const [key, value] of Object.entries(req.headers)) {
-    if (value === undefined) continue;
-    if (Array.isArray(value)) {
-      for (const entry of value) headers.append(key, entry);
-      continue;
-    }
-    headers.set(key, value);
-  }
-
+/**
+ * Derive the ISG regeneration request from the raw Node request. Only the
+ * forwarded origin and the path survive: everything else is request-specific
+ * state that must not influence output destined for a shared cache.
+ */
+function createNodeISGRequest(req: VercelNodeRequest): Request {
   // Vercel terminates TLS in front of the function and always sets the
   // forwarded headers itself, so there is no untrusted hop to distrust here.
-  const protocol = headers.get("x-forwarded-proto") ?? "https";
-  const host = headers.get("x-forwarded-host") ?? headers.get("host") ?? "localhost";
+  const protocol = readNodeHeader(req, "x-forwarded-proto") ?? "https";
+  const host =
+    readNodeHeader(req, "x-forwarded-host") ?? readNodeHeader(req, "host") ?? "localhost";
   const url = new URL(req.url ?? "/", `${protocol}://${host}`);
-  const method = req.method ?? "GET";
-  const init: RequestInit = { headers, method };
 
-  if (!BODYLESS_METHODS.has(method.toUpperCase())) {
-    const body = await readNodeRequestBody(req);
-    if (body.byteLength > 0) init.body = body;
-  }
-
-  return new Request(url, init);
+  return createISGRegenerationRequest(url.pathname, url);
 }
 
-async function readNodeRequestBody(req: VercelNodeRequest): Promise<ArrayBuffer> {
-  const chunks: Uint8Array[] = [];
-  let size = 0;
+function readNodeHeader(req: VercelNodeRequest, name: string): string | undefined {
+  // Node lowercases incoming header names, but the type allows any casing.
+  const value = req.headers[name] ?? req.headers[name.toUpperCase()];
+  return Array.isArray(value) ? value[0] : value;
+}
 
-  for await (const chunk of req) {
-    const bytes = typeof chunk === "string" ? new TextEncoder().encode(chunk) : chunk;
-    chunks.push(bytes);
-    size += bytes.byteLength;
+/**
+ * Vercel stores whatever a prerender function returns in the ISR cache and
+ * replays it to every later visitor. Build-time prerendering refuses to emit
+ * documents carrying credential headers at all; a runtime regeneration cannot
+ * fail the build, so strip them and keep serving the page.
+ */
+function prepareVercelISGResponse(request: Request, response: Response): Response {
+  const pathname = new URL(request.url).pathname;
+  const dangerous = [...response.headers.keys()].filter(isDangerousPrerenderHeader);
+
+  let prepared = response;
+  if (dangerous.length > 0) {
+    const headers = new Headers(response.headers);
+    for (const name of dangerous) headers.delete(name);
+    console.error(
+      `Stripped ${dangerous.map((name) => `"${name}"`).join(", ")} from the ISG response for ` +
+        `"${pathname}" before Vercel's prerender cache stored it — cached ISG output is replayed ` +
+        "to every visitor. Move cookies and credential headers to API routes, middleware " +
+        "responses, or an SSR route.",
+    );
+    prepared = new Response(response.body, {
+      headers,
+      status: response.status,
+      statusText: response.statusText,
+    });
   }
 
-  const body = new ArrayBuffer(size);
-  const view = new Uint8Array(body);
-  let offset = 0;
-  for (const chunk of chunks) {
-    view.set(chunk, offset);
-    offset += chunk.byteLength;
+  if (prepared.status === 200 && !isCacheableISGResponse(prepared)) {
+    console.warn(
+      `The ISG response for "${pathname}" marks itself uncacheable (Cache-Control private/no-store ` +
+        "or Vary on Cookie/Authorization), but Vercel's prerender cache stores it regardless. " +
+        "Render this route as SSR instead if its output is request-specific.",
+    );
   }
 
-  return body;
+  return prepared;
 }
 
 async function writeNodeResponse(res: VercelNodeResponse, response: Response): Promise<void> {

--- a/packages/adapter-vercel/test/index.test.ts
+++ b/packages/adapter-vercel/test/index.test.ts
@@ -45,7 +45,6 @@ describe("createVercelNodeListener", () => {
         headers: { host: "example.com" },
         method: "GET",
         url: "/pricing",
-        async *[Symbol.asyncIterator]() {},
       },
       {
         statusCode: 0,
@@ -66,6 +65,100 @@ describe("createVercelNodeListener", () => {
 
     expect(listenerSettled).toBe(true);
     expect(new TextDecoder().decode(chunks[0])).toBe("ok");
+  });
+
+  function invokeListener(
+    handler: (request: Request) => Promise<Response> | Response,
+    req: {
+      headers: Record<string, string | string[] | undefined>;
+      method?: string;
+      url?: string;
+    },
+  ): Promise<{ body: string; headers: Record<string, string | string[]> }> {
+    const listener = createVercelNodeListener(async (request) => handler(request));
+    const chunks: Uint8Array[] = [];
+    const headers: Record<string, string | string[]> = {};
+
+    return listener(req, {
+      statusCode: 0,
+      setHeader(name, value) {
+        headers[name] = value;
+      },
+      write(chunk) {
+        chunks.push(chunk);
+      },
+      end() {},
+    }).then(() => ({
+      body: chunks.map((chunk) => new TextDecoder().decode(chunk)).join(""),
+      headers,
+    }));
+  }
+
+  it("renders ISG output on a sanitized request instead of the visitor's", async () => {
+    let seen: Request | undefined;
+    await invokeListener(
+      (request) => {
+        seen = request;
+        return new Response("ok");
+      },
+      {
+        headers: {
+          authorization: "Bearer visitor-token",
+          cookie: "session=visitor-session",
+          host: "example.com",
+          "x-forwarded-proto": "https",
+        },
+        method: "POST",
+        url: "/pricing?utm_source=email",
+      },
+    );
+
+    // Vercel keys the prerender cache on the path alone, so nothing
+    // request-specific may reach the render.
+    expect(seen?.url).toBe("https://example.com/pricing");
+    expect(seen?.method).toBe("GET");
+    expect(seen?.headers.get("cookie")).toBeNull();
+    expect(seen?.headers.get("authorization")).toBeNull();
+    expect(Object.fromEntries(seen?.headers ?? new Headers())).toEqual({
+      accept: "text/html",
+    });
+  });
+
+  it("strips credential headers before Vercel caches the response", async () => {
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const { body, headers } = await invokeListener(
+      () =>
+        new Response("<html>ok</html>", {
+          headers: {
+            "content-type": "text/html",
+            "set-cookie": "session=leaked; Path=/",
+            "x-api-key": "secret",
+          },
+        }),
+      { headers: { host: "example.com" }, url: "/pricing" },
+    );
+
+    expect(body).toBe("<html>ok</html>");
+    expect(headers["set-cookie"]).toBeUndefined();
+    expect(headers["x-api-key"]).toBeUndefined();
+    expect(headers["content-type"]).toBe("text/html");
+    expect(consoleError).toHaveBeenCalledWith(expect.stringContaining('"set-cookie"'));
+
+    consoleError.mockRestore();
+  });
+
+  it("warns when an ISG response marks itself uncacheable", async () => {
+    const consoleWarn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    await invokeListener(
+      () => new Response("<html>ok</html>", { headers: { "cache-control": "private" } }),
+      { headers: { host: "example.com" }, url: "/pricing" },
+    );
+
+    expect(consoleWarn).toHaveBeenCalledWith(expect.stringContaining("uncacheable"));
+
+    consoleWarn.mockRestore();
   });
 });
 

--- a/packages/framework/src/index.ts
+++ b/packages/framework/src/index.ts
@@ -154,6 +154,7 @@ export {
   hasWebhookRevalidate,
   isAuthorizedRevalidationRequest,
   isCacheableISGResponse,
+  isDangerousPrerenderHeader,
   jsonResponse,
   normalizeRouteRevalidate,
   PRACHT_REVALIDATE_ENDPOINT,

--- a/packages/framework/src/prerender.ts
+++ b/packages/framework/src/prerender.ts
@@ -1,6 +1,6 @@
 import { resolveApp } from "./app.ts";
 import { buildPathFromSegments } from "./route-matching.ts";
-import { normalizeRouteRevalidate } from "./revalidation.ts";
+import { isDangerousPrerenderHeader, normalizeRouteRevalidate } from "./revalidation.ts";
 import { resolveRegistryModule } from "./runtime-manifest.ts";
 import { handlePrachtRequest } from "./runtime.ts";
 import type {
@@ -38,16 +38,6 @@ export interface PrerenderAppOptions {
   /** Maximum number of pages rendered concurrently. Defaults to 10. */
   concurrency?: number;
 }
-
-const DANGEROUS_PRERENDER_HEADER_NAMES = new Set([
-  "authorization",
-  "proxy-authenticate",
-  "proxy-authorization",
-  "set-cookie",
-  "www-authenticate",
-]);
-const SECRET_SHAPED_PRERENDER_HEADER_RE =
-  /^x-.*(?:api[-_]?key|client[-_]?secret|credential|jwt[-_]?secret|password|private[-_]?key|refresh[-_]?token|secret|session[-_]?secret|token|webhook[-_]?secret)(?:$|[-_])/i;
 
 export async function prerenderApp(options: PrerenderAppOptions): Promise<PrerenderResult[]>;
 export async function prerenderApp(
@@ -148,14 +138,6 @@ function assertSafePrerenderHeaders(
     `Refusing to prerender ${item.render.toUpperCase()} route "${item.pathname}" because its document headers include ${names}. ` +
       "SSG/ISG document headers are serialized into public static output and replayed for every visitor. " +
       "Move cookies/authentication headers to API routes, loaders, middleware responses, or SSR-only routes.",
-  );
-}
-
-function isDangerousPrerenderHeader(name: string): boolean {
-  const normalized = name.toLowerCase();
-  return (
-    DANGEROUS_PRERENDER_HEADER_NAMES.has(normalized) ||
-    SECRET_SHAPED_PRERENDER_HEADER_RE.test(normalized)
   );
 }
 

--- a/packages/framework/src/revalidation.ts
+++ b/packages/framework/src/revalidation.ts
@@ -59,6 +59,30 @@ export function isCacheableISGResponse(response: Response): boolean {
   return true;
 }
 
+const DANGEROUS_PRERENDER_HEADER_NAMES = new Set([
+  "authorization",
+  "proxy-authenticate",
+  "proxy-authorization",
+  "set-cookie",
+  "www-authenticate",
+]);
+const SECRET_SHAPED_PRERENDER_HEADER_RE =
+  /^x-.*(?:api[-_]?key|client[-_]?secret|credential|jwt[-_]?secret|password|private[-_]?key|refresh[-_]?token|secret|session[-_]?secret|token|webhook[-_]?secret)(?:$|[-_])/i;
+
+/**
+ * Headers that must never ride along with output stored in a shared cache.
+ * Prerendered documents — and ISG responses regenerated at runtime — are
+ * replayed verbatim to every visitor, so a `Set-Cookie` or credential header
+ * produced by one render would be handed to all of them.
+ */
+export function isDangerousPrerenderHeader(name: string): boolean {
+  const normalized = name.toLowerCase();
+  return (
+    DANGEROUS_PRERENDER_HEADER_NAMES.has(normalized) ||
+    SECRET_SHAPED_PRERENDER_HEADER_RE.test(normalized)
+  );
+}
+
 export type RevalidationRequestResult =
   | {
       ok: true;
@@ -186,8 +210,20 @@ export function isAuthorizedRevalidationRequest(
   return constantTimeEqual(provided, token);
 }
 
-export function createISGRegenerationRequest(pathname: string, originalRequest?: Request): Request {
-  const baseUrl = originalRequest ? new URL(originalRequest.url) : new URL("http://localhost");
+/**
+ * Build the request an ISG render runs on. The rendered HTML lands in a shared
+ * cache and is replayed to every later visitor, so the render must not see the
+ * triggering visitor's cookies, credentials, or query string — only the path.
+ * `base` supplies the origin (a `Request`, `URL`, or absolute URL string).
+ */
+export function createISGRegenerationRequest(
+  pathname: string,
+  base?: Request | URL | string,
+): Request {
+  const baseUrl =
+    base === undefined
+      ? new URL("http://localhost")
+      : new URL(base instanceof Request ? base.url : base);
   const regenerationUrl = new URL(pathname, baseUrl);
 
   return new Request(regenerationUrl, {

--- a/packages/framework/src/server.ts
+++ b/packages/framework/src/server.ts
@@ -100,6 +100,7 @@ export type {
 } from "./testing-capabilities.ts";
 export { buildLlmsTxt } from "./llms-txt.ts";
 export type { BuildLlmsTxtOptions, LlmsTxtSection } from "./llms-txt.ts";
+export { prefersMarkdown } from "./runtime-negotiation.ts";
 export { prerenderApp } from "./prerender.ts";
 export {
   createISGRegenerationRequest,
@@ -108,6 +109,7 @@ export {
   hasWebhookRevalidate,
   isAuthorizedRevalidationRequest,
   isCacheableISGResponse,
+  isDangerousPrerenderHeader,
   jsonResponse,
   normalizeRouteRevalidate,
   PRACHT_REVALIDATE_ENDPOINT,

--- a/skills/configure-isg/SKILL.md
+++ b/skills/configure-isg/SKILL.md
@@ -158,9 +158,15 @@ pracht typegen   # if src/routes.ts changed
 
 1. Never overwrite `wrangler.jsonc`/`wrangler.toml` or `vercel.json` — diff
    and merge, confirming collisions with `AskUserQuestion`.
-2. Never propose ISG for personalized responses: `Set-Cookie` or
-   `Cache-Control: private`/`no-store` output fails regeneration, and
-   `Vary: Cookie`/`Authorization`/`*` is kept out of shared caches by design.
+2. Never propose ISG for personalized responses. ISG HTML renders always run
+   on a sanitized request (`GET`, `Accept: text/html`, path only — no cookies,
+   credentials, query, or body); Cloudflare Workers Caching uses the same
+   isolation with `Accept: text/markdown` for its markdown cache variant. A
+   loader that reads the session therefore sees an anonymous visitor. On top of that, `Set-Cookie` or
+   `Cache-Control: private`/`no-store` output fails regeneration on Node and
+   Cloudflare (on Vercel the credential headers are stripped and the mismatch
+   is logged), and `Vary: Cookie`/`Authorization`/`*` is kept out of shared
+   caches by design.
 3. Always pair `render: "isg"` with an explicit `revalidate` policy — without
    one the route silently behaves like SSG.
 4. On Vercel, set `PRACHT_REVALIDATE_TOKEN` in the build environment, not


### PR DESCRIPTION
## Summary

- Vercel ISG prerender functions and Cloudflare Workers Caching renders were invoked with a faithful copy of the visitor's request, so loaders, middleware, and `createContext` saw that visitor's `Cookie`/`Authorization` headers while producing HTML that both platforms store in a shared, path-keyed cache and replay to every later visitor.
- Both paths now render on the sanitized ISG request the Node and worker-managed Cloudflare regeneration paths already used — `GET`, canonical `Accept` (`text/html`, or `text/markdown` for that Workers Caching variant), pathname only, no query string or body.
- The Vercel Node launcher additionally strips credential headers (`Set-Cookie`, `Authorization`, `WWW-Authenticate`, `Proxy-Authenticate`, secret-shaped `x-*`) from the response before Vercel's prerender cache stores it — the same set build-time prerendering refuses outright — and logs a warning when a response marks itself uncacheable, since Vercel caches it regardless.
- Supporting changes: `createISGRegenerationRequest(pathname, base)` accepts a `URL` or absolute URL string as its base, and `@pracht/core` exports `isDangerousPrerenderHeader` and `prefersMarkdown` for adapters writing into a shared cache.

## Testing

- [ ] `pnpm run verify` (build, format, lint, typecheck, test, e2e)

Build, format, lint, and typecheck pass, and all 765 tests across the three changed packages (`@pracht/core`, `@pracht/adapter-vercel`, `@pracht/adapter-cloudflare`) pass. A full `pnpm run verify` could not complete on this machine: an unrelated process has leaked ~10k zombie children and pinned the per-uid process table at its limit, so the CLI/start suites fail with `spawnSync ... EAGAIN`. Worth a re-run on CI or after the machine is cleared.

## Checklist

- [x] Docs updated if needed
- [x] Skills updated if needed
- [x] Changeset added if published packages changed
