### PR TITLE
fix(cli): stop the app-graph server leaking a partial dep-optimizer cache

### DIFF
--- a/.changeset/cli-metadata-server-no-discovery.md
+++ b/.changeset/cli-metadata-server-no-discovery.md
@@ -1,0 +1,14 @@
+---
+"@pracht/cli": patch
+---
+
+Stop the CLI's app-graph server from pre-bundling dependencies.
+
+`pracht inspect`, `plan`, `report`, graph-aware `verify`, and the MCP server
+each boot a silent middleware-mode Vite server, evaluate one SSR module to read
+the resolved app graph, and close it again — it never answers a browser
+request. Dependency discovery was still running, and it outlives
+`server.close()`: the scan keeps writing `node_modules/.vite/deps_temp_*` after
+the command has moved on. Passing `optimizeDeps: { noDiscovery: true }` skips
+work these commands never use and stops them leaving a partial optimizer cache
+behind.

--- a/packages/cli/src/app-server.ts
+++ b/packages/cli/src/app-server.ts
@@ -41,6 +41,13 @@ export async function withAppServer<T>(
   const server = await createServer({
     root,
     logLevel: "silent",
+    // This server exists to evaluate one SSR module and is closed immediately;
+    // it never answers a browser request. Dependency pre-bundling is therefore
+    // pure cost — and it outlives `server.close()`, so the scan keeps writing
+    // `node_modules/.vite/deps_temp_*` after the command has moved on.
+    optimizeDeps: {
+      noDiscovery: true,
+    },
     server: {
       middlewareMode: true,
     },

--- a/packages/cli/test/cli-dev-typegen.test.js
+++ b/packages/cli/test/cli-dev-typegen.test.js
@@ -9,6 +9,7 @@ import {
   cliPath,
   createRepoTempDir,
   runCli,
+  stopChild,
   waitFor,
   writeProjectFile,
   writeTypedManifestApp,
@@ -44,9 +45,9 @@ describe("@pracht/cli dev typegen", () => {
       );
       expect(existsSync(join(appDir, "src/pracht.d.ts"))).toBe(false);
     } finally {
-      child.kill("SIGTERM");
+      await stopChild(child);
     }
-  }, 90_000);
+  }, 120_000);
 
   it("pracht dev keeps generated route types in sync with route files", async () => {
     const appDir = createRepoTempDir("pracht-cli-dev-typegen-");
@@ -125,7 +126,7 @@ export const routes = [
         () => output,
       );
     } finally {
-      child.kill("SIGTERM");
+      await stopChild(child);
     }
-  }, 90_000);
+  }, 120_000);
 });

--- a/packages/cli/test/helpers/cli-fixtures.js
+++ b/packages/cli/test/helpers/cli-fixtures.js
@@ -5,10 +5,12 @@
 // own worker) but never within one, so these tests are split into several
 // focused files that all pull their app fixtures from here.
 import { execFileSync, spawnSync } from "node:child_process";
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
+
+import { removeTempDir } from "./remove-temp-dir.ts";
 
 export const cliPath = fileURLToPath(new URL("../../bin/pracht.js", import.meta.url));
 export const repoRoot = resolve(dirname(cliPath), "../../..");
@@ -40,7 +42,35 @@ const tempDirs = [];
 /** Removes every temp dir created since the last cleanup. Call from afterEach. */
 export function cleanupTempDirs() {
   while (tempDirs.length > 0) {
-    rmSync(tempDirs.pop(), { force: true, recursive: true });
+    removeTempDir(tempDirs.pop());
+  }
+}
+
+/**
+ * Terminate a spawned CLI process and wait for it to actually exit.
+ *
+ * `child.kill()` only delivers the signal; without awaiting the exit the
+ * process keeps writing into its temp directory while `cleanupTempDirs()`
+ * removes it.
+ */
+export async function stopChild(child, timeoutMs = 10_000) {
+  if (child.exitCode !== null || child.signalCode !== null) return;
+
+  const exited = new Promise((resolve) => child.once("exit", resolve));
+  child.kill("SIGTERM");
+
+  let timer;
+  const timedOut = new Promise((resolve) => {
+    timer = setTimeout(() => resolve("timeout"), timeoutMs);
+  });
+
+  try {
+    if ((await Promise.race([exited, timedOut])) === "timeout") {
+      child.kill("SIGKILL");
+      await exited;
+    }
+  } finally {
+    clearTimeout(timer);
   }
 }
 

--- a/packages/cli/test/helpers/remove-temp-dir.ts
+++ b/packages/cli/test/helpers/remove-temp-dir.ts
@@ -1,0 +1,30 @@
+import { existsSync, rmSync } from "node:fs";
+
+/**
+ * Remove a test temp directory that a still-running Vite dep optimizer may be
+ * writing into.
+ *
+ * `rmSync`'s own `maxRetries` does not help here: it snapshots the directory
+ * with `readdirSync` and then only retries the final `rmdir`, so an entry
+ * written *after* that snapshot (`node_modules/.vite/deps_temp_<hash>`) is
+ * never removed and every retry fails with the same `ENOTEMPTY`. The optimizer
+ * can also recreate the tree moments after a successful removal. Re-running the
+ * whole removal until the directory stays gone is what actually converges.
+ */
+export function removeTempDir(dir: string, attempts = 10, delayMs = 100): void {
+  for (let attempt = 1; attempt < attempts; attempt++) {
+    try {
+      rmSync(dir, { force: true, recursive: true });
+      if (!existsSync(dir)) return;
+    } catch {
+      // Fall through to the retry delay; the final attempt below reports.
+    }
+    sleepSync(delayMs);
+  }
+  // Let a genuine failure surface instead of passing silently.
+  rmSync(dir, { force: true, recursive: true });
+}
+
+function sleepSync(ms: number): void {
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
+}

--- a/packages/cli/test/mcp-server.test.ts
+++ b/packages/cli/test/mcp-server.test.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
@@ -8,6 +8,7 @@ import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
 import { afterEach, describe, expect, it } from "vitest";
 
 import { createPrachtMcpServer } from "../src/mcp-server.ts";
+import { removeTempDir } from "./helpers/remove-temp-dir.ts";
 
 const testDir = dirname(fileURLToPath(import.meta.url));
 const repoRoot = resolve(testDir, "../../..");
@@ -24,7 +25,10 @@ afterEach(async () => {
     await cleanups.pop()?.();
   }
   while (tempDirs.length > 0) {
-    rmSync(tempDirs.pop()!, { force: true, recursive: true });
+    // The in-process Vite dep optimizer can still be writing into
+    // node_modules/.vite as the tree comes down, and it recreates entries
+    // after a plain rmSync; retry until the directory stays gone.
+    removeTempDir(tempDirs.pop()!);
   }
 });
 


### PR DESCRIPTION
## Summary

CI on #278 failed with `ENOTEMPTY: directory not empty, rmdir '.../packages/cli/test/.tmp/pracht-cli-dev-typegen-hint-XXXX/node_modules/.vite'`. Chasing it turned up two causes — one in the CLI itself, one in the test fixtures.

**The CLI fix.** `withAppServer()` boots a silent middleware-mode Vite server, evaluates one SSR module to read the resolved app graph, and closes it. It never answers a browser request, but dependency discovery was still running — and it outlives `server.close()`, recreating `node_modules/.vite/deps_temp_*` within 250ms of the caller removing the directory. `optimizeDeps: { noDiscovery: true }` skips work `pracht inspect`, `plan`, `report`, graph-aware `verify`, and `pracht mcp` never use, and stops them leaving a partial optimizer cache behind in the app they were pointed at.

**The test fixes.**

- `child.kill("SIGTERM")` only *delivers* the signal. Vite installs an async SIGTERM handler (`closeServerAndExit` → `await server.close()` → `process.exit()`), so the spawned `pracht dev` in `cli-dev-typegen.test.js` was still writing while `afterEach` removed the tree — measured: the child was still alive at `rmSync` time in 6/6 runs. `stopChild()` now awaits the child's `exit`, escalating to `SIGKILL` after a timeout.
- Temp-dir removal is retried through a shared `removeTempDir()`. `rmSync`'s own `maxRetries`/`retryDelay` is **not** a fix here: Node's rimraf snapshots the directory with `readdirSync` and then only retries the final `rmdir`, so an entry written after that snapshot is never removed and every retry fails identically — it just adds ~5s of blocking sleep before the same error.
- The two dev-server tests go 90s → 120s: they already budget three 30s `waitFor` calls, and awaiting the child exit adds up to 10s on a degraded run.

## Testing

- [x] `pnpm run verify` (build, format, lint, typecheck, test, e2e)

`packages/cli/test/.tmp` had accumulated stale `pracht-mcp-inspect-*/node_modules/.vite/deps_temp_*` trees; `mcp-server.test.ts` leaked 7 of 10 runs before this change. After it: **0** leaked directories across repeated runs of both suites and a full `pnpm verify`. `pracht inspect routes|capabilities` verified against a real app.

Adversarial review confirmed the race window is real and measurable, that `pracht dev` spawns no grandchildren (so killing the direct child provably stops every writer), that `exit` is the right event to await, and that the `e2e/` suites already await exit before removing their temp dirs. It also proved the first revision's `maxRetries` backstop was inert and found the `mcp-server.test.ts` leak, both of which this revision addresses.

## Checklist

- [ ] Docs updated if needed — N/A
- [ ] Skills updated if needed — N/A
- [x] Changeset added if published packages changed — `.changeset/cli-metadata-server-no-discovery.md` (`@pracht/cli` patch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)