### PR TITLE
fix(start): point the Cloudflare scaffold at the built worker entry

### DIFF
--- a/.changeset/cf-scaffold-worker-entry.md
+++ b/.changeset/cf-scaffold-worker-entry.md
@@ -1,0 +1,34 @@
+---
+"create-pracht": patch
+"@pracht/cli": patch
+---
+
+Point the Cloudflare scaffold's `wrangler.jsonc` at the built worker entry.
+
+`create-pracht --adapter=cf` wrote `"main": "dist/server/server.js"`. That
+module also exports the build metadata the CLI's prerender pass needs
+(`buildTarget`, the manifests, the resolved app, ...), and workerd validates
+every named export of the deployed entry module — so a freshly scaffolded
+Cloudflare app could not start at all:
+
+```
+✘ [ERROR] service core:user:my-app: Uncaught TypeError: Incorrect type for map
+  entry 'buildTarget': the provided value is not of type 'function or
+  ExportedHandler'.
+```
+
+`pracht build` already emits `dist/server/worker.js` for exactly this reason —
+a thin wrapper re-exporting only the default handler and any Worker entrypoint
+classes — and both `docs/ADAPTERS.md` and the repo's example apps use it. Only
+the scaffold was out of sync.
+
+`pracht doctor` / `pracht verify` now warn when a Cloudflare app's wrangler
+config points `main` at that file, so projects scaffolded before this fix are
+told before they deploy rather than at `wrangler dev` time. The config is read
+the way wrangler reads it — `wrangler.json` before `wrangler.jsonc` before
+`wrangler.toml`, comments and trailing commas stripped rather than pattern
+matched — and every `env.<name>.main` override is reported alongside the
+top-level entry. It is a warning rather than an error, and stays silent unless
+it has actually read an offending entry: both the adapter detection and the
+wrangler reader are conservative heuristics, so this must never fail a build or
+claim a config it could not fully parse is fine.

--- a/examples/docs/wrangler.jsonc
+++ b/examples/docs/wrangler.jsonc
@@ -1,7 +1,7 @@
 {
   "$schema": "node_modules/wrangler/config-schema.json",
   "name": "pracht-docs",
-  "main": "dist/server/server.js",
+  "main": "dist/server/worker.js",
   "compatibility_date": "2026-04-06",
   "assets": {
     "binding": "ASSETS",

--- a/packages/cli/src/commands/preview.ts
+++ b/packages/cli/src/commands/preview.ts
@@ -7,10 +7,10 @@ import { defineCommand } from "citty";
 
 import { requirePositiveInteger } from "../utils.js";
 import { readProjectConfig, type ProjectConfig } from "../project.js";
+import { findWranglerConfig } from "../wrangler-config.js";
 import { runBuild } from "./build.js";
 
 const SERVER_ENTRY = "dist/server/server.js";
-const WRANGLER_CONFIG_FILES = ["wrangler.jsonc", "wrangler.json", "wrangler.toml"];
 const ADAPTER_TARGETS = new Set(["cloudflare", "node", "vercel"]);
 
 export type AdapterTarget = "cloudflare" | "node" | "vercel";
@@ -159,14 +159,6 @@ async function readBuildTarget(root: string): Promise<AdapterTarget | null> {
   } catch {
     return null;
   }
-}
-
-function findWranglerConfig(root: string): string | null {
-  for (const name of WRANGLER_CONFIG_FILES) {
-    const candidate = resolve(root, name);
-    if (existsSync(candidate)) return candidate;
-  }
-  return null;
 }
 
 function printVercelGuidance(): void {

--- a/packages/cli/src/verification-checks.ts
+++ b/packages/cli/src/verification-checks.ts
@@ -19,12 +19,16 @@ import {
   toModuleSpecifier,
   type Check,
 } from "./verification-helpers.js";
+import { detectAdapterTarget } from "./commands/preview.js";
+import { findWranglerConfig, readWranglerMainEntries } from "./wrangler-config.js";
 import {
   collectDuplicateRoutePaths,
   describePagesFile,
   scanPagesDirectory,
   type PagesRoute,
 } from "./verification-pages.js";
+
+const SERVER_ENTRY_PATH = "dist/server/server.js";
 
 export function collectConfigChecks(
   project: ProjectConfig,
@@ -482,6 +486,47 @@ export function collectPackageChecks(
       createCheck(
         "ok",
         `Found adapter dependency ${adapterPackages.map((name) => JSON.stringify(name)).join(", ")}.`,
+      ),
+    );
+  }
+
+  collectCloudflareEntryCheck(project, dirname(packageJsonPath), checks);
+}
+
+/**
+ * `dist/server/server.js` also exports the build metadata the CLI's prerender
+ * pass needs (buildTarget, manifests, the resolved app, ...). workerd validates
+ * every named export of the deployed entry module and refuses to start when one
+ * of them is not a handler, so pointing `main` at it fails at `wrangler dev` /
+ * `wrangler deploy` time with an opaque type error. `pracht build` writes
+ * `dist/server/worker.js` for exactly this reason.
+ *
+ * Reported as a warning, and only ever about an entry that was actually read.
+ * Two things here are heuristics — which adapter the vite config resolves to
+ * (a text match) and which `main` entries a wrangler config declares (a
+ * conservative reader that skips shapes it does not recognize) — so this must
+ * not be able to fail a build. It stays silent when nothing is provably wrong
+ * rather than claiming the config is fine: "no entries read" means unknown,
+ * not correct.
+ */
+function collectCloudflareEntryCheck(project: ProjectConfig, root: string, checks: Check[]): void {
+  if (detectAdapterTarget(project) !== "cloudflare") return;
+
+  const configFile = findWranglerConfig(root);
+  if (!configFile) return;
+
+  const display = displayPath(root, configFile);
+
+  for (const entry of readWranglerMainEntries(configFile)) {
+    if (!normalizePath(entry.main).endsWith(SERVER_ENTRY_PATH)) continue;
+
+    const where = entry.environment ? ` for environment "${entry.environment}"` : "";
+    checks.push(
+      createCheck(
+        "warning",
+        `${display} sets "main"${where} to ${JSON.stringify(entry.main)}. ` +
+          'Point it at "dist/server/worker.js" — the deploy entry `pracht build` emits. ' +
+          "workerd rejects server.js because it also exports build metadata that is not a Worker handler.",
       ),
     );
   }

--- a/packages/cli/src/wrangler-config.ts
+++ b/packages/cli/src/wrangler-config.ts
@@ -1,0 +1,178 @@
+import { existsSync, readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+/**
+ * Wrangler's own lookup order (`wrangler.json` wins over `wrangler.jsonc`,
+ * which wins over `wrangler.toml`). Anything that reasons about "the config
+ * wrangler will load" has to agree with this exactly, or it reports on a file
+ * the deploy never reads.
+ */
+export const WRANGLER_CONFIG_FILES = ["wrangler.json", "wrangler.jsonc", "wrangler.toml"];
+
+export function findWranglerConfig(root: string): string | null {
+  for (const name of WRANGLER_CONFIG_FILES) {
+    const candidate = resolve(root, name);
+    if (existsSync(candidate)) return candidate;
+  }
+  return null;
+}
+
+/** A `main` entry with the environment it belongs to (`null` = top level). */
+export interface WranglerMainEntry {
+  environment: string | null;
+  main: string;
+}
+
+/**
+ * Every `main` a wrangler config declares: the top-level one plus each
+ * `env.<name>.main` override, since `main` is inheritable per environment and
+ * `wrangler deploy --env <name>` ships the override.
+ *
+ * Returns an empty array when the file cannot be read or parsed — callers
+ * report on what they can prove, never on a guess.
+ */
+export function readWranglerMainEntries(configFile: string): WranglerMainEntry[] {
+  let source: string;
+  try {
+    source = readFileSync(configFile, "utf-8");
+  } catch {
+    return [];
+  }
+
+  return configFile.endsWith(".toml") ? readTomlMainEntries(source) : readJsonMainEntries(source);
+}
+
+function readJsonMainEntries(source: string): WranglerMainEntry[] {
+  let config: unknown;
+  try {
+    config = JSON.parse(stripJsonComments(source).replace(/,(\s*[}\]])/g, "$1"));
+  } catch {
+    return [];
+  }
+  if (!config || typeof config !== "object") return [];
+
+  const entries: WranglerMainEntry[] = [];
+  const root = config as Record<string, unknown>;
+  if (typeof root.main === "string") {
+    entries.push({ environment: null, main: root.main });
+  }
+
+  const env = root.env;
+  if (env && typeof env === "object") {
+    for (const [name, value] of Object.entries(env as Record<string, unknown>)) {
+      if (value && typeof value === "object") {
+        const main = (value as Record<string, unknown>).main;
+        if (typeof main === "string") entries.push({ environment: name, main });
+      }
+    }
+  }
+
+  return entries;
+}
+
+/** Removes `//` and block comments without touching comment-like text inside strings. */
+function stripJsonComments(source: string): string {
+  let out = "";
+  let inString = false;
+  let inLineComment = false;
+  let inBlockComment = false;
+
+  for (let i = 0; i < source.length; i++) {
+    const char = source[i]!;
+    const next = source[i + 1];
+
+    if (inLineComment) {
+      if (char === "\n") {
+        inLineComment = false;
+        out += char;
+      }
+      continue;
+    }
+    if (inBlockComment) {
+      if (char === "*" && next === "/") {
+        inBlockComment = false;
+        i++;
+      }
+      continue;
+    }
+    if (inString) {
+      out += char;
+      if (char === "\\") {
+        out += next ?? "";
+        i++;
+      } else if (char === '"') {
+        inString = false;
+      }
+      continue;
+    }
+    if (char === '"') {
+      inString = true;
+      out += char;
+      continue;
+    }
+    if (char === "/" && next === "/") {
+      inLineComment = true;
+      i++;
+      continue;
+    }
+    if (char === "/" && next === "*") {
+      inBlockComment = true;
+      i++;
+      continue;
+    }
+    out += char;
+  }
+
+  return out;
+}
+
+// Enough TOML for the one key this reads. Deliberately conservative: a shape
+// this does not recognize yields no entry, and callers must treat "no entries"
+// as "unknown" rather than "fine" — see collectCloudflareEntryCheck.
+//
+// `[table]` and `[[array.of.tables]]` headers, both of which may carry a
+// trailing comment. Missing a header would attribute the keys under it to the
+// wrong scope, so the array form matters even though it never holds `main`.
+const TOML_TABLE_RE = /^\s*\[\[?\s*([^\]]+?)\s*\]\]?\s*(?:#.*)?$/;
+const TOML_VALUE = String.raw`(?:"([^"]*)"|'([^']*)')`;
+const TOML_MAIN_RE = new RegExp(String.raw`^\s*main\s*=\s*${TOML_VALUE}\s*(?:#.*)?$`);
+// A dotted key at the top level: `env.production.main = "..."`.
+const TOML_DOTTED_ENV_MAIN_RE = new RegExp(
+  String.raw`^\s*env\s*\.\s*([^.\s]+)\s*\.\s*main\s*=\s*${TOML_VALUE}\s*(?:#.*)?$`,
+);
+
+function readTomlMainEntries(source: string): WranglerMainEntry[] {
+  const entries: WranglerMainEntry[] = [];
+  let table: string | null = null;
+
+  for (const line of source.split(/\r?\n/)) {
+    const tableMatch = TOML_TABLE_RE.exec(line);
+    if (tableMatch) {
+      table = tableMatch[1]!;
+      continue;
+    }
+
+    if (table === null) {
+      const dotted = TOML_DOTTED_ENV_MAIN_RE.exec(line);
+      if (dotted) {
+        entries.push({ environment: dotted[1]!, main: dotted[2] ?? dotted[3]! });
+        continue;
+      }
+    }
+
+    const mainMatch = TOML_MAIN_RE.exec(line);
+    if (!mainMatch) continue;
+    const main = mainMatch[1] ?? mainMatch[2]!;
+
+    if (table === null) {
+      entries.push({ environment: null, main });
+      continue;
+    }
+    // `[env.production]` — anything deeper (`[env.x.vars]`, `[build]`) is not a
+    // deployable entry point and is ignored.
+    const envMatch = /^env\s*\.\s*([^.\s]+)$/.exec(table);
+    if (envMatch) entries.push({ environment: envMatch[1]!, main });
+  }
+
+  return entries;
+}

--- a/packages/cli/test/cli-doctor-verify.test.js
+++ b/packages/cli/test/cli-doctor-verify.test.js
@@ -13,6 +13,38 @@ import {
 
 afterEach(cleanupTempDirs);
 
+function writeCloudflareManifestApp(appDir) {
+  writeManifestApp(appDir);
+  writeProjectFile(
+    appDir,
+    "package.json",
+    JSON.stringify(
+      {
+        name: "fixture-app",
+        private: true,
+        dependencies: {
+          "@pracht/adapter-cloudflare": "workspace:*",
+          "@pracht/cli": "workspace:*",
+        },
+      },
+      null,
+      2,
+    ),
+  );
+  writeProjectFile(
+    appDir,
+    "vite.config.ts",
+    `import { defineConfig } from "vite";
+import { pracht } from "@pracht/vite-plugin";
+import { cloudflareAdapter } from "@pracht/adapter-cloudflare";
+
+export default defineConfig({
+  plugins: [pracht({ adapter: cloudflareAdapter() })],
+});
+`,
+  );
+}
+
 describe("@pracht/cli doctor and verify", () => {
   it("reports a healthy manifest app in doctor json output", () => {
     const appDir = createTempDir("pracht-cli-doctor-ok-");
@@ -276,5 +308,130 @@ export const app = defineApp({
           check.message.includes("src/routes/dashboard.tsx"),
       ),
     ).toBe(true);
+  });
+  it("flags a Cloudflare wrangler config pointing at the non-worker server entry", () => {
+    const appDir = createTempDir("pracht-cli-doctor-cf-entry-");
+    writeCloudflareManifestApp(appDir);
+    writeProjectFile(
+      appDir,
+      "wrangler.jsonc",
+      `{
+  "name": "fixture-app",
+  "main": "dist/server/server.js",
+  "compatibility_date": "2026-04-06"
+}
+`,
+    );
+
+    const result = runCli(["doctor", "--json"], { cwd: appDir });
+    const report = JSON.parse(result.stdout);
+
+    // A warning, not an error: adapter detection and wrangler parsing are both
+    // heuristics, so this must never fail a build.
+    expect(report.ok).toBe(true);
+    expect(
+      report.checks.some(
+        (check) =>
+          check.status === "warning" &&
+          check.message.includes("wrangler.jsonc") &&
+          check.message.includes("dist/server/worker.js"),
+      ),
+    ).toBe(true);
+  });
+
+  it("flags a Cloudflare env override pointing at the non-worker server entry", () => {
+    const appDir = createTempDir("pracht-cli-doctor-cf-env-");
+    writeCloudflareManifestApp(appDir);
+    writeProjectFile(
+      appDir,
+      "wrangler.jsonc",
+      `{
+  "name": "fixture-app",
+  // "main": "dist/server/server.js",
+  "main": "dist/server/worker.js",
+  "env": { "production": { "main": "dist/server/server.js" } }
+}
+`,
+    );
+
+    const result = runCli(["doctor", "--json"], { cwd: appDir });
+    const report = JSON.parse(result.stdout);
+
+    expect(
+      report.checks.some(
+        (check) => check.status === "warning" && check.message.includes('environment "production"'),
+      ),
+    ).toBe(true);
+  });
+
+  it("does not flag a commented-out Cloudflare main", () => {
+    const appDir = createTempDir("pracht-cli-doctor-cf-comment-");
+    writeCloudflareManifestApp(appDir);
+    writeProjectFile(
+      appDir,
+      "wrangler.jsonc",
+      `{
+  "name": "fixture-app",
+  // "main": "dist/server/server.js",
+  "main": "dist/server/worker.js",
+}
+`,
+    );
+
+    const result = runCli(["doctor", "--json"], { cwd: appDir });
+    const report = JSON.parse(result.stdout);
+
+    expect(report.ok).toBe(true);
+    // Silence on success: the reader skips wrangler shapes it does not
+    // recognize, so a clean pass is "nothing provably wrong", not "verified".
+    expect(report.checks.some((check) => check.message.includes("wrangler"))).toBe(false);
+  });
+
+  it("ignores a wrangler config when the app does not build for Cloudflare", () => {
+    const appDir = createTempDir("pracht-cli-doctor-cf-other-adapter-");
+    writeManifestApp(appDir);
+    writeProjectFile(
+      appDir,
+      "package.json",
+      JSON.stringify(
+        {
+          name: "fixture-app",
+          private: true,
+          dependencies: { "@pracht/cli": "workspace:*" },
+          devDependencies: { "@pracht/adapter-cloudflare": "workspace:*" },
+        },
+        null,
+        2,
+      ),
+    );
+    writeProjectFile(
+      appDir,
+      "wrangler.toml",
+      'name = "side-worker"\nmain = "dist/server/server.js"\n',
+    );
+
+    const result = runCli(["doctor", "--json"], { cwd: appDir });
+    const report = JSON.parse(result.stdout);
+
+    expect(report.ok).toBe(true);
+    expect(report.checks.some((check) => check.message.includes("wrangler"))).toBe(false);
+  });
+
+  it("accepts a Cloudflare wrangler config pointing at the built worker entry", () => {
+    const appDir = createTempDir("pracht-cli-doctor-cf-entry-ok-");
+    writeCloudflareManifestApp(appDir);
+    writeProjectFile(
+      appDir,
+      "wrangler.toml",
+      'name = "fixture-app"\nmain = "dist/server/worker.js"\n',
+    );
+
+    const result = runCli(["doctor", "--json"], { cwd: appDir });
+    const report = JSON.parse(result.stdout);
+
+    expect(report.ok).toBe(true);
+    // Silence on success: the reader skips wrangler shapes it does not
+    // recognize, so a clean pass is "nothing provably wrong", not "verified".
+    expect(report.checks.some((check) => check.message.includes("wrangler"))).toBe(false);
   });
 });

--- a/packages/cli/test/wrangler-config.test.ts
+++ b/packages/cli/test/wrangler-config.test.ts
@@ -1,0 +1,196 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  findWranglerConfig,
+  readWranglerMainEntries,
+  WRANGLER_CONFIG_FILES,
+} from "../src/wrangler-config.ts";
+
+const dirs: string[] = [];
+
+afterEach(() => {
+  while (dirs.length > 0) rmSync(dirs.pop()!, { force: true, recursive: true });
+});
+
+function writeConfig(name: string, contents: string): string {
+  const dir = mkdtempSync(join(tmpdir(), "pracht-wrangler-"));
+  dirs.push(dir);
+  const file = join(dir, name);
+  writeFileSync(file, contents, "utf-8");
+  return file;
+}
+
+describe("findWranglerConfig", () => {
+  it("uses wrangler's own precedence: .json, then .jsonc, then .toml", () => {
+    expect(WRANGLER_CONFIG_FILES).toEqual(["wrangler.json", "wrangler.jsonc", "wrangler.toml"]);
+
+    const dir = mkdtempSync(join(tmpdir(), "pracht-wrangler-order-"));
+    dirs.push(dir);
+    writeFileSync(join(dir, "wrangler.toml"), 'main = "a.js"\n', "utf-8");
+    writeFileSync(join(dir, "wrangler.jsonc"), '{ "main": "b.js" }', "utf-8");
+    expect(findWranglerConfig(dir)).toBe(join(dir, "wrangler.jsonc"));
+
+    writeFileSync(join(dir, "wrangler.json"), '{ "main": "c.js" }', "utf-8");
+    expect(findWranglerConfig(dir)).toBe(join(dir, "wrangler.json"));
+  });
+
+  it("returns null when no config exists", () => {
+    const dir = mkdtempSync(join(tmpdir(), "pracht-wrangler-none-"));
+    dirs.push(dir);
+    expect(findWranglerConfig(dir)).toBeNull();
+  });
+});
+
+describe("readWranglerMainEntries", () => {
+  it("ignores commented-out jsonc keys", () => {
+    const file = writeConfig(
+      "wrangler.jsonc",
+      `{
+  "name": "app",
+  // "main": "dist/server/server.js",
+  /* "main": "dist/server/legacy.js", */
+  "main": "dist/server/worker.js"
+}
+`,
+    );
+
+    expect(readWranglerMainEntries(file)).toEqual([
+      { environment: null, main: "dist/server/worker.js" },
+    ]);
+  });
+
+  it("does not treat comment-like text inside a string as a comment", () => {
+    const file = writeConfig(
+      "wrangler.json",
+      '{ "name": "a//b", "main": "dist/server/worker.js" }',
+    );
+
+    expect(readWranglerMainEntries(file)).toEqual([
+      { environment: null, main: "dist/server/worker.js" },
+    ]);
+  });
+
+  it("tolerates trailing commas", () => {
+    const file = writeConfig(
+      "wrangler.jsonc",
+      '{\n  "main": "dist/server/worker.js",\n  "assets": { "binding": "ASSETS", },\n}\n',
+    );
+
+    expect(readWranglerMainEntries(file)).toEqual([
+      { environment: null, main: "dist/server/worker.js" },
+    ]);
+  });
+
+  it("reports the top-level main and every env override", () => {
+    const file = writeConfig(
+      "wrangler.json",
+      JSON.stringify({
+        main: "dist/server/worker.js",
+        env: {
+          production: { main: "dist/server/server.js" },
+          staging: { vars: { A: "1" } },
+        },
+      }),
+    );
+
+    expect(readWranglerMainEntries(file)).toEqual([
+      { environment: null, main: "dist/server/worker.js" },
+      { environment: "production", main: "dist/server/server.js" },
+    ]);
+  });
+
+  it("does not mistake a nested main for the top-level one", () => {
+    const file = writeConfig(
+      "wrangler.json",
+      JSON.stringify({
+        env: { staging: { main: "dist/server/server.js" } },
+        main: "dist/server/worker.js",
+      }),
+    );
+
+    expect(readWranglerMainEntries(file)).toEqual([
+      { environment: null, main: "dist/server/worker.js" },
+      { environment: "staging", main: "dist/server/server.js" },
+    ]);
+  });
+
+  it("reads toml with either quote style, ignoring non-env tables", () => {
+    const file = writeConfig(
+      "wrangler.toml",
+      [
+        "name = 'app'",
+        "main = 'dist/server/worker.js'  # the deploy entry",
+        "",
+        "[build]",
+        'main = "dist/server/ignored.js"',
+        "",
+        "[env.production]",
+        'main = "dist/server/server.js"',
+      ].join("\r\n"),
+    );
+
+    expect(readWranglerMainEntries(file)).toEqual([
+      { environment: null, main: "dist/server/worker.js" },
+      { environment: "production", main: "dist/server/server.js" },
+    ]);
+  });
+
+  it("returns nothing for unparseable or main-less configs", () => {
+    expect(readWranglerMainEntries(writeConfig("wrangler.json", "{ not json"))).toEqual([]);
+    expect(readWranglerMainEntries(writeConfig("wrangler.json", '{ "name": "app" }'))).toEqual([]);
+    expect(readWranglerMainEntries(join(tmpdir(), "pracht-missing-wrangler.json"))).toEqual([]);
+  });
+  it("attributes main correctly across headers carrying trailing comments", () => {
+    const file = writeConfig(
+      "wrangler.toml",
+      [
+        'main = "dist/server/worker.js"',
+        "",
+        "[[kv_namespaces]]",
+        'binding = "KV"',
+        "",
+        "[env.staging]  # wrangler deploy --env staging",
+        'main = "dist/server/server.js"',
+      ].join("\n"),
+    );
+
+    expect(readWranglerMainEntries(file)).toEqual([
+      { environment: null, main: "dist/server/worker.js" },
+      { environment: "staging", main: "dist/server/server.js" },
+    ]);
+  });
+
+  it("reads dotted toml env keys", () => {
+    const file = writeConfig(
+      "wrangler.toml",
+      ['main = "dist/server/worker.js"', 'env.production.main = "dist/server/server.js"'].join(
+        "\n",
+      ),
+    );
+
+    expect(readWranglerMainEntries(file)).toEqual([
+      { environment: null, main: "dist/server/worker.js" },
+      { environment: "production", main: "dist/server/server.js" },
+    ]);
+  });
+
+  it("skips toml shapes it cannot read rather than guessing", () => {
+    // An inline `env` table is valid TOML this reader does not parse. Reporting
+    // nothing is correct; callers must not read that as "config is fine".
+    const file = writeConfig(
+      "wrangler.toml",
+      [
+        'main = "dist/server/worker.js"',
+        'env = { production = { main = "dist/server/server.js" } }',
+      ].join("\n"),
+    );
+
+    expect(readWranglerMainEntries(file)).toEqual([
+      { environment: null, main: "dist/server/worker.js" },
+    ]);
+  });
+});

--- a/packages/start/src/index.js
+++ b/packages/start/src/index.js
@@ -970,7 +970,11 @@ function createWranglerConfig(projectName) {
     "{",
     '  "$schema": "node_modules/wrangler/config-schema.json",',
     `  "name": ${JSON.stringify(projectName)},`,
-    '  "main": "dist/server/server.js",',
+    // `pracht build` writes this thin wrapper next to server.js. It re-exports
+    // only the default handler and any Worker entrypoint classes: workerd
+    // validates every named export of the deployed entry module and rejects the
+    // build metadata (buildTarget, manifests, ...) server.js also exports.
+    '  "main": "dist/server/worker.js",',
     `  "compatibility_date": ${JSON.stringify(compatibilityDate)},`,
     '  "assets": {',
     '    "binding": "ASSETS",',

--- a/packages/start/test/index.test.js
+++ b/packages/start/test/index.test.js
@@ -176,7 +176,10 @@ describe("create-pracht", () => {
     expect(packageJson).toContain('"typecheck": "tsc --noEmit"');
     expect(packageJson).toContain('"wrangler": "^4.81.0"');
     expect(packageJson).not.toContain('"@cloudflare/vite-plugin"');
-    expect(wranglerConfig).toContain('"main": "dist/server/server.js"');
+    // Not server.js: workerd rejects the build metadata that module also
+    // exports, so the deployed entry has to be the wrapper `pracht build` emits.
+    expect(wranglerConfig).toContain('"main": "dist/server/worker.js"');
+    expect(wranglerConfig).not.toContain('"main": "dist/server/server.js"');
     expect(existsSync(join(targetDir, "wrangler.jsonc"))).toBe(true);
     expect(existsSync(join(targetDir, "Dockerfile"))).toBe(false);
     expect(existsSync(join(targetDir, ".dockerignore"))).toBe(false);


### PR DESCRIPTION
## Summary

- `create-pracht --adapter=cf` wrote `"main": "dist/server/server.js"` into `wrangler.jsonc`. That module also exports the build metadata the CLI's prerender pass needs (`buildTarget`, the manifests, the resolved app, …), and workerd validates every named export of the deployed entry module — so **a freshly scaffolded Cloudflare app could not start at all**:

  ```
  ✘ [ERROR] service core:user:my-app: Uncaught TypeError: Incorrect type for map entry
    'buildTarget': the provided value is not of type 'function or ExportedHandler'.
  ```

  Reproduced with the scaffold's own resolved toolchain (wrangler 4.120.0), and independently on wrangler 4.81.0 against `examples/cloudflare`. Switching `main` to `worker.js` makes `wrangler dev`, `pracht preview`, and `wrangler deploy` all work.
- `pracht build` already emits `dist/server/worker.js` for exactly this reason — a thin wrapper re-exporting only the default handler and any Worker entrypoint classes — and both `docs/ADAPTERS.md` and the repo's example apps use it. Only the scaffold was out of sync. `examples/docs/wrangler.jsonc` had the same wrong entry and is fixed here too.
- `pracht doctor` / `pracht verify` now **warn** when a Cloudflare app's wrangler config points `main` at `server.js`, so apps scaffolded before this fix hear about it before they deploy rather than at `wrangler dev` time.

The new check reads the config the way wrangler does, in a shared `wrangler-config.ts` that `pracht preview` now uses too (its copy had the precedence backwards):

- `wrangler.json` → `wrangler.jsonc` → `wrangler.toml`, matching wrangler's own lookup order.
- Comments and trailing commas are parsed out with a string-aware stripper, not pattern-matched, so a commented-out `// "main": "dist/server/server.js"` above the real one does not trip it.
- The top-level `main` **and** every `env.<name>.main` override are reported, since `main` is inheritable per environment and `wrangler deploy --env production` ships the override.
- It is a **warning, not an error**, and it stays silent unless it actually read an offending entry. Both the adapter detection (a text match over the vite config) and the wrangler reader (which skips TOML shapes like inline `env` tables) are conservative heuristics — so it must never fail a build, and must never claim a config it could not fully parse is fine.

## Testing

- [x] `pnpm run verify` (build, format, lint, typecheck, test, e2e)

New: `packages/cli/test/wrangler-config.test.ts` (12 cases — precedence, JSONC comments, comment-like text inside strings, trailing commas, env overrides, nested-vs-top-level ordering, TOML quote styles and trailing comments on `[table]`/`[[array]]` headers, dotted `env.x.main` keys, unparseable input) and 5 doctor cases in `cli-doctor-verify.test.js`. Verified to fail without the source change.

Two adversarial review passes. The first found six defects in the original regex-based check — JSONC comments causing a false error, wrangler's config precedence being backwards, first-match-wins across nested `main` keys, TOML single-quoted values, dependency-presence as the trigger, and `examples/docs` still carrying the bug. The second found three more: the `error` severity could still fail CI for a Node-target app whose vite config merely mentions the Cloudflare adapter, TOML `env` overrides the reader misses were being papered over by a green "ok" check, and `[table]` headers with trailing comments leaked scope. This revision addresses all nine.

## Checklist

- [x] Docs updated if needed — `docs/ADAPTERS.md` already documented `worker.js` correctly; the scaffold was the thing out of sync
- [ ] Skills updated if needed — N/A (`skills/pre-deploy/SKILL.md` already documents this workerd error)
- [x] Changeset added if published packages changed — `.changeset/cf-scaffold-worker-entry.md` (`create-pracht` + `@pracht/cli` patch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)