### PR TITLE
fix(cli): warn when a Markdown route has no transform plugin

### DIFF
--- a/.changeset/pages-markdown-transform-check.md
+++ b/.changeset/pages-markdown-transform-check.md
@@ -1,0 +1,25 @@
+---
+"@pracht/cli": patch
+---
+
+Warn when a pages-router Markdown page has no transform plugin.
+
+`docs/ROUTING.md` lists `.md` in the pages-router file-convention table and only
+warns that **`.mdx`** needs a transform plugin. `.md` needs one too. Without it
+the framework happily registers the route — it shows up in `pracht inspect
+routes`, and `doctor` and `verify` both reported the app healthy — and then:
+
+- the route 500s at request time with a raw parser error (`Parse failure:
+  Invalid Character`), because Vite hands the Markdown to the JS parser, and
+- `pracht build` exits 1 with an internal `RolldownError` stack.
+
+`doctor` and `verify` now warn when a Markdown route is registered and the vite
+config names no known Markdown transform plugin — in both routers (a `.md`
+manifest route module breaks identically), for the not-found page as well as
+ordinary routes, and under `--changed` scope, which is how you meet this in CI
+right after adding the page. The docs state the requirement for both
+extensions.
+
+The check is a warning and says so: a custom or re-exported plugin is invisible
+to a text match, so it reports "no *known* Markdown transform plugin" and tells
+you to ignore it if you have one.

--- a/docs/ROUTING.md
+++ b/docs/ROUTING.md
@@ -668,9 +668,12 @@ directory and generates the route manifest automatically.
 | `pages/_app.tsx`        | _(shell, not a route)_ |
 | `pages/_anything.tsx`   | _(ignored)_            |
 
-Markdown and MDX pages are routed the same way as `.tsx` pages. If you want to
-render `.mdx` files, add the corresponding Vite transform plugin such as
-`@mdx-js/rollup` alongside `pracht()`.
+Markdown and MDX pages are routed the same way as `.tsx` pages, but pracht does
+not transform them: `.md` **and** `.mdx` both need a Vite transform plugin such
+as `@mdx-js/rollup` registered alongside `pracht()`. Without one, Vite hands the
+raw Markdown to the JS parser and the route fails at request time (`Invalid
+Character`) and at build time. `pracht doctor` and `pracht verify` warn when a
+Markdown page is routed and no such plugin is registered.
 
 ### Shell via `_app.tsx`
 

--- a/packages/cli/src/verification-checks.ts
+++ b/packages/cli/src/verification-checks.ts
@@ -130,6 +130,14 @@ export function collectManifestVerification(
       changedFiles,
     );
   }
+
+  // `.md` / `.mdx` are valid manifest route modules and break exactly the same
+  // way a pages-router Markdown page does.
+  collectMarkdownTransformCheck(
+    project,
+    checks,
+    relativeModules.map((modulePath) => resolve(dirname(manifestPath), modulePath)),
+  );
 }
 
 function collectChangedManifestModuleChecks(
@@ -231,6 +239,17 @@ export function collectPagesVerification(
     collectChangedPagesChecks(project, checks, pagesDir, changedFiles);
   }
 
+  // Both scopes: adding a Markdown page and running `verify --changed` is the
+  // most likely way to meet this, and a `404.md` breaks the build exactly like
+  // a routed one.
+  collectMarkdownTransformCheck(
+    project,
+    checks,
+    pages
+      .filter((page) => page.kind === "route" || page.kind === "not-found")
+      .map((page) => page.file),
+  );
+
   if (notFoundPages.length > 1) {
     checks.push(
       createCheck(
@@ -262,6 +281,49 @@ export function collectPagesVerification(
       ),
     );
   }
+}
+
+const MARKDOWN_PAGE_RE = /\.mdx?$/;
+// Plugin specifiers that transform Markdown/MDX into a renderable module,
+// matched against the raw vite config text. Necessarily a heuristic: a custom
+// or re-exported plugin is invisible here, which is why this warns and says so
+// rather than asserting the app is broken.
+const MARKDOWN_PLUGIN_HINTS = ["@mdx-js/rollup", "vite-plugin-mdx", "vite-plugin-markdown"];
+
+/**
+ * A `.md` / `.mdx` route is registered like any other, but nothing renders it
+ * unless a transform plugin is configured: Vite hands the raw Markdown to the
+ * JS parser, so the route 500s at request time with `Invalid Character` and
+ * `pracht build` fails with a raw parser stack. Both `doctor` and `verify`
+ * would otherwise report the app healthy.
+ */
+function collectMarkdownTransformCheck(
+  project: ProjectConfig,
+  checks: Check[],
+  files: string[],
+): void {
+  const markdownFiles = files.filter((file) => MARKDOWN_PAGE_RE.test(file));
+  if (markdownFiles.length === 0) return;
+
+  const config = project.rawConfig;
+  if (MARKDOWN_PLUGIN_HINTS.some((hint) => config.includes(hint))) return;
+
+  const shown = markdownFiles
+    .slice(0, 3)
+    .map((file) => JSON.stringify(displayPath(project.root, file)))
+    .join(", ");
+
+  checks.push(
+    createCheck(
+      "warning",
+      `${markdownFiles.length} Markdown route${markdownFiles.length === 1 ? "" : "s"} ` +
+        `(${shown}${markdownFiles.length > 3 ? ", ..." : ""}) but no known Markdown transform ` +
+        "plugin in the vite config. Pracht does not transform Markdown: without a plugin such as " +
+        "`@mdx-js/rollup` registered alongside `pracht()`, Vite hands the raw source to the JS " +
+        "parser and these routes fail at request and build time. Ignore this if you register a " +
+        "custom or re-exported Markdown plugin.",
+    ),
+  );
 }
 
 function collectChangedPagesChecks(

--- a/packages/cli/test/cli-doctor-verify.test.js
+++ b/packages/cli/test/cli-doctor-verify.test.js
@@ -434,4 +434,95 @@ export const app = defineApp({
     // recognize, so a clean pass is "nothing provably wrong", not "verified".
     expect(report.checks.some((check) => check.message.includes("wrangler"))).toBe(false);
   });
+  it("warns when a Markdown page is routed with no transform plugin", () => {
+    const appDir = createTempDir("pracht-cli-doctor-md-page-");
+    writePagesApp(appDir);
+    writeProjectFile(appDir, "src/pages/guide.md", "# Guide\n\nHello.\n");
+
+    const result = runCli(["doctor", "--json"], { cwd: appDir });
+    const report = JSON.parse(result.stdout);
+
+    // A warning, not an error: the app is only broken if it is actually built
+    // or requested, and a plugin this list does not know about may well handle it.
+    expect(report.ok).toBe(true);
+    expect(
+      report.checks.some(
+        (check) =>
+          check.status === "warning" &&
+          check.message.includes("Markdown route") &&
+          check.message.includes("src/pages/guide.md"),
+      ),
+    ).toBe(true);
+  });
+
+  it("stays quiet about Markdown routes when a transform plugin is registered", () => {
+    const withPlugin = createTempDir("pracht-cli-doctor-md-plugin-");
+    const withoutPlugin = createTempDir("pracht-cli-doctor-md-no-plugin-");
+
+    for (const appDir of [withPlugin, withoutPlugin]) {
+      writePagesApp(appDir);
+      writeProjectFile(appDir, "src/pages/guide.md", "# Guide\n\nHello.\n");
+    }
+    writeProjectFile(
+      withPlugin,
+      "vite.config.ts",
+      `import { defineConfig } from "vite";
+import { pracht } from "@pracht/vite-plugin";
+import mdx from "@mdx-js/rollup";
+
+export default defineConfig({
+  plugins: [mdx(), pracht({ pagesDir: "/src/pages" })],
+});
+`,
+    );
+
+    const hasWarning = (appDir) =>
+      JSON.parse(runCli(["doctor", "--json"], { cwd: appDir }).stdout).checks.some((check) =>
+        check.message.includes("Markdown route"),
+      );
+
+    // Paired: the negative case only means something next to a positive one in
+    // the same shape, otherwise it passes with the feature deleted.
+    expect(hasWarning(withoutPlugin)).toBe(true);
+    expect(hasWarning(withPlugin)).toBe(false);
+  });
+
+  it("warns about a Markdown not-found page and under --changed scope", () => {
+    const appDir = createTempDir("pracht-cli-doctor-md-404-");
+    writePagesApp(appDir);
+    writeProjectFile(appDir, "src/pages/404.md", "# Gone\n");
+
+    const full = JSON.parse(runCli(["doctor", "--json"], { cwd: appDir }).stdout);
+    expect(
+      full.checks.some(
+        (check) => check.status === "warning" && check.message.includes("src/pages/404.md"),
+      ),
+    ).toBe(true);
+
+    initializeGitRepo(appDir);
+    writeProjectFile(appDir, "src/pages/404.md", "# Gone for good\n");
+    const changed = JSON.parse(runCli(["verify", "--changed", "--json"], { cwd: appDir }).stdout);
+    expect(changed.checks.some((check) => check.message.includes("Markdown route"))).toBe(true);
+  });
+
+  it("warns about a Markdown route module in a manifest app", () => {
+    const appDir = createTempDir("pracht-cli-doctor-md-manifest-");
+    writeManifestApp(appDir, {
+      routesSource: `import { defineApp, route } from "@pracht/core";
+
+export const app = defineApp({
+  routes: [route("/guide", "./routes/guide.md", { id: "guide", render: "ssg" })],
+});
+`,
+    });
+    writeProjectFile(appDir, "src/routes/guide.md", "# Guide\n");
+
+    const report = JSON.parse(runCli(["doctor", "--json"], { cwd: appDir }).stdout);
+
+    expect(
+      report.checks.some(
+        (check) => check.status === "warning" && check.message.includes("src/routes/guide.md"),
+      ),
+    ).toBe(true);
+  });
 });


### PR DESCRIPTION
## Summary

- `docs/ROUTING.md` lists `.md` in the pages-router file-convention table and only warned that **`.mdx`** needs a Vite transform plugin. `.md` needs one too — and the framework registers the route regardless:

  - `pracht inspect routes` lists it (`/guide  id=guide  render=ssr  file=/src/pages/guide.md`)
  - `pracht doctor` and `pracht verify` both report **no blocking issues**
  - `GET /guide` returns 500 with a raw parser error (`Parse failure: Invalid Character`), because Vite hands the Markdown to the JS parser
  - `pracht build` exits 1 with a 10-frame internal `RolldownError` stack

  The framework registers a route it cannot render and its own validators bless it.
- `doctor` and `verify` now warn when a Markdown route is registered and the vite config names no known Markdown transform plugin, and the docs state the requirement for both extensions.
- Coverage is deliberately wider than the reported case, because the same failure reaches users through three other doors:
  - **`--changed` scope**, which is how this actually hits CI — you add a page, CI runs changed-scope verify. It previously printed `OK  Changed page route "src/pages/guide.md" resolves to "/guide"` for the exact file that breaks the build.
  - **`404.md`**, classified as the not-found page rather than a route, and equally broken.
  - **Manifest apps**, where `.md`/`.mdx` are valid route modules that fail identically — and which `MODULE_SOURCE_RE` does not even match, so changed-scope verification could not see them at all.

It is a **warning**, not an error, and the message says "no *known* Markdown transform plugin … ignore this if you register a custom or re-exported one". The plugin list is a text match over the vite config, so a hand-written `./plugins/markdown.ts` is invisible to it — that must not fail anyone's build, and the message must not assert a failure it has not proven.

## Testing

- [x] `pnpm run verify` (build, format, lint, typecheck, test, e2e)

Four tests: the pages case, a paired plugin/no-plugin comparison in the same shape, the `404.md` + `--changed` case, and the manifest case.

Adversarial review confirmed the premise end to end (dev 500 and build failure reproduced, then fixed by installing `@mdx-js/rollup` — and confirmed plugin ordering relative to `pracht()` does not matter, since `pracht:client-module-transform` is `enforce: "post"`). It found the `--changed` gap, the `404.md` gap, the manifest gap, an over-assertive message, Vue-only entries in the plugin list, and that the original negative test was vacuous — it passed with the feature deleted. All six are addressed; the paired test above is the fix for the last one.

## Checklist

- [x] Docs updated if needed — `docs/ROUTING.md`
- [ ] Skills updated if needed — N/A
- [x] Changeset added if published packages changed — `.changeset/pages-markdown-transform-check.md` (`@pracht/cli` patch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)