### PR TITLE
fix(vite-plugin): dedupe preact

### DIFF
--- a/.changeset/preact-dedupe.md
+++ b/.changeset/preact-dedupe.md
@@ -1,0 +1,24 @@
+---
+"@pracht/vite-plugin": patch
+---
+
+Dedupe Preact so a second copy in the graph cannot break hooks.
+
+Preact keeps hook state on module-level `options` belonging to the instance
+that rendered the tree. A second copy — from package-manager hoisting, a
+`link:`ed package, or a UI library that depends on Preact itself — makes every
+hook-using component fail during SSR with:
+
+```
+Cannot read properties of undefined (reading '__H')
+```
+
+which names neither the component nor the cause. The plugin now sets
+`resolve.dedupe` for `preact` and `preact-render-to-string`, which covers dev
+SSR, the client bundle, and edge SSR builds (where `ssr.noExternal` bundles
+everything). Production Node servers keep Preact external and resolve it
+through Node at runtime, so a duplicate there is still a `node_modules` layout
+problem rather than something Vite can collapse.
+
+Apps that already resolve a single Preact are unaffected: two example apps
+build to byte-identical output.

--- a/packages/vite-plugin/src/index.ts
+++ b/packages/vite-plugin/src/index.ts
@@ -138,6 +138,16 @@ export function pracht(options: PrachtPluginOptions = {}): Plugin[] {
         // Expose PRACHT_PUBLIC_-prefixed vars on import.meta.env (client and
         // server) while keeping Vite's default VITE_ prefix working.
         envPrefix: ["VITE_", PUBLIC_ENV_PREFIX],
+        resolve: {
+          // Preact's hook state lives in module-level `options` on the Preact
+          // instance that rendered the tree. A second copy in the graph — from
+          // hoisting, a linked package, or a UI library with its own Preact
+          // dependency — makes any hook-using component die during SSR with
+          // `Cannot read properties of undefined (reading '__H')`, which names
+          // neither the component nor the cause. Collapsing the family onto one
+          // copy is the only sane default.
+          dedupe: PREACT_DEDUPE,
+        },
         define: {
           __PRACHT_PUBLIC_ENV__: publicEnvDefine,
           __PRACHT_AGENT_SURFACE__: agentSurfaceDefine,
@@ -481,6 +491,13 @@ const PRACHT_OPTIMIZE_DEPS_INCLUDE = [
   "@pracht/core/islands-client",
   "@pracht/core/manifest",
 ];
+
+// Package names only: Vite matches `dedupe` against the bare package id, so a
+// subpath entry such as `preact/hooks` would never match. Deduping `preact`
+// already covers every subpath, since they all resolve through that package —
+// and with them the `options` object `preact/hooks` mutates, which is the
+// state a second copy splits in two.
+const PREACT_DEDUPE = ["preact", "preact-render-to-string"];
 
 function createPrachtOptimizeDepsInclude(root: string): string[] {
   // Vite deliberately leaves workspace-linked packages un-optimized (they are

--- a/packages/vite-plugin/test/plugin-build-config.test.ts
+++ b/packages/vite-plugin/test/plugin-build-config.test.ts
@@ -10,6 +10,7 @@ const edgeAdapter: PrachtAdapter = {
 };
 
 interface BuildConfig {
+  resolve?: { dedupe?: string[] };
   ssr?: { noExternal?: boolean; target?: string };
   define?: Record<string, unknown>;
   environments?: {

--- a/packages/vite-plugin/test/preact-dedupe.test.ts
+++ b/packages/vite-plugin/test/preact-dedupe.test.ts
@@ -1,0 +1,64 @@
+import { resolveConfig } from "vite";
+import { describe, expect, it } from "vitest";
+
+import { pracht, type PrachtAdapter } from "../src/index.ts";
+
+const edgeAdapter: PrachtAdapter = {
+  id: "cloudflare",
+  edge: true,
+  serverImports: "",
+  createServerEntryModule: () => "export default {};",
+};
+
+// Asserting on the *resolved* config, not on what the hook returns: the bug
+// this guards against is a second Preact copy reaching the SSR environment, and
+// top-level `resolve.dedupe` only helps there because Vite propagates it into
+// `environments.ssr`. A test that reads the hook's return value would stay
+// green if that propagation ever stopped — while hook-using components went
+// back to failing SSR with `Cannot read properties of undefined (reading
+// '__H')`.
+describe("preact dedupe", () => {
+  it("reaches the ssr environment in a dev server config", async () => {
+    const config = await resolveConfig(
+      { configFile: false, logLevel: "silent", plugins: [pracht()] },
+      "serve",
+    );
+
+    expect(config.resolve.dedupe).toContain("preact");
+    expect(config.environments.ssr?.resolve.dedupe).toContain("preact");
+    expect(config.environments.client?.resolve.dedupe).toContain("preact");
+  });
+
+  it("reaches the ssr environment in an edge ssr build, alongside the edge conditions", async () => {
+    const config = await resolveConfig(
+      {
+        build: { ssr: true },
+        configFile: false,
+        logLevel: "silent",
+        plugins: [pracht({ adapter: edgeAdapter })],
+      },
+      "build",
+    );
+
+    expect(config.environments.ssr?.resolve.dedupe).toContain("preact");
+    // The plugin overrides ssr resolve conditions for edge builds; dedupe has
+    // to survive alongside that override rather than be replaced by it.
+    expect(config.environments.ssr?.resolve.conditions).toContain("worker");
+  });
+
+  it("keeps a user's own dedupe and alias entries", async () => {
+    const config = await resolveConfig(
+      {
+        configFile: false,
+        logLevel: "silent",
+        plugins: [pracht()],
+        resolve: { alias: { "@app": "/src" }, dedupe: ["lodash-es"] },
+      },
+      "serve",
+    );
+
+    expect(config.resolve.dedupe).toContain("lodash-es");
+    expect(config.resolve.dedupe).toContain("preact");
+    expect(config.resolve.alias.some((entry) => entry.find === "@app")).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

- The plugin set no `resolve.dedupe` at all. With two Preact copies in the module graph — package-manager hoisting, a `link:`ed package, or a UI library that depends on Preact itself — every hook-using component fails during SSR with:

  ```
  Cannot read properties of undefined (reading '__H')
  ```

  Preact keeps hook state on module-level `options` belonging to the instance that rendered the tree, so a second copy splits it. The error names neither the component nor the cause, and `pracht doctor` had no Preact checks, so there was nothing to diagnose it with. Found while dogfooding: a scaffolded app with `link:`ed `@pracht/*` packages 500'd on its islands route until `resolve.dedupe` was added by hand to the app's vite config.
- The plugin now dedupes `preact` and `preact-render-to-string`. Package names only — Vite matches `dedupe` against the bare package id, so a `preact/hooks` entry can never match, and deduping `preact` already covers every subpath.
- Scope, stated honestly in the changeset: this covers dev SSR, the client bundle, and edge SSR builds (where `ssr.noExternal` bundles everything). Production Node servers keep Preact external and resolve it through Node at runtime, so a duplicate there remains a `node_modules` layout problem Vite cannot collapse.

## Testing

- [x] `pnpm run verify` (build, format, lint, typecheck, test, e2e)

End-to-end against the app that surfaced this (two physically distinct Preact installs): `GET /islands` returns 500 with the `__H` error on `origin/main` and 200 with full island HTML on this branch.

`packages/vite-plugin/test/preact-dedupe.test.ts` asserts on the **resolved** config rather than the hook's return value. That matters: the bug is a second copy reaching the SSR environment, and top-level `resolve.dedupe` only helps there because Vite propagates it into `environments.ssr` — a test reading the hook's output would stay green if that propagation ever stopped, which is exactly the regression it exists to catch. It covers the dev server, the edge SSR build (dedupe surviving alongside the plugin's own `environments.ssr.resolve.conditions` override), and a user config setting its own `resolve.dedupe` + `resolve.alias`. All three fail without the source change.

Adversarial review verified the merge semantics (user `dedupe`/`alias` and `@preact/preset-vite`'s `react` → `preact/compat` aliases all survive), that dedupe genuinely reaches `environments.ssr` in both dev and edge builds, that an unresolvable dedupe target degrades gracefully rather than failing the build, and that `examples/islands` and `examples/cloudflare` build to **byte-identical** output (same shasums) before and after. It also caught that four of the six originally-listed entries were dead subpath matches and that the first version of the test could not detect its own failure mode; both are fixed here.

## Checklist

- [ ] Docs updated if needed — N/A
- [ ] Skills updated if needed — N/A
- [x] Changeset added if published packages changed — `.changeset/preact-dedupe.md` (`@pracht/vite-plugin` patch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)