### PR TITLE
fix(cli): load `.env` into `process.env` for `pracht dev`

### DIFF
--- a/.changeset/dev-dotenv.md
+++ b/.changeset/dev-dotenv.md
@@ -1,0 +1,26 @@
+---
+"@pracht/cli": patch
+---
+
+Load `.env` into `process.env` for `pracht dev`.
+
+Vite reads `.env` files but only exposes prefixed keys through
+`import.meta.env`; it never writes to `process.env`. Server-side code reads
+`process.env` (that is what `serverEnv` resolves to on Node and Vercel), so an
+unprefixed secret in `.env` was simply invisible. Writing
+`PRACHT_CONFIRMATION_SECRET` into the file the scaffold's `.gitignore` already
+anticipates had no effect, and a destructive capability failed closed with
+`confirmation_unavailable` while the value sat right there.
+
+Wrangler already does this for Cloudflare apps ("Using secrets defined in
+.env"), so the identical project behaved differently per adapter.
+
+Dev only. Real environment variables win over the file, `.env.local` beats
+`.env.development` beats `.env`, and `NODE_ENV` is never taken from the file
+(Vite refuses `NODE_ENV=production` there on purpose, and the dev server is
+always mode `development` whatever the shell says).
+
+`pracht build`, the production server, and `pracht verify` / `pracht doctor`
+still read only the real environment: verification reports on what a deployment
+will have, so a destructive capability whose secret lives only in `.env` stays
+an error — its message now says where the value has to live instead.

--- a/docs/ENV.md
+++ b/docs/ENV.md
@@ -107,6 +107,30 @@ to `Record<string, string | undefined>`.
 Custom setups can call `setServerEnv(env)` (exported from
 `@pracht/core/env/server` and `@pracht/core/server`) to install another source.
 
+## `.env` files
+
+`pracht dev` loads `.env` files into `process.env` before starting, so a
+server-only secret written to `.env` reaches loaders, middleware, API routes,
+and `serverEnv` — the same thing wrangler does for Cloudflare apps. Real
+environment variables always win over the file, and `.env.local` beats
+`.env.development` beats `.env`. `NODE_ENV` is never taken from the file: Vite
+refuses `NODE_ENV=production` there on purpose, and the dev server is always
+mode `development`.
+
+`pracht verify` and `pracht doctor` deliberately do **not** read `.env`. They
+report on the environment a deployment will have, so a destructive capability
+whose `PRACHT_CONFIRMATION_SECRET` lives only in `.env` is still an error —
+dev will work, production would fail closed.
+
+Vite's own `.env` handling is separate and unchanged: it only exposes
+`PRACHT_PUBLIC_`/`VITE_`-prefixed keys through `import.meta.env`, and never
+writes to `process.env`. That is why an unprefixed key in `.env` was previously
+invisible to server code.
+
+`pracht build` and the production server do **not** read `.env` — a deployed
+app's environment belongs to the platform. Set real environment variables (or
+Cloudflare secrets / Vercel environment variables) there.
+
 ## Client-leak detection
 
 During `pracht build` the plugin scans every client chunk for references to

--- a/packages/cli/src/commands/dev.ts
+++ b/packages/cli/src/commands/dev.ts
@@ -5,6 +5,7 @@ import { defineCommand } from "citty";
 import { createServer, type ViteDevServer } from "vite";
 
 import { collectAppGraph } from "../app-graph.js";
+import { loadDotEnvIntoProcess } from "../dotenv.js";
 import { formatDevBanner, supportsColor } from "../dev-banner.js";
 import { readProjectConfig, resolveProjectPath } from "../project.js";
 import { requirePositiveInteger } from "../utils.js";
@@ -27,6 +28,15 @@ export default defineCommand({
     },
   },
   async run({ args }) {
+    const root = process.cwd();
+    // Server-side code reads `process.env`; Vite only surfaces `.env` through
+    // `import.meta.env`. Without this a secret in `.env` is invisible to
+    // loaders, middleware, API routes, and the capability confirmation gate.
+    // Ahead of the port resolution below so a `PORT` in `.env` is honoured
+    // rather than half-applied. Vite's dev server is always mode
+    // `development`, whatever NODE_ENV says.
+    loadDotEnvIntoProcess(root, "development");
+
     // `pracht dev 4000` (legacy positional) still works alongside `--port`.
     const positionalPort = args._?.[0] != null ? String(args._[0]) : undefined;
     const port = requirePositiveInteger(
@@ -34,7 +44,6 @@ export default defineCommand({
       "port",
       3000,
     );
-    const root = process.cwd();
 
     const server = await createServer({
       root,

--- a/packages/cli/src/dotenv.ts
+++ b/packages/cli/src/dotenv.ts
@@ -1,0 +1,42 @@
+import { loadEnv } from "vite";
+
+/**
+ * Load `.env` files into `process.env` for the local dev server.
+ *
+ * Vite reads `.env` files, but only exposes prefixed keys through
+ * `import.meta.env` — it never writes them to `process.env`. Server-side code
+ * reads `process.env` (that is what `serverEnv` resolves to on Node and
+ * Vercel), so an unprefixed secret in `.env` was simply invisible: a
+ * `PRACHT_CONFIRMATION_SECRET` sitting in the file the user just created had no
+ * effect, and the destructive-capability gate failed closed with
+ * `confirmation_unavailable`.
+ *
+ * Wrangler already does this for Cloudflare apps ("Using secrets defined in
+ * .env"), so the same project behaved differently per adapter.
+ *
+ * Real environment variables always win over the file, matching Vite, wrangler,
+ * and dotenv. `.env.local` beats `.env.<mode>` beats `.env`, which `loadEnv`
+ * already implements.
+ *
+ * `mode` is required rather than derived from `NODE_ENV`: Vite's dev server is
+ * always mode `development` whatever `NODE_ENV` says, and guessing wrong would
+ * load `.env.production` into a dev server.
+ */
+export function loadDotEnvIntoProcess(root: string, mode: string): string[] {
+  // An empty prefix asks Vite for every key in the `.env` files, not just the
+  // client-exposed ones — this is the server-side environment.
+  const fileEnv = loadEnv(mode, root, "");
+  const applied: string[] = [];
+
+  for (const [key, value] of Object.entries(fileEnv)) {
+    // Vite refuses `NODE_ENV=production` from a `.env` file on purpose, and
+    // only honours `NODE_ENV=development`. Assigning it here would run ahead of
+    // that guard and silently flip the dev server into production mode.
+    if (key === "NODE_ENV") continue;
+    if (key in process.env) continue;
+    process.env[key] = value;
+    applied.push(key);
+  }
+
+  return applied;
+}

--- a/packages/cli/src/verification-capabilities.ts
+++ b/packages/cli/src/verification-capabilities.ts
@@ -333,7 +333,10 @@ function collectSingleCapabilityChecks(
         problems.push(
           "is destructive and exposed over HTTP without PRACHT_CONFIRMATION_SECRET in the " +
             "environment — the prepare/commit confirmation flow needs the secret and the " +
-            "runtime fails closed without it",
+            "runtime fails closed without it. Verification reads the real environment, not " +
+            "`.env`: `pracht dev` loads that file, but a deployed server takes its " +
+            "environment from the platform, so set a real variable (or a Cloudflare secret / " +
+            "Vercel environment variable) there",
         );
       }
     }

--- a/packages/cli/test/cli-dev-typegen.test.js
+++ b/packages/cli/test/cli-dev-typegen.test.js
@@ -49,6 +49,51 @@ describe("@pracht/cli dev typegen", () => {
     }
   }, 120_000);
 
+  it("pracht dev exposes .env values to the server process", async () => {
+    // Regression guard for the call site, not just the helper: `pracht dev`
+    // has to load `.env` into `process.env` before Vite starts, or an
+    // unprefixed key stays invisible to loaders, middleware, API routes, and
+    // `serverEnv`. The vite config is evaluated by that same process, so it is
+    // the cheapest place to observe what server code would see.
+    const appDir = createRepoTempDir("pracht-cli-dev-dotenv-");
+    writeTypedManifestApp(appDir);
+    writeProjectFile(appDir, ".env", "PRACHT_DOTENV_PROBE=from-dot-env\n");
+
+    const configPath = join(appDir, "vite.config.ts");
+    writeProjectFile(
+      appDir,
+      "vite.config.ts",
+      `console.log("PROBE:" + process.env.PRACHT_DOTENV_PROBE);\n` +
+        readFileSync(configPath, "utf-8"),
+    );
+
+    const child = spawn(process.execPath, [cliPath, "dev", "--port", "3987"], {
+      cwd: appDir,
+      env: process.env,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    let output = "";
+    child.stdout.setEncoding("utf-8");
+    child.stderr.setEncoding("utf-8");
+    child.stdout.on("data", (chunk) => {
+      output += chunk;
+    });
+    child.stderr.on("data", (chunk) => {
+      output += chunk;
+    });
+
+    try {
+      await waitFor(
+        () => output.includes("PROBE:"),
+        30_000,
+        () => output,
+      );
+      expect(output).toContain("PROBE:from-dot-env");
+    } finally {
+      await stopChild(child);
+    }
+  }, 120_000);
+
   it("pracht dev keeps generated route types in sync with route files", async () => {
     const appDir = createRepoTempDir("pracht-cli-dev-typegen-");
     writeTypedManifestApp(appDir);

--- a/packages/cli/test/dotenv.test.ts
+++ b/packages/cli/test/dotenv.test.ts
@@ -1,0 +1,91 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { loadDotEnvIntoProcess } from "../src/dotenv.ts";
+
+const dirs: string[] = [];
+const touchedKeys: string[] = [];
+
+afterEach(() => {
+  for (const key of touchedKeys.splice(0)) delete process.env[key];
+  while (dirs.length > 0) rmSync(dirs.pop()!, { force: true, recursive: true });
+});
+
+function createRoot(files: Record<string, string>): string {
+  const dir = mkdtempSync(join(tmpdir(), "pracht-dotenv-"));
+  dirs.push(dir);
+  for (const [name, contents] of Object.entries(files)) {
+    writeFileSync(join(dir, name), contents, "utf-8");
+  }
+  return dir;
+}
+
+describe("loadDotEnvIntoProcess", () => {
+  it("exposes unprefixed keys on process.env", () => {
+    touchedKeys.push("PRACHT_TEST_SECRET");
+    const root = createRoot({ ".env": "PRACHT_TEST_SECRET=from-file\n" });
+
+    expect(loadDotEnvIntoProcess(root, "development")).toContain("PRACHT_TEST_SECRET");
+    expect(process.env.PRACHT_TEST_SECRET).toBe("from-file");
+  });
+
+  it("never overrides a real environment variable", () => {
+    touchedKeys.push("PRACHT_TEST_SECRET");
+    process.env.PRACHT_TEST_SECRET = "from-environment";
+    const root = createRoot({ ".env": "PRACHT_TEST_SECRET=from-file\n" });
+
+    expect(loadDotEnvIntoProcess(root, "development")).not.toContain("PRACHT_TEST_SECRET");
+    expect(process.env.PRACHT_TEST_SECRET).toBe("from-environment");
+  });
+
+  it("never assigns NODE_ENV", () => {
+    // Vite refuses `NODE_ENV=production` from a .env file on purpose and only
+    // honours `NODE_ENV=development`; assigning it here would run ahead of that
+    // guard and silently flip the dev server into production mode.
+    touchedKeys.push("PRACHT_TEST_OTHER");
+    const root = createRoot({ ".env": "NODE_ENV=production\nPRACHT_TEST_OTHER=1\n" });
+    const before = process.env.NODE_ENV;
+
+    const applied = loadDotEnvIntoProcess(root, "development");
+
+    expect(applied).toEqual(["PRACHT_TEST_OTHER"]);
+    expect(process.env.NODE_ENV).toBe(before);
+  });
+
+  it("honours the requested mode rather than NODE_ENV", () => {
+    touchedKeys.push("PRACHT_TEST_TARGET");
+    const root = createRoot({
+      ".env.development": "PRACHT_TEST_TARGET=dev\n",
+      ".env.production": "PRACHT_TEST_TARGET=prod\n",
+    });
+    const previousNodeEnv = process.env.NODE_ENV;
+    process.env.NODE_ENV = "production";
+
+    try {
+      loadDotEnvIntoProcess(root, "development");
+      expect(process.env.PRACHT_TEST_TARGET).toBe("dev");
+    } finally {
+      if (previousNodeEnv === undefined) delete process.env.NODE_ENV;
+      else process.env.NODE_ENV = previousNodeEnv;
+    }
+  });
+
+  it("lets .env.local win over .env", () => {
+    touchedKeys.push("PRACHT_TEST_LAYERED");
+    const root = createRoot({
+      ".env": "PRACHT_TEST_LAYERED=base\n",
+      ".env.local": "PRACHT_TEST_LAYERED=local\n",
+    });
+
+    loadDotEnvIntoProcess(root, "development");
+
+    expect(process.env.PRACHT_TEST_LAYERED).toBe("local");
+  });
+
+  it("returns nothing when there is no .env file", () => {
+    expect(loadDotEnvIntoProcess(createRoot({}), "development")).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

- Vite reads `.env` files but only exposes prefixed keys through `import.meta.env` — it never writes to `process.env`. Server-side code reads `process.env` (that is what `serverEnv` resolves to on Node and Vercel), so **an unprefixed secret in `.env` was simply invisible**. Writing `PRACHT_CONFIRMATION_SECRET` into the file the scaffold's own `.gitignore` already anticipates had no effect, and a destructive capability answered `confirmation_unavailable` with the value sitting right there.
- Wrangler already does this for Cloudflare apps (`Using secrets defined in .env`), so the identical project behaved differently depending on the adapter — which is how this was found.

Deliberately narrow, because this mutates global process state:

- **Dev only.** `pracht build` and the production server still leave the environment to the platform.
- **Mode is passed explicitly** as `"development"` rather than derived from `NODE_ENV`. Vite's dev server is always mode `development` whatever `NODE_ENV` says, so deriving it would load `.env.production` into a dev server whenever `NODE_ENV=production` is exported — putting production credentials in front of loaders *and* baking the production `PRACHT_PUBLIC_` values into the dev client bundle.
- **`NODE_ENV` is never assigned from the file.** Vite refuses `NODE_ENV=production` in `.env` on purpose and only honours `development`; assigning it first would run ahead of that guard and silently flip the dev server to `isProduction: true` with no warning.
- **It runs before the port is resolved**, so a `PORT` in `.env` is honoured rather than half-applied (the dev server on 3000 while app code reads 8080).
- Real environment variables win over the file, and `.env.local` beats `.env.development` beats `.env` — Vite's own precedence, inherited from `loadEnv`.

**`verify` and `doctor` deliberately do not read `.env`.** They report on the environment a *deployment* will have, so a destructive capability whose secret lives only in `.env` is still an error — dev will work, production would fail closed. The message now says where the value has to live instead of just naming the variable.

## Testing

- [x] `pnpm run verify` (build, format, lint, typecheck, test, e2e)

Six helper tests (precedence, real-env-wins, `NODE_ENV` never assigned, mode honoured over `NODE_ENV`, `.env.local` layering, no-file) plus a `pracht dev` **call-site** test that spawns the real CLI and asserts the value is visible to the process Vite runs in.

Adversarial review found seven issues in the first version, including three severe ones this PR now avoids: `.env.production` contaminating a dev server via `NODE_ENV`, `NODE_ENV` from the file defeating Vite's guard, and — because `runVerification` was also mutating `process.env` — the long-lived `pracht mcp` server permanently retaining the first project's secrets and false-passing a second project's destructive-capability check on them. That is why verification no longer loads `.env` at all. It also caught that the original tests covered the helper but not either call site, and that a `MODE`/`BASE_URL` filter was both incorrectly justified and actively dropping legitimate keys.

## Checklist

- [x] Docs updated if needed — `docs/ENV.md` gains a `.env` files section covering precedence and the dev/verify split
- [ ] Skills updated if needed — N/A
- [x] Changeset added if published packages changed — `.changeset/dev-dotenv.md` (`@pracht/cli` patch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)