### PR TITLE
fix(core): deliver revalidated route data to the `data` prop

### DIFF
--- a/.changeset/route-data-prop-revalidation.md
+++ b/.changeset/route-data-prop-revalidation.md
@@ -1,0 +1,23 @@
+---
+"@pracht/core": patch
+---
+
+Deliver revalidated route data to the `data` prop, not just `useRouteData()`.
+
+`componentProps` was built once when a route state was resolved, so a component
+written as `Component({ data }: RouteComponentProps<typeof loader>)` — the shape
+`create-pracht` scaffolds and `pracht generate route` emits — kept rendering the
+data it was first given. Revalidation commits into the runtime provider, which
+only context consumers observed, so `useRevalidate()`, `<Form capability>`, and
+effect-driven revalidation after a successful non-`read` capability call all
+silently left the page stale for prop-reading components. The client router now
+renders route components through a wrapper that reads the provider, so the prop
+and the hook always agree.
+
+The provider's "reset from props" effect could also discard a revalidation
+outright: effects are deferred to a frame, and a revalidation that settled
+before the mount effect ran was overwritten by the initial props. Committed data
+is now stored with the props that produced it and staleness is derived during
+render, so the reset is a no-op when a newer commit exists — while a commit made
+before a navigation is still discarded rather than published as the next route's
+data.

--- a/docs/DATA_LOADING.md
+++ b/docs/DATA_LOADING.md
@@ -30,6 +30,13 @@ The route component can be a function default export or a named `Component`
 export. Named route exports such as `loader`, `head`, `headers`, `markdown`,
 `ErrorBoundary`, and `getStaticPaths` remain separate special exports.
 
+The `data` prop is reactive: it tracks navigation *and* revalidation
+(`useRevalidate()`, a successful non-`read` capability call, a `<Form capability>`
+submission), so it always holds the same value
+[`useRouteData()`](#useroutedata) would return. Pick whichever reads better —
+the prop for a component that only needs its own route's data, the hook for
+components nested below the route.
+
 A `markdown` string export opts the route into Markdown-for-Agents content
 negotiation: when a request arrives with `Accept: text/markdown`, the runtime
 still executes middleware, the route loader, and document header resolution

--- a/packages/framework/src/router.ts
+++ b/packages/framework/src/router.ts
@@ -47,7 +47,11 @@ import {
   routeNeedsServerFetch,
 } from "./runtime-client-fetch.ts";
 import { deserializeRouteError, type SerializedRouteError } from "./runtime-errors.ts";
-import { type PrachtHydrationState, PrachtRuntimeProvider } from "./runtime-context.ts";
+import {
+  type PrachtHydrationState,
+  PrachtRuntimeProvider,
+  RouteDataContext,
+} from "./runtime-context.ts";
 import type { RouteStateResult } from "./runtime-client-fetch.ts";
 
 interface RouteRenderState {
@@ -284,6 +288,29 @@ export async function initClientRouter(options: InitClientRouterOptions): Promis
   // outgoing page's height would clamp the restored position).
   let afterCommitCallback: (() => void) | null = null;
 
+  // The route component's `data` prop is a snapshot taken when the route state
+  // was resolved, but revalidation (`useRevalidate()`, `<Form capability>`, the
+  // capability-settled listener) commits new data to the runtime provider
+  // instead of re-resolving the route. Reading the provider here keeps the prop
+  // and `useRouteData()` on the same value, so a component that destructures
+  // `{ data }` sees a refresh exactly like a hook consumer does.
+  function RouteComponent({
+    Component,
+    componentProps,
+  }: {
+    Component: FunctionComponent;
+    componentProps: Record<string, unknown>;
+  }) {
+    const runtime = useContext(RouteDataContext);
+    // Error and SPA-pending states pass props that carry no loader data
+    // (`{ error }` / `{}`); only the loaded-data shape tracks the provider.
+    const props =
+      runtime && "data" in componentProps
+        ? { ...componentProps, data: runtime.data }
+        : componentProps;
+    return h(Component as FunctionComponent<Record<string, unknown>>, props);
+  }
+
   function RouterRoot({ initialState }: { initialState: RouteRenderState }) {
     const [routeState, setRouteState] = useState(initialState);
     updateRouteState = setRouteState;
@@ -297,13 +324,10 @@ export async function initClientRouter(options: InitClientRouterOptions): Promis
       afterCommitCallback = null;
       callback();
     }, [version]);
+    const routeElement = h(RouteComponent, { Component, componentProps });
     const componentTree = Shell
-      ? h(
-          Shell as FunctionComponent<Record<string, unknown>>,
-          null,
-          h(Component as FunctionComponent<Record<string, unknown>>, componentProps),
-        )
-      : h(Component as FunctionComponent<Record<string, unknown>>, componentProps);
+      ? h(Shell as FunctionComponent<Record<string, unknown>>, null, routeElement)
+      : routeElement;
 
     return h(
       NavigateContext.Provider as FunctionComponent<Record<string, unknown>>,

--- a/packages/framework/src/runtime-context.ts
+++ b/packages/framework/src/runtime-context.ts
@@ -57,18 +57,24 @@ export function PrachtRuntimeProvider<TData>({
 }) {
   registerRuntimeRoutes(routes);
 
-  const [routeDataState, setRouteDataState] = useState({
+  // A locally committed value (revalidation) is stored with the props that
+  // were current when it was committed, so later renders can tell whether it
+  // still belongs to the route on screen.
+  const [routeDataState, setRouteDataState] = useState(() => ({
     data,
+    routeId,
+    source: data,
     stateVersion,
-  });
-  const routeData = routeDataState.stateVersion === stateVersion ? routeDataState.data : data;
-
-  useEffect(() => {
-    setRouteDataState({
-      data,
-      stateVersion,
-    });
-  }, [data, routeId, stateVersion, url]);
+    url,
+  }));
+  // A new route state (navigation) supersedes anything committed for the
+  // previous one. This is derived during render rather than reset from an
+  // effect so it cannot lag behind the props.
+  const isStaleRoute =
+    routeDataState.stateVersion !== stateVersion ||
+    routeDataState.routeId !== routeId ||
+    routeDataState.url !== url;
+  const routeData = isStaleRoute ? data : routeDataState.data;
 
   const context = useMemo(
     () => ({
@@ -76,15 +82,41 @@ export function PrachtRuntimeProvider<TData>({
       params,
       routeId,
       routes,
+      // Stamped with the route state this context belongs to, never with
+      // whatever the provider rendered last: a revalidation started on one
+      // route can settle after a navigation, and the commit has to be
+      // discarded as stale rather than published as the new route's data.
       setData: (nextData: unknown) =>
         setRouteDataState({
           data: nextData as TData,
+          routeId,
+          source: data,
           stateVersion,
+          url,
         }),
       url,
     }),
+    // `data` is deliberately not a dependency: it is read only as the `source`
+    // stamp, and adding it would fan out a new context value on every
+    // re-render above the provider (see runtime-context.test.ts).
     [routeData, params, routeId, routes, stateVersion, url],
   );
+
+  // A fresh `data` prop for the same route state (a re-render above the
+  // provider) replaces the committed value. The functional update is what
+  // makes this safe: effects are deferred to a frame, so this can run *after*
+  // a revalidation has already committed newer data, and comparing against the
+  // source the commit was made from keeps it from overwriting that.
+  useEffect(() => {
+    setRouteDataState((current) =>
+      current.source === data &&
+      current.stateVersion === stateVersion &&
+      current.routeId === routeId &&
+      current.url === url
+        ? current
+        : { data, routeId, source: data, stateVersion, url },
+    );
+  }, [data, routeId, stateVersion, url]);
 
   // Effect-driven revalidation: capabilities are effect-classed, so the
   // runtime can refresh route data after any successful non-`read` call made

--- a/packages/framework/test/router-client.test.ts
+++ b/packages/framework/test/router-client.test.ts
@@ -219,6 +219,177 @@ describe("initClientRouter", () => {
     expect(fetchSpy).toHaveBeenCalledTimes(1);
   });
 
+  it("refreshes the route component's data prop when route data revalidates", async () => {
+    // `RouteComponentProps` is what `create-pracht` and `pracht generate route`
+    // emit, so the prop has to track revalidation exactly like `useRouteData()`.
+    function Dashboard({ data }: { data: { count: number } }) {
+      const hookData = useRouteData<{ count: number }>();
+      const revalidate = useRevalidate();
+      return h(
+        "main",
+        null,
+        h("span", { id: "prop-count" }, String(data.count)),
+        h("span", { id: "hook-count" }, String(hookData.count)),
+        h("button", { id: "refresh", onClick: () => void revalidate() }, "Refresh"),
+      );
+    }
+
+    const app = resolveApp(
+      defineApp({
+        routes: [route("/dashboard", "./routes/dashboard.tsx", { id: "dashboard", render: "ssr" })],
+      }),
+    );
+
+    history.replaceState(null, "", "/dashboard");
+    fetchSpy.mockResolvedValue(createJsonResponse({ data: { count: 2 } }));
+
+    await initClientRouter({
+      app,
+      routeModules: {
+        "./routes/dashboard.tsx": async () => ({ default: Dashboard }),
+      },
+      shellModules: {},
+      initialState: {
+        data: { count: 1 },
+        routeId: "dashboard",
+        url: "/dashboard",
+      },
+      root,
+      findModuleKey: (_modules, file) => file,
+    });
+
+    expect(root.querySelector("#prop-count")?.textContent).toBe("1");
+    expect(root.querySelector("#hook-count")?.textContent).toBe("1");
+
+    root.querySelector<HTMLButtonElement>("#refresh")?.click();
+    await flush();
+    await flush();
+
+    expect(root.querySelector("#hook-count")?.textContent).toBe("2");
+    expect(root.querySelector("#prop-count")?.textContent).toBe("2");
+  });
+
+  it("discards a revalidation that settles after navigating away", async () => {
+    // A revalidation started on one route must never publish its result as the
+    // next route's data — not through `useRouteData()` and not through the
+    // `data` prop.
+    function Dashboard({ data }: { data: { label: string } }) {
+      const revalidate = useRevalidate();
+      const navigate = useNavigate();
+      return h(
+        "main",
+        null,
+        h("span", { id: "label" }, data.label),
+        h("button", { id: "refresh", onClick: () => void revalidate() }, "Refresh"),
+        h("button", { id: "to-settings", onClick: () => void navigate("/settings") }, "Settings"),
+      );
+    }
+
+    function Settings({ data }: { data: { label: string } }) {
+      return h("main", null, h("span", { id: "label" }, data.label));
+    }
+
+    const app = resolveApp(
+      defineApp({
+        routes: [
+          route("/dashboard", "./routes/dashboard.tsx", { id: "dashboard", render: "ssr" }),
+          route("/settings", "./routes/settings.tsx", { id: "settings", render: "ssr" }),
+        ],
+      }),
+    );
+
+    root.innerHTML =
+      '<main><span id="label">DASHBOARD-1</span><button id="refresh">Refresh</button>' +
+      '<button id="to-settings">Settings</button></main>';
+    history.replaceState(null, "", "/dashboard");
+
+    let releaseDashboardRevalidation!: () => void;
+    const heldDashboardRevalidation = new Promise<Response>((resolve) => {
+      releaseDashboardRevalidation = () =>
+        resolve(createJsonResponse({ data: { label: "DASHBOARD-2" } }));
+    });
+
+    fetchSpy.mockImplementation((input: string) =>
+      input.startsWith("/settings")
+        ? Promise.resolve(createJsonResponse({ data: { label: "SETTINGS" } }))
+        : heldDashboardRevalidation,
+    );
+
+    await initClientRouter({
+      app,
+      routeModules: {
+        "./routes/dashboard.tsx": async () => ({ default: Dashboard }),
+        "./routes/settings.tsx": async () => ({ default: Settings }),
+      },
+      shellModules: {},
+      initialState: {
+        data: { label: "DASHBOARD-1" },
+        routeId: "dashboard",
+        url: "/dashboard",
+      },
+      root,
+      findModuleKey: (_modules, file) => file,
+    });
+
+    root.querySelector<HTMLButtonElement>("#refresh")?.click();
+    await flush();
+
+    root.querySelector<HTMLButtonElement>("#to-settings")?.click();
+    await flush();
+    await flush();
+    expect(root.querySelector("#label")?.textContent).toBe("SETTINGS");
+
+    releaseDashboardRevalidation();
+    await flush();
+    await flush();
+
+    expect(root.querySelector("#label")?.textContent).toBe("SETTINGS");
+  });
+
+  it("keeps the error prop when an error boundary renders", async () => {
+    // Error and SPA-pending states pass props without loader data; the runtime
+    // must not graft `data` onto them.
+    function Boom() {
+      return h("main", null, "never");
+    }
+
+    function ErrorBoundary(props: { error: Error }) {
+      return h(
+        "main",
+        null,
+        h("span", { id: "message" }, props.error.message),
+        h("span", { id: "prop-keys" }, Object.keys(props).sort().join(",")),
+      );
+    }
+
+    const app = resolveApp(
+      defineApp({
+        routes: [route("/boom", "./routes/boom.tsx", { id: "boom", render: "ssr" })],
+      }),
+    );
+
+    history.replaceState(null, "", "/boom");
+
+    await initClientRouter({
+      app,
+      routeModules: {
+        "./routes/boom.tsx": async () => ({ ErrorBoundary, default: Boom }),
+      },
+      shellModules: {},
+      initialState: {
+        data: null,
+        error: { message: "loader exploded", name: "Error", status: 500 },
+        routeId: "boom",
+        url: "/boom",
+      },
+      root,
+      findModuleKey: (_modules, file) => file,
+    });
+
+    expect(root.querySelector("#message")?.textContent).toBe("loader exploded");
+    expect(root.querySelector("#prop-keys")?.textContent).toBe("error");
+  });
+
   it("bypasses the HTTP cache when a form redirect reloads cached route data", async () => {
     function Cart() {
       const data = useRouteData<{ count: number }>();


### PR DESCRIPTION
## Summary

- Route components that read loader data through the `data` prop (`RouteComponentProps`) never saw revalidated data. `componentProps` was a snapshot built once in `resolveRouteState()`; revalidation commits into `PrachtRuntimeProvider`, which only `useRouteData()` consumers observed. That made `useRevalidate()`, `<Form capability>`, and effect-driven revalidation after a successful non-`read` capability call silently no-ops on screen — for exactly the component shape `create-pracht` scaffolds and `pracht generate route` emits. `docs/CAPABILITIES.md`'s promise that "the route's loader data revalidates automatically" was false for scaffolded code.
- The client router now renders route components through a `RouteComponent` wrapper that reads `RouteDataContext`, so the prop and the hook always agree. Error (`{ error }`) and SPA-pending (`{}`) states pass props without loader data and are left untouched.
- Second, related defect fixed here: the provider's reset-from-props `useEffect` could discard a revalidation outright. Effects are deferred to a frame, so a revalidation that settled before the mount effect ran was overwritten by the initial props (reproduced in jsdom: `setData({count: 2})` landed, then the mount effect put `{count: 1}` back). Committed data now carries the props that produced it, staleness is derived during render, and the reset is a functional no-op when a newer commit exists.
- `setData` still stamps the route state its context was created for, so a revalidation that settles *after* a navigation is discarded as stale rather than published as the next route's data.

Found while dogfooding the framework across all three adapters; this was the highest-impact finding.

## Testing

- [x] `pnpm run verify` (build, format, lint, typecheck, test, e2e)

Three tests added to `packages/framework/test/router-client.test.ts`, each verified to fail without the corresponding source change:

- `refreshes the route component's data prop when route data revalidates` — fails on `router.ts` revert (prop stuck at `1`) and on `runtime-context.ts` revert (hook stuck at `1`), so both halves are load-bearing.
- `discards a revalidation that settles after navigating away` — pins the cross-route isolation of `setData`.
- `keeps the error prop when an error boundary renders` — guards the `"data" in componentProps` discrimination.

Two adversarial review passes were run against the diff. The first found a cross-route data leak introduced by an earlier version of this change (a `useRef` read of the provider's latest props let route A's revalidation commit onto route B); that approach was dropped and the regression test above pins it. The second pass could not break it: revalidation across `popstate`, same-URL re-navigation, `notFound` routes, overlapping revalidations, capability-settled events after navigation, blocking shells, and hydration identity were all checked.

## Checklist

- [x] Docs updated if needed — `docs/DATA_LOADING.md` now states the `data` prop is reactive and equivalent to `useRouteData()`
- [ ] Skills updated if needed — N/A
- [x] Changeset added if published packages changed — `.changeset/route-data-prop-revalidation.md` (`@pracht/core` patch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)