### PR TITLE
fix: dogfooding polish (dev server, MCP, CLI, scaffold)

### DIFF
--- a/.changeset/dogfood-polish.md
+++ b/.changeset/dogfood-polish.md
@@ -1,0 +1,46 @@
+---
+"@pracht/core": patch
+"@pracht/vite-plugin": patch
+"@pracht/cli": patch
+"create-pracht": patch
+---
+
+A batch of smaller fixes found while dogfooding the framework end to end.
+
+- **Dev server no longer injects the Vite client into non-HTML responses.** A
+  missing `content-type` was treated as `text/html`, so `transformIndexHtml`
+  ran over bodiless responses — an MCP `notifications/*` 202 came back with
+  `<script type="module" src="/@vite/client">` as its body, and so did
+  redirects. Production was unaffected.
+- **The remote MCP endpoint reports the negotiated protocol version.** Every
+  JSON-RPC response stamped `mcp-protocol-version` with the newest version the
+  server supports, so a client that initialized at an older version was told
+  the connection speaks one it never agreed to.
+- **`pracht plan`, `report`, and `verify --changed` no longer leak git's
+  stderr.** Outside a git repository — which is what `create-pracht --no-git`
+  produces — `fatal: not a git repository` printed above each command's own,
+  much better, explanation.
+- **`pracht inspect` reports `hydration=full` instead of `hydration=n/a`** for
+  routes that use the default, and the `pracht dev` route table gains a
+  HYDRATION column when at least one route opts out — `/islands` and `/static`
+  were previously indistinguishable from a fully hydrated route in the table
+  whose job is to say what runs where.
+- **Scaffolded READMEs list the build command**, and bun scaffolds say
+  `bun run build`. Every adapter's README covered install/dev/typecheck/
+  preview/start but not `build` — and `bun build` is Bun's own bundler, which
+  shadows the package script (unlike `bun dev` / `bun start` / `bun preview`,
+  which fall through to it). `AGENTS.md` had the same collision.
+- **The generated `.mcp.json` invokes `@pracht/cli`.** It ran `npx pracht mcp`,
+  which resolves to a registry package literally named `pracht` whenever the
+  local bin is not on the path.
+
+Documentation, for behaviour that is working as intended but was undocumented:
+
+- `docs/API_VALIDATION.md` notes that API routes and capabilities use different
+  error envelopes (and different `path` encodings), which an agent calling both
+  surfaces of one app has to handle.
+- `docs/ADAPTERS.md` documents Cloudflare's trailing-slash redirect on
+  prerendered nested routes, which makes canonical URLs differ from Node.
+- `docs/ROUTING.md` lists what the pages router does not have — middleware,
+  named shells, capabilities (and therefore WebMCP, remote MCP, and
+  `pracht eval`), constraints, and `agents`.

--- a/docs/ADAPTERS.md
+++ b/docs/ADAPTERS.md
@@ -371,6 +371,17 @@ With the option on:
   key, so SSR pages (including authenticated ones) and API GET responses
   would be edge-cached across users.
 
+#### Trailing slashes
+
+The assets binding's default `html_handling` redirects a prerendered nested
+route to its trailing-slash form: `GET /guide` answers `307 → /guide/` on
+Cloudflare where Node answers `200`. That makes the canonical URL of every
+prerendered nested route differ between adapters, and the generated `llms.txt`
+emits the non-slash form, so an agent following it takes a redirect on
+Cloudflare only. Set `assets.html_handling` in `wrangler.jsonc` (for example
+`"none"` alongside your own routing, or `"drop-trailing-slash"`) when you need
+one canonical form across adapters.
+
 #### Cache-key cardinality
 
 Workers Caching keys inbound requests by the exact path and query string.

--- a/docs/API_VALIDATION.md
+++ b/docs/API_VALIDATION.md
@@ -19,6 +19,14 @@ Each piece degrades gracefully: `defineApi` works without typegen (runtime
 validation only), and `apiFetch` works without registered types (every path
 accepted, payloads `unknown`).
 
+> **API routes and capabilities use different error envelopes.** A `defineApi`
+> validation failure answers `{ "error": "validation", "issues": [{ "in", "path",
+> "message" }] }` with `path` as an array of segments. A
+> [capability](CAPABILITIES.md) answers the typed
+> `{ "ok": false, "error": { "code": "invalid_input", "issues": [{ "path", "message" }] } }`
+> with `path` as a JSON pointer. An agent that calls both surfaces of one app
+> has to handle both shapes.
+
 ---
 
 ## Validated Routes with `defineApi()`

--- a/docs/ROUTING.md
+++ b/docs/ROUTING.md
@@ -639,6 +639,23 @@ Next.js), pracht offers an optional pages-based routing mode. Instead of writing
 a route manifest in `src/routes.ts`, you set a `pagesDir` option and pracht
 auto-discovers routes from the file system.
 
+### What the pages router does not have
+
+Auto-discovery replaces the manifest, and several features are registered
+*through* that manifest — so they are unavailable in `pagesDir` mode:
+
+| Feature | Pages router |
+| --- | --- |
+| Render + hydration modes, dynamic and catch-all routes, `getStaticPaths`, API routes | ✅ (`RENDER_MODE` / `HYDRATION` exports) |
+| Shells | one, `_app.tsx` — no named shells or per-route assignment |
+| Middleware | ❌ no registration seam |
+| [Capabilities](CAPABILITIES.md) | ❌ — and therefore no capability HTTP endpoints, no WebMCP, no remote MCP, no `pracht eval` |
+| `defineApp({ constraints })`, `agents` | ❌ |
+
+If you start with the pages router and later need any of these, you can eject
+to an explicit manifest with `generateRoutesFile` — see [Ejecting to Explicit
+Manifest](#ejecting-to-explicit-manifest).
+
 ### Setup
 
 ```typescript

--- a/packages/cli/src/commands/inspect.ts
+++ b/packages/cli/src/commands/inspect.ts
@@ -130,14 +130,14 @@ function printInspectReport(report: InspectReport): void {
     console.log("\nRoutes");
     for (const route of report.routes) {
       console.log(
-        `  ${route.path}  id=${route.id}  render=${route.render ?? "n/a"}  hydration=${route.hydration ?? "n/a"}  file=${route.file}`,
+        `  ${route.path}  id=${route.id}  render=${route.render ?? "n/a"}  hydration=${route.hydration ?? "full"}  file=${route.file}`,
       );
     }
 
     console.log("\nNot found page");
     console.log(
       report.notFound
-        ? `  ${report.notFound.path}  shell=${report.notFound.shell ?? "n/a"}  hydration=${report.notFound.hydration ?? "n/a"}  file=${report.notFound.file}`
+        ? `  ${report.notFound.path}  shell=${report.notFound.shell ?? "n/a"}  hydration=${report.notFound.hydration ?? "full"}  file=${report.notFound.file}`
         : "  None declared — unmatched URLs return a plain-text 404.",
     );
   }

--- a/packages/cli/src/dev-banner.ts
+++ b/packages/cli/src/dev-banner.ts
@@ -5,7 +5,10 @@ import type { AppGraphApiRoute, AppGraphRoute } from "./app-graph.js";
 export interface DevBannerRoute extends Pick<
   AppGraphRoute,
   "middleware" | "path" | "render" | "shell"
-> {}
+> {
+  // Optional: only set when a route opts out of the default full hydration.
+  hydration?: AppGraphRoute["hydration"];
+}
 
 export interface DevBannerApiRoute extends Pick<AppGraphApiRoute, "methods" | "path"> {}
 
@@ -86,23 +89,32 @@ export function formatDevBanner(options: DevBannerOptions): string {
   } else {
     // The not-found page is listed after the routes it can never shadow: its
     // "path" is a label, not a pattern, so it is excluded from the count.
-    const rows = [...routes, ...(notFound ? [notFound] : [])].map((route) => [
+    const allRoutes = [...routes, ...(notFound ? [notFound] : [])];
+    // Only worth a column when some route actually opts out of full hydration:
+    // otherwise `/islands` and `/static` are indistinguishable from every other
+    // route in the table that tells you what runs where.
+    const showHydration = allRoutes.some((route) => route.hydration && route.hydration !== "full");
+    const rows = allRoutes.map((route) => [
       route.path,
       route.render ?? "ssr",
+      ...(showHydration ? [route.hydration ?? "full"] : []),
       route.shell ?? "-",
       route.middleware.length > 0 ? route.middleware.join(", ") : "-",
     ]);
-    const header = ["ROUTE", "MODE", "SHELL", "MIDDLEWARE"];
+    const header = [
+      "ROUTE",
+      "MODE",
+      ...(showHydration ? ["HYDRATION"] : []),
+      "SHELL",
+      "MIDDLEWARE",
+    ];
     const widths = columnWidths([header, ...rows]);
     lines.push(`    ${paint(formatRow(header, widths), ANSI.dim)}`);
     for (const row of rows) {
-      const [path, mode, shell, middleware] = row;
-      const cells = [
-        path.padEnd(widths[0]),
-        paint(mode.padEnd(widths[1]), MODE_COLORS[mode] ?? ANSI.dim),
-        shell.padEnd(widths[2]),
-        middleware,
-      ];
+      const cells = row.map((cell, index) => {
+        const padded = index === row.length - 1 ? cell : cell.padEnd(widths[index]);
+        return index === 1 ? paint(padded, MODE_COLORS[cell] ?? ANSI.dim) : padded;
+      });
       lines.push(`    ${cells.join("  ")}`.trimEnd());
     }
   }

--- a/packages/cli/src/graph-snapshot.ts
+++ b/packages/cli/src/graph-snapshot.ts
@@ -107,8 +107,12 @@ export function readGraphSnapshotFromDisk(root: string): GraphSnapshot | null {
 /** Read the committed snapshot at a git ref, or null when absent/unreadable. */
 export function readGraphSnapshotFromRef(root: string, ref: string): GraphSnapshot | null {
   try {
+    // stderr silenced: outside a git repo this prints `fatal: not a git
+    // repository` straight to the user's terminal before the caller has a
+    // chance to explain that a missing baseline is fine.
     const prefix = execFileSync("git", ["-C", root, "rev-parse", "--show-prefix"], {
       encoding: "utf-8",
+      stdio: ["ignore", "pipe", "ignore"],
     }).trim();
     const contents = execFileSync(
       "git",

--- a/packages/cli/src/verification-scope.ts
+++ b/packages/cli/src/verification-scope.ts
@@ -11,18 +11,26 @@ import {
 } from "./verification-helpers.js";
 
 export function collectChangedFiles(root: string): { files: string[]; warning: string | null } {
+  // stderr silenced throughout: outside a git repo these print `fatal: not a
+  // git repository` straight to the user's terminal, ahead of the warning below
+  // that explains the situation properly.
+  const git = {
+    encoding: "utf-8" as const,
+    stdio: ["ignore", "pipe", "ignore"] as ("ignore" | "pipe")[],
+  };
+
   try {
     const repoRoot = execFileSync("git", ["rev-parse", "--show-toplevel"], {
       cwd: root,
-      encoding: "utf-8",
+      ...git,
     }).trim();
     const prefix = execFileSync("git", ["rev-parse", "--show-prefix"], {
       cwd: root,
-      encoding: "utf-8",
+      ...git,
     }).trim();
     const output = execFileSync("git", ["status", "--porcelain", "--untracked-files=all"], {
       cwd: repoRoot,
-      encoding: "utf-8",
+      ...git,
     });
     const files = new Set<string>();
 

--- a/packages/cli/test/dev-banner.test.ts
+++ b/packages/cli/test/dev-banner.test.ts
@@ -173,6 +173,31 @@ describe("formatDevBanner", () => {
     expect(banner).toContain("Capabilities (0)  MCP endpoint /mcp");
     expect(banner).toContain("    (none)");
   });
+  it("adds a hydration column only when a route opts out of full hydration", () => {
+    const withoutIslands = formatDevBanner({
+      apiRoutes: [],
+      color: false,
+      localUrls: ["http://localhost:3000/"],
+      routes: [{ middleware: [], path: "/", render: "ssg", shell: "public" }],
+    });
+    expect(withoutIslands).not.toContain("HYDRATION");
+
+    const withIslands = formatDevBanner({
+      apiRoutes: [],
+      color: false,
+      localUrls: ["http://localhost:3000/"],
+      routes: [
+        { middleware: [], path: "/", render: "ssg", shell: "public" },
+        { hydration: "islands", middleware: [], path: "/islands", render: "ssg", shell: "public" },
+        { hydration: "none", middleware: [], path: "/static", render: "ssg", shell: "public" },
+      ],
+    });
+    expect(withIslands).toContain("HYDRATION");
+    expect(withIslands).toMatch(/\/islands\s+ssg\s+islands/);
+    expect(withIslands).toMatch(/\/static\s+ssg\s+none/);
+    // A route that never opted out still reads as what it is.
+    expect(withIslands).toMatch(/\/\s+ssg\s+full/);
+  });
 });
 
 describe("supportsColor", () => {

--- a/packages/framework/src/runtime-mcp.ts
+++ b/packages/framework/src/runtime-mcp.ts
@@ -107,8 +107,7 @@ export interface HandleMcpRequestOptions<TContext> {
 /**
  * Handle one request to the MCP endpoint. Always resolves — protocol problems
  * become JSON-RPC errors, capability problems become tool errors.
- */
-export async function handleMcpRequest<TContext>(
+ */ export async function handleMcpRequest<TContext>(
   options: HandleMcpRequestOptions<TContext>,
 ): Promise<Response> {
   const { request } = options;
@@ -147,8 +146,18 @@ export async function handleMcpRequest<TContext>(
   }
 
   const declaredVersion = request.headers.get(MCP_PROTOCOL_VERSION_HEADER);
+  // Clients send the negotiated version on every request after initialize;
+  // before that (and on the initialize call itself) the newest supported
+  // version is the honest answer until `initialize` narrows it below.
+  let activeVersion =
+    declaredVersion && isSupportedProtocolVersion(declaredVersion)
+      ? declaredVersion
+      : MCP_LATEST_PROTOCOL_VERSION;
+  const respond = (status: number, payload: unknown): Response =>
+    jsonRpcResponse(status, activeVersion, payload);
+
   if (declaredVersion && !isSupportedProtocolVersion(declaredVersion)) {
-    return jsonRpcResponse(400, {
+    return respond(400, {
       jsonrpc: "2.0",
       id: null,
       error: {
@@ -161,7 +170,7 @@ export async function handleMcpRequest<TContext>(
   }
 
   if (!acceptsJson(request)) {
-    return jsonRpcResponse(406, {
+    return respond(406, {
       jsonrpc: "2.0",
       id: null,
       error: { code: JSONRPC_INVALID_REQUEST, message: "Client must accept application/json." },
@@ -172,7 +181,7 @@ export async function handleMcpRequest<TContext>(
   try {
     payload = JSON.parse(await request.text());
   } catch {
-    return jsonRpcResponse(400, {
+    return respond(400, {
       jsonrpc: "2.0",
       id: null,
       error: { code: JSONRPC_PARSE_ERROR, message: "Parse error." },
@@ -182,7 +191,7 @@ export async function handleMcpRequest<TContext>(
   // JSON-RPC batching was removed from MCP; reject it rather than
   // half-supporting it.
   if (Array.isArray(payload)) {
-    return jsonRpcResponse(400, {
+    return respond(400, {
       jsonrpc: "2.0",
       id: null,
       error: { code: JSONRPC_INVALID_REQUEST, message: "JSON-RPC batching is not supported." },
@@ -196,7 +205,7 @@ export async function handleMcpRequest<TContext>(
     params?: unknown;
   };
   if (message?.jsonrpc !== "2.0" || typeof message.method !== "string") {
-    return jsonRpcResponse(400, {
+    return respond(400, {
       jsonrpc: "2.0",
       id: null,
       error: { code: JSONRPC_INVALID_REQUEST, message: "Invalid JSON-RPC 2.0 request." },
@@ -209,7 +218,7 @@ export async function handleMcpRequest<TContext>(
     return new Response(null, { status: 202 });
   }
   if (typeof message.id !== "string" && typeof message.id !== "number") {
-    return jsonRpcResponse(400, {
+    return respond(400, {
       jsonrpc: "2.0",
       id: null,
       error: { code: JSONRPC_INVALID_REQUEST, message: "Invalid JSON-RPC 2.0 request id." },
@@ -222,7 +231,7 @@ export async function handleMcpRequest<TContext>(
       options.exposeErrors && options.resolutionError instanceof Error
         ? `: ${options.resolutionError.message}`
         : ".";
-    return jsonRpcResponse(200, {
+    return respond(200, {
       jsonrpc: "2.0",
       id,
       error: {
@@ -237,7 +246,7 @@ export async function handleMcpRequest<TContext>(
     (entry) => !isValidMcpToolName(mcpToolName(entry.name)),
   );
   if (invalidToolNames.length > 0) {
-    return jsonRpcResponse(200, {
+    return respond(200, {
       jsonrpc: "2.0",
       id,
       error: {
@@ -253,7 +262,7 @@ export async function handleMcpRequest<TContext>(
   if (collisions.length > 0) {
     // `pracht verify` reports this at build time; refuse to serve an
     // ambiguous tool list rather than picking a winner at random.
-    return jsonRpcResponse(200, {
+    return respond(200, {
       jsonrpc: "2.0",
       id,
       error: {
@@ -271,7 +280,7 @@ export async function handleMcpRequest<TContext>(
     case "initialize": {
       const params = readInitializeParams(message.params);
       if (!params) {
-        return jsonRpcResponse(200, {
+        return respond(200, {
           jsonrpc: "2.0",
           id,
           error: {
@@ -281,11 +290,12 @@ export async function handleMcpRequest<TContext>(
           },
         });
       }
-      return jsonRpcResponse(200, {
+      activeVersion = negotiateProtocolVersion(params.protocolVersion);
+      return respond(200, {
         jsonrpc: "2.0",
         id,
         result: {
-          protocolVersion: negotiateProtocolVersion(params.protocolVersion),
+          protocolVersion: activeVersion,
           capabilities: { tools: { listChanged: false } },
           serverInfo: options.mcp.serverInfo ?? { name: "pracht", version: "0.0.0" },
           instructions: options.mcp.instructions,
@@ -294,20 +304,20 @@ export async function handleMcpRequest<TContext>(
     }
 
     case "ping":
-      return jsonRpcResponse(200, { jsonrpc: "2.0", id, result: {} });
+      return respond(200, { jsonrpc: "2.0", id, result: {} });
 
     case "tools/list":
-      return jsonRpcResponse(200, {
+      return respond(200, {
         jsonrpc: "2.0",
         id,
         result: { tools: mcpExposedCapabilities(options.capabilities).map(toolDescriptor) },
       });
 
     case "tools/call":
-      return handleToolsCall(options, id, message.params);
+      return handleToolsCall(options, id, message.params, activeVersion);
 
     default:
-      return jsonRpcResponse(200, {
+      return respond(200, {
         jsonrpc: "2.0",
         id,
         error: {
@@ -321,7 +331,6 @@ export async function handleMcpRequest<TContext>(
 // ---------------------------------------------------------------------------
 // tools/list
 // ---------------------------------------------------------------------------
-
 function toolDescriptor(entry: ResolvedCapability) {
   const { capability } = entry;
   return {
@@ -352,6 +361,10 @@ async function handleToolsCall<TContext>(
   options: HandleMcpRequestOptions<TContext>,
   id: string | number,
   rawParams: unknown,
+  // Threaded rather than defaulted: `tools/call` is the method that does the
+  // work, so it is the one that most needs to agree with the version the
+  // client negotiated.
+  protocolVersion: string,
 ): Promise<Response> {
   const params = (rawParams ?? {}) as {
     name?: unknown;
@@ -360,7 +373,7 @@ async function handleToolsCall<TContext>(
   };
 
   if (typeof params.name !== "string") {
-    return jsonRpcResponse(200, {
+    return jsonRpcResponse(200, protocolVersion, {
       jsonrpc: "2.0",
       id,
       error: { code: JSONRPC_INVALID_PARAMS, message: "tools/call requires a string `name`." },
@@ -370,7 +383,7 @@ async function handleToolsCall<TContext>(
     params.arguments !== undefined &&
     (!params.arguments || typeof params.arguments !== "object" || Array.isArray(params.arguments))
   ) {
-    return jsonRpcResponse(200, {
+    return jsonRpcResponse(200, protocolVersion, {
       jsonrpc: "2.0",
       id,
       error: {
@@ -384,7 +397,7 @@ async function handleToolsCall<TContext>(
   const match = exposed.find((entry) => mcpToolName(entry.name) === params.name);
   if (!match) {
     // An unknown tool is a protocol-level error, not a tool execution failure.
-    return jsonRpcResponse(200, {
+    return jsonRpcResponse(200, protocolVersion, {
       jsonrpc: "2.0",
       id,
       error: {
@@ -441,7 +454,7 @@ async function handleToolsCall<TContext>(
     };
   }
 
-  return jsonRpcResponse(200, {
+  return jsonRpcResponse(200, protocolVersion, {
     jsonrpc: "2.0",
     id,
     result: toolResult(match, envelope, response.status),
@@ -593,12 +606,15 @@ function isNonBrowserRequest(request: Request): boolean {
   return !request.headers.has("origin") && !request.headers.has("sec-fetch-site");
 }
 
-function jsonRpcResponse(status: number, body: unknown): Response {
+function jsonRpcResponse(status: number, protocolVersion: string, body: unknown): Response {
   return new Response(JSON.stringify(body), {
     status,
     headers: {
       "content-type": "application/json; charset=utf-8",
-      [MCP_PROTOCOL_VERSION_HEADER]: MCP_LATEST_PROTOCOL_VERSION,
+      // The negotiated version, not simply the newest one we support: a client
+      // that initialized at an older version should not be told the connection
+      // is speaking a version it never agreed to.
+      [MCP_PROTOCOL_VERSION_HEADER]: protocolVersion,
     },
   });
 }

--- a/packages/framework/test/remote-mcp.test.ts
+++ b/packages/framework/test/remote-mcp.test.ts
@@ -14,7 +14,12 @@ import {
   route,
   setCapabilityAuditHook,
 } from "../src/index.ts";
-import { MCP_PROTOCOL_VERSION_HEADER, resolveMcpEndpoint } from "../src/runtime-mcp.ts";
+import {
+  MCP_LATEST_PROTOCOL_VERSION,
+  MCP_PROTOCOL_VERSION_HEADER,
+  MCP_PROTOCOL_VERSIONS,
+  resolveMcpEndpoint,
+} from "../src/runtime-mcp.ts";
 import type { CapabilityAuditEvent, ModuleRegistry, PrachtAgentsConfig } from "../src/types.ts";
 
 const ORIGIN = "https://app.example";
@@ -785,5 +790,74 @@ describe("destructive capabilities stay off the MCP surface", () => {
     };
 
     expect(mcpExposedCapabilities([smuggled as never])).toEqual([]);
+  });
+});
+
+describe("mcp protocol version header", () => {
+  it("reports the negotiated version, not simply the newest supported one", async () => {
+    const older = MCP_PROTOCOL_VERSIONS[MCP_PROTOCOL_VERSIONS.length - 1]!;
+    expect(older).not.toBe(MCP_LATEST_PROTOCOL_VERSION);
+
+    const { response, json } = await mcp({
+      jsonrpc: "2.0",
+      id: 1,
+      method: "initialize",
+      params: {
+        protocolVersion: older,
+        capabilities: {},
+        clientInfo: { name: "probe", version: "1" },
+      },
+    });
+
+    expect(json?.result.protocolVersion).toBe(older);
+    // A client that initialized at an older version must not be told the
+    // connection is speaking a version it never agreed to.
+    expect(response.headers.get(MCP_PROTOCOL_VERSION_HEADER)).toBe(older);
+  });
+
+  it("echoes the version a later request declares", async () => {
+    const older = MCP_PROTOCOL_VERSIONS[MCP_PROTOCOL_VERSIONS.length - 1]!;
+
+    const { response } = await mcp(
+      { jsonrpc: "2.0", id: 2, method: "tools/list" },
+      { headers: { [MCP_PROTOCOL_VERSION_HEADER]: older } },
+    );
+
+    expect(response.headers.get(MCP_PROTOCOL_VERSION_HEADER)).toBe(older);
+  });
+
+  it("reports the negotiated version on tools/call, not just the handshake", async () => {
+    // The method that actually does work is the one most worth getting right,
+    // and it lives outside the request-scoped responder.
+    const older = MCP_PROTOCOL_VERSIONS[MCP_PROTOCOL_VERSIONS.length - 1]!;
+
+    const { response } = await mcp(
+      {
+        jsonrpc: "2.0",
+        id: 4,
+        method: "tools/call",
+        params: { name: "notes_search", arguments: { query: "a" } },
+      },
+      { headers: { [MCP_PROTOCOL_VERSION_HEADER]: older } },
+    );
+
+    expect(response.headers.get(MCP_PROTOCOL_VERSION_HEADER)).toBe(older);
+  });
+
+  it("reports the negotiated version on a tools/call error", async () => {
+    const older = MCP_PROTOCOL_VERSIONS[MCP_PROTOCOL_VERSIONS.length - 1]!;
+
+    const { response } = await mcp(
+      { jsonrpc: "2.0", id: 5, method: "tools/call", params: { name: "nope", arguments: {} } },
+      { headers: { [MCP_PROTOCOL_VERSION_HEADER]: older } },
+    );
+
+    expect(response.headers.get(MCP_PROTOCOL_VERSION_HEADER)).toBe(older);
+  });
+
+  it("falls back to the newest supported version when none is declared", async () => {
+    const { response } = await mcp({ jsonrpc: "2.0", id: 3, method: "tools/list" });
+
+    expect(response.headers.get(MCP_PROTOCOL_VERSION_HEADER)).toBe(MCP_LATEST_PROTOCOL_VERSION);
   });
 });

--- a/packages/start/src/index.js
+++ b/packages/start/src/index.js
@@ -672,7 +672,9 @@ function createMcpConfig() {
       mcpServers: {
         pracht: {
           command: "npx",
-          args: ["pracht", "mcp"],
+          // Not `npx pracht`: that resolves to a registry package literally
+          // named `pracht` whenever the local bin is not on the path.
+          args: ["--yes", "@pracht/cli", "mcp"],
         },
       },
     },
@@ -1097,7 +1099,10 @@ function createDockerignore() {
 }
 
 function createAgentInstructions({ adapter, agentTools, packageManager, router, tailwind }) {
-  const runCmd = packageManager === "npm" ? "npm run" : packageManager;
+  // `bun build` is Bun's own bundler and shadows the package script, so bun
+  // needs the explicit `run` form the same way npm does.
+  const runCmd =
+    packageManager === "npm" || packageManager === "bun" ? `${packageManager} run` : packageManager;
 
   const lines = [
     "# Pracht App",
@@ -1196,6 +1201,12 @@ function createAgentInstructions({ adapter, agentTools, packageManager, router, 
 function createReadme({ adapter, agentTools, packageManager, projectName, router, tailwind }) {
   const installCommand = packageManager === "npm" ? "npm install" : `${packageManager} install`;
   const devCommand = packageManager === "npm" ? "npm run dev" : `${packageManager} dev`;
+  // `bun build` is Bun's own bundler and shadows the package script, unlike
+  // `bun dev` / `bun start` / `bun preview`, which fall through to it.
+  const buildCommand =
+    packageManager === "npm" || packageManager === "bun"
+      ? `${packageManager} run build`
+      : `${packageManager} build`;
   const previewCommand = packageManager === "npm" ? "npm run preview" : `${packageManager} preview`;
   const startCommand = packageManager === "npm" ? "npm run start" : `${packageManager} start`;
   const deployCommand = packageManager === "npm" ? "npm run deploy" : `${packageManager} deploy`;
@@ -1211,6 +1222,7 @@ function createReadme({ adapter, agentTools, packageManager, projectName, router
     "",
     `- \`${installCommand}\``,
     `- \`${devCommand}\``,
+    `- \`${buildCommand}\``,
     `- \`${typecheckCommand}\``,
   ];
 

--- a/packages/start/test/index.test.js
+++ b/packages/start/test/index.test.js
@@ -98,6 +98,8 @@ describe("create-pracht", () => {
     expect(dockerfile).toContain('CMD ["node", "dist/server/server.js"]');
     expect(dockerignore).toContain("node_modules");
     expect(dockerignore).toContain(".env*");
+    // The build command was missing from every scaffold README.
+    expect(readme).toContain("pnpm build");
     expect(readme).toContain("docker build");
     expect(readme).toContain("pnpm typecheck");
     expect(readme).toContain("`pracht verify` validates routes and constraints.");
@@ -480,7 +482,9 @@ describe("create-pracht", () => {
     const mcpConfig = JSON.parse(await readFile(join(targetDir, ".mcp.json"), "utf-8"));
     expect(mcpConfig.mcpServers.pracht).toEqual({
       command: "npx",
-      args: ["pracht", "mcp"],
+      // Not `npx pracht`: that resolves to a registry package literally named
+      // `pracht` whenever the local bin is not on the path.
+      args: ["--yes", "@pracht/cli", "mcp"],
     });
 
     const skillFile = join(targetDir, ".claude/skills/add-auth/SKILL.md");

--- a/packages/vite-plugin/src/plugin-dev-ssr.ts
+++ b/packages/vite-plugin/src/plugin-dev-ssr.ts
@@ -157,7 +157,12 @@ export function createDevSSRMiddleware(
         return next();
       }
 
-      const contentType = response.headers.get("content-type") ?? "text/html";
+      // Only transform what actually is HTML. Defaulting a missing
+      // content-type to `text/html` made Vite inject its client script into
+      // bodiless responses — an MCP `notifications/*` 202 came back with
+      // `<script type="module" src="/@vite/client">` as its body, and so did
+      // redirects.
+      const contentType = response.headers.get("content-type") ?? "";
       let body = await response.text();
 
       if (contentType.includes("text/html")) {


### PR DESCRIPTION
## Summary

The medium/low findings from the same dogfooding pass as #278–#286, batched. Each is independent; none needed a design decision.

**Fixes**

1. **Dev server injected the Vite client into non-HTML responses.** A missing `content-type` was treated as `text/html`, so `transformIndexHtml` ran over bodiless responses: an MCP `notifications/*` 202 came back with `<script type="module" src="/@vite/client">` as its body, and so did redirects. Production was unaffected.
2. **Remote MCP reported the wrong protocol version.** Every JSON-RPC response stamped `mcp-protocol-version` with the newest version the server supports, so a client that initialized at `2025-06-18` was told the connection speaks `2025-11-25`. Now the negotiated version — including on `tools/call`, which lives outside the request-scoped responder and was the one path the first revision of this PR missed.
3. **`plan`, `report`, and `verify --changed` leaked git's stderr.** Outside a git repository — exactly what `create-pracht --no-git` produces — `fatal: not a git repository` printed above each command's own, much better, explanation.
4. **Hydration was invisible.** `pracht inspect` reported `hydration=n/a` for routes using the default (the default is `full`), and the `pracht dev` route table had no hydration column at all — so `/islands` and `/static` looked identical to every other route in the table whose whole job is to say what runs where. The column appears only when some route opts out.
5. **Scaffold.** Every adapter's README covered install/dev/typecheck/preview/start but not `build`; and `bun build` is Bun's own bundler, which shadows the package script (unlike `bun dev`/`start`/`preview`, which fall through) — so bun scaffolds now say `bun run build`, in the README and in `AGENTS.md`. The generated `.mcp.json` ran `npx pracht mcp`, which resolves to a registry package literally named `pracht` whenever the local bin is not on the path; `npm view pracht` is a 404, so that fails outright.

**Docs** — behaviour that is intended but was undocumented, and cost real time to discover:

- `docs/API_VALIDATION.md`: API routes and capabilities use different error envelopes *and* different `path` encodings (array segments vs JSON pointer). An agent calling both surfaces of one app has to handle both.
- `docs/ADAPTERS.md`: Cloudflare's assets binding redirects `GET /guide` → `307 /guide/` where Node answers 200, so canonical URLs differ per adapter — and `llms.txt` emits the non-slash form.
- `docs/ROUTING.md`: a table of what the pages router does not have (middleware, named shells, capabilities — and therefore WebMCP, remote MCP and `pracht eval` — constraints, and `agents`), since `README.md` presents it as a peer option.

## Testing

- [x] `pnpm run verify` (build, format, lint, typecheck, test, e2e)

Five MCP version tests (initialize negotiation, declared-header echo, `tools/call` success and error, and the no-header fallback) and a dev-banner test covering both column layouts.

Adversarial review verified every doc claim against live apps rather than the code comments — both error envelopes reproduced byte-for-byte, the Cloudflare 307 reproduced under `wrangler dev` along with the documented `html_handling` remedy, and every row of the pages-router table traced to the code that enforces it. It confirmed item 1 causes no HMR regression (the devtools page, dev 404, and error overlay call `transformIndexHtml` directly and never route through the changed line). It found three defects — `tools/call` still stamping the latest version with tests shaped to miss it, the `bun build` collision, and `verify --changed` still leaking git stderr — all fixed here.

## Checklist

- [x] Docs updated if needed — `docs/API_VALIDATION.md`, `docs/ADAPTERS.md`, `docs/ROUTING.md`
- [ ] Skills updated if needed — N/A
- [x] Changeset added if published packages changed — `.changeset/dogfood-polish.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)