### PR TITLE
Fix adapter and pages-router audit gaps

### DIFF
--- a/.changeset/steady-agent-pages.md
+++ b/.changeset/steady-agent-pages.md
@@ -1,0 +1,13 @@
+---
+"@pracht/core": patch
+"@pracht/vite-plugin": patch
+"@pracht/cli": patch
+"@pracht/adapter-node": patch
+"@pracht/adapter-cloudflare": patch
+"@pracht/adapter-vercel": patch
+"create-pracht": patch
+---
+
+Keep WebMCP tools available on islands-mode responses that render no UI islands, while preserving zero-JavaScript `hydration: "none"` routes and carrying the requirement safely through built-in adapters and prerendering.
+
+Add fail-closed pages-router ISG time policies through `export const REVALIDATE = seconds`, harden static discovery against comments, strings, Markdown fences, shell misuse, and ambiguous config, teach generation, build, doctor, verify, docs, and skills the contract, and align generated human documentation with agent guidance about pages-router limitations.

--- a/docs/CAPABILITIES.md
+++ b/docs/CAPABILITIES.md
@@ -33,6 +33,11 @@ Capabilities are registered in the app manifest, exactly like shells and
 middleware. Registration is deliberately opt-in: no API route or loader is
 ever inferred as a capability.
 
+On `hydration: "islands"` routes, Pracht retains the islands bootstrap whenever
+WebMCP is exposed, even if a particular response renders zero island
+components. This keeps the agent projection stable across conditional UI.
+`hydration: "none"` intentionally remains zero-JS and cannot expose WebMCP.
+
 ```ts
 // src/routes.ts
 import { defineApp } from "@pracht/core";

--- a/docs/FRAMEWORK_PERMUTATION_AUDIT_2026-08-11.md
+++ b/docs/FRAMEWORK_PERMUTATION_AUDIT_2026-08-11.md
@@ -1,0 +1,314 @@
+# Framework permutation audit follow-up — 2026-08-11
+
+## Purpose
+
+This is a fresh residual audit of the human and agentic framework surfaces after
+the twelve findings in
+[`FRAMEWORK_PERMUTATION_AUDIT_2026-08-10.md`](FRAMEWORK_PERMUTATION_AUDIT_2026-08-10.md)
+were remediated. It focuses on cross-products that the earlier audit did not
+fully execute: render mode × hydration mode, pages router × edge adapter,
+WebMCP × islands rendering, and the difference between the guidance shown to a
+human and the guidance seeded for an agent.
+
+The goals were to find:
+
+- gaps in the public `examples/docs` site;
+- misleading or incomplete API surfaces;
+- adoption footguns in generated projects and deployment workflows;
+- runtime bugs on the human or agentic surface.
+
+This report records the original evidence, the implemented remediation, and
+the proof used to close each finding.
+
+## Remediation status
+
+| Finding | Status | Fix and proof |
+| --- | --- | --- |
+| F-01 | Fixed | The generated server carries an explicit per-app bootstrap requirement through dev, prerendering, and all built-in adapters. Zero-island WebMCP pages register and execute the real tool; `hydration: "none"` stays script-free; error-boundary and cross-app isolation regressions are covered. |
+| F-02 | Fixed | Pages can export a positive integer `REVALIDATE` time policy. Build, `doctor`, and `verify` reject missing, malformed, or misplaced policies. Static discovery ignores comments, strings, and root or nested Markdown fences; `_app`/`404` policy misuse fails closed. Node, Cloudflare, and Vercel builds emit their native ISG metadata with the exact interval. |
+| F-03 | Fixed | Public routing/getting-started/capability docs, root references, the pages example, authoring guide, generated README/AGENTS guidance, and bundled skills now share the pages-router boundary and ISG contract. Scaffold parity tests cover both audiences. |
+
+## Test baseline
+
+- Commit: `f840b1f399aad261dcafc0d0d420a0daa007371a` (`origin/main`)
+- Node.js: `v22.22.3`
+- pnpm: `11.3.0`
+- Host: macOS
+- External deployments: not created
+
+Cloudflare was exercised with the generated Worker under `wrangler dev`.
+Vercel was exercised through Build Output API v3 artifacts and the exported
+edge handler. Node was exercised through the generated production server.
+
+## Coverage
+
+### Scaffold matrix
+
+All 24 `create-pracht` dry-run combinations emitted the expected files:
+
+- adapters: Node, Cloudflare, Vercel;
+- routers: manifest, pages;
+- templates: minimal, Tailwind;
+- agent tooling: enabled, disabled.
+
+The checks verified adapter/router/template metadata, the presence of
+`.mcp.json` and the skill catalog only when agent tooling was enabled, and the
+absence of those files when it was disabled.
+
+Fresh pages-router projects were then generated for all three adapters. Each
+project built and typechecked against the packages in this workspace. Their
+human runtime paths were exercised as follows:
+
+| Adapter | Runtime | Human probes | Result |
+| --- | --- | --- | --- |
+| Node | generated production server | `/`, `/api/health`, `/llms.txt`, custom 404 | Passed |
+| Cloudflare | `wrangler dev` production preview | `/`, `/api/health`, `/llms.txt`, custom 404 | Passed |
+| Vercel | exported edge handler | `/`, `/api/health`, custom 404 | Passed |
+
+For the authoring-agent surface, `pracht inspect routes --json`, `pracht
+doctor --json`, build, and typecheck succeeded on all three pages-router
+projects. Pages mode intentionally has no runtime capabilities, WebMCP, remote
+MCP, `agents`, or constraints because those registrations require the explicit
+manifest.
+
+### Render and hydration matrix
+
+The ten supported render/hydration combinations were put in one manifest app:
+
+| Render | `full` | `islands` | `none` |
+| --- | --- | --- | --- |
+| SSG | Tested | Tested | Tested |
+| SSR | Tested | Tested | Tested |
+| ISG | Tested | Tested | Tested |
+| SPA | Tested | Invalid by design | Invalid by design |
+
+All ten routes built successfully with Node, Cloudflare, and Vercel: 30 build
+combinations. The same ten routes were requested from each real local runtime
+surface:
+
+- Node generated production server: 10/10 returned 200 with the expected
+  full-client, islands-bootstrap, or zero-JavaScript shape;
+- Cloudflare workerd preview: 10/10 returned 200 after expected static-route
+  trailing-slash redirects, with the expected JavaScript shape;
+- Vercel exported edge handler: 10/10 returned 200 with the expected
+  JavaScript shape.
+
+The SPA restriction is correctly enforced by `resolveApp()`: SPA always uses
+full hydration, while `spa` + `islands`/`none` is a configuration error.
+
+### Human and agentic manifest surfaces
+
+The same capability-enabled manifest was built or served on all three
+adapters. The following paths passed on Node, Cloudflare, and Vercel:
+
+- human SSR page (`/notes`);
+- typed HTTP capability (`notes.search`);
+- remote MCP discovery (`tools/list`, exposing `notes_search` and
+  `notes_create`);
+- human approval boundary for destructive HTTP capabilities (prepare returns
+  `409 confirmation_required`; an identical confirmed request commits);
+- production output contains the WebMCP chunk when a capability opts in.
+
+The repository's focused browser/deployment rerun passed 33/33 tests, covering
+the generated capability client, `<Form capability>`, `useCapability`, WebMCP,
+remote MCP, eval, Node output, Vercel output, and client/server bundle
+boundaries. The final repository gate is recorded under
+[Verification](#verification).
+
+## Findings
+
+Severity reflects adoption impact and how likely the behavior is to remain
+silent until production.
+
+### F-01 — WebMCP silently disappears from islands routes that render zero islands
+
+**Severity:** High
+
+**Category:** Agentic runtime bug
+
+The public capability guide says the WebMCP shim works in both full-hydration
+and islands modes. The generated islands bootstrap does contain the WebMCP
+feature detection and registration import. However, the server injects that
+bootstrap only when the current render captured at least one island component.
+
+A route with all of the following conditions therefore exposes no WebMCP
+tools:
+
+```ts
+route("/notes", () => import("./routes/notes.tsx"), {
+  render: "ssr",
+  hydration: "islands",
+});
+```
+
+- the app registers an `expose.webmcp: true` capability;
+- the app has a valid `src/islands/` directory and the islands/WebMCP chunks
+  are present in the client build;
+- this particular response renders zero island components.
+
+The observed HTML contained no Pracht client or islands script. The control
+route that rendered one island contained the islands bootstrap, and that
+bootstrap contained the WebMCP registration code. The result reproduced in
+development and in the Node, Cloudflare, and Vercel production output paths.
+
+The other projections remained healthy: the human page returned 200, the HTTP
+capability returned its typed success envelope, and remote MCP listed the
+tools. Only the in-page agent projection silently vanished.
+
+This is also data-dependent. If an island is conditional on loader data, the
+same URL can advertise WebMCP on one response and omit it on another even
+though `pracht inspect capabilities`, generated types, and the capability graph
+remain unchanged.
+
+**Recommended action:** inject a WebMCP-capable bootstrap for every
+`hydration: "islands"` response when the app has a WebMCP projection, even when
+the island capture is empty. Alternatively, emit a separate minimal WebMCP
+entry independent of island usage. Add production and dev tests for zero,
+one, and conditionally rendered islands.
+
+### F-02 — Pages-router `isg` is accepted but silently produces immutable SSG output
+
+**Severity:** High
+
+**Category:** API/runtime/tooling footgun
+
+The public pages-router guide lists `"isg"` as a valid `RENDER_MODE`. The pages
+manifest generator extracts `RENDER_MODE` and `HYDRATION`, but it has no export
+or plugin option for a per-route revalidation policy. The resolved graph can
+therefore contain this state:
+
+```json
+{
+  "path": "/",
+  "render": "isg",
+  "revalidate": null
+}
+```
+
+Fresh Node, Cloudflare, and Vercel pages-router starters were changed from
+`RENDER_MODE = "ssg"` to `RENDER_MODE = "isg"` and rebuilt. All three builds
+succeeded, but all three emitted static HTML with no runtime ISG mechanism:
+
+- Node: `dist/client/index.html`, no `dist/server/isg-manifest.json`;
+- Cloudflare: static `index.html`, no server/client ISG manifest;
+- Vercel: `.vercel/output/static/index.html`, no route function and no
+  `.prerender-config.json`.
+
+`pracht doctor --json` and `pracht verify --json` both reported `ok: true` on
+all three projects. No build warning explained that the route was frozen.
+
+The shipped `configure-isg` skill already knows the limitation and says that a
+pages-router `isg` route silently behaves like SSG unless the app ejects to an
+explicit manifest. That warning does not appear in the public routing or
+rendering docs, the generated human README, `doctor`, `verify`, or build
+output.
+
+**Impact:** a developer can choose a documented render mode, deploy
+successfully, and discover later that pricing, catalog, CMS, or other supposedly
+revalidated content never changes.
+
+**Recommended action:** either add a pages-router revalidation contract (for
+example, a statically analyzable `REVALIDATE` export) or reject pages-router
+`isg` in graph resolution until it can carry a policy. At minimum, `doctor`,
+`verify`, and `build` should fail closed or emit a prominent warning, and the
+public docs should direct users to eject before configuring ISG.
+
+### F-03 — The public pages-router guide omits its manifest-only feature boundary
+
+**Severity:** Medium
+
+**Category:** Human/agent documentation parity gap
+
+The root routing reference and generated `AGENTS.md` accurately state that
+pages mode has no registration seam for:
+
+- named shells or per-route shell assignment;
+- manifest middleware;
+- capabilities and therefore capability HTTP endpoints, WebMCP, remote MCP,
+  and `pracht eval`;
+- `defineApp({ constraints })` and `agents`.
+
+The public `examples/docs` pages-router section omits that table and moves
+directly from its introduction to setup. The getting-started guide also says
+the adapter and router can be changed later in `vite.config.ts` without
+explaining that switching to pages mode removes these features or that moving
+back requires an eject/code-generation step.
+
+The generated human README for a pages-router starter likewise lists files,
+commands, skills, and MCP setup without the limitations. The generated
+`AGENTS.md` does include the complete warning. An agent is therefore given a
+more accurate product boundary than the human who created the project or read
+the public site.
+
+**Impact:** users can select pages routing for an agent-ready application and
+only discover after adoption that the runtime agent surface and policy model
+require a router migration.
+
+**Recommended action:** copy the curated limitation/ejection table from
+`docs/ROUTING.md` into `examples/docs/src/routes/docs/routing.md`, link it from
+getting started and capabilities, and include the same warning in the
+generated human README. Keep the human README and `AGENTS.md` assertions under
+one scaffold parity test.
+
+## Confirmed behavior and intentional limitations
+
+The audit also confirmed the following and did not classify them as defects:
+
+- All 24 scaffold file permutations are internally consistent.
+- Node, Cloudflare, and Vercel fresh pages-router starters build and typecheck.
+- All ten valid render/hydration combinations behave consistently across the
+  three adapters.
+- `spa` + `islands`/`none` is rejected by design.
+- Pages mode supports human routes, `_app.tsx`, API routes, typed routes,
+  authoring MCP/inspection, and generated agent skills; runtime capabilities
+  remain a documented manifest-only feature in the root reference.
+- A fresh project does not contain generated typed-route files until
+  `pracht typegen` or `pracht dev` runs. `typegen --check` failing before that
+  opt-in generation is expected and was not treated as a defect.
+- Vercel still intentionally has no Pracht-owned faithful local production
+  preview; direct Build Output handler execution was used instead.
+- `hydration: "none"` intentionally ships no client code and therefore cannot
+  host in-page WebMCP tools. F-01 concerns the explicitly supported islands
+  mode, whose generated bootstrap promises WebMCP support.
+
+## Verification
+
+The audit reproduction baseline completed these commands and probes:
+
+- `pnpm run build`: passed;
+- 24/24 `create-pracht --dry-run --json` permutations: passed;
+- three fresh pages-router adapter builds + typechecks: passed;
+- 30 render/hydration adapter builds: passed;
+- 10/10 Node production render/hydration requests: passed;
+- 10/10 Cloudflare workerd render/hydration requests: passed;
+- 10/10 Vercel handler render/hydration requests: passed;
+- focused browser/deployment suite: 33/33 passed.
+
+The remediation then added permanent regression coverage and completed:
+
+- focused framework, code-generation, CLI, and built-in adapter unit suites:
+  passed;
+- a real browser WebMCP execution on `/agent-tools`, whose response renders no
+  UI islands: passed;
+- built Node server, Cloudflare Worker, and Vercel edge-handler requests to the
+  same zero-island route: passed with a hashed bootstrap and no island marker;
+- pages-router ISG builds for Node, Cloudflare, and Vercel: passed with the
+  exact 60-second native policy, including a Vercel function and fallback but
+  no static pricing route;
+- adversarial parser cases for comment/string lookalikes, quoted config
+  constants, unrelated duplicate config properties, root and CommonMark-nested
+  fenced examples, top-level MDX exports, and `_app`/`404` misuse: passed;
+- final `pnpm run verify`: passed build, formatting, lint, generated-type
+  checks, typecheck, unit tests, and E2E.
+
+Two independent adversarial review passes were run against the remediation.
+They found and drove fixes for Node ISG regeneration propagation, misleading
+zero-island diagnostics, missing Cloudflare/Vercel response assertions, an
+undiscovered Playwright spec, comment/string/config spoofing, Markdown fence
+handling, and ignored `_app` policies. Their final re-reviews reported no
+remaining findings.
+
+The in-app browser-control surface was unavailable during the initial focused
+F-01 probe. The permanent Playwright regression now executes the registered
+tool through `document.modelContext` on the zero-island route, and the three
+built-in adapter tests request their emitted production handlers directly.

--- a/docs/ISLANDS.md
+++ b/docs/ISLANDS.md
@@ -174,8 +174,11 @@ outer island.)
   also excluded from the generated full client-router entry, so server-only
   helpers imported by those page modules are not emitted into public client
   chunks.
-- If an islands route renders zero islands, no script tag is emitted at all —
-  the output is as static as `hydration: "none"`.
+- If an islands route renders zero islands, no hydration script is emitted
+  unless the app exposes WebMCP tools. In that case the islands bootstrap is
+  retained because it owns the page-level WebMCP registration; the human UI
+  still hydrates no components. `hydration: "none"` always remains zero-JS and
+  therefore never exposes in-page tools.
 
 Test tooling can wait for `html[data-pracht-islands-hydrated="true"]` (set
 after all `load` islands hydrate) and per-island `data-hydrated="true"`

--- a/docs/RENDERING_MODES.md
+++ b/docs/RENDERING_MODES.md
@@ -95,6 +95,16 @@ authenticated webhook. Node and Cloudflare serve stale HTML immediately while a
 new version is generated in the background for time-based revalidation. Vercel
 uses Build Output API prerender functions and the platform ISR cache.
 
+In pages-router mode, express the time policy as static page exports:
+
+```tsx
+export const RENDER_MODE = "isg";
+export const REVALIDATE = 3600;
+```
+
+Pages-router ISG supports positive-integer time policies only. Webhook or
+combined revalidation requires ejecting to an explicit manifest.
+
 Every HTML regeneration — on any adapter — renders on a sanitized request
 (`GET`, `Accept: text/html`, path only). The visitor whose request triggered it
 never lends their cookies or credentials to the render, because the resulting

--- a/docs/ROUTING.md
+++ b/docs/ROUTING.md
@@ -747,6 +747,26 @@ overridable globally via `pagesDefaultRender`:
 pracht({ pagesDir: "/src/pages", pagesDefaultRender: "ssg" });
 ```
 
+An ISG page must pair the mode with a statically analyzable positive integer
+time policy:
+
+```tsx
+export const RENDER_MODE = "isg";
+export const REVALIDATE = 3600;
+```
+
+`REVALIDATE` is seconds. Missing, invalid, zero, or non-ISG policies fail
+build, `pracht doctor`, and `pracht verify`; they never degrade to immutable
+SSG output. Pages mode supports time revalidation only. Eject to an explicit
+manifest for `webhookRevalidate()` or combined policies.
+
+Policies belong on page routes, not `_app.tsx` or `404.tsx`. Static discovery
+ignores declarations in comments, strings, and Markdown/MDX fenced examples;
+top-level MDX exports still work. `pagesDefaultRender` can be an inline string
+or a quoted `const`. If `doctor` cannot resolve a composed value it warns and
+the build remains authoritative; pages that export `REVALIDATE` should also
+export `RENDER_MODE = "isg"` so verification can fail closed.
+
 ### Per-Route Hydration Mode
 
 Page files can also export a `HYDRATION` constant to opt into partial

--- a/e2e/capabilities.test.ts
+++ b/e2e/capabilities.test.ts
@@ -276,6 +276,43 @@ test("webmcp shim registers page tools and execute() round-trips over HTTP", asy
   expect(envelope.data.notes[0].title).toBe("Capabilities");
 });
 
+test("zero-island responses keep the WebMCP projection executable", async ({ page }) => {
+  const scriptRequests: string[] = [];
+  page.on("request", (request) => {
+    const pathname = new URL(request.url()).pathname;
+    if (pathname.endsWith(".js")) scriptRequests.push(pathname);
+  });
+  await page.addInitScript(() => {
+    const registered: unknown[] = [];
+    (window as unknown as { __webmcpTools: unknown[] }).__webmcpTools = registered;
+    (document as unknown as { modelContext: unknown }).modelContext = {
+      registerTool(tool: unknown) {
+        registered.push(tool);
+        return Promise.resolve();
+      },
+    };
+  });
+
+  await page.goto("/agent-tools");
+  await expect(page.getByRole("heading", { name: "Agent tools without UI islands" })).toBeVisible();
+  await expect(page.locator("pracht-island")).toHaveCount(0);
+  await page.waitForFunction(
+    () => (window as unknown as { __webmcpTools?: unknown[] }).__webmcpTools?.length === 1,
+  );
+  expect(scriptRequests).toContain("/@pracht/islands.js");
+
+  const result = await page.evaluate(async () => {
+    const tool = (
+      window as unknown as {
+        __webmcpTools: { name: string; execute: (input: unknown) => Promise<unknown> }[];
+      }
+    ).__webmcpTools[0];
+    return tool.execute({ query: "capabilities" });
+  });
+  const content = (result as { content: { text: string }[] }).content;
+  expect(JSON.parse(content[0].text).data.notes[0].title).toBe("Capabilities");
+});
+
 test("without the WebMCP API the page works and registers nothing", async ({ page }) => {
   const errors: string[] = [];
   page.on("pageerror", (error) => errors.push(String(error)));

--- a/e2e/cloudflare-build.test.ts
+++ b/e2e/cloudflare-build.test.ts
@@ -1,6 +1,6 @@
 import { spawnSync } from "node:child_process";
 import { cpSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
-import { fileURLToPath } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 import { resolve } from "node:path";
 
 import { expect, test } from "@playwright/test";
@@ -10,6 +10,7 @@ import { fixtureCopyFilter } from "./fixture-copy.ts";
 
 const repoRoot = resolve(fileURLToPath(new URL(".", import.meta.url)), "..");
 const fixtureDir = resolve(repoRoot, "examples/cloudflare");
+const basicFixtureDir = resolve(repoRoot, "examples/basic");
 const cliEntry = resolve(repoRoot, "packages/cli/bin/pracht.js");
 
 function createTempCloudflareExample(): { exampleDir: string; tempDir: string } {
@@ -171,6 +172,50 @@ test("prerendered SSG pages include client JS and working framework context", as
     // The asset file referenced in the manifest must exist on disk
     const assetPath = resolve(distDir, "client", clientEntry.file);
     expect(existsSync(assetPath)).toBe(true);
+  } finally {
+    rmSync(tempDir, { force: true, recursive: true });
+  }
+});
+
+test("built Cloudflare worker bootstraps WebMCP on a zero-island route", async () => {
+  test.setTimeout(120_000);
+  const tempRoot = resolve(repoRoot, ".tmp");
+  mkdirSync(tempRoot, { recursive: true });
+  const tempDir = mkdtempSync(resolve(tempRoot, "pracht-cloudflare-agent-tools-"));
+  const exampleDir = resolve(tempDir, "project");
+
+  try {
+    cpSync(basicFixtureDir, exampleDir, {
+      filter: fixtureCopyFilter(basicFixtureDir),
+      recursive: true,
+    });
+    const result = spawnSync(process.execPath, [cliEntry, "build"], {
+      cwd: exampleDir,
+      encoding: "utf-8",
+      env: {
+        ...process.env,
+        NODE_OPTIONS: "--experimental-strip-types",
+        PRACHT_ADAPTER: "cloudflare",
+      },
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    if (result.status !== 0) {
+      throw new Error(result.stderr || result.stdout || "Cloudflare basic build failed");
+    }
+
+    const serverEntryPath = resolve(exampleDir, "dist/server/server.js");
+    const { default: worker } = await import(pathToFileURL(serverEntryPath).href);
+    const response = await worker.fetch(
+      new Request("https://example.com/agent-tools"),
+      { ASSETS: { fetch: async () => new Response("not found", { status: 404 }) } },
+      { waitUntil() {} },
+    );
+    expect(response.status).toBe(200);
+    const html = await response.text();
+    expect(html).not.toContain("<pracht-island");
+    expect(html).toMatch(
+      /<script type="module" src="\/assets\/islands-client-[^"]+\.js"><\/script>/,
+    );
   } finally {
     rmSync(tempDir, { force: true, recursive: true });
   }

--- a/e2e/node-build.test.ts
+++ b/e2e/node-build.test.ts
@@ -80,6 +80,14 @@ test("pracht build emits a deployable Node server entry", async () => {
     expect(homeHtml).toMatch(/<script type="module" src="\/assets\/client-[^"]+\.js"><\/script>/);
     expect(homeHtml).toContain('rel="modulepreload"');
 
+    const agentToolsResponse = await fetch(`http://127.0.0.1:${port}/agent-tools`);
+    expect(agentToolsResponse.status).toBe(200);
+    const agentToolsHtml = await agentToolsResponse.text();
+    expect(agentToolsHtml).not.toContain("<pracht-island");
+    expect(agentToolsHtml).toMatch(
+      /<script type="module" src="\/assets\/islands-client-[^"]+\.js"><\/script>/,
+    );
+
     const homeMarkdown = await fetch(`http://127.0.0.1:${port}/`, {
       headers: { accept: "text/markdown" },
     });

--- a/e2e/pages-isg-build.test.ts
+++ b/e2e/pages-isg-build.test.ts
@@ -1,0 +1,67 @@
+import { execFileSync } from "node:child_process";
+import { cpSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { expect, test } from "@playwright/test";
+
+import { fixtureCopyFilter } from "./fixture-copy.ts";
+
+const repoRoot = resolve(fileURLToPath(new URL("..", import.meta.url)));
+const fixtureDir = resolve(repoRoot, "examples/pages-router");
+const cliEntry = resolve(repoRoot, "packages/cli/bin/pracht.js");
+
+test("pages-router ISG emits adapter-native time revalidation across adapters", () => {
+  test.setTimeout(180_000);
+  const tempRoot = resolve(repoRoot, ".tmp");
+  mkdirSync(tempRoot, { recursive: true });
+  const tempDir = mkdtempSync(resolve(tempRoot, "pracht-pages-isg-"));
+
+  try {
+    for (const adapter of ["node", "cloudflare", "vercel"] as const) {
+      const projectDir = resolve(tempDir, adapter);
+      cpSync(fixtureDir, projectDir, { filter: fixtureCopyFilter(fixtureDir), recursive: true });
+      execFileSync(process.execPath, [cliEntry, "build"], {
+        cwd: projectDir,
+        env: {
+          ...process.env,
+          NODE_OPTIONS: "--experimental-strip-types",
+          PRACHT_ADAPTER: adapter,
+        },
+        stdio: "pipe",
+      });
+
+      if (adapter === "node") {
+        const manifest = JSON.parse(
+          readFileSync(resolve(projectDir, "dist/server/isg-manifest.json"), "utf-8"),
+        );
+        expect(manifest["/pricing"].revalidate).toEqual({ kind: "time", seconds: 60 });
+      } else if (adapter === "cloudflare") {
+        const manifest = JSON.parse(
+          readFileSync(resolve(projectDir, "dist/client/_pracht/isg.json"), "utf-8"),
+        );
+        expect(manifest["/pricing"].revalidate).toEqual({ kind: "time", seconds: 60 });
+      } else {
+        const config = JSON.parse(
+          readFileSync(
+            resolve(projectDir, ".vercel/output/functions/pricing.prerender-config.json"),
+            "utf-8",
+          ),
+        );
+        expect(config.expiration).toBe(60);
+        expect(config).toHaveProperty("fallback");
+        expect(existsSync(resolve(projectDir, ".vercel/output/functions/pricing.func"))).toBe(true);
+        expect(
+          existsSync(
+            resolve(projectDir, ".vercel/output/functions/pricing.prerender-fallback.html"),
+          ),
+        ).toBe(true);
+        expect(existsSync(resolve(projectDir, ".vercel/output/static/pricing/index.html"))).toBe(
+          false,
+        );
+      }
+    }
+  } finally {
+    rmSync(tempDir, { force: true, recursive: true });
+  }
+});

--- a/e2e/vercel-build.test.ts
+++ b/e2e/vercel-build.test.ts
@@ -144,6 +144,17 @@ test("pracht build emits a deployable Vercel Build Output setup", async () => {
     expect(functionSource).toContain("async function handle(request, context)");
     expect(functionSource).toContain("createVercelNodeListener");
 
+    const { default: edgeHandler } = await import(pathToFileURL(serverEntryPath).href);
+    const agentToolsResponse = await edgeHandler(new Request("https://example.com/agent-tools"), {
+      waitUntil() {},
+    });
+    expect(agentToolsResponse.status).toBe(200);
+    const agentToolsHtml = await agentToolsResponse.text();
+    expect(agentToolsHtml).not.toContain("<pracht-island");
+    expect(agentToolsHtml).toMatch(
+      /<script type="module" src="\/assets\/islands-client-[^"]+\.js"><\/script>/,
+    );
+
     // The prerender function runs on Node with the same Web-API-only bundle the
     // edge function uses — drive its launcher the way Vercel's Node launcher
     // does to prove the emitted function boots and renders.

--- a/examples/basic/src/pracht-routes.ts
+++ b/examples/basic/src/pracht-routes.ts
@@ -12,6 +12,10 @@ export const routes = [
     path: "/notes",
   },
   {
+    id: "agent-tools",
+    path: "/agent-tools",
+  },
+  {
     id: "product",
     path: "/products/:productId",
   },

--- a/examples/basic/src/pracht.d.ts
+++ b/examples/basic/src/pracht.d.ts
@@ -17,6 +17,12 @@ declare module "@pracht/core" {
         search: SearchParamsInput;
         data: RouteLoaderData<typeof import("./routes/notes")>;
       };
+      "agent-tools": {
+        path: "/agent-tools";
+        params: Record<never, never>;
+        search: SearchParamsInput;
+        data: RouteLoaderData<typeof import("./routes/agent-tools")>;
+      };
       "product": {
         path: "/products/:productId";
         params: { "productId": RouteParamInput; };

--- a/examples/basic/src/routes.ts
+++ b/examples/basic/src/routes.ts
@@ -57,6 +57,11 @@ export const app = defineApp({
         speculation: "prefetch",
       }),
       route("/notes", () => import("./routes/notes.tsx"), { id: "notes", render: "ssr" }),
+      route("/agent-tools", () => import("./routes/agent-tools.tsx"), {
+        id: "agent-tools",
+        render: "ssr",
+        hydration: "islands",
+      }),
       route("/products/:productId", () => import("./routes/product.tsx"), {
         id: "product",
         render: "ssg",

--- a/examples/basic/src/routes/agent-tools.tsx
+++ b/examples/basic/src/routes/agent-tools.tsx
@@ -1,0 +1,15 @@
+export function head() {
+  return { title: "Agent tools" };
+}
+
+export function Component() {
+  return (
+    <main>
+      <h1>Agent tools without UI islands</h1>
+      <p>
+        This server-rendered page has no interactive island components, while the app-level WebMCP
+        projection remains available to browser agents.
+      </p>
+    </main>
+  );
+}

--- a/examples/docs/src/routes/docs/capabilities.md
+++ b/examples/docs/src/routes/docs/capabilities.md
@@ -31,6 +31,10 @@ input validation → middleware chain → run() → output validation
 
 Capabilities are registered in `defineApp()`, exactly like shells and middleware. Registration is deliberately opt-in — no API route or loader is ever inferred as a capability.
 
+Capabilities require the explicit manifest router. A pages-router project can still use Pracht's authoring MCP server and generated skills, but it has no registration seam for capability HTTP endpoints, WebMCP, remote MCP, or runtime agent policy. [Eject the pages router to a manifest](/docs/routing#ejecting-to-explicit-manifest) before adding capabilities.
+
+On `hydration: "islands"` routes, Pracht retains the page bootstrap whenever WebMCP is exposed, even when a response renders zero island components. Conditional UI therefore cannot make the agent tools silently appear or disappear. `hydration: "none"` remains deliberately zero-JavaScript and cannot expose in-page WebMCP tools.
+
 ```ts [src/routes.ts]
 export const app = defineApp({
   capabilities: {

--- a/examples/docs/src/routes/docs/getting-started.md
+++ b/examples/docs/src/routes/docs/getting-started.md
@@ -25,7 +25,7 @@ yarn create pracht my-app
 bunx create-pracht my-app
 ```
 
-The CLI will ask you to choose an adapter (Node.js, Cloudflare Workers, or Vercel), whether to use the explicit manifest router or the file-system pages router, whether to add Tailwind CSS, and whether to seed the agent tooling. You can change the adapter and router later in `vite.config.ts`.
+The CLI will ask you to choose an adapter (Node.js, Cloudflare Workers, or Vercel), whether to use the explicit manifest router or the file-system pages router, whether to add Tailwind CSS, and whether to seed the agent tooling. Adapters can be changed later in `vite.config.ts`. Moving from pages routing to manifest routing is an explicit ejection step because named shells, route middleware, capabilities, constraints, and runtime agent configuration live in the manifest; see [Pages Router](/docs/routing#pages-router-auto-discovery).
 
 For reproducible setup in CI, demos, or agents, pass the same choices as flags:
 

--- a/examples/docs/src/routes/docs/routing.md
+++ b/examples/docs/src/routes/docs/routing.md
@@ -245,6 +245,20 @@ group({ pathPrefix: "/admin", shell: "admin", middleware: ["auth"] }, [
 
 For projects that prefer file-system routing — especially when migrating from Next.js — pracht offers an optional pages-based routing mode. Instead of writing a route manifest, set `pagesDir` and pracht auto-discovers routes from the file system.
 
+### What the pages router does not have
+
+Auto-discovery replaces the manifest, so features registered through that manifest are unavailable:
+
+| Feature | Pages router |
+| --- | --- |
+| Render and hydration modes, dynamic/catch-all routes, `getStaticPaths`, API routes | ✅ |
+| Shells | one `_app.tsx`; no named shells or per-route assignment |
+| Route middleware | ❌ no registration seam |
+| [Capabilities](/docs/capabilities) | ❌ no capability HTTP endpoints, WebMCP, remote MCP, or `pracht eval` |
+| `defineApp({ constraints })`, `agents` | ❌ |
+
+If the app needs any of these, [eject to an explicit manifest](#ejecting-to-explicit-manifest). The authoring MCP server and generated skills still work in pages mode; they do not add a runtime agent surface.
+
 ### Setup
 
 ```ts [vite.config.ts]
@@ -308,6 +322,17 @@ Valid values: `"ssr"` | `"ssg"` | `"isg"` | `"spa"`. The default is `"ssr"`, ove
 ```ts [vite.config.ts]
 pracht({ pagesDir: "/src/pages", pagesDefaultRender: "ssg" });
 ```
+
+ISG pages must also export a positive integer time policy:
+
+```tsx [src/pages/pricing.tsx]
+export const RENDER_MODE = "isg";
+export const REVALIDATE = 3600;
+```
+
+`REVALIDATE` is a statically analyzable number of seconds. Missing, zero, dynamic, or non-ISG policies fail build, `doctor`, and `verify` instead of silently freezing the page. Pages mode supports time revalidation only; webhook or combined policies require ejection to a manifest.
+
+Put the policy on the page route, not `_app.tsx` or `404.tsx`. Declarations inside comments, strings, and Markdown/MDX fenced examples are ignored, while top-level MDX exports work. `pagesDefaultRender` can be an inline string or a quoted `const`; more dynamic composition produces a `doctor` warning and is evaluated authoritatively by the build. Export `RENDER_MODE = "isg"` next to `REVALIDATE` when the default cannot be resolved statically.
 
 ### Route Priority
 

--- a/examples/pages-router/README.md
+++ b/examples/pages-router/README.md
@@ -45,4 +45,16 @@ export default defineConfig({
 ```
 
 All four render modes (SSR, SSG, ISG, SPA) work with the pages router — export
-a `RENDER_MODE` constant from any page to opt into a specific mode.
+a `RENDER_MODE` constant from any page to opt into a specific mode. ISG also
+requires a positive integer time policy:
+
+```ts
+export const RENDER_MODE = "isg";
+export const REVALIDATE = 3600;
+```
+
+Webhook or combined revalidation policies require ejecting to an explicit
+manifest. Pages mode also has no registration seam for named shells, route
+middleware, capabilities/WebMCP/remote MCP, constraints, or runtime agents.
+`REVALIDATE` belongs on each ISG page, never `_app.tsx` or `404.tsx`.
+Declarations shown inside Markdown/MDX fenced examples are ignored.

--- a/examples/pages-router/package.json
+++ b/examples/pages-router/package.json
@@ -4,7 +4,9 @@
   "private": true,
   "type": "module",
   "dependencies": {
+    "@pracht/adapter-cloudflare": "workspace:*",
     "@pracht/adapter-node": "workspace:*",
+    "@pracht/adapter-vercel": "workspace:*",
     "@pracht/core": "workspace:*"
   },
   "devDependencies": {

--- a/examples/pages-router/src/pages/pricing.tsx
+++ b/examples/pages-router/src/pages/pricing.tsx
@@ -1,0 +1,17 @@
+import type { LoaderArgs, RouteComponentProps } from "@pracht/core";
+
+export const RENDER_MODE = "isg";
+export const REVALIDATE = 60;
+
+export function loader(_args: LoaderArgs) {
+  return { generatedAt: new Date().toISOString() };
+}
+
+export function Component({ data }: RouteComponentProps<typeof loader>) {
+  return (
+    <main>
+      <h1>Pricing</h1>
+      <p>Generated at {data.generatedAt}</p>
+    </main>
+  );
+}

--- a/examples/pages-router/src/pracht-routes.ts
+++ b/examples/pages-router/src/pracht-routes.ts
@@ -8,12 +8,20 @@ export const routes = [
     path: "/",
   },
   {
+    id: "-alice",
+    path: "/@alice",
+  },
+  {
     id: "about",
     path: "/about",
   },
   {
     id: "blog-slug",
     path: "/blog/:slug",
+  },
+  {
+    id: "pricing",
+    path: "/pricing",
   },
 ] as const satisfies readonly HrefRouteDefinition[];
 

--- a/examples/pages-router/vite.config.ts
+++ b/examples/pages-router/vite.config.ts
@@ -1,17 +1,30 @@
 import { defineConfig } from "vite";
 import { pracht } from "@pracht/vite-plugin";
 
-async function resolveAdapter() {
+type DeployTarget = "cloudflare" | "node" | "vercel";
+
+async function resolveAdapter(target: DeployTarget) {
+  if (target === "cloudflare") {
+    const { cloudflareAdapter } = await import("@pracht/adapter-cloudflare");
+    return cloudflareAdapter({ inspectorPort: false, persistState: false });
+  }
+  if (target === "vercel") {
+    const { vercelAdapter } = await import("@pracht/adapter-vercel");
+    return vercelAdapter();
+  }
   const { nodeAdapter } = await import("@pracht/adapter-node");
   return nodeAdapter();
 }
 
-export default defineConfig(async () => ({
-  plugins: [
-    pracht({
-      pagesDir: "/src/pages",
-      adapter: await resolveAdapter(),
-      llmsTxt: { title: "Pracht Pages Example" },
-    }),
-  ],
-}));
+export default defineConfig(async () => {
+  const target = (process.env.PRACHT_ADAPTER ?? "node") as DeployTarget;
+  return {
+    plugins: [
+      pracht({
+        pagesDir: "/src/pages",
+        adapter: await resolveAdapter(target),
+        llmsTxt: { title: "Pracht Pages Example" },
+      }),
+    ],
+  };
+});

--- a/examples/pages-router/wrangler.jsonc
+++ b/examples/pages-router/wrangler.jsonc
@@ -1,0 +1,12 @@
+{
+  "$schema": "node_modules/wrangler/config-schema.json",
+  "name": "pracht-pages-router-example",
+  "compatibility_date": "2026-08-01",
+  "main": "dist/server/worker.js",
+  "assets": {
+    "binding": "ASSETS",
+    "directory": "dist/client",
+    "html_handling": "drop-trailing-slash",
+    "run_worker_first": true,
+  },
+}

--- a/packages/adapter-cloudflare/src/index.ts
+++ b/packages/adapter-cloudflare/src/index.ts
@@ -234,6 +234,8 @@ export function createCloudflareServerEntryModule(
     "    registry,",
     "    apiRoutes,",
     "    clientEntryUrl: clientEntryUrl ?? undefined,",
+    "    islandsEntryUrl: islandsEntryUrl ?? undefined,",
+    "    islandsBootstrapRequired,",
     "    cssManifest,",
     "    jsManifest,",
     `    assetsBinding: ${JSON.stringify(assetsBinding)},`,

--- a/packages/adapter-cloudflare/src/runtime.ts
+++ b/packages/adapter-cloudflare/src/runtime.ts
@@ -65,6 +65,8 @@ export interface CloudflareAdapterOptions<
   registry?: ModuleRegistry;
   apiRoutes?: ResolvedApiRoute[];
   clientEntryUrl?: string;
+  islandsEntryUrl?: string;
+  islandsBootstrapRequired?: boolean;
   cssManifest?: Record<string, string[]>;
   jsManifest?: Record<string, string[]>;
   assetsBinding?: string;
@@ -117,6 +119,8 @@ export function createCloudflareFetchHandler<
         context,
         apiRoutes: options.apiRoutes,
         clientEntryUrl: options.clientEntryUrl,
+        islandsEntryUrl: options.islandsEntryUrl,
+        islandsBootstrapRequired: options.islandsBootstrapRequired,
         cssManifest: options.cssManifest,
         jsManifest: options.jsManifest,
       } satisfies HandlePrachtRequestOptions<TContext>);
@@ -184,6 +188,8 @@ export function createCloudflareFetchHandler<
       context,
       apiRoutes: options.apiRoutes,
       clientEntryUrl: options.clientEntryUrl,
+      islandsEntryUrl: options.islandsEntryUrl,
+      islandsBootstrapRequired: options.islandsBootstrapRequired,
       cssManifest: options.cssManifest,
       jsManifest: options.jsManifest,
     } satisfies HandlePrachtRequestOptions<TContext>);

--- a/packages/adapter-cloudflare/test/index.test.ts
+++ b/packages/adapter-cloudflare/test/index.test.ts
@@ -37,6 +37,8 @@ describe("createCloudflareServerEntryModule", () => {
     );
     expect(source).toContain("createContext: createPrachtContext");
     expect(source).toContain("createCloudflareFetchHandler");
+    expect(source).toContain("islandsEntryUrl: islandsEntryUrl ?? undefined");
+    expect(source).toContain("islandsBootstrapRequired");
   });
 
   it("re-exports Cloudflare primitives from a dedicated module", () => {

--- a/packages/adapter-node/src/node-entry.ts
+++ b/packages/adapter-node/src/node-entry.ts
@@ -48,6 +48,8 @@ export function createNodeServerEntryModule(options: NodeServerEntryModuleOption
     "  markdownManifest,",
     "  apiRoutes,",
     "  clientEntryUrl: clientEntryUrl ?? undefined,",
+    "  islandsEntryUrl: islandsEntryUrl ?? undefined,",
+    "  islandsBootstrapRequired,",
     "  cssManifest,",
     "  jsManifest,",
     `  canonicalOrigin: ${JSON.stringify(canonicalOrigin ?? undefined)},`,

--- a/packages/adapter-node/src/node-handler.ts
+++ b/packages/adapter-node/src/node-handler.ts
@@ -49,6 +49,8 @@ export interface NodeAdapterOptions<TContext = unknown> {
   isgManifest?: Record<string, ISGManifestEntry>;
   apiRoutes?: ResolvedApiRoute[];
   clientEntryUrl?: string;
+  islandsEntryUrl?: string;
+  islandsBootstrapRequired?: boolean;
   cssManifest?: Record<string, string[]>;
   jsManifest?: Record<string, string[]>;
   headersManifest?: HeadersManifest;
@@ -187,6 +189,8 @@ export function createNodeRequestHandler<TContext = unknown>(
       request,
       apiRoutes: options.apiRoutes,
       clientEntryUrl: options.clientEntryUrl,
+      islandsEntryUrl: options.islandsEntryUrl,
+      islandsBootstrapRequired: options.islandsBootstrapRequired,
       cssManifest: options.cssManifest,
       jsManifest: options.jsManifest,
     } satisfies HandlePrachtRequestOptions<TContext>);

--- a/packages/adapter-node/src/node-isg.ts
+++ b/packages/adapter-node/src/node-isg.ts
@@ -37,6 +37,8 @@ export async function regenerateISGPage<TContext>(
       registry: options.registry,
       request,
       clientEntryUrl: options.clientEntryUrl,
+      islandsEntryUrl: options.islandsEntryUrl,
+      islandsBootstrapRequired: options.islandsBootstrapRequired,
       cssManifest: options.cssManifest,
       jsManifest: options.jsManifest,
     });

--- a/packages/adapter-node/test/index.test.ts
+++ b/packages/adapter-node/test/index.test.ts
@@ -88,6 +88,8 @@ describe("createNodeServerEntryModule", () => {
     );
     expect(source).toContain("createContext: createPrachtContext");
     expect(source).toContain("maxBodySize: 10485760");
+    expect(source).toContain("islandsEntryUrl: islandsEntryUrl ?? undefined");
+    expect(source).toContain("islandsBootstrapRequired");
   });
 });
 
@@ -214,7 +216,13 @@ describe("createNodeRequestHandler", () => {
 
     const createContextCalls: string[] = [];
     const app = defineApp({
-      routes: [route("/isg", "./routes/isg.tsx", { render: "isg", revalidate: timeRevalidate(1) })],
+      routes: [
+        route("/isg", "./routes/isg.tsx", {
+          render: "isg",
+          revalidate: timeRevalidate(1),
+          hydration: "islands",
+        }),
+      ],
     });
 
     const handler = createNodeRequestHandler({
@@ -229,6 +237,8 @@ describe("createNodeRequestHandler", () => {
           revalidate: timeRevalidate(1),
         },
       },
+      islandsBootstrapRequired: true,
+      islandsEntryUrl: "/assets/islands-agent.js",
       registry: {
         routeModules: {
           "./routes/isg.tsx": async () => ({
@@ -262,10 +272,15 @@ describe("createNodeRequestHandler", () => {
     expect(response.headers.get("x-pracht-isg")).toBe("stale");
     await expect(response.text()).resolves.toContain("stale");
 
-    await waitFor(() => readFileSync(htmlPath, "utf-8").includes("missing"));
+    await waitFor(
+      () =>
+        readFileSync(htmlPath, "utf-8").includes("missing") &&
+        readFileSync(htmlPath, "utf-8").includes("/assets/islands-agent.js"),
+    );
 
     expect(createContextCalls).toEqual(["missing"]);
     expect(readFileSync(htmlPath, "utf-8")).toContain("missing");
+    expect(readFileSync(htmlPath, "utf-8")).toContain("/assets/islands-agent.js");
   });
 
   it("authenticates webhook ISG revalidation and regenerates opted-in paths", async () => {

--- a/packages/adapter-vercel/src/index.ts
+++ b/packages/adapter-vercel/src/index.ts
@@ -36,6 +36,8 @@ export interface VercelAdapterOptions<
   registry?: ModuleRegistry;
   apiRoutes?: ResolvedApiRoute[];
   clientEntryUrl?: string;
+  islandsEntryUrl?: string;
+  islandsBootstrapRequired?: boolean;
   cssManifest?: Record<string, string[]>;
   jsManifest?: Record<string, string[]>;
   createContext?: (args: VercelContextArgs<TVercelContext>) => TContext | Promise<TContext>;
@@ -88,6 +90,8 @@ export function createVercelEdgeHandler<
       context: prachtContext,
       apiRoutes: options.apiRoutes,
       clientEntryUrl: options.clientEntryUrl,
+      islandsEntryUrl: options.islandsEntryUrl,
+      islandsBootstrapRequired: options.islandsBootstrapRequired,
       cssManifest: options.cssManifest,
       jsManifest: options.jsManifest,
     } satisfies HandlePrachtRequestOptions<TContext>);
@@ -261,6 +265,8 @@ export function createVercelServerEntryModule(
     "    registry,",
     "    apiRoutes,",
     "    clientEntryUrl: clientEntryUrl ?? undefined,",
+    "    islandsEntryUrl: islandsEntryUrl ?? undefined,",
+    "    islandsBootstrapRequired,",
     "    cssManifest,",
     "    jsManifest,",
     "    createContext: createPrachtContext,",

--- a/packages/adapter-vercel/test/index.test.ts
+++ b/packages/adapter-vercel/test/index.test.ts
@@ -21,6 +21,8 @@ describe("createVercelServerEntryModule", () => {
     );
     expect(source).toContain("createContext: createPrachtContext");
     expect(source).toContain("createVercelEdgeHandler");
+    expect(source).toContain("islandsEntryUrl: islandsEntryUrl ?? undefined");
+    expect(source).toContain("islandsBootstrapRequired");
     expect(source).toContain('export const vercelFunctionName = "app";');
   });
 });

--- a/packages/cli/src/authoring-guide.ts
+++ b/packages/cli/src/authoring-guide.ts
@@ -41,7 +41,10 @@ adapters for Node, Cloudflare Workers, and Vercel.
 - \`src/capabilities/\` — typed application operations (see below).
 
 Pages-router apps replace the manifest with \`src/pages/\` file routing
-(\`export const RENDER_MODE = "ssg"\` in the page file). **The pages router has
+(\`export const RENDER_MODE = "ssg"\` in the page file). Pages ISG also requires
+\`export const REVALIDATE = 3600\`; it supports time policies only and fails
+build/doctor/verify when the policy is missing or misplaced, including on
+\`_app\` or \`404\`. Fenced Markdown/MDX examples are ignored. **The pages router has
 no manifest, so it has no middleware, capabilities, constraints, or \`agents\`**
 — if a task needs auth or the agent surface, use manifest routing (or eject
 with \`generateRoutesFile\`).

--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -165,6 +165,8 @@ export async function runBuild(root: string, options: BuildOptions = {}): Promis
     const { pages, isgManifest } = await prerenderApp({
       app: serverMod.resolvedApp,
       clientEntryUrl: clientEntryUrl ?? undefined,
+      islandsEntryUrl: serverMod.islandsEntryUrl ?? undefined,
+      islandsBootstrapRequired: serverMod.islandsBootstrapRequired === true,
       cssManifest,
       jsManifest,
       registry: serverMod.registry,

--- a/packages/cli/src/commands/generate-source.ts
+++ b/packages/cli/src/commands/generate-source.ts
@@ -27,13 +27,19 @@ export function buildManifestRouteModuleSource(opts: RouteModuleParts): string {
   return `${sections.join("\n")}\n`;
 }
 
-export function buildPagesRouteModuleSource(opts: RouteModuleParts & { render: string }): string {
+export function buildPagesRouteModuleSource(
+  opts: RouteModuleParts & { render: string; revalidateSeconds?: number },
+): string {
   const sections = buildRouteModuleSections(opts);
 
   // Insert RENDER_MODE before the first exported declaration (after imports)
   const firstExportIdx = sections.findIndex((s) => s.startsWith("export"));
   const insertAt = firstExportIdx === -1 ? sections.length : firstExportIdx;
-  sections.splice(insertAt, 0, `export const RENDER_MODE = ${quote(opts.render)};`, "");
+  const policyExports = [`export const RENDER_MODE = ${quote(opts.render)};`];
+  if (opts.revalidateSeconds !== undefined) {
+    policyExports.push(`export const REVALIDATE = ${opts.revalidateSeconds};`);
+  }
+  sections.splice(insertAt, 0, ...policyExports, "");
 
   return `${sections.join("\n")}\n`;
 }

--- a/packages/cli/src/commands/generate.ts
+++ b/packages/cli/src/commands/generate.ts
@@ -231,6 +231,11 @@ export interface RouteArgs {
 export function generateRoute(args: RouteArgs, project: ProjectConfig): GenerateResult {
   const routePath = normalizeRoutePathString(args.path);
   const render = requireEnum(args.render, "render", ["spa", "ssr", "ssg", "isg"], "ssr");
+  if (render !== "isg" && args.revalidate !== undefined) {
+    throw new Error("`--revalidate` is only valid together with `--render isg`.");
+  }
+  const revalidateSeconds =
+    render === "isg" ? requirePositiveInteger(args.revalidate, "revalidate", 3600) : undefined;
   const includeLoader = Boolean(args.loader);
   const includeErrorBoundary = Boolean(args["error-boundary"]);
   const middleware = parseCommaList(args.middleware);
@@ -252,6 +257,7 @@ export function generateRoute(args: RouteArgs, project: ProjectConfig): Generate
       includeStaticPaths,
       project,
       render,
+      revalidateSeconds,
       routePath,
       title,
     });
@@ -309,8 +315,7 @@ export function generateRoute(args: RouteArgs, project: ProjectConfig): Generate
     meta.push(`middleware: [${middleware.map((item) => quote(item)).join(", ")}]`);
   }
   if (render === "isg") {
-    const seconds = requirePositiveInteger(args.revalidate, "revalidate", 3600);
-    meta.push(`revalidate: timeRevalidate(${seconds})`);
+    meta.push(`revalidate: timeRevalidate(${revalidateSeconds})`);
   }
 
   nextManifestSource = insertArrayItem(
@@ -372,6 +377,7 @@ function generatePagesRoute({
   includeStaticPaths,
   project,
   render,
+  revalidateSeconds,
   routePath,
   title,
 }: {
@@ -380,6 +386,7 @@ function generatePagesRoute({
   includeStaticPaths: boolean;
   project: ProjectConfig;
   render: string;
+  revalidateSeconds?: number;
   routePath: string;
   title: string;
 }): GenerateResult {
@@ -391,6 +398,7 @@ function generatePagesRoute({
       includeLoader,
       includeStaticPaths,
       render,
+      revalidateSeconds,
       routePath,
       title,
     }),

--- a/packages/cli/src/project.ts
+++ b/packages/cli/src/project.ts
@@ -1,5 +1,6 @@
 import { existsSync, mkdirSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
 import { basename, dirname, isAbsolute, relative, resolve } from "node:path";
+import { maskCommentsAndStrings } from "@pracht/capabilities/static";
 
 import { ensureTrailingNewline } from "./utils.js";
 import { PROJECT_DEFAULTS } from "./constants.js";
@@ -13,6 +14,7 @@ export interface ProjectConfig {
   middlewareDir: string;
   mode: "manifest" | "pages";
   pagesDefaultRender: string;
+  pagesDefaultRenderIsStatic: boolean;
   pagesDir: string;
   rawConfig: string;
   root: string;
@@ -24,19 +26,22 @@ export interface ProjectConfig {
 export function readProjectConfig(root: string): ProjectConfig {
   const configFile = findConfigFile(root);
   const rawConfig = configFile ? readFileSync(configFile, "utf-8") : "";
+  const hasPagesDefaultRender = hasConfigProperty(rawConfig, "pagesDefaultRender");
+  const resolvedPagesDefaultRender = readQuotedConfigValue(rawConfig, "pagesDefaultRender");
   const config: Record<string, unknown> = {
     ...PROJECT_DEFAULTS,
     configFile,
-    hasPrachtPlugin: /\bpracht\s*\(/.test(rawConfig),
+    hasPrachtPlugin: /\bpracht\s*\(/.test(maskCommentsAndStrings(rawConfig)),
     mode: "manifest" as const,
     rawConfig,
     root,
+    pagesDefaultRenderIsStatic: !hasPagesDefaultRender || resolvedPagesDefaultRender !== null,
   };
 
   for (const key of Object.keys(PROJECT_DEFAULTS)) {
     const value = readQuotedConfigValue(rawConfig, key);
     if (typeof value === "string") {
-      config[key] = normalizeConfigPath(value);
+      config[key] = key === "pagesDefaultRender" ? value : normalizeConfigPath(value);
     }
   }
 
@@ -149,9 +154,30 @@ function findConfigFile(root: string): string | null {
 
 function readQuotedConfigValue(source: string, key: string): string | null {
   if (!source) return null;
-  const pattern = new RegExp(`${key}\\s*:\\s*(["'\\\`])([^"'\\\`]+)\\1`);
-  const match = source.match(pattern);
-  return match ? match[2] : null;
+  const masked = maskCommentsAndStrings(source);
+  const properties = [...masked.matchAll(new RegExp(`\\b${key}\\s*:`, "g"))];
+  if (properties.length !== 1) return null;
+  const property = properties[0];
+
+  const valueStart = (property.index ?? 0) + property[0].length;
+  const direct = readQuotedValueAt(source, valueStart);
+  if (direct !== null) return direct;
+
+  const identifier = /^\s*([A-Za-z_$][\w$]*)\b/.exec(source.slice(valueStart))?.[1];
+  if (!identifier) return null;
+  const declarations = [...masked.matchAll(new RegExp(`\\bconst\\s+${identifier}\\s*=`, "g"))];
+  if (declarations.length !== 1) return null;
+  const declaration = declarations[0];
+  return readQuotedValueAt(source, (declaration.index ?? 0) + declaration[0].length);
+}
+
+function hasConfigProperty(source: string, key: string): boolean {
+  return new RegExp(`\\b${key}\\s*:`).test(maskCommentsAndStrings(source));
+}
+
+function readQuotedValueAt(source: string, start: number): string | null {
+  const match = /^\s*(["'`])([^"'`]+)\1/.exec(source.slice(start));
+  return match?.[2] ?? null;
 }
 
 function normalizeConfigPath(value: string): string {

--- a/packages/cli/src/verification-checks.ts
+++ b/packages/cli/src/verification-checks.ts
@@ -395,10 +395,99 @@ export function collectPagesVerification(
   const pages = scanPagesDirectory(pagesDir);
   const routes = pages.filter((page) => page.kind === "route");
   const notFoundPages = pages.filter((page) => page.kind === "not-found");
+  const appShells = pages.filter((page) => page.kind === "shell");
   const duplicates = collectDuplicateRoutePaths(routes as PagesRoute[]).map((entry) => ({
     ...entry,
     files: entry.files.map((file) => displayPath(project.root, file)),
   }));
+
+  if (!project.pagesDefaultRenderIsStatic) {
+    checks.push(
+      createCheck(
+        "warning",
+        "pagesDefaultRender could not be resolved statically. The build evaluates the live " +
+          "configuration and will still reject ISG pages without a revalidation policy.",
+      ),
+    );
+  } else if (!new Set(["spa", "ssr", "ssg", "isg"]).has(project.pagesDefaultRender)) {
+    checks.push(
+      createCheck("error", 'pagesDefaultRender must resolve to "spa", "ssr", "ssg", or "isg".'),
+    );
+  }
+
+  for (const shell of appShells) {
+    if (shell.hasRevalidateExport) {
+      checks.push(
+        createCheck(
+          "error",
+          `Pages app shell ${JSON.stringify(displayPath(project.root, shell.file))} exports ` +
+            "REVALIDATE, but app shells are not ISG routes. Declare the policy on each ISG " +
+            "page instead.",
+        ),
+      );
+    }
+  }
+
+  for (const page of notFoundPages) {
+    if (page.hasRevalidateExport) {
+      checks.push(
+        createCheck(
+          "error",
+          `Pages not-found module ${JSON.stringify(displayPath(project.root, page.file))} exports ` +
+            "REVALIDATE, but not-found responses are never ISG routes.",
+        ),
+      );
+    }
+  }
+
+  for (const route of routes as PagesRoute[]) {
+    const display = displayPath(project.root, route.file);
+    const render =
+      route.renderMode ??
+      (project.pagesDefaultRenderIsStatic ? project.pagesDefaultRender : undefined);
+    if (route.revalidate.kind === "invalid") {
+      checks.push(
+        createCheck(
+          "error",
+          `Pages route ${JSON.stringify(display)} must export REVALIDATE as a positive integer ` +
+            "literal number of seconds (for example, `export const REVALIDATE = 60`).",
+        ),
+      );
+      continue;
+    }
+    if (render === "isg" && route.revalidate.kind === "missing") {
+      checks.push(
+        createCheck(
+          "error",
+          `Pages route ${JSON.stringify(display)} uses render mode "isg" but does not export a ` +
+            "revalidation policy. Add `export const REVALIDATE = 60` with a positive integer " +
+            "number of seconds, or use another render mode.",
+        ),
+      );
+      continue;
+    }
+    if (render === undefined && route.revalidate.kind === "time") {
+      checks.push(
+        createCheck(
+          "error",
+          `Pages route ${JSON.stringify(display)} exports REVALIDATE, but its effective render ` +
+            'mode cannot be resolved statically. Export `RENDER_MODE = "isg"` on the page ' +
+            "or use a statically resolvable pagesDefaultRender value.",
+        ),
+      );
+      continue;
+    }
+    if (render !== "isg" && route.revalidate.kind === "time") {
+      checks.push(
+        createCheck(
+          "error",
+          `Pages route ${JSON.stringify(display)} exports REVALIDATE but its effective render ` +
+            `mode is ${JSON.stringify(render)}. REVALIDATE is only valid with ` +
+            '`RENDER_MODE = "isg"` (or `pagesDefaultRender: "isg"`).',
+        ),
+      );
+    }
+  }
 
   if (scope === "full") {
     checks.push(createCheck("ok", `Found pages directory at ${project.pagesDir}.`));

--- a/packages/cli/src/verification-pages.ts
+++ b/packages/cli/src/verification-pages.ts
@@ -1,11 +1,13 @@
+import { maskCommentsAndStrings } from "@pracht/capabilities/static";
+import { readFileSync } from "node:fs";
 import { basename, relative } from "node:path";
 
 import { hasPagesAppShell, listFilesRecursively } from "./project.js";
 import { normalizeRoutePath, PAGE_SOURCE_RE } from "./verification-helpers.js";
 
 export type PagesFile =
-  | { file: string; kind: "shell" }
-  | { file: string; kind: "not-found" }
+  | { file: string; kind: "shell"; hasRevalidateExport: boolean }
+  | { file: string; kind: "not-found"; hasRevalidateExport: boolean }
   | { file: string; kind: "ignored" }
   | PagesRoute;
 
@@ -13,6 +15,11 @@ export interface PagesRoute {
   file: string;
   kind: "route";
   routePath: string;
+  renderMode?: string;
+  revalidate:
+    | { kind: "missing" }
+    | { kind: "invalid"; expression: string }
+    | { kind: "time"; seconds: number };
 }
 
 export function scanPagesDirectory(pagesDir: string): PagesFile[] {
@@ -25,9 +32,15 @@ export function describePagesFile(pagesDir: string, file: string): PagesFile {
   const relativePath = relative(pagesDir, file).replace(/\\/g, "/");
   const routePath = relativePath.replace(/\.(tsx?|tsrx|jsx?|mdx?)$/, "");
   const name = basename(routePath);
+  const source = readFileSync(file, "utf-8");
+  const analysisSource = maskMarkdownFences(source, relativePath);
 
   if (hasPagesAppShell(file)) {
-    return { file, kind: "shell" };
+    return {
+      file,
+      kind: "shell",
+      hasRevalidateExport: extractRevalidate(analysisSource).kind !== "missing",
+    };
   }
 
   if (name.startsWith("_")) {
@@ -36,11 +49,21 @@ export function describePagesFile(pagesDir: string, file: string): PagesFile {
 
   const withoutIndex = routePath.replace(/\/index$/, "");
   if (withoutIndex === "404") {
-    return { file, kind: "not-found" };
+    return {
+      file,
+      kind: "not-found",
+      hasRevalidateExport: extractRevalidate(analysisSource).kind !== "missing",
+    };
   }
 
   if (routePath === "index") {
-    return { file, kind: "route", routePath: "/" };
+    return {
+      file,
+      kind: "route",
+      routePath: "/",
+      renderMode: extractQuotedExport(analysisSource, "RENDER_MODE"),
+      revalidate: extractRevalidate(analysisSource),
+    };
   }
 
   const normalized = withoutIndex
@@ -51,7 +74,105 @@ export function describePagesFile(pagesDir: string, file: string): PagesFile {
     file,
     kind: "route",
     routePath: normalizeRoutePath(`/${normalized}`),
+    renderMode: extractQuotedExport(analysisSource, "RENDER_MODE"),
+    revalidate: extractRevalidate(analysisSource),
   };
+}
+
+function extractQuotedExport(source: string, name: string): string | undefined {
+  const masked = maskCommentsAndStrings(source);
+  const declarations = [...masked.matchAll(new RegExp(`export\\s+const\\s+${name}\\s*=`, "g"))];
+  if (declarations.length !== 1) return undefined;
+  const declaration = declarations[0];
+  const valueStart = (declaration.index ?? 0) + declaration[0].length;
+  return source
+    .slice(valueStart)
+    .trimStart()
+    .match(/^["'](\w+)["']/)?.[1];
+}
+
+function extractRevalidate(source: string): PagesRoute["revalidate"] {
+  const matches = [
+    ...maskCommentsAndStrings(source).matchAll(/export\s+const\s+REVALIDATE\s*=\s*([^;\n]+)/g),
+  ];
+  if (matches.length === 0) return { kind: "missing" };
+  if (matches.length > 1) return { kind: "invalid", expression: "duplicate exports" };
+  const match = matches[0];
+
+  const expression = match[1].trim().replace(/\s+as\s+const$/, "");
+  if (!/^\d(?:_?\d)*$/.test(expression)) {
+    return { kind: "invalid", expression };
+  }
+
+  const seconds = Number(expression.replaceAll("_", ""));
+  if (!Number.isSafeInteger(seconds) || seconds <= 0) {
+    return { kind: "invalid", expression };
+  }
+  return { kind: "time", seconds };
+}
+
+/** Mask Markdown fenced examples while preserving source offsets and top-level MDX exports. */
+function maskMarkdownFences(source: string, relativePath: string): string {
+  if (!/\.mdx?$/.test(relativePath)) return source;
+
+  const chars = source.split("");
+  let activeFence: { character: "`" | "~"; continuationIndent: number; length: number } | null =
+    null;
+  for (const line of source.matchAll(/.*(?:\r?\n|$)/g)) {
+    if (line[0] === "") continue;
+    const lineStart = line.index ?? 0;
+    const content = line[0].replace(/\r?\n$/, "");
+    const stripped = stripMarkdownContainerPrefix(content);
+    const fenceContent: string =
+      activeFence && stripped.content.startsWith(" ".repeat(activeFence.continuationIndent))
+        ? stripped.content.slice(activeFence.continuationIndent)
+        : stripped.content;
+    const opening: RegExpExecArray | null = activeFence
+      ? null
+      : /^ {0,3}(`{3,}|~{3,})/.exec(fenceContent);
+    const closing = activeFence
+      ? new RegExp(`^ {0,3}\\${activeFence.character}{${activeFence.length},}[ \\t]*$`).test(
+          fenceContent,
+        )
+      : false;
+
+    if (activeFence || opening) {
+      for (let offset = 0; offset < line[0].length; offset += 1) {
+        const index = lineStart + offset;
+        if (chars[index] !== "\n" && chars[index] !== "\r") chars[index] = " ";
+      }
+    }
+
+    if (closing) {
+      activeFence = null;
+    } else if (opening) {
+      activeFence = {
+        character: opening[1][0] as "`" | "~",
+        continuationIndent: stripped.continuationIndent,
+        length: opening[1].length,
+      };
+    }
+  }
+  return chars.join("");
+}
+
+function stripMarkdownContainerPrefix(line: string): {
+  content: string;
+  continuationIndent: number;
+} {
+  let content = line;
+  let continuationIndent = 0;
+  while (true) {
+    const quote = /^ {0,3}> ?/.exec(content);
+    if (quote) {
+      content = content.slice(quote[0].length);
+      continue;
+    }
+    const list = /^ {0,3}(?:[-+*]|\d{1,9}[.)])[ \t]+/.exec(content);
+    if (!list) return { content, continuationIndent };
+    continuationIndent += list[0].length;
+    content = content.slice(list[0].length);
+  }
 }
 
 export function collectDuplicateRoutePaths(

--- a/packages/cli/test/cli-doctor-verify.test.js
+++ b/packages/cli/test/cli-doctor-verify.test.js
@@ -171,6 +171,168 @@ export const app = defineApp({
     );
   });
 
+  it.each(["doctor", "verify"])("fails %s for pages ISG without REVALIDATE", (command) => {
+    const appDir = createTempDir(`pracht-cli-${command}-pages-isg-missing-`);
+    writePagesApp(appDir);
+    writeProjectFile(
+      appDir,
+      "src/pages/index.tsx",
+      'export const RENDER_MODE = "isg";\nexport function Component() { return null; }',
+    );
+
+    const result = runCliStatus([command, "--json"], { cwd: appDir });
+    expect(result.status).toBe(1);
+    const report = JSON.parse(result.stdout);
+    expect(report.ok).toBe(false);
+    expect(report.checks.some((check) => check.message.includes("does not export"))).toBe(true);
+  });
+
+  it.each(["doctor", "verify"])(
+    "accepts pages ISG with a positive time policy in %s",
+    (command) => {
+      const appDir = createTempDir(`pracht-cli-${command}-pages-isg-valid-`);
+      writePagesApp(appDir);
+      writeProjectFile(
+        appDir,
+        "src/pages/index.tsx",
+        'export const RENDER_MODE = "isg";\nexport const REVALIDATE = 60;\nexport function Component() { return null; }',
+      );
+
+      const result = runCli([command, "--json"], { cwd: appDir });
+      expect(JSON.parse(result.stdout).ok).toBe(true);
+    },
+  );
+
+  it("reads an inline pagesDefaultRender as a render mode rather than a path", () => {
+    const appDir = createTempDir("pracht-cli-doctor-pages-default-isg-");
+    writePagesApp(appDir);
+    writeProjectFile(
+      appDir,
+      "vite.config.ts",
+      'import { pracht } from "@pracht/vite-plugin";\npracht({ pagesDir: "/src/pages", pagesDefaultRender: "isg" });',
+    );
+    writeProjectFile(
+      appDir,
+      "src/pages/index.tsx",
+      "export const REVALIDATE = 90;\nexport function Component() { return null; }",
+    );
+
+    const report = JSON.parse(runCli(["doctor", "--json"], { cwd: appDir }).stdout);
+    expect(report.ok).toBe(true);
+  });
+
+  it("resolves a pagesDefaultRender identifier bound to a quoted const", () => {
+    const appDir = createTempDir("pracht-cli-doctor-pages-default-const-");
+    writePagesApp(appDir);
+    writeProjectFile(
+      appDir,
+      "vite.config.ts",
+      'import { pracht } from "@pracht/vite-plugin";\nconst mode = "isg";\npracht({ pagesDir: "/src/pages", pagesDefaultRender: mode });',
+    );
+    writeProjectFile(
+      appDir,
+      "src/pages/index.tsx",
+      "export const REVALIDATE = 90;\nexport function Component() { return null; }",
+    );
+
+    const report = JSON.parse(runCli(["doctor", "--json"], { cwd: appDir }).stdout);
+    expect(report.ok).toBe(true);
+  });
+
+  it("warns for an unresolved non-ISG default without letting comments spoof it", () => {
+    const appDir = createTempDir("pracht-cli-doctor-pages-default-unresolved-");
+    writePagesApp(appDir);
+    writeProjectFile(
+      appDir,
+      "vite.config.ts",
+      [
+        'import { pracht } from "@pracht/vite-plugin";',
+        "const mode = getMode();",
+        'function getMode() { return "ssr"; }',
+        'const unrelated = { pagesDefaultRender: "isg" };',
+        '// pagesDefaultRender: "isg"',
+        'pracht({ pagesDir: "/src/pages", pagesDefaultRender: mode });',
+      ].join("\n"),
+    );
+    writeProjectFile(appDir, "src/pages/index.tsx", "export function Component() { return null; }");
+
+    const report = JSON.parse(runCli(["doctor", "--json"], { cwd: appDir }).stdout);
+    expect(report.ok).toBe(true);
+    expect(report.checks.some((check) => check.message.includes("could not be resolved"))).toBe(
+      true,
+    );
+  });
+
+  it("does not let commented or string-contained RENDER_MODE authorize REVALIDATE", () => {
+    const appDir = createTempDir("pracht-cli-doctor-pages-commented-render-");
+    writePagesApp(appDir);
+    writeProjectFile(
+      appDir,
+      "src/pages/index.tsx",
+      [
+        '// export const RENDER_MODE = "isg";',
+        "const example = 'export const RENDER_MODE = \"isg\"';",
+        "export const REVALIDATE = 60;",
+        "export function Component() { return example; }",
+      ].join("\n"),
+    );
+
+    const result = runCliStatus(["doctor", "--json"], { cwd: appDir });
+    expect(result.status).toBe(1);
+    expect(
+      JSON.parse(result.stdout).checks.some((check) => check.message.includes("only valid")),
+    ).toBe(true);
+  });
+
+  it("ignores Markdown fenced policy examples", () => {
+    const appDir = createTempDir("pracht-cli-doctor-pages-markdown-fence-");
+    writePagesApp(appDir);
+    writeProjectFile(
+      appDir,
+      "vite.config.ts",
+      'import { pracht } from "@pracht/vite-plugin";\npracht({ pagesDir: "/src/pages", pagesDefaultRender: "isg" });',
+    );
+    writeProjectFile(
+      appDir,
+      "src/pages/guide.mdx",
+      [
+        "# Guide",
+        "",
+        "> ```ts",
+        '> export const RENDER_MODE = "isg";',
+        "> export const REVALIDATE = 60;",
+        "> ```",
+        "",
+        "- ~~~ts",
+        '  export const RENDER_MODE = "isg";',
+        "  export const REVALIDATE = 30;",
+        "  ~~~",
+        "",
+        "10. ~~~ts",
+        "    export const REVALIDATE = 15;",
+        "    ~~~",
+        "",
+        "export const REVALIDATE = 75;",
+      ].join("\n"),
+    );
+
+    const report = JSON.parse(runCli(["doctor", "--json"], { cwd: appDir }).stdout);
+    expect(report.ok).toBe(true);
+  });
+
+  it("rejects REVALIDATE on the pages app shell", () => {
+    const appDir = createTempDir("pracht-cli-doctor-pages-shell-policy-");
+    writePagesApp(appDir);
+    writeProjectFile(appDir, "src/pages/index.tsx", "export function Component() { return null; }");
+    writeProjectFile(appDir, "src/pages/_app.tsx", "export const REVALIDATE = 60;");
+
+    const result = runCliStatus(["doctor", "--json"], { cwd: appDir });
+    expect(result.status).toBe(1);
+    expect(
+      JSON.parse(result.stdout).checks.some((check) => check.message.includes("app shell")),
+    ).toBe(true);
+  });
+
   it("rejects a second pages-router not-found file in changed verification", () => {
     const appDir = createTempDir("pracht-cli-verify-pages-not-found-duplicate-");
     writePagesApp(appDir);

--- a/packages/cli/test/cli-generate.test.js
+++ b/packages/cli/test/cli-generate.test.js
@@ -136,4 +136,31 @@ describe("@pracht/cli generate", () => {
     expect(routeSource).toContain("export function getStaticPaths()");
     expect(routeSource).toContain('slug: "example-slug"');
   });
+
+  it("scaffolds pages-router ISG with its required policy", () => {
+    const appDir = createTempDir("pracht-cli-pages-isg-");
+    writePagesApp(appDir);
+
+    runCli(["generate", "route", "--path", "/pricing", "--render", "isg", "--revalidate", "120"], {
+      cwd: appDir,
+    });
+
+    const routeSource = readFileSync(join(appDir, "src/pages/pricing.tsx"), "utf-8");
+    expect(routeSource).toContain('export const RENDER_MODE = "isg";');
+    expect(routeSource).toContain("export const REVALIDATE = 120;");
+  });
+
+  it("rejects misplaced revalidation before creating a route file", () => {
+    const appDir = createTempDir("pracht-cli-pages-invalid-revalidate-");
+    writePagesApp(appDir);
+
+    const result = spawnSync(
+      process.execPath,
+      [cliPath, "generate", "route", "--path", "/broken", "--render", "ssr", "--revalidate", "60"],
+      { cwd: appDir, encoding: "utf-8" },
+    );
+    expect(result.status).not.toBe(0);
+    expect(`${result.stdout}${result.stderr}`).toContain("only valid together");
+    expect(existsSync(join(appDir, "src/pages/broken.tsx"))).toBe(false);
+  });
 });

--- a/packages/framework/src/prerender.ts
+++ b/packages/framework/src/prerender.ts
@@ -33,6 +33,9 @@ export interface PrerenderAppOptions {
   app: PrachtApp;
   registry?: ModuleRegistry;
   clientEntryUrl?: string;
+  islandsEntryUrl?: string;
+  /** Force the islands bootstrap for zero-island pages that own another projection. */
+  islandsBootstrapRequired?: boolean;
   /** Per-source-file CSS map produced by the vite plugin. */
   cssManifest?: Record<string, string[]>;
   /** Per-source-file JS map produced by the vite plugin for modulepreload hints. */
@@ -89,6 +92,8 @@ export async function prerenderApp(
             request,
             registry: options.registry,
             clientEntryUrl: options.clientEntryUrl,
+            islandsEntryUrl: options.islandsEntryUrl,
+            islandsBootstrapRequired: options.islandsBootstrapRequired,
             cssManifest: options.cssManifest,
             jsManifest: options.jsManifest,
           }),

--- a/packages/framework/src/runtime-response.ts
+++ b/packages/framework/src/runtime-response.ts
@@ -52,6 +52,7 @@ interface HandleRequestOptionsLike {
   debugErrors?: boolean;
   clientEntryUrl?: string;
   islandsEntryUrl?: string;
+  islandsBootstrapRequired?: boolean;
   cssManifest?: Record<string, string[]>;
   jsManifest?: Record<string, string[]>;
   registry?: import("./types.ts").ModuleRegistry;
@@ -262,14 +263,18 @@ export async function renderRouteErrorResponse<TContext>(options: {
       ...new Set((islandCapture?.islands ?? []).map((usage) => usage.descriptor.file)),
     ];
     let islandsEntryUrl: string | undefined;
-    if (islandFiles.length > 0) {
+    const needsIslandsBootstrap =
+      hydration === "islands" &&
+      (islandFiles.length > 0 || options.options.islandsBootstrapRequired === true);
+    if (needsIslandsBootstrap) {
       islandsEntryUrl = options.options.islandsEntryUrl ?? getIslandsClientEntryUrl();
       if (!islandsEntryUrl) {
         throw new Error(
-          `Route "${options.routeArgs.route.path}" uses hydration: "islands" and rendered ` +
-            `${islandFiles.length} island(s) in its error boundary, but no islands bootstrap URL is registered. ` +
-            "This usually means the @pracht/vite-plugin islands entry was not built — " +
-            "check that your islands live in the configured islands directory.",
+          `Route "${options.routeArgs.route.path}" uses hydration: "islands" and requires the ` +
+            `islands bootstrap${islandFiles.length > 0 ? ` for ${islandFiles.length} island(s) in its error boundary` : " for a page-level runtime projection"}, but no bootstrap URL is registered. ` +
+            (islandFiles.length > 0
+              ? "This usually means the @pracht/vite-plugin islands entry was not built — check that your islands live in the configured islands directory."
+              : "This usually means generated page-runtime metadata was not forwarded by the deployment adapter."),
         );
       }
     }

--- a/packages/framework/src/runtime.ts
+++ b/packages/framework/src/runtime.ts
@@ -189,6 +189,12 @@ export interface HandlePrachtRequestOptions<TContext = unknown> {
    * via `setIslandsClientEntryUrl()`.
    */
   islandsEntryUrl?: string;
+  /**
+   * Emit the islands bootstrap on islands-mode responses even when the render
+   * captured no island components. Generated entries enable this when the
+   * bootstrap owns another page-level runtime projection such as WebMCP.
+   */
+  islandsBootstrapRequired?: boolean;
   /** Per-source-file CSS map produced by the vite plugin. */
   cssManifest?: Record<string, string[]>;
   /** Per-source-file JS chunk map produced by the vite plugin for modulepreload hints. */
@@ -867,14 +873,18 @@ export async function handlePrachtRequest<TContext>(
             ...new Set((islandCapture?.islands ?? []).map((usage) => usage.descriptor.file)),
           ];
           let islandsEntryUrl: string | undefined;
-          if (islandFiles.length > 0) {
+          const needsIslandsBootstrap =
+            hydration === "islands" &&
+            (islandFiles.length > 0 || options.islandsBootstrapRequired === true);
+          if (needsIslandsBootstrap) {
             islandsEntryUrl = options.islandsEntryUrl ?? getIslandsClientEntryUrl();
             if (!islandsEntryUrl) {
               throw new Error(
-                `Route "${match.route.path}" uses hydration: "islands" and rendered ` +
-                  `${islandFiles.length} island(s), but no islands bootstrap URL is registered. ` +
-                  "This usually means the @pracht/vite-plugin islands entry was not built — " +
-                  "check that your islands live in the configured islands directory.",
+                `Route "${match.route.path}" uses hydration: "islands" and requires the ` +
+                  `islands bootstrap${islandFiles.length > 0 ? ` for ${islandFiles.length} rendered island(s)` : " for a page-level runtime projection"}, but no bootstrap URL is registered. ` +
+                  (islandFiles.length > 0
+                    ? "This usually means the @pracht/vite-plugin islands entry was not built — check that your islands live in the configured islands directory."
+                    : "This usually means generated page-runtime metadata was not forwarded by the deployment adapter."),
               );
             }
           }

--- a/packages/framework/test/islands.test.ts
+++ b/packages/framework/test/islands.test.ts
@@ -33,6 +33,8 @@ interface RenderRouteOptions {
   Component: (props: any) => any;
   ErrorBoundary?: (props: any) => any;
   hydration?: "full" | "islands" | "none";
+  islandsBootstrapRequired?: boolean;
+  islandsEntryUrl?: string;
   loader?: () => unknown;
   speculation?: "prefetch" | "prerender";
 }
@@ -61,6 +63,8 @@ async function renderRoute(options: RenderRouteOptions): Promise<string> {
     },
     request: new Request("http://localhost/"),
     debugErrors: true,
+    islandsBootstrapRequired: options.islandsBootstrapRequired,
+    islandsEntryUrl: options.islandsEntryUrl,
   });
 
   return response.text();
@@ -169,6 +173,65 @@ describe("islands server rendering", () => {
     expect(html).not.toContain('<script type="module"');
   });
 
+  it("keeps the bootstrap when a zero-island response owns a page-level projection", async () => {
+    registerTestIslands();
+
+    const html = await renderRoute({
+      hydration: "islands",
+      islandsBootstrapRequired: true,
+      Component: () => h("main", null, "agent tools without UI islands"),
+    });
+
+    expect(html).not.toContain("<pracht-island");
+    expect(html).toContain('<script type="module" src="/assets/islands-client-test.js"></script>');
+  });
+
+  it("keeps hydration none script-free even when another projection needs the islands entry", async () => {
+    registerTestIslands();
+
+    const html = await renderRoute({
+      hydration: "none",
+      islandsBootstrapRequired: true,
+      Component: () => h("main", null, "deliberately zero JavaScript"),
+    });
+
+    expect(html).not.toContain("<script");
+  });
+
+  it("fails closed when a required zero-island bootstrap URL is missing", async () => {
+    const html = await renderRoute({
+      hydration: "islands",
+      islandsBootstrapRequired: true,
+      Component: () => h("main", null, "agent tools"),
+    });
+
+    expect(html).toContain("requires the islands bootstrap");
+    expect(html).toContain("page-level runtime projection");
+    expect(html).toContain("no bootstrap URL is registered");
+  });
+
+  it("keeps per-app bootstrap requirements and URLs isolated", async () => {
+    setIslandsClientEntryUrl("/assets/global-should-not-win.js");
+    const [agentHtml, staticHtml] = await Promise.all([
+      renderRoute({
+        hydration: "islands",
+        islandsBootstrapRequired: true,
+        islandsEntryUrl: "/assets/app-a-agent.js",
+        Component: () => h("main", null, "app a"),
+      }),
+      renderRoute({
+        hydration: "islands",
+        islandsBootstrapRequired: false,
+        islandsEntryUrl: "/assets/app-b-islands.js",
+        Component: () => h("main", null, "app b"),
+      }),
+    ]);
+
+    expect(agentHtml).toContain("/assets/app-a-agent.js");
+    expect(agentHtml).not.toContain("global-should-not-win");
+    expect(staticHtml).not.toContain("<script");
+  });
+
   it("renders islands as plain components on full-hydration routes", async () => {
     registerTestIslands();
 
@@ -269,6 +332,23 @@ describe("islands server rendering", () => {
     expect(html).not.toContain('id="pracht-state"');
     expect(html).toContain('<script type="module" src="/assets/islands-client-test.js"></script>');
     expect(html).not.toContain("/@pracht/client.js");
+  });
+
+  it("keeps the bootstrap for zero-island error boundaries with a page-level projection", async () => {
+    registerTestIslands();
+    const html = await renderRoute({
+      hydration: "islands",
+      islandsBootstrapRequired: true,
+      loader: () => {
+        throw new Error("Broken agent page");
+      },
+      Component: () => h("main", null, "ok"),
+      ErrorBoundary: () => h("section", null, "agent-safe fallback"),
+    });
+
+    expect(html).toContain("agent-safe fallback");
+    expect(html).not.toContain("<pracht-island");
+    expect(html).toContain("/assets/islands-client-test.js");
   });
 });
 

--- a/packages/start/src/index.js
+++ b/packages/start/src/index.js
@@ -1336,6 +1336,12 @@ function createDockerignore() {
   ].join("\n");
 }
 
+const PAGES_ROUTER_LIMITATIONS =
+  "**The pages router has no manifest**, so these manifest-only features are unavailable: named shells (there is one, `_app.tsx`), route middleware, capabilities (and therefore capability HTTP endpoints, WebMCP, remote MCP, and `pracht eval`), `defineApp({ constraints })`, and `agents`. If the app needs auth policy or a runtime agent surface, eject with `generateRoutesFile` from `@pracht/vite-plugin/pages-router`, remove `pagesDir`, and customize the generated manifest.";
+
+const PAGES_ROUTER_ISG_POLICY =
+  'Pages-router ISG supports time revalidation only: pair `export const RENDER_MODE = "isg"` with a positive integer such as `export const REVALIDATE = 3600`. Missing or misplaced policies fail `pracht build`, `doctor`, and `verify`. Webhook revalidation and combined policies require an explicit manifest.';
+
 function createAgentInstructions({ adapter, agentTools, packageManager, router, tailwind }) {
   // `bun build` is Bun's own bundler and shadows the package script, so bun
   // needs the explicit `run` form the same way npm does.
@@ -1400,9 +1406,9 @@ function createAgentInstructions({ adapter, agentTools, packageManager, router, 
       "- `src/pages/404.tsx` — not-found page, wired automatically (never a URL of its own)",
     );
     lines.push("");
-    lines.push(
-      "**The pages router has no manifest**, so these manifest-only features are unavailable: named shells (there is one, `_app.tsx`), middleware, capabilities (and therefore capability HTTP endpoints, WebMCP, remote MCP, and `pracht eval`), `defineApp({ constraints })`, and `agents`. If a task needs auth or the agent surface, eject to an explicit manifest with the `generateRoutesFile` plugin option first — do not hand-roll a substitute.",
-    );
+    lines.push(PAGES_ROUTER_LIMITATIONS);
+    lines.push("");
+    lines.push(PAGES_ROUTER_ISG_POLICY);
   } else {
     lines.push("This app uses **manifest routing**.");
     lines.push("");
@@ -1513,6 +1519,12 @@ function createReadme({
     lines.push("- `src/pages/_app.tsx` is the app shell.");
     lines.push("- `src/pages/index.tsx` is the home page.");
     lines.push("- `src/pages/404.tsx` is the not-found page; pracht wires it automatically.");
+    lines.push("");
+    lines.push("## Pages-router boundaries");
+    lines.push("");
+    lines.push(PAGES_ROUTER_LIMITATIONS);
+    lines.push("");
+    lines.push(PAGES_ROUTER_ISG_POLICY);
   } else {
     lines.push("- `src/routes.ts` defines your app manifest.");
     lines.push("- `src/routes/home.tsx` is the first page.");

--- a/packages/start/test/index.test.js
+++ b/packages/start/test/index.test.js
@@ -377,10 +377,14 @@ describe("create-pracht", () => {
     expect(existsSync(join(targetDir, "src/routes/not-found.tsx"))).toBe(false);
     expect(existsSync(join(targetDir, "src/routes.ts"))).toBe(false);
     expect(readme).toContain("src/pages/");
+    expect(readme).toContain("The pages router has no manifest");
+    expect(readme).toContain("export const REVALIDATE = 3600");
 
     const agents = await readFile(join(targetDir, "AGENTS.md"), "utf-8");
     expect(agents).toContain("pages routing");
     expect(agents).toContain("src/pages/");
+    expect(agents).toContain("The pages router has no manifest");
+    expect(agents).toContain("export const REVALIDATE = 3600");
   });
 
   it("seeds pnpm edge build policy for every router and template permutation", async () => {

--- a/packages/vite-plugin/src/index.ts
+++ b/packages/vite-plugin/src/index.ts
@@ -31,6 +31,7 @@ import {
   createPrachtCapabilitiesClientModuleSource,
   createPrachtWebmcpModuleSource,
   hasAgentSurface,
+  hasWebmcpCapabilities,
   resolveCapabilityModulePaths,
 } from "./plugin-capabilities.ts";
 import {
@@ -110,14 +111,15 @@ export function pracht(options: PrachtPluginOptions = {}): Plugin[] {
       const isSSRBuild = env.isSsrBuild;
 
       // Emit the islands bootstrap as its own client entry so islands-mode
-      // routes can load it without the full client runtime. Only added when
-      // the app actually has an islands directory, so builds of apps without
-      // islands are byte-for-byte unchanged.
+      // routes can load it without the full client runtime. WebMCP also owns
+      // this entry on islands routes, including responses that render no
+      // island components and apps that have no islands directory.
       const configRoot = _config.root ?? process.cwd();
       const wantsIslandsEntry =
         env.command === "build" &&
         !isSSRBuild &&
-        existsSync(resolveConfigPath(configRoot, resolved.islandsDir));
+        (existsSync(resolveConfigPath(configRoot, resolved.islandsDir)) ||
+          hasWebmcpCapabilities(resolved, configRoot));
 
       // `publicEnv` needs every PRACHT_PUBLIC_ key, but reading the whole
       // `import.meta.env` object to enumerate them makes Vite inline *all*

--- a/packages/vite-plugin/src/pages-router.ts
+++ b/packages/vite-plugin/src/pages-router.ts
@@ -1,5 +1,6 @@
 import { readdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
 import { basename, extname, join, relative } from "node:path";
+import { maskCommentsAndStrings } from "@pracht/capabilities/static";
 import { detectLoaderExport } from "./route-loader-hints.ts";
 
 export interface ScannedPage {
@@ -11,6 +12,8 @@ export interface ScannedPage {
   isDynamic: boolean;
   renderMode?: string;
   hydrationMode?: string;
+  revalidateSeconds?: number;
+  hasRevalidateExport?: boolean;
   hasLoader?: boolean;
 }
 
@@ -25,6 +28,13 @@ const SHELL_EXTENSIONS = new Set([".tsx", ".tsrx", ".ts", ".jsx", ".js"]);
 export function scanPagesDirectory(pagesDir: string): ScannedPage[] {
   const pages: ScannedPage[] = [];
   scan(pagesDir, pagesDir, pages);
+  const appShell = pages.find((page) => page.routePath === "__shell__");
+  if (appShell?.hasRevalidateExport) {
+    throw new Error(
+      `[pracht] Pages app shell ${JSON.stringify(appShell.relativePath)} exports REVALIDATE, ` +
+        "but app shells are not ISG routes. Declare the policy on each ISG page instead.",
+    );
+  }
   return sortRoutes(pages);
 }
 
@@ -56,9 +66,11 @@ function scan(dir: string, root: string, pages: ScannedPage[]): void {
     const rel = relative(root, abs);
     const routePath = filePathToRoutePath(rel);
     const source = readFileSync(abs, "utf-8");
-    const renderMode = extractRenderMode(source);
-    const hydrationMode = extractHydrationMode(source);
-    const hasLoader = detectLoaderExport(source);
+    const analysisSource = maskMarkdownFences(source, rel);
+    const renderMode = extractQuotedPageExport(analysisSource, "RENDER_MODE", rel);
+    const hydrationMode = extractQuotedPageExport(analysisSource, "HYDRATION", rel);
+    const revalidate = extractRevalidateSeconds(analysisSource, rel);
+    const hasLoader = detectLoaderExport(analysisSource);
 
     pages.push({
       absolutePath: abs,
@@ -69,6 +81,8 @@ function scan(dir: string, root: string, pages: ScannedPage[]): void {
       isDynamic: routePath.split("/").some((segment) => segment.startsWith(":")),
       renderMode,
       hydrationMode,
+      revalidateSeconds: revalidate.seconds,
+      hasRevalidateExport: revalidate.present,
       hasLoader,
     });
   }
@@ -136,18 +150,124 @@ function getRouteSegmentSpecificity(segment: string): number {
   return 3;
 }
 
-const RENDER_MODE_RE = /export\s+const\s+RENDER_MODE\s*=\s*["'](\w+)["']/;
+function extractQuotedPageExport(
+  source: string,
+  name: "RENDER_MODE" | "HYDRATION",
+  relativePath: string,
+): string | undefined {
+  const masked = maskCommentsAndStrings(source);
+  const declarations = [...masked.matchAll(new RegExp(`export\\s+const\\s+${name}\\s*=`, "g"))];
+  if (declarations.length === 0) return undefined;
+  if (declarations.length > 1) {
+    throw new Error(
+      `[pracht] Pages route ${JSON.stringify(relativePath)} exports ${name} more than once.`,
+    );
+  }
 
-function extractRenderMode(source: string): string | undefined {
-  const match = RENDER_MODE_RE.exec(source);
-  return match ? match[1] : undefined;
+  const declaration = declarations[0];
+  const valueStart = (declaration.index ?? 0) + declaration[0].length;
+  return source
+    .slice(valueStart)
+    .trimStart()
+    .match(/^["'](\w+)["']/)?.[1];
 }
 
-const HYDRATION_RE = /export\s+const\s+HYDRATION\s*=\s*["'](\w+)["']/;
+const REVALIDATE_RE = /export\s+const\s+REVALIDATE\s*=\s*([^;\n]+)/;
 
-function extractHydrationMode(source: string): string | undefined {
-  const match = HYDRATION_RE.exec(source);
-  return match ? match[1] : undefined;
+function extractRevalidateSeconds(
+  source: string,
+  relativePath: string,
+): { present: boolean; seconds?: number } {
+  const matches = [...maskCommentsAndStrings(source).matchAll(new RegExp(REVALIDATE_RE, "g"))];
+  if (matches.length === 0) return { present: false };
+  if (matches.length > 1) {
+    throw new Error(
+      `[pracht] Pages route ${JSON.stringify(relativePath)} exports REVALIDATE more than once.`,
+    );
+  }
+  const match = matches[0];
+
+  const expression = match[1].trim().replace(/\s+as\s+const$/, "");
+  if (!/^\d(?:_?\d)*$/.test(expression)) {
+    throw new Error(
+      `[pracht] Pages route ${JSON.stringify(relativePath)} must export REVALIDATE as a ` +
+        "positive integer literal number of seconds (for example, `export const REVALIDATE = 60`).",
+    );
+  }
+
+  const seconds = Number(expression.replaceAll("_", ""));
+  if (!Number.isSafeInteger(seconds) || seconds <= 0) {
+    throw new Error(
+      `[pracht] Pages route ${JSON.stringify(relativePath)} must export REVALIDATE as a ` +
+        "positive integer literal number of seconds within JavaScript's safe integer range.",
+    );
+  }
+
+  return { present: true, seconds };
+}
+
+/** Mask Markdown fenced examples while preserving source offsets and top-level MDX exports. */
+function maskMarkdownFences(source: string, relativePath: string): string {
+  if (!/\.mdx?$/.test(relativePath)) return source;
+
+  const chars = source.split("");
+  let activeFence: { character: "`" | "~"; continuationIndent: number; length: number } | null =
+    null;
+  for (const line of source.matchAll(/.*(?:\r?\n|$)/g)) {
+    if (line[0] === "") continue;
+    const lineStart = line.index ?? 0;
+    const content = line[0].replace(/\r?\n$/, "");
+    const stripped = stripMarkdownContainerPrefix(content);
+    const fenceContent: string =
+      activeFence && stripped.content.startsWith(" ".repeat(activeFence.continuationIndent))
+        ? stripped.content.slice(activeFence.continuationIndent)
+        : stripped.content;
+    const opening: RegExpExecArray | null = activeFence
+      ? null
+      : /^ {0,3}(`{3,}|~{3,})/.exec(fenceContent);
+    const closing = activeFence
+      ? new RegExp(`^ {0,3}\\${activeFence.character}{${activeFence.length},}[ \\t]*$`).test(
+          fenceContent,
+        )
+      : false;
+
+    if (activeFence || opening) {
+      for (let offset = 0; offset < line[0].length; offset += 1) {
+        const index = lineStart + offset;
+        if (chars[index] !== "\n" && chars[index] !== "\r") chars[index] = " ";
+      }
+    }
+
+    if (closing) {
+      activeFence = null;
+    } else if (opening) {
+      activeFence = {
+        character: opening[1][0] as "`" | "~",
+        continuationIndent: stripped.continuationIndent,
+        length: opening[1].length,
+      };
+    }
+  }
+  return chars.join("");
+}
+
+function stripMarkdownContainerPrefix(line: string): {
+  content: string;
+  continuationIndent: number;
+} {
+  let content = line;
+  let continuationIndent = 0;
+  while (true) {
+    const quote = /^ {0,3}> ?/.exec(content);
+    if (quote) {
+      content = content.slice(quote[0].length);
+      continue;
+    }
+    const list = /^ {0,3}(?:[-+*]|\d{1,9}[.)])[ \t]+/.exec(content);
+    if (!list) return { content, continuationIndent };
+    continuationIndent += list[0].length;
+    content = content.slice(list[0].length);
+  }
 }
 
 export function generatePagesManifestSource(
@@ -168,17 +288,40 @@ export function generatePagesManifestSource(
     (f) => basename(f, extname(f)) === "_app" && SHELL_EXTENSIONS.has(extname(f)),
   );
 
-  const lines: string[] = ['import { defineApp, group, route } from "@pracht/core/manifest";', ""];
+  const coreImports = pages.some((page) => page.revalidateSeconds !== undefined)
+    ? "defineApp, group, route, timeRevalidate"
+    : "defineApp, group, route";
+  const lines: string[] = [`import { ${coreImports} } from "@pracht/core/manifest";`, ""];
 
   const routeEntries: string[] = [];
   // `pages/404.tsx` is the app's not-found page, not a route: it renders with
   // a 404 status when nothing matches, and it is never reachable at a URL of
   // its own (which is what would let it shadow a static asset).
   const notFoundPage = pages.find((page) => page.routePath === "/404");
+  if (notFoundPage?.hasRevalidateExport) {
+    throw new Error(
+      `[pracht] Pages not-found module ${JSON.stringify(notFoundPage.relativePath)} exports ` +
+        "REVALIDATE, but not-found responses are never ISG routes.",
+    );
+  }
 
   for (const page of pages) {
     if (page === notFoundPage) continue;
     const render = page.renderMode ?? defaultRender;
+    if (render === "isg" && page.revalidateSeconds === undefined) {
+      throw new Error(
+        `[pracht] Pages route ${JSON.stringify(page.relativePath)} uses render mode "isg" but ` +
+          "does not export a revalidation policy. Add `export const REVALIDATE = 60` with a " +
+          "positive integer number of seconds, or use another render mode.",
+      );
+    }
+    if (render !== "isg" && page.hasRevalidateExport) {
+      throw new Error(
+        `[pracht] Pages route ${JSON.stringify(page.relativePath)} exports REVALIDATE but its ` +
+          `effective render mode is ${JSON.stringify(render)}. REVALIDATE is only valid with ` +
+          '`RENDER_MODE = "isg"` (or `pagesDefaultRender: "isg"`).',
+      );
+    }
     const filePath = prefix
       ? `${prefix}/${page.relativePath.replace(/\\/g, "/")}`
       : `./${page.relativePath.replace(/\\/g, "/")}`;
@@ -191,6 +334,9 @@ export function generatePagesManifestSource(
     ];
     if (page.hydrationMode) {
       metaParts.push(`hydration: ${JSON.stringify(page.hydrationMode)}`);
+    }
+    if (page.revalidateSeconds !== undefined) {
+      metaParts.push(`revalidate: timeRevalidate(${page.revalidateSeconds})`);
     }
     routeEntries.push(
       `    route(${JSON.stringify(page.routePath)}, ${fileRef}, { ${metaParts.join(", ")} })`,

--- a/packages/vite-plugin/src/plugin-codegen.ts
+++ b/packages/vite-plugin/src/plugin-codegen.ts
@@ -298,6 +298,7 @@ export function createPrachtServerModuleSource(
     : { clientEntryUrl: null, islandsEntryUrl: null, cssManifest: {}, jsManifest: {} };
   const adapter = resolved.adapter;
   const llmsTxtConfig = resolveLlmsTxtConfig(resolved, buildOptions.root);
+  const islandsBootstrapRequired = hasWebmcpCapabilities(resolved, buildOptions.root);
 
   // The adapter tells us what extra imports it needs (e.g. handlePrachtRequest).
   // Always import prerenderApp so the CLI uses the same bundled copy of
@@ -344,6 +345,7 @@ export function createPrachtServerModuleSource(
     `export const buildTarget = ${JSON.stringify(adapter?.id ?? "node")};`,
     `export const clientEntryUrl = ${JSON.stringify(clientBuild.clientEntryUrl ?? CLIENT_BROWSER_PATH)};`,
     `export const islandsEntryUrl = ${JSON.stringify(islandsEntryUrl ?? null)};`,
+    `export const islandsBootstrapRequired = ${JSON.stringify(islandsBootstrapRequired)};`,
     `export const cssManifest = ${JSON.stringify(clientBuild.cssManifest)};`,
     `export const jsManifest = ${JSON.stringify(clientBuild.jsManifest)};`,
     `export const prerenderConcurrency = ${JSON.stringify(resolved.prerenderConcurrency)};`,

--- a/packages/vite-plugin/src/plugin-dev-ssr.ts
+++ b/packages/vite-plugin/src/plugin-dev-ssr.ts
@@ -144,6 +144,8 @@ export function createDevSSRMiddleware(
         request: webRequest,
         debugErrors: true,
         clientEntryUrl: CLIENT_BROWSER_PATH,
+        islandsEntryUrl: ISLANDS_CLIENT_BROWSER_PATH,
+        islandsBootstrapRequired: serverMod.islandsBootstrapRequired === true,
         apiRoutes: serverMod.apiRoutes,
         timings,
       });

--- a/packages/vite-plugin/src/plugin-options.ts
+++ b/packages/vite-plugin/src/plugin-options.ts
@@ -121,6 +121,9 @@ export function resolveOptions(options: PrachtPluginOptions): ResolvedPrachtPlug
   if (resolved.llmsTxt === undefined) {
     resolved.llmsTxt = false;
   }
+  if (!new Set(["spa", "ssr", "ssg", "isg"]).has(resolved.pagesDefaultRender)) {
+    throw new Error('pracht({ pagesDefaultRender }) expects "spa", "ssr", "ssg", or "isg".');
+  }
   if (!Number.isInteger(resolved.prerenderConcurrency) || resolved.prerenderConcurrency <= 0) {
     throw new Error("pracht({ prerenderConcurrency }) expects a positive integer.");
   }

--- a/packages/vite-plugin/test/capabilities-codegen.test.ts
+++ b/packages/vite-plugin/test/capabilities-codegen.test.ts
@@ -12,6 +12,7 @@ import {
 import {
   createPrachtClientModuleSource,
   createPrachtIslandsClientModuleSource,
+  createPrachtServerModuleSource,
 } from "../src/plugin-codegen.ts";
 
 const tempDirs: string[] = [];
@@ -584,10 +585,16 @@ describe("client entry integration", () => {
     expect(createPrachtIslandsClientModuleSource({}, { root: withWebmcp })).toContain(
       'import("virtual:pracht/webmcp")',
     );
+    expect(createPrachtServerModuleSource({}, { root: withWebmcp })).toContain(
+      "export const islandsBootstrapRequired = true;",
+    );
 
     for (const root of [withoutWebmcp, none]) {
       expect(createPrachtClientModuleSource({}, { root })).not.toContain("webmcp");
       expect(createPrachtIslandsClientModuleSource({}, { root })).not.toContain("webmcp");
+      expect(createPrachtServerModuleSource({}, { root })).toContain(
+        "export const islandsBootstrapRequired = false;",
+      );
     }
   });
 });

--- a/packages/vite-plugin/test/pages-router.test.ts
+++ b/packages/vite-plugin/test/pages-router.test.ts
@@ -66,6 +66,222 @@ describe("scanPagesDirectory", () => {
     expect(source.match(/hydration:/g)).toHaveLength(1);
   });
 
+  it("turns a pages ISG policy into time-based revalidation", () => {
+    const pagesDir = makeTempPagesDir();
+    writeFileSync(
+      join(pagesDir, "index.tsx"),
+      [
+        'export const RENDER_MODE = "isg";',
+        "export const REVALIDATE = 1_200 as const;",
+        "export function Component() { return null; }",
+        "",
+      ].join("\n"),
+    );
+
+    const pages = scanPagesDirectory(pagesDir);
+    expect(pages[0].revalidateSeconds).toBe(1200);
+    const source = generatePagesManifestSource(pages, { pagesDir });
+    expect(source).toContain("timeRevalidate");
+    expect(source).toContain('render: "isg"');
+    expect(source).toContain("revalidate: timeRevalidate(1200)");
+  });
+
+  it("fails closed when an effective pages ISG route has no policy", () => {
+    const pagesDir = makeTempPagesDir();
+    writeFileSync(
+      join(pagesDir, "index.tsx"),
+      'export const RENDER_MODE = "isg";\nexport function Component() { return null; }\n',
+    );
+
+    expect(() => generatePagesManifestSource(scanPagesDirectory(pagesDir), { pagesDir })).toThrow(
+      /does not export a revalidation policy/,
+    );
+    expect(() =>
+      generatePagesManifestSource(scanPagesDirectory(pagesDir), {
+        pagesDir,
+        pagesDefaultRender: "isg",
+      }),
+    ).toThrow(/does not export a revalidation policy/);
+  });
+
+  it("requires every route inheriting an ISG default to declare its own policy", () => {
+    const pagesDir = makeTempPagesDir();
+    writeFileSync(
+      join(pagesDir, "index.tsx"),
+      "export const REVALIDATE = 60;\nexport function Component() { return null; }\n",
+    );
+    writeFileSync(
+      join(pagesDir, "live.tsx"),
+      'export const RENDER_MODE = "ssr";\nexport function Component() { return null; }\n',
+    );
+
+    const source = generatePagesManifestSource(scanPagesDirectory(pagesDir), {
+      pagesDir,
+      pagesDefaultRender: "isg",
+    });
+    expect(source).toContain("revalidate: timeRevalidate(60)");
+    expect(source).toContain('route("/live"');
+  });
+
+  it.each(["ssr", "ssg", "spa"])("rejects REVALIDATE on %s pages", (render) => {
+    const pagesDir = makeTempPagesDir();
+    writeFileSync(
+      join(pagesDir, "index.tsx"),
+      `export const RENDER_MODE = "${render}";\nexport const REVALIDATE = 60;\n`,
+    );
+
+    expect(() => generatePagesManifestSource(scanPagesDirectory(pagesDir), { pagesDir })).toThrow(
+      /REVALIDATE is only valid/,
+    );
+  });
+
+  it.each(["0", "-1", "1.5", "1e3", '"60"', "SECONDS", "30 * 2"])(
+    "rejects unsupported REVALIDATE expression %s",
+    (expression) => {
+      const pagesDir = makeTempPagesDir();
+      writeFileSync(
+        join(pagesDir, "index.tsx"),
+        `export const RENDER_MODE = "isg";\nexport const REVALIDATE = ${expression};\n`,
+      );
+      expect(() => scanPagesDirectory(pagesDir)).toThrow(/positive integer literal/);
+    },
+  );
+
+  it("ignores commented and string-contained policy declarations", () => {
+    const pagesDir = makeTempPagesDir();
+    writeFileSync(
+      join(pagesDir, "index.tsx"),
+      [
+        'export const RENDER_MODE = "isg";',
+        "// export const REVALIDATE = 60;",
+        'const text = "export const REVALIDATE = 120";',
+        "export function Component() { return text; }",
+        "",
+      ].join("\n"),
+    );
+    expect(() => generatePagesManifestSource(scanPagesDirectory(pagesDir), { pagesDir })).toThrow(
+      /does not export a revalidation policy/,
+    );
+  });
+
+  it("ignores commented and string-contained render and hydration exports", () => {
+    const pagesDir = makeTempPagesDir();
+    writeFileSync(
+      join(pagesDir, "index.tsx"),
+      [
+        '// export const RENDER_MODE = "isg";',
+        "const example = 'export const HYDRATION = \"islands\"';",
+        'export const RENDER_MODE = "ssr";',
+        'export const HYDRATION = "none";',
+        "export const REVALIDATE = 60;",
+        "export function Component() { return example; }",
+        "",
+      ].join("\n"),
+    );
+
+    const pages = scanPagesDirectory(pagesDir);
+    expect(pages[0]).toMatchObject({ renderMode: "ssr", hydrationMode: "none" });
+    expect(() => generatePagesManifestSource(pages, { pagesDir })).toThrow(
+      /REVALIDATE is only valid/,
+    );
+  });
+
+  it("ignores Markdown fenced policy examples but retains top-level MDX exports", () => {
+    const pagesDir = makeTempPagesDir();
+    writeFileSync(
+      join(pagesDir, "guide.mdx"),
+      [
+        'export const RENDER_MODE = "isg";',
+        "export const REVALIDATE = 90;",
+        "",
+        "# Guide",
+        "",
+        "```ts",
+        'export const RENDER_MODE = "ssr";',
+        "export const REVALIDATE = 10;",
+        "```",
+        "",
+      ].join("\n"),
+    );
+    writeFileSync(
+      join(pagesDir, "reference.md"),
+      [
+        "# Reference",
+        "",
+        "~~~ts",
+        'export const RENDER_MODE = "isg";',
+        "export const REVALIDATE = 60;",
+        "~~~",
+        "",
+      ].join("\n"),
+    );
+    writeFileSync(
+      join(pagesDir, "nested.md"),
+      [
+        "# Nested examples",
+        "",
+        "> ```ts",
+        '> export const RENDER_MODE = "isg";',
+        "> export const REVALIDATE = 60;",
+        "> ```",
+        "",
+        "- ~~~ts",
+        '  export const RENDER_MODE = "isg";',
+        "  export const REVALIDATE = 30;",
+        "  ~~~",
+        "",
+      ].join("\n"),
+    );
+    writeFileSync(
+      join(pagesDir, "ordered.mdx"),
+      [
+        "10. ~~~ts",
+        '    export const RENDER_MODE = "ssr";',
+        "    export const REVALIDATE = 30;",
+        "    ~~~",
+        "",
+        'export const RENDER_MODE = "isg";',
+        "export const REVALIDATE = 75;",
+        "",
+      ].join("\n"),
+    );
+
+    const pages = scanPagesDirectory(pagesDir);
+    expect(pages.find((page) => page.routePath === "/guide")).toMatchObject({
+      renderMode: "isg",
+      revalidateSeconds: 90,
+    });
+    expect(pages.find((page) => page.routePath === "/reference")).toMatchObject({
+      renderMode: undefined,
+      revalidateSeconds: undefined,
+    });
+    expect(pages.find((page) => page.routePath === "/nested")).toMatchObject({
+      renderMode: undefined,
+      revalidateSeconds: undefined,
+    });
+    expect(pages.find((page) => page.routePath === "/ordered")).toMatchObject({
+      renderMode: "isg",
+      revalidateSeconds: 75,
+    });
+    expect(() => generatePagesManifestSource(pages, { pagesDir })).not.toThrow();
+  });
+
+  it("rejects REVALIDATE on the pages app shell", () => {
+    const pagesDir = makeTempPagesDir();
+    writeFileSync(join(pagesDir, "index.tsx"), "export function Component() { return null; }\n");
+    writeFileSync(join(pagesDir, "_app.tsx"), "export const REVALIDATE = 60;\n");
+    expect(() => scanPagesDirectory(pagesDir)).toThrow(/app shell.*REVALIDATE/s);
+  });
+
+  it("rejects REVALIDATE on the not-found page", () => {
+    const pagesDir = makeTempPagesDir();
+    writeFileSync(join(pagesDir, "index.tsx"), "export function Component() { return null; }\n");
+    writeFileSync(join(pagesDir, "404.tsx"), "export const REVALIDATE = 60;\n");
+    expect(() => generatePagesManifestSource(scanPagesDirectory(pagesDir), { pagesDir })).toThrow(
+      /not-found.*REVALIDATE/s,
+    );
+  });
+
   it("wires pages/404 as the app notFound page instead of a route", () => {
     const pagesDir = makeTempPagesDir();
 

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -43,7 +43,7 @@ export default defineConfig({
     {
       name: "basic",
       testMatch:
-        /basic\.test\.ts|navigation\.test\.ts|node-build\.test\.ts|cloudflare-build\.test\.ts|vercel-build\.test\.ts|client-bundle-strip\.test\.ts|tsrx-build\.test\.ts|islands-build\.test\.ts|env-safety\.test\.ts|not-found\.test\.ts/,
+        /basic\.test\.ts|navigation\.test\.ts|node-build\.test\.ts|cloudflare-build\.test\.ts|vercel-build\.test\.ts|pages-isg-build\.test\.ts|client-bundle-strip\.test\.ts|tsrx-build\.test\.ts|islands-build\.test\.ts|env-safety\.test\.ts|not-found\.test\.ts/,
       use: {
         baseURL: e2eUrls.basic,
       },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -183,9 +183,15 @@ importers:
 
   examples/pages-router:
     dependencies:
+      '@pracht/adapter-cloudflare':
+        specifier: workspace:*
+        version: link:../../packages/adapter-cloudflare
       '@pracht/adapter-node':
         specifier: workspace:*
         version: link:../../packages/adapter-node
+      '@pracht/adapter-vercel':
+        specifier: workspace:*
+        version: link:../../packages/adapter-vercel
       '@pracht/core':
         specifier: workspace:*
         version: link:../../packages/framework

--- a/skills/configure-isg/SKILL.md
+++ b/skills/configure-isg/SKILL.md
@@ -62,12 +62,18 @@ route("/pricing", () => import("./routes/pricing.tsx"), {
 - `revalidate` accepts one policy or an array (`RouteRevalidate`); the array
   above means "hourly, or sooner when a webhook names this path".
 
-**Pages router caveat:** `export const RENDER_MODE = "isg"` exists, but there
-is no `REVALIDATE` page constant — the pages scanner only extracts
-`RENDER_MODE` and `HYDRATION`, so pages-router ISG routes are frozen
-build-time snapshots. To attach a policy, eject to an explicit manifest with
-`generateRoutesFile` from `@pracht/vite-plugin/pages-router` (see
-docs/ROUTING.md "Ejecting to Explicit Manifest") and edit the generated route.
+**Pages router:** time-based ISG is expressed with two static page exports:
+
+```ts
+export const RENDER_MODE = "isg";
+export const REVALIDATE = 3600;
+```
+
+`REVALIDATE` must be a positive integer literal number of seconds. Build,
+`doctor`, and `verify` reject a missing or misplaced policy. Pages mode does
+not accept policies on `_app` or `404`, and fenced Markdown/MDX examples are
+ignored. It does not support webhook or combined policies; eject with `generateRoutesFile`
+from `@pracht/vite-plugin/pages-router` for those.
 
 For dynamic routes, `getStaticPaths()` enumerates the prerendered params.
 Paths it did not enumerate render per-request without a cached copy, and

--- a/skills/migrate-nextjs/SKILL.md
+++ b/skills/migrate-nextjs/SKILL.md
@@ -53,7 +53,7 @@ If the source Next.js project uses the **pages router** (`pages/` directory), pr
 2. Copy `pages/` to `src/pages/`
 3. Convert `_app.tsx` to pracht shell format (`Shell` export + `children` prop)
 4. Convert `getServerSideProps`/`getStaticProps` to `loader` exports
-5. Add `export const RENDER_MODE = "ssg"` to static pages, `"ssr"` for dynamic (default is `"ssr"`)
+5. Add `export const RENDER_MODE = "ssg"` to static pages, `"ssr"` for dynamic (default is `"ssr"`). For time-revalidated pages, export `RENDER_MODE = "isg"` and a positive integer `REVALIDATE` in seconds. Webhook policies require ejection.
 6. Run dev server, iterate on errors
 7. Optionally run `generateRoutesFile` to eject to explicit manifest
 

--- a/skills/tune-render-mode/SKILL.md
+++ b/skills/tune-render-mode/SKILL.md
@@ -141,6 +141,9 @@ on the router `mode` from Step 1:
   `export const RENDER_MODE = "ssg"` in the page module (valid values
   `"ssr" | "ssg" | "isg" | "spa"`; the default is `"ssr"`, overridable
   globally via `pracht({ pagesDefaultRender: "..." })` in vite config).
+  For ISG, also add a positive integer time policy such as
+  `export const REVALIDATE = 3600`; pages mode requires it and supports
+  time-based revalidation only. Eject for webhook or combined policies.
   Hydration is `export const HYDRATION = "..."` in the same file. If most
   pages want the same mode, prefer changing `pagesDefaultRender` over adding
   a constant to every file.


### PR DESCRIPTION
## Summary

- Keep WebMCP available on islands-mode pages that render zero UI islands, with explicit per-app propagation through development, prerendering, error boundaries, ISG regeneration, and the Node, Cloudflare, and Vercel adapters.
- Add fail-closed pages-router ISG time policies through `REVALIDATE`, including generation, build, doctor, verify, adapter-native metadata, and adversarial static-source parsing.
- Align public docs, generated human and agent guidance, examples, bundled skills, and the framework permutation audit report.
- Relevant issue: N/A.

## Testing

- [x] `pnpm run verify` (build, format, lint, typecheck, test, e2e)
- [x] Built Node, Cloudflare, and Vercel handlers request the zero-island WebMCP route successfully.
- [x] Pages-router ISG build matrix verifies native 60-second policies for Node, Cloudflare, and Vercel.
- [x] Two adversarial review cycles completed with no remaining findings.

## Checklist

- [x] Docs updated if needed
- [x] Skills updated if needed
- [x] Changeset added if published packages changed
