### PR TITLE
fix(start): pin the Cloudflare scaffold's compatibility_date

### DIFF
--- a/.changeset/cf-scaffold-compat-date.md
+++ b/.changeset/cf-scaffold-compat-date.md
@@ -1,0 +1,21 @@
+---
+"create-pracht": patch
+---
+
+Pin the Cloudflare scaffold's `compatibility_date` instead of generating today's.
+
+`create-pracht --adapter=cf` wrote `new Date().toISOString().slice(0, 10)` into
+`wrangler.jsonc`. workerd refuses to start when asked for a compatibility date
+newer than the one its binary was built with, and the scaffold date is — by
+construction — at or beyond the newest released workerd, so a freshly
+scaffolded Cloudflare app could not run `wrangler dev` or `pracht preview` on
+the day it was created:
+
+```
+✘ [ERROR] service core:user:my-app: This Worker requires compatibility date
+  "2026-08-10", but the newest date supported by this server binary is
+  "2026-08-08".
+```
+
+The scaffold now emits a fixed date that the oldest wrangler it accepts
+already supports, matching how the repo's own example apps are configured.

--- a/packages/start/src/index.js
+++ b/packages/start/src/index.js
@@ -25,6 +25,28 @@ const FALLBACK_VERSION_RANGES = {
   vercel: "^56.5.0",
 };
 
+/**
+ * Cloudflare `compatibility_date` for scaffolded apps.
+ *
+ * This has to be a date the installed workerd already knows about — workerd
+ * refuses to start when asked for a date newer than the one its binary was
+ * built with ("This Worker requires compatibility date X, but the newest date
+ * supported by this server binary is Y"). Using today's date is therefore
+ * always wrong: it is, by construction, at or beyond the newest released
+ * workerd, so a freshly scaffolded app could not run `wrangler dev` on the day
+ * it was created.
+ *
+ * Keep it at or below the ceiling of the oldest wrangler this scaffold accepts
+ * (see `devDependencies.wrangler` below). That ceiling is *not* the workerd
+ * version date — it usually runs a little ahead of it — so check it rather
+ * than infer it: install that wrangler and start a worker with a candidate
+ * date; the error message names the newest date the binary supports.
+ *
+ * `packages/start/test/index.test.js` fails once this drifts too far behind, so
+ * a new app never silently opts out of years of default-on runtime behaviour.
+ */
+const WRANGLER_COMPATIBILITY_DATE = "2026-04-06";
+
 async function fetchLatestVersion(packageName) {
   const res = await fetch(`https://registry.npmjs.org/${packageName}/latest`);
   if (!res.ok) {
@@ -964,7 +986,7 @@ function createHealthRoute(adapter) {
 }
 
 function createWranglerConfig(projectName) {
-  const compatibilityDate = new Date().toISOString().slice(0, 10);
+  const compatibilityDate = WRANGLER_COMPATIBILITY_DATE;
 
   return [
     "{",

--- a/packages/start/test/index.test.js
+++ b/packages/start/test/index.test.js
@@ -175,6 +175,11 @@ describe("create-pracht", () => {
     expect(packageJson).toContain('"preview": "pracht preview"');
     expect(packageJson).toContain('"typecheck": "tsc --noEmit"');
     expect(packageJson).toContain('"wrangler": "^4.81.0"');
+    // A fixed date, never a generated one: workerd refuses to start when asked
+    // for a compatibility date newer than its own binary, so "today" is by
+    // construction at or beyond the newest release and breaks the app on the
+    // day it is scaffolded.
+    expect(wranglerConfig).toMatch(/"compatibility_date": "\d{4}-\d{2}-\d{2}"/);
     expect(packageJson).not.toContain('"@cloudflare/vite-plugin"');
     expect(wranglerConfig).toContain('"main": "dist/server/server.js"');
     expect(existsSync(join(targetDir, "wrangler.jsonc"))).toBe(true);
@@ -214,6 +219,37 @@ describe("create-pracht", () => {
     const agents = await readFile(join(targetDir, "AGENTS.md"), "utf-8");
     expect(agents).toContain("wrangler.jsonc");
     expect(agents).toContain("Cloudflare Workers adapter");
+  });
+
+  it("keeps the scaffolded Cloudflare compatibility date from going stale", async () => {
+    const root = await mkdtemp(join(tmpdir(), "pracht-start-cf-compat-"));
+    const targetDir = join(root, "my-cf-app");
+
+    await scaffoldProject({
+      adapter: {
+        description: "Cloudflare Workers with wrangler deploy",
+        id: "cloudflare",
+        label: "Cloudflare Workers",
+        packageName: "@pracht/adapter-cloudflare",
+        short: "cf",
+      },
+      packageManager: "pnpm",
+      resolveRemoteVersions: false,
+      targetDir,
+    });
+
+    const wranglerConfig = await readFile(join(targetDir, "wrangler.jsonc"), "utf-8");
+    const date = /"compatibility_date": "([^"]+)"/.exec(wranglerConfig)?.[1];
+    const ageDays = (Date.now() - Date.parse(`${date}T00:00:00Z`)) / 86_400_000;
+
+    // The date is pinned because workerd rejects anything newer than its own
+    // binary. Pinned dates rot silently, so fail once it is far enough behind
+    // that new apps are opting out of a year of default-on runtime behaviour:
+    // bump WRANGLER_COMPATIBILITY_DATE (and the wrangler pin) in
+    // packages/start/src/index.js to the newest date that wrangler's workerd
+    // accepts, then update this expectation's sibling docs.
+    expect(ageDays).toBeGreaterThan(0);
+    expect(ageDays).toBeLessThan(365);
   });
 
   it("scaffolds a vercel starter", async () => {

--- a/skills/pracht-deploy/SKILL.md
+++ b/skills/pracht-deploy/SKILL.md
@@ -112,7 +112,7 @@ To smoke-test the built worker locally first, run `pracht preview` — it builds
 {
   "name": "my-pracht-app",
   "main": "dist/server/worker.js",
-  "compatibility_date": "2024-01-01",
+  "compatibility_date": "2026-04-06",
   "assets": {
     "binding": "ASSETS",
     "directory": "dist/client",

--- a/skills/pre-deploy/SKILL.md
+++ b/skills/pre-deploy/SKILL.md
@@ -93,7 +93,11 @@ a markdown summary (graph diff + verify + budgets) worth attaching to it.
   metadata (`buildTarget`, manifests, `resolvedApp`, ...) that `server.js`
   exports for the prerender pass.
 - `assets.directory` points to `dist/client`.
-- `compatibility_date` is set and recent.
+- `compatibility_date` is set, and is a date the installed workerd supports.
+  It must not be *newer* than the runtime: workerd refuses to start with
+  "This Worker requires compatibility date X, but the newest date supported
+  by this server binary is Y". Never set it to today's date — that is by
+  construction at or beyond the newest released workerd.
 - Bindings declared in wrangler config for every `context.env.*` access in
   loaders, middleware, and API routes (grep, then cross-check).
 - **No Node-only APIs in the server bundle.** Grep the server files for:


### PR DESCRIPTION
## Summary

- `create-pracht --adapter=cf` set `compatibility_date` to `new Date().toISOString().slice(0, 10)`. workerd refuses to start when asked for a compatibility date newer than the one its binary was built with — and the scaffold date is, by construction, at or beyond the newest released workerd. **Every new Cloudflare app was broken on the day it was created:**

  ```
  ✘ [ERROR] service core:user:my-app: This Worker requires compatibility date "2026-08-10",
    but the newest date supported by this server binary is "2026-08-08".
  ```

  Reproduced with the scaffold's own resolved toolchain (wrangler 4.120.0 → workerd 1.20260801.1).
- The date is now a constant that the *oldest* wrangler the scaffold accepts already supports, matching how the repo's own example apps are configured. Verified empirically against `workerd@1.20260405.1` (what wrangler 4.81.0, the scaffold's `^4.81.0` floor, bundles): `2026-04-06` is accepted, with the binary's real ceiling at `2026-04-12`.

  Worth recording for whoever bumps this: workerd's ceiling runs *ahead* of its own version date, so the obvious "use the workerd version date" proxy would wrongly condemn a valid value. The comment on the constant says to check the ceiling rather than infer it.
- Pinned dates rot silently — a new app would otherwise opt out of default-on runtime behaviour for as long as nobody remembers to bump it. The test now fails once the pin is a year behind, with a message saying what to change, instead of only asserting the literal.
- The deploy skills are updated: `skills/pracht-deploy` carried a `2024-01-01` example, and `skills/pre-deploy` asked for a date that is "set and recent" — which would flag the scaffold's own correct output. Both now state the real constraint (must not be *newer* than the runtime; never today's date).

## Testing

- [x] `pnpm run verify` (build, format, lint, typecheck, test, e2e)

Scaffolded a Cloudflare app and confirmed the emitted `compatibility_date`. Adversarial review drove `workerd@1.20260405.1` directly through miniflare to confirm the pin is accepted with headroom, and confirmed `workerd@1.20260401.1` (wrangler 4.80.0) accepts it too, so a below-floor resolution is also safe. It also rejected an earlier assertion (`not.toContain(today)`) as redundant and only able to false-fail — replaced by the staleness bound above.

Note: `wrangler dev` on a scaffolded app also needs the `main` fix in #280; the two are independent and compose on merge.

## Checklist

- [ ] Docs updated if needed — N/A (`docs/ADAPTERS.md` has no wrangler compatibility-date example)
- [x] Skills updated if needed — `skills/pracht-deploy`, `skills/pre-deploy`
- [x] Changeset added if published packages changed — `.changeset/cf-scaffold-compat-date.md` (`create-pracht` patch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)