### PR TITLE
fix(cli): serve `Accept: text/markdown` on Vercel

### DIFF
--- a/.changeset/vercel-markdown-routing.md
+++ b/.changeset/vercel-markdown-routing.md
@@ -1,0 +1,29 @@
+---
+"@pracht/cli": patch
+---
+
+Serve `Accept: text/markdown` on Vercel for routes that export `markdown`.
+
+Vercel serves prerendered files from its routing table before any function
+runs, and the generated table rewrote every prerendered route to its static
+HTML unconditionally. A markdown-preferring request for a route that exports
+`markdown` therefore got HTML, and the render function — which handles the
+negotiation correctly — was never reached. Node and Cloudflare both answer with
+markdown, and the generated `llms.txt` annotates the route with
+`supports \`Accept: text/markdown\`` on every adapter, so Vercel was advertising
+a capability it did not have.
+
+The build now emits an `Accept`-conditional route to the render function ahead
+of the static rewrite, for each prerendered route in the markdown manifest and
+only those — including ISG routes, which route to the render function rather
+than their prerender function (that one re-renders on a sanitized
+`Accept: text/html` to keep its shared cache entry correct, so it can only ever
+produce HTML). Routes without a `markdown` export keep their static fast path
+whatever the client sends.
+
+The header pattern is written case-insensitively, because Vercel compiles
+`has.value` without the `i` flag and media types are case-insensitive — an
+agent sending `Accept: TEXT/MARKDOWN` must not get a different answer here than
+it gets on Node or Cloudflare. The trade, stated plainly: on markdown routes a
+client can force a function invocation with the header alone, even at `q=0`.
+That is why the entry is scoped to routes that actually export `markdown`.

--- a/docs/ADAPTERS.md
+++ b/docs/ADAPTERS.md
@@ -796,6 +796,21 @@ and hashed assets are never re-rendered because a client sent an odd `Accept`.
 The build emits an empty manifest for SSR-only apps too, so public files keep
 the same guarantee even when the app has no prerendered documents.
 
+Vercel reaches the same outcome through its routing table rather than adapter
+code, because the platform serves prerendered files before any function runs.
+The build emits an `Accept`-conditional route to the render function, ahead of
+the static rewrite, for each prerendered route in the markdown manifest — and
+only those. The header match there is coarser than `prefersMarkdown()` by
+necessity (Vercel's `has` takes a regex, not a q-value parser), so anything
+mentioning `text/markdown` reaches the function, which then applies the real
+negotiation and still answers HTML when HTML is preferred. The trade is that on
+those routes a client can force a function invocation with the header alone,
+even at `q=0` — so the entry is emitted only for routes that actually export
+`markdown`. Every other prerendered page keeps its static fast path whatever
+the client sends. ISG routes that export `markdown` route to the render
+function rather than their prerender function, which re-renders on a sanitized
+`Accept: text/html` and can only produce HTML.
+
 ---
 
 ## ISG Webhook Revalidation

--- a/packages/cli/src/build-shared.ts
+++ b/packages/cli/src/build-shared.ts
@@ -36,6 +36,8 @@ interface VercelBuildOutputOptions {
   functionName?: string;
   headersManifest?: Record<string, Record<string, string>>;
   isgManifest: Record<string, ISGManifestEntry>;
+  /** Prerendered routes whose module exports `markdown`. */
+  markdownRoutes?: string[];
   revalidateToken?: string;
   regions?: VercelRegions;
   root: string;
@@ -46,6 +48,7 @@ export function writeVercelBuildOutput({
   functionName,
   headersManifest = {},
   isgManifest,
+  markdownRoutes = [],
   revalidateToken = process.env.PRACHT_REVALIDATE_TOKEN || randomBytes(32).toString("hex"),
   regions,
   root,
@@ -89,6 +92,7 @@ export function writeVercelBuildOutput({
       createVercelOutputConfig({
         functionName,
         headersManifest,
+        markdownRoutes,
         staticRoutes,
         isgRoutes: Object.keys(isgManifest),
       }),
@@ -238,14 +242,23 @@ function linkVercelPrerenderFunction({
   }
 }
 
+// `has.value` is compiled without the `i` flag, so case-insensitivity has to be
+// written out. Media types are case-insensitive per RFC 9110, and the runtime's
+// own negotiation lowercases before comparing — a client sending
+// `Accept: TEXT/MARKDOWN` must not get a different answer on Vercel than it
+// gets on Node or Cloudflare.
+const ACCEPT_MARKDOWN_PATTERN = ".*[tT][eE][xX][tT]/[mM][aA][rR][kK][dD][oO][wW][nN].*";
+
 function createVercelOutputConfig({
   functionName,
   headersManifest,
+  markdownRoutes,
   staticRoutes,
   isgRoutes,
 }: {
   functionName?: string;
   headersManifest: Record<string, Record<string, string>>;
+  markdownRoutes: string[];
   isgRoutes: string[];
   staticRoutes: string[];
 }): Record<string, unknown> {
@@ -263,7 +276,31 @@ function createVercelOutputConfig({
     },
   ];
 
+  // Routes that export `markdown` answer `Accept: text/markdown` with their
+  // source instead of HTML, which only the function can do — so they have to
+  // reach it before the static rewrite below claims them. Node and Cloudflare
+  // make the same decision inside the adapter; on Vercel the routing table is
+  // the adapter, and without this entry a markdown-preferring agent silently
+  // gets HTML while `llms.txt` advertises markdown support.
+  //
+  // The header match is intentionally coarser than the runtime's negotiation:
+  // `has` takes a regex, not a q-value parser. Anything mentioning
+  // `text/markdown` is handed to the function, which then runs the real
+  // `prefersMarkdown()` check and still answers HTML when HTML is preferred.
+  //
+  // The cost, stated plainly: on these routes a client can force a function
+  // invocation by sending the header, even with `q=0`. It is bounded to routes
+  // that actually export `markdown` — every other prerendered page keeps its
+  // static fast path whatever the client asks for.
+  const markdownRouteSet = new Set(markdownRoutes);
+  const markdownRouteEntry = (route: string) => ({
+    dest: target,
+    has: [{ type: "header", key: "accept", value: ACCEPT_MARKDOWN_PATTERN }],
+    src: routeToRouteExpression(route),
+  });
+
   for (const route of sortStaticRoutes(staticRoutes)) {
+    if (markdownRouteSet.has(route)) routes.push(markdownRouteEntry(route));
     routes.push({
       dest: routeToStaticHtmlPath(route),
       src: routeToRouteExpression(route),
@@ -271,6 +308,10 @@ function createVercelOutputConfig({
   }
 
   for (const route of isgRoutes) {
+    // ISG markdown routes go to the render function, not to their prerender
+    // function: that one re-renders on a sanitized `Accept: text/html` to keep
+    // the shared cache entry correct, so it can only ever produce HTML.
+    if (markdownRouteSet.has(route)) routes.push(markdownRouteEntry(route));
     routes.push({
       dest: route,
       src: routeToRouteExpression(route),

--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -302,6 +302,7 @@ export async function runBuild(root: string, options: BuildOptions = {}): Promis
         functionName: serverMod.vercelFunctionName,
         isgManifest,
         headersManifest,
+        markdownRoutes: Object.keys(markdownManifest),
         regions: serverMod.vercelRegions,
         root,
         staticRoutes: pages

--- a/packages/cli/test/vercel-build-output.test.ts
+++ b/packages/cli/test/vercel-build-output.test.ts
@@ -33,6 +33,103 @@ describe("writeVercelBuildOutput", () => {
     return root;
   }
 
+  it("routes markdown-preferring requests for markdown routes to the function", () => {
+    const root = createBuildRoot();
+
+    writeVercelBuildOutput({
+      isgManifest: {},
+      markdownRoutes: ["/guide"],
+      root,
+      staticRoutes: ["/", "/guide", "/pricing"],
+    });
+
+    const config = JSON.parse(readFileSync(join(root, ".vercel/output/config.json"), "utf-8")) as {
+      routes: { dest?: string; has?: unknown[]; src?: string }[];
+    };
+
+    const guideRoutes = config.routes.filter((entry) => entry.src === "^/guide/?$");
+    // The Accept-conditional entry has to come first, or the static rewrite
+    // claims the request and the function never runs.
+    expect(guideRoutes).toEqual([
+      {
+        dest: "/render",
+        has: [
+          {
+            type: "header",
+            key: "accept",
+            value: ".*[tT][eE][xX][tT]/[mM][aA][rR][kK][dD][oO][wW][nN].*",
+          },
+        ],
+        src: "^/guide/?$",
+      },
+      { dest: "/guide/index.html", src: "^/guide/?$" },
+    ]);
+
+    // Routes without a `markdown` export keep their static fast path whatever
+    // the client sends.
+    for (const src of ["^/$", "^/pricing/?$"]) {
+      expect(config.routes.filter((entry) => entry.src === src)).toHaveLength(1);
+    }
+  });
+
+  it("emits markdown routing only for routes that export markdown", () => {
+    const withMarkdown = createBuildRoot();
+    const withoutMarkdown = createBuildRoot();
+
+    writeVercelBuildOutput({
+      isgManifest: {},
+      markdownRoutes: ["/guide"],
+      root: withMarkdown,
+      staticRoutes: ["/", "/guide"],
+    });
+    writeVercelBuildOutput({
+      isgManifest: {},
+      root: withoutMarkdown,
+      staticRoutes: ["/", "/guide"],
+    });
+
+    const routesJson = (root: string) =>
+      readFileSync(join(root, ".vercel/output/config.json"), "utf-8");
+
+    // Paired: the negative assertion alone would pass with the feature deleted.
+    expect(routesJson(withMarkdown)).toContain("mM][aA][rR][kK]");
+    expect(routesJson(withoutMarkdown)).not.toContain("mM][aA][rR][kK]");
+  });
+
+  it("routes ISG markdown routes to the render function, not the prerender function", () => {
+    const root = createBuildRoot();
+
+    writeVercelBuildOutput({
+      functionName: "ssr-handler",
+      isgManifest: { "/pricing": { revalidate: timeRevalidate(60) } },
+      markdownRoutes: ["/pricing"],
+      root,
+      staticRoutes: ["/"],
+    });
+
+    const config = JSON.parse(readFileSync(join(root, ".vercel/output/config.json"), "utf-8")) as {
+      routes: { dest?: string; has?: unknown[]; src?: string }[];
+    };
+
+    // The prerender function re-renders on a sanitized `Accept: text/html` to
+    // keep its shared cache entry correct, so it can only ever produce HTML —
+    // markdown has to reach the render function instead.
+    expect(config.routes.filter((entry) => entry.src === "^/pricing/?$")).toEqual([
+      {
+        dest: "/ssr-handler",
+        has: [
+          {
+            type: "header",
+            key: "accept",
+            value: ".*[tT][eE][xX][tT]/[mM][aA][rR][kK][dD][oO][wW][nN].*",
+          },
+        ],
+        src: "^/pricing/?$",
+      },
+      { dest: "/pricing", src: "^/pricing/?$" },
+    ]);
+  });
+
   it("emits ISG routes as Node serverless functions", () => {
     const root = createBuildRoot();
 


### PR DESCRIPTION
## Summary

- Routes that export `markdown` answer `Accept: text/markdown` with their source instead of HTML. Node and Cloudflare implement that in adapter code. On Vercel the **routing table is the adapter** — and `createVercelOutputConfig` rewrote every prerendered route to its static HTML with no `has` condition, so a markdown-preferring agent silently got HTML and the render function was never reached.

  The render function itself is correct: invoked directly it returns `text/markdown`. Only the routing never sent it the request. Meanwhile the generated `llms.txt` annotates the route with `supports \`Accept: text/markdown\`` on *every* adapter, so Vercel was advertising a capability it did not have, and `docs/ADAPTERS.md#markdown-and-the-static-fast-path` discussed only "the Node and Cloudflare adapters" without saying Vercel differs.
- The build now emits an `Accept`-conditional route to the render function immediately ahead of the static rewrite, for each prerendered route in the markdown manifest and **only** those.
- ISG routes that export `markdown` are covered too, and route to the **render** function rather than their prerender function — that one re-renders on a sanitized `Accept: text/html` to keep its shared cache entry correct, so it can only ever produce HTML.
- The header pattern is written case-insensitively (`[tT][eE][xX][tT]/…`). Vercel compiles `has.value` without the `i` flag, and media types are case-insensitive per RFC 9110, so `Accept: TEXT/MARKDOWN` would otherwise get HTML on Vercel and markdown everywhere else.

**The trade, stated plainly:** the match is coarser than `prefersMarkdown()` because `has` takes a regex, not a q-value parser. Anything mentioning `text/markdown` reaches the function, which then applies the real negotiation and still answers HTML when HTML is preferred — but a client can force a function invocation on those routes with the header alone, even at `q=0`. That is the cost of `.changeset/markdown-static-fast-path.md`'s guarantee not being expressible in a routing table, and it is why the entry is scoped to routes that actually export `markdown`. Every other prerendered page keeps its static fast path whatever the client sends. Documented in `docs/ADAPTERS.md`.

## Testing

- [x] `pnpm run verify` (build, format, lint, typecheck, test, e2e)

Four tests: ordering (the conditional entry must precede the static rewrite or it never runs), scoping (paired with/without-markdown builds, so the negative assertion is not vacuous), ISG routing to the render function with a custom `functionName`, and non-markdown routes keeping a single entry.

Adversarial review validated the emitted config against `@vercel/routing-utils` `normalizeRoutes`, confirmed first-match-wins ordering pre-`handle: filesystem`, confirmed an absent `Accept`, `*/*`, and a real browser Accept string all keep the static path, and confirmed `src` is byte-identical between the new and existing entries for routes with regex metacharacters. It found the ISG gap, the case-sensitivity divergence, and a vacuous test — all three are fixed here.

One thing it raised that this PR does **not** change: whether Vercel honours the top-level `headers` array the build already emits (which is where `Vary: Accept` and the baseline security headers live). That is pre-existing behaviour and needs a real deploy to confirm; flagging rather than guessing.

## Checklist

- [x] Docs updated if needed — `docs/ADAPTERS.md` gains the Vercel paragraph in the markdown fast-path section
- [ ] Skills updated if needed — N/A
- [x] Changeset added if published packages changed — `.changeset/vercel-markdown-routing.md` (`@pracht/cli` patch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)