### PR TITLE
fix: replace stale prerendered markup for all client-only initial search errors

### DIFF
--- a/.changeset/stale-hydration-fallback.md
+++ b/.changeset/stale-hydration-fallback.md
@@ -1,0 +1,5 @@
+---
+"@pracht/core": patch
+---
+
+Replace stale prerendered markup for every client-only initial search error, not just the unhandled fallback. Hydrating an error boundary whose root differs from the prerendered page, or committing the resolved state after a skipped SPA pending hydration, previously appended a second subtree instead of replacing the document. The first client render into an unclaimed root now clears server markup it cannot hydrate over; server-rendered error boundaries and successful hydration are unchanged.

--- a/docs/DATA_LOADING.md
+++ b/docs/DATA_LOADING.md
@@ -91,7 +91,8 @@ Routes without a schema receive `Record<string, string | string[]>`.
 Invalid search reaching the route runtime returns HTTP 400 and is handled by
 the route or shell `ErrorBoundary`. Prerendered SSG/ISG HTML has already been
 served with its static status; full hydration validates the visitor's query
-and renders the nearest boundary, or a plain error message when none exists.
+and replaces the prerendered content with the nearest boundary, or with a
+plain error message when none exists.
 
 The schema is isomorphic: full-hydration routes validate on the server and
 again from the browser's current URL, so keep schema code browser-safe and

--- a/examples/docs/src/routes/docs/data-loading.md
+++ b/examples/docs/src/routes/docs/data-loading.md
@@ -84,8 +84,8 @@ without a schema receive a raw `Record<string, string | string[]>`.
 Invalid search reaching the route runtime returns HTTP 400 and is handled by
 the nearest route or shell `ErrorBoundary`. Prerendered SSG/ISG HTML has already
 been served with its static status; full hydration validates the visitor's
-query and renders the nearest boundary, or a plain error message when none
-exists.
+query and replaces the prerendered content with the nearest boundary, or with
+a plain error message when none exists.
 
 The schema is isomorphic: full-hydration routes validate on the server and
 again from the browser's current URL, so keep schema code browser-safe and

--- a/packages/framework/src/router.ts
+++ b/packages/framework/src/router.ts
@@ -348,13 +348,32 @@ export async function initClientRouter(options: InitClientRouterOptions): Promis
     );
   }
 
+  // Preact owns `root` once it has rendered or hydrated into it. Before that,
+  // any children are server markup an initial render() would append to rather
+  // than replace — so every first commit into the root funnels through the two
+  // helpers below.
+  let rootClaimed = false;
+
+  function hydrateRouterRoot(routeState: RouteRenderState): void {
+    rootClaimed = true;
+    hydrate(h(RouterRoot, { initialState: routeState }), root);
+  }
+
+  function renderRouterRoot(routeState: RouteRenderState): void {
+    if (!rootClaimed && root.hasChildNodes()) {
+      root.replaceChildren();
+    }
+    rootClaimed = true;
+    render(h(RouterRoot, { initialState: routeState }), root);
+  }
+
   function applyRouteState(routeState: RouteRenderState): void {
     if (updateRouteState) {
       updateRouteState(routeState);
       return;
     }
 
-    render(h(RouterRoot, { initialState: routeState }), root);
+    renderRouterRoot(routeState);
   }
 
   async function resolveRouteState(
@@ -388,6 +407,12 @@ export async function initClientRouter(options: InitClientRouterOptions): Promis
     const routeError = state.error ? deserializeRouteError(state.error) : searchError;
     const ErrorBoundary = routeMod.ErrorBoundary ?? resolvedShell?.ErrorBoundary;
     const usesClientErrorFallback = routeError && !ErrorBoundary && renderUnhandledError;
+    // A server-sent error was rendered by the server, so boundary markup in
+    // the document matches and hydration is safe. A client-only search error
+    // means the document still holds the successful prerender — no error tree,
+    // boundary or not, can hydrate over it, so the initial commit must replace
+    // the document instead.
+    const clientOnlyError = searchError !== null && !state.error;
     const Component = (
       routeError
         ? (ErrorBoundary ?? (renderUnhandledError ? ClientRouteErrorFallback : undefined))
@@ -405,7 +430,9 @@ export async function initClientRouter(options: InitClientRouterOptions): Promis
       componentProps,
       data: state.data,
       params: match.params,
-      replaceDocument: Boolean(usesClientErrorFallback),
+      replaceDocument: Boolean(
+        usesClientErrorFallback || (renderUnhandledError && clientOnlyError),
+      ),
       routeId: match.route.id ?? "",
       search,
       url: currentUrl,
@@ -713,7 +740,7 @@ export async function initClientRouter(options: InitClientRouterOptions): Promis
         initialShellPromise,
       );
       if (pendingState) {
-        hydrate(h(RouterRoot, { initialState: pendingState }), root);
+        hydrateRouterRoot(pendingState);
       }
 
       try {
@@ -765,14 +792,11 @@ export async function initClientRouter(options: InitClientRouterOptions): Promis
         true,
       );
       if (initialRouteState) {
-        if (initialRouteState.replaceDocument) {
-          root.replaceChildren();
-          render(h(RouterRoot, { initialState: initialRouteState }), root);
-        } else if (initialMatch.route.render === "spa") {
-          render(h(RouterRoot, { initialState: initialRouteState }), root);
+        if (initialRouteState.replaceDocument || initialMatch.route.render === "spa") {
+          renderRouterRoot(initialRouteState);
         } else {
           markHydrating();
-          hydrate(h(RouterRoot, { initialState: initialRouteState }), root);
+          hydrateRouterRoot(initialRouteState);
         }
       }
     }

--- a/packages/framework/test/router-client.test.ts
+++ b/packages/framework/test/router-client.test.ts
@@ -181,6 +181,185 @@ describe("initClientRouter", () => {
     expect(root.textContent).toBe("Invalid search parameters: page: must be a positive integer");
   });
 
+  it("replaces prerendered content when a route boundary handles an invalid visitor search", async () => {
+    history.replaceState(null, "", "/products?page=nope");
+    root.innerHTML = "<main>prerendered default</main>";
+
+    const app = resolveApp(
+      defineApp({
+        routes: [route("/products", "./routes/products.tsx", { render: "ssg" })],
+      }),
+    );
+
+    await initClientRouter({
+      app,
+      routeModules: {
+        "./routes/products.tsx": async () => ({
+          search: {
+            "~standard": {
+              version: 1,
+              vendor: "test",
+              validate: () => ({
+                issues: [{ message: "must be a positive integer", path: ["page"] }],
+              }),
+            },
+          },
+          ErrorBoundary: ({ error }: { error: Error }) => h("section", null, error.message),
+          default: () => h("main", null, "products"),
+        }),
+      },
+      shellModules: {},
+      initialState: {
+        data: undefined,
+        routeId: "products",
+        url: "/products",
+      },
+      root,
+      findModuleKey: (_modules, file) => file,
+    });
+
+    // The prerendered <main> must be gone: hydrating a mismatched boundary
+    // root over it would append a second subtree instead of replacing it.
+    expect(root.querySelector("main")).toBeNull();
+    expect(root.textContent).toBe("Invalid search parameters: page: must be a positive integer");
+  });
+
+  it("replaces prerendered content when a shell boundary handles an invalid visitor search", async () => {
+    history.replaceState(null, "", "/products?page=nope");
+    root.innerHTML = '<div id="shell"><main>prerendered default</main></div>';
+
+    const app = resolveApp(
+      defineApp({
+        shells: { app: "./shells/app.tsx" },
+        routes: [route("/products", "./routes/products.tsx", { render: "ssg", shell: "app" })],
+      }),
+    );
+
+    await initClientRouter({
+      app,
+      routeModules: {
+        "./routes/products.tsx": async () => ({
+          search: {
+            "~standard": {
+              version: 1,
+              vendor: "test",
+              validate: () => ({
+                issues: [{ message: "must be a positive integer", path: ["page"] }],
+              }),
+            },
+          },
+          default: () => h("main", null, "products"),
+        }),
+      },
+      shellModules: {
+        "./shells/app.tsx": async () => ({
+          Shell: ({ children }: { children: ComponentChildren }) =>
+            h("div", { id: "shell" }, children),
+          ErrorBoundary: ({ error }: { error: Error }) => h("section", null, error.message),
+        }),
+      },
+      initialState: {
+        data: undefined,
+        routeId: "products",
+        url: "/products",
+      },
+      root,
+      findModuleKey: (_modules, file) => file,
+    });
+
+    expect(root.querySelectorAll("#shell")).toHaveLength(1);
+    expect(root.querySelector("main")).toBeNull();
+    expect(root.textContent).toBe("Invalid search parameters: page: must be a positive integer");
+  });
+
+  it("replaces the pending SPA document when the client rejects the visitor search", async () => {
+    history.replaceState(null, "", "/settings?page=nope");
+    root.innerHTML = "<section><p>Loading</p></section>";
+    fetchSpy.mockResolvedValue(createJsonResponse({ data: null }));
+
+    const app = resolveApp(
+      defineApp({
+        shells: { app: "./shells/app.tsx" },
+        routes: [route("/settings", "./routes/settings.tsx", { render: "spa", shell: "app" })],
+      }),
+    );
+
+    await initClientRouter({
+      app,
+      routeModules: {
+        "./routes/settings.tsx": async () => ({
+          search: {
+            "~standard": {
+              version: 1,
+              vendor: "test",
+              validate: () => ({
+                issues: [{ message: "must be a positive integer", path: ["page"] }],
+              }),
+            },
+          },
+          default: () => h("main", null, "Ready"),
+        }),
+      },
+      shellModules: {
+        "./shells/app.tsx": async () => ({
+          Shell: ({ children }: { children: ComponentChildren }) => h("section", null, children),
+          Loading: () => h("p", null, "Loading"),
+        }),
+      },
+      initialState: {
+        data: null,
+        pending: true,
+        routeId: "settings",
+        url: "/settings?page=nope",
+      },
+      root,
+      findModuleKey: (_modules, file) => file,
+    });
+
+    // Pending hydration is skipped on schema disagreement, so the resolved
+    // error state is Preact's first commit into a root that still holds the
+    // server's pending markup — it must replace, not append to it.
+    expect(root.querySelector("section")).toBeNull();
+    expect(root.textContent).toBe("Invalid search parameters: page: must be a positive integer");
+  });
+
+  it("hydrates server-rendered error boundaries without replacing the document", async () => {
+    history.replaceState(null, "", "/boom");
+    root.innerHTML = '<main id="boundary">loader exploded</main>';
+    const prerendered = root.querySelector("#boundary");
+
+    const app = resolveApp(
+      defineApp({
+        routes: [route("/boom", "./routes/boom.tsx", { id: "boom", render: "ssr" })],
+      }),
+    );
+
+    await initClientRouter({
+      app,
+      routeModules: {
+        "./routes/boom.tsx": async () => ({
+          ErrorBoundary: ({ error }: { error: Error }) =>
+            h("main", { id: "boundary" }, error.message),
+          default: () => h("main", null, "never"),
+        }),
+      },
+      shellModules: {},
+      initialState: {
+        data: null,
+        error: { message: "loader exploded", name: "Error", status: 500 },
+        routeId: "boom",
+        url: "/boom",
+      },
+      root,
+      findModuleKey: (_modules, file) => file,
+    });
+
+    // Server-sent errors were rendered by the server, so the boundary markup
+    // matches — the prerendered node must survive hydration untouched.
+    expect(root.querySelector("#boundary")).toBe(prerendered);
+    expect(root.textContent).toBe("loader exploded");
+  });
+
   it("hydrates SPA loading shells with validated search state", async () => {
     history.replaceState(null, "", "/settings?page=2");
     root.innerHTML = "<section><span>2</span><p>Loading</p></section>";


### PR DESCRIPTION
## Summary

- Stacked on #236. A browser regression investigation showed the stale-hydration fix there is incomplete: Preact appends a second subtree when hydrating a mismatched error tree over prerendered markup, and `replaceDocument` only covered the unhandled no-boundary fallback.
- Broadens `replaceDocument` to every client-only initial search error: a route or shell `ErrorBoundary` whose root differs from the prerendered page now gets a replacing client render instead of `hydrate()`. Server-sent errors keep hydrating, since the server rendered the matching boundary markup.
- Centralizes first commits into the root via `renderRouterRoot()`/`hydrateRouterRoot()`. The `render()` path clears server markup Preact never claimed, which also fixes the SPA-pending resolution: when pending hydration is skipped after a client/server schema disagreement, `applyRouteState()` previously appended to the unmanaged pending document.
- Adds the missing coverage: route-boundary root mismatch, shell-boundary handling, the skipped-pending SPA path, and a node-identity regression guard that server-rendered error boundaries still hydrate in place. The route-boundary and SPA-pending tests fail without this fix.

## Testing

- [x] `pnpm run verify` (build, format, lint, typecheck, test, e2e)

## Checklist

- [x] Docs updated if needed (DATA_LOADING.md + docs example: invalid visitor search *replaces* prerendered content)
- [x] Skills updated if needed — N/A, no skill describes this internal commit path
- [x] Changeset added if published packages changed (`@pracht/core` patch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)