### PR TITLE
fix(core): let loaders and API handlers throw a Response

### DIFF
--- a/.changeset/loader-thrown-response.md
+++ b/.changeset/loader-thrown-response.md
@@ -1,0 +1,29 @@
+---
+"@pracht/core": patch
+---
+
+Let loaders and API handlers short-circuit with a thrown `Response`.
+
+`return redirect(...)` from a loader worked; `throw redirect(...)` — the idiom
+every Remix / React Router user reaches for, and the only shape that composes —
+produced a bare 500 with no message explaining why:
+
+```
+HTTP/1.1 500 Internal Server Error
+{ "phase": "loader", "routeId": "dashboard", "status": 500 }
+```
+
+A thrown `Response` is now treated exactly like a returned one, in both page
+loaders and API route handlers. That is what makes an auth gate composable: the
+redirect can live in a shared `requireUser()` helper the loader awaits, where a
+`return` value cannot escape and the caller cannot forget to propagate it.
+Thrown `Error`s are unaffected and still render the error boundary. A thrown
+`Response` is the answer, so it is sent as-is: it does not render an
+`ErrorBoundary`, and a thrown 404 does not render the `notFound` page — use
+`throw notFound()` when you want that. Capabilities are unchanged: their
+dispatch always answers with the typed `{ ok, data }` envelope, so gate them in
+their named middleware instead.
+
+Redirecting from a loader was also undocumented — `docs/DATA_LOADING.md` never
+mentioned `redirect()`, which appeared only in middleware examples. It now has
+a section covering both forms.

--- a/docs/DATA_LOADING.md
+++ b/docs/DATA_LOADING.md
@@ -109,6 +109,58 @@ For SPA routes, the initial HTML can still include the matched shell and an
 optional shell `Loading` export so the page is not blank before the route-state
 request resolves.
 
+### Redirecting from a loader
+
+A loader can answer with a `Response` instead of data — most often a redirect.
+`return` it or `throw` it; both take the same path:
+
+```typescript
+import { redirect, type LoaderArgs } from "@pracht/core";
+
+export async function loader({ request, context }: LoaderArgs) {
+  const session = await getSession(request);
+  if (!session) return redirect("/login", { request });
+  return { user: session.user };
+}
+```
+
+Throwing is what makes an auth gate composable: the decision can live in a
+shared helper, and the caller cannot forget to propagate it.
+
+```typescript
+// src/server/auth.ts
+export async function requireUser(request: Request) {
+  const session = await getSession(request);
+  if (!session) throw redirect("/login", { request });
+  return session.user;
+}
+
+// src/routes/dashboard.tsx — no `if` at the call site, and no way to
+// accidentally continue with an unauthenticated user.
+export async function loader({ request }: LoaderArgs) {
+  const user = await requireUser(request);
+  return { projects: await listProjects(user.id) };
+}
+```
+
+`redirect()` validates the target's scheme and rejects CR/LF injection.
+Cross-origin targets are allowed — OAuth and SSO need them — so if the target
+comes from user input (a `?redirect=` parameter), check it against your own
+allowlist first. See the `audit-redirects` skill.
+
+A thrown `Response` is the answer, so it is sent as-is: it does **not** render
+an `ErrorBoundary`, and a thrown 404 does not render the
+[`notFound` page](#custom-404-pages). Use `throw notFound()` and
+`throw new PrachtHttpError(...)` when you want those; a thrown `Response` is
+for when you have already decided what the response is.
+
+| Surface | How to short-circuit |
+| --- | --- |
+| Route loader | `return` or `throw` a `Response` |
+| API route handler | `return` or `throw` a `Response` |
+| Middleware | `return` a `Response` (that is already its return type) |
+| Capability `run()` | Neither — dispatch always answers with the `{ ok, data }` envelope. Gate the capability in its named middleware instead. |
+
 ### Error handling
 
 Throw `PrachtHttpError` for structured error responses:

--- a/packages/framework/src/runtime-middleware.ts
+++ b/packages/framework/src/runtime-middleware.ts
@@ -74,6 +74,24 @@ export function buildRedirectResponse(
  *   return next();
  * };
  * ```
+ *
+ * In a **page loader or API route handler**, `return` and `throw` both work.
+ * Throw when the decision is made somewhere the return value cannot escape
+ * from — a shared `requireUser()` helper, a nested `await` — so the caller
+ * cannot forget to propagate it:
+ *
+ * ```ts
+ * export async function loader({ request, context }: LoaderArgs) {
+ *   const user = await requireUser(request, context); // throws redirect("/login")
+ *   return { user };
+ * }
+ * ```
+ *
+ * Capabilities are the exception: their dispatch answers with the typed
+ * `{ ok, data }` envelope on every transport, so a `Response` thrown from a
+ * capability `run()` has nowhere to go and surfaces as an `internal_error`.
+ * Gate capabilities in their named middleware, which returns a `Response`
+ * like any other middleware.
  */
 export function redirect(target: string, options: RedirectOptions = {}): Response {
   if (typeof options === "number") {

--- a/packages/framework/src/runtime.ts
+++ b/packages/framework/src/runtime.ts
@@ -369,8 +369,23 @@ export async function handlePrachtRequest<TContext>(
           withEnhancedCapabilityFormRedirect(response, options.request),
         );
       } catch (error: unknown) {
+        // Same short-circuit contract as page loaders: a thrown `Response` is
+        // the handler answering, not failing. Guarded because this runs inside
+        // the catch, where a further throw would reject out of
+        // `handlePrachtRequest` instead of becoming a 500.
+        let thrownResponseFailure: unknown;
+        if (error instanceof Response) {
+          try {
+            return withDefaultSecurityHeaders(
+              withEnhancedCapabilityFormRedirect(error, options.request),
+            );
+          } catch (normalizeError: unknown) {
+            thrownResponseFailure = normalizeError;
+          }
+        }
+
         return renderApiErrorResponse({
-          error,
+          error: thrownResponseFailure ?? error,
           middlewareFiles: apiMiddlewareFiles,
           options,
           phase: currentPhase,
@@ -921,6 +936,30 @@ export async function handlePrachtRequest<TContext>(
         loaderCache: match.route.loaderCache,
       });
     } catch (error: unknown) {
+      // A thrown `Response` is a deliberate short-circuit, not a failure: it is
+      // how a loader aborts its own render to redirect (`throw redirect(...)`)
+      // or answer directly, which returning cannot express from inside a helper
+      // the loader called. Same value either way, so it takes the same path a
+      // returned `Response` does.
+      //
+      // Normalizing here means normalizing *inside* the catch, where a throw
+      // has nothing left to catch it and would reject out of
+      // `handlePrachtRequest` — an unhandled rejection in the adapter, not a
+      // 500. A shared module-scope `Response` with a body delivered twice does
+      // exactly that (the second read finds the body disturbed), so failures
+      // fall through to the error renderer like any other loader fault.
+      let thrownResponseFailure: unknown;
+      if (error instanceof Response) {
+        try {
+          return normalizePageResponse(error, {
+            isRouteStateRequest,
+            loaderCache: match.route.loaderCache,
+          });
+        } catch (normalizeError: unknown) {
+          thrownResponseFailure = normalizeError;
+        }
+      }
+
       // A 404 thrown by a loader or middleware (`throw notFound()`) is not a
       // crash — it means "this URL has no content". Render the app-level
       // not-found page for it, unless the route declares its own
@@ -937,7 +976,7 @@ export async function handlePrachtRequest<TContext>(
       }
 
       return renderRouteErrorResponse({
-        error,
+        error: thrownResponseFailure ?? error,
         isRouteStateRequest,
         loaderFile,
         options,

--- a/packages/framework/test/runtime.test.ts
+++ b/packages/framework/test/runtime.test.ts
@@ -553,6 +553,145 @@ describe("handlePrachtRequest with separate data modules", () => {
   });
 });
 
+describe("handlePrachtRequest short-circuit Responses", () => {
+  it("treats a Response thrown by a loader as the answer, not a crash", async () => {
+    // `throw redirect(...)` is what makes an auth gate composable: the decision
+    // can live in a helper the loader awaits, where a `return` cannot escape.
+    const app = defineApp({
+      routes: [route("/dashboard", "./routes/dashboard.tsx", { id: "dashboard", render: "ssr" })],
+    });
+
+    const response = await handlePrachtRequest({
+      app,
+      registry: {
+        routeModules: {
+          "./routes/dashboard.tsx": async () => ({
+            Component: () => h("main", null, "never rendered"),
+            loader: async ({ request }: { request: Request }) => {
+              throw redirect("/login", { request });
+            },
+          }),
+        },
+      },
+      request: new Request("http://localhost/dashboard"),
+    });
+
+    expect(response.status).toBe(302);
+    expect(response.headers.get("location")).toBe("/login");
+  });
+
+  it("treats a Response thrown by an API handler as the answer", async () => {
+    const app = defineApp({ routes: [route("/", "./routes/home.tsx")] });
+
+    const response = await handlePrachtRequest({
+      apiRoutes: resolveApiRoutes(["/src/api/report.ts"]),
+      app,
+      registry: {
+        apiModules: {
+          "/src/api/report.ts": async () => ({
+            GET: async () => {
+              throw new Response("teapot", { status: 418 });
+            },
+          }),
+        },
+      },
+      request: new Request("http://localhost/api/report"),
+    });
+
+    expect(response.status).toBe(418);
+    await expect(response.text()).resolves.toBe("teapot");
+  });
+
+  it("still reports a thrown Error from a loader as a 500", async () => {
+    const app = defineApp({
+      routes: [route("/boom", "./routes/boom.tsx", { id: "boom", render: "ssr" })],
+    });
+
+    const response = await handlePrachtRequest({
+      app,
+      registry: {
+        routeModules: {
+          "./routes/boom.tsx": async () => ({
+            Component: () => h("main", null, "never"),
+            loader: async () => {
+              throw new Error("loader exploded");
+            },
+          }),
+        },
+      },
+      request: new Request("http://localhost/boom"),
+    });
+
+    expect(response.status).toBe(500);
+  });
+});
+
+it("delivers a thrown redirect to a client navigation as route-state JSON", async () => {
+  // Client navigations fetch with `redirect: "manual"`, so a raw 302 would
+  // be opaque to them. The returned-Response path already encodes redirects
+  // as JSON for route-state requests; the thrown path has to match.
+  const app = defineApp({
+    routes: [route("/dashboard", "./routes/dashboard.tsx", { id: "dashboard", render: "ssr" })],
+  });
+
+  const response = await handlePrachtRequest({
+    app,
+    registry: {
+      routeModules: {
+        "./routes/dashboard.tsx": async () => ({
+          Component: () => h("main", null, "never rendered"),
+          loader: async ({ request }: { request: Request }) => {
+            throw redirect("/login", { request });
+          },
+        }),
+      },
+    },
+    request: new Request("http://localhost/dashboard", {
+      headers: { "x-pracht-route-state-request": "1" },
+    }),
+  });
+
+  expect(response.status).toBe(200);
+  await expect(response.json()).resolves.toEqual({ redirect: "/login" });
+});
+
+it("reports a failure while delivering a thrown Response as a 500", async () => {
+  // The short-circuit runs inside the catch, where a further throw would
+  // reject out of handlePrachtRequest instead of becoming a response. A
+  // module-scope Response with a body, thrown twice, does exactly that.
+  const shared = new Response(JSON.stringify({ data: null }), { status: 401 });
+  const app = defineApp({
+    routes: [route("/gate", "./routes/gate.tsx", { id: "gate", render: "ssr" })],
+  });
+  const send = () =>
+    handlePrachtRequest({
+      app,
+      registry: {
+        routeModules: {
+          "./routes/gate.tsx": async () => ({
+            Component: () => h("main", null, "never"),
+            loader: async () => {
+              throw shared;
+            },
+          }),
+        },
+      },
+      request: new Request("http://localhost/gate", {
+        headers: { "x-pracht-route-state-request": "1" },
+      }),
+    });
+
+  // The adapter reads the body out to write the response; the second
+  // delivery then finds the shared body disturbed. The point is that this
+  // resolves to a 500 rather than rejecting out of handlePrachtRequest.
+  const first = await send();
+  expect(first.status).toBe(401);
+  await first.text();
+
+  const second = await send();
+  expect(second.status).toBe(500);
+});
+
 describe("handlePrachtRequest route component exports", () => {
   it("renders a function default export while preserving named loader exports", async () => {
     const app = defineApp({


### PR DESCRIPTION
## Summary

- `return redirect(...)` from a route loader worked. `throw redirect(...)` — the idiom every Remix / React Router user reaches for — produced a bare 500 with no message explaining why:

  ```
  HTTP/1.1 500 Internal Server Error
  { "phase": "loader", "routeId": "redirect-me", "status": 500 }
  ```

  Throwing is not a stylistic preference: it is the only shape that composes. A shared `requireUser()` helper cannot `return` a redirect on the loader's behalf, so without this every auth gate has to be re-checked at each call site, and forgetting one silently continues with an unauthenticated user.
- A thrown `Response` now takes the same path a returned one does, in page loaders and API route handlers.
- The short-circuit runs inside the `catch`, so it is itself guarded. Without that guard a failure while delivering the thrown Response has nothing left to catch it and rejects out of `handlePrachtRequest` — an unhandled rejection in the adapter (the Node handler has no try/catch around the call), which on Node ≥15 terminates the process with the request socket hanging. A shared module-scope `Response` with a body, delivered twice, does exactly that; it now becomes a 500 like any other loader fault.
- Scope, documented rather than implied: a thrown `Response` **is** the answer, so it is sent as-is — it does not render an `ErrorBoundary`, and a thrown 404 does not render the `notFound` page (`throw notFound()` remains the way to ask for those). Capability dispatch is deliberately unchanged: it always answers with the typed `{ ok, data }` envelope on every transport, so a `Response` thrown from `run()` has nowhere to go. Gate capabilities in their named middleware. The `redirect()` JSDoc says so at the call site.
- Redirecting from a loader was **entirely undocumented** — `docs/DATA_LOADING.md` never mentioned `redirect()`, which appeared only in middleware examples. It now has a section covering both forms, the composable-helper pattern, and a table of what each surface supports.

## Testing

- [x] `pnpm run verify` (build, format, lint, typecheck, test, e2e)

Five tests in a new `handlePrachtRequest short-circuit Responses` group: thrown redirect from a loader, thrown Response from an API handler, a thrown `Error` still producing a 500, a thrown redirect on the **client-navigation** path (route-state requests fetch with `redirect: "manual"`, so a raw 302 would be opaque — it has to be encoded as `{"redirect": "/login"}` exactly like the returned path), and the double-delivery case above. Each verified to fail without the corresponding source change: removing the guard turns the last one into `TypeError: Response body object should not be disturbed or locked` escaping the handler.

Adversarial review checked ordering against `notFound()` (`PrachtHttpError extends Error`, never a `Response`, so `throw notFound()` still renders the notFound page), `loaderCache` leakage (a thrown 302 gets `no-store`, never `private, max-age=N`), `withEnhancedCapabilityFormRedirect` on the API path (gated on the form header *and* a 3xx status, so a thrown 418 or streamed body passes untouched), SSG/ISG prerendering (a thrown redirect warns and skips rather than writing a wrong static file), and middleware. It found the unhandled-rejection path, the capability gap, and the missing client-navigation coverage; all three are addressed here.

## Checklist

- [x] Docs updated if needed — `docs/DATA_LOADING.md` gains a "Redirecting from a loader" section
- [ ] Skills updated if needed — N/A
- [x] Changeset added if published packages changed — `.changeset/loader-thrown-response.md` (`@pracht/core` patch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)