### PR TITLE
fix: close the 2026-08-11 adapter permutation audit findings

### DIFF
--- a/.changeset/audit-2026-08-11-fixes.md
+++ b/.changeset/audit-2026-08-11-fixes.md
@@ -1,0 +1,62 @@
+---
+"@pracht/adapter-cloudflare": patch
+"@pracht/adapter-vercel": patch
+"@pracht/adapter-node": patch
+"create-pracht": patch
+"@pracht/core": minor
+"@pracht/cli": minor
+---
+
+Close the findings of the 2026-08-11 framework permutation audit.
+
+**Vercel ISG webhook revalidation could never authenticate.** The adapter read
+`PRACHT_REVALIDATE_TOKEN` through a `globalThis.process.env` alias; the package
+bundler inlined that single-use alias, and the *app* build's `process.env`
+define then collapsed it to `return {}[PRACHT_REVALIDATE_TOKEN_ENV]`. Every
+`POST /__pracht/revalidate` answered `401` regardless of configuration, on both
+the Edge render function and the Node ISG launcher. The read now goes through
+`serverEnv` via a new `resolveRevalidationToken()` in `@pracht/core`, which all
+three adapters share, and the Vercel build E2E asserts both the absence of
+collapsed env reads in the emitted bundle and a working authenticated request —
+unit tests against `src/` could not catch a defect the build introduced.
+
+**A uniform default `Cache-Control` across adapters.** `preventHeuristicCaching`
+moved from `@pracht/adapter-cloudflare` into `@pracht/core` and now runs on Node
+and Vercel too, so `GET`/`HEAD` responses with no caching policy get
+`private, no-cache` on every adapter. A shared cache in front of the origin may
+otherwise apply heuristic freshness to an authenticated SSR page, and `Cookie` is
+not part of its cache key. Previously an app hardened on Cloudflare lost the
+protection when it moved to Node or Vercel. Any CDN-targeted policy the app sets
+itself — including the vendor-neutral `CDN-Cache-Control` — suppresses the
+default, and ISG document responses are exempt on every adapter so a route's
+caching headers do not depend on whether its snapshot exists yet.
+
+**A Web Bot Auth signer.** `@pracht/core/agent-auth` is a new entry point
+exporting `signAgentRequest()`, `createAgentSignatureHeaders()`, and
+`generateAgentKeyPair()` — the RFC 9421 signing side the framework verified but
+never shipped. `pracht eval` scenarios gain a `signAs` block (and per-step
+`"sign": false`), so a capability declaring `agentPolicy: "require"` is finally
+reachable from the framework's own agent-task harness rather than only from
+Playwright.
+
+**Revalidation webhooks explain themselves.** `POST /__pracht/revalidate` adds a
+`details` array naming why each path was skipped (`not_a_route`, `not_isg`,
+`not_prerendered`, `no_webhook_policy`) or failed. The three existing path
+arrays are unchanged. All three adapters now build the response through one
+shared `RevalidationReport`.
+
+**llms.txt no longer advertises framework plumbing.** Paths containing a
+`_pracht` or `__pracht` segment — such as the `@pracht/image` endpoint at
+`/api/_pracht/image` — are excluded from the generated index by default. A build
+that would overwrite a hand-authored `public/llms.txt` now warns instead of
+discarding it silently, and `pracht llms` gains `--out` plus a note about the
+two unrelated documents that share the name.
+
+**Verification and scaffolding.** `pracht verify` warns when a Cloudflare app's
+assets binding leaves `html_handling` at a default that 307-redirects every
+prerendered route, and reports when no `.pracht/app-graph.json` snapshot exists
+rather than staying silent. `create-pracht` points `.mcp.json` at the project's
+own CLI (`npx --no-install pracht mcp`) instead of the registry's latest, names
+the pages router's manifest-only tradeoffs at the router prompt, and documents
+in `--help` that `--template` and `--tailwind` set the same thing (last one
+wins).

--- a/docs/ADAPTERS.md
+++ b/docs/ADAPTERS.md
@@ -378,13 +378,8 @@ With the option on:
   never stored in the shared edge cache.
 - Route-state JSON (client navigations) stays `no-store` and always reaches
   the Worker.
-- Everything pracht did **not** deliberately mark cacheable gets
-  `Cache-Control: private, no-cache` (unless the response already sets its
-  own `Cache-Control`). With Workers Caching enabled, Cloudflare would
-  otherwise apply heuristic freshness (~2 hours for 200s) to responses that
-  carry no `Cache-Control` header — and `Cookie` is not part of the cache
-  key, so SSR pages (including authenticated ones) and API GET responses
-  would be edge-cached across users.
+- (See [Default `Cache-Control`](#default-cache-control) — this applies on
+  every adapter, not only with Workers Caching enabled.)
 
 #### Trailing slashes
 
@@ -847,6 +842,43 @@ export const nodeListener = createVercelNodeListener(handle);
 
 ---
 
+## Default `Cache-Control`
+
+Every adapter stamps `Cache-Control: private, no-cache` on `GET`/`HEAD`
+responses that carry no caching policy of their own.
+
+A shared cache in front of the app — Cloudflare's Workers Caching, a CDN, an
+nginx reverse proxy — may apply RFC 9111 heuristic freshness to a `200` with no
+`Cache-Control`, and `Cookie` is not part of its cache key. Without the default,
+an authenticated SSR page or an API `GET` can be stored and replayed to a
+different user. That hazard belongs to "shared cache in front of an origin", not
+to any one platform, so Node, Cloudflare, and Vercel apply the identical default
+through one shared implementation: an app hardened on one adapter keeps the
+protection when it moves to another.
+
+Untouched: anything that already declares a policy — route-state JSON, static
+assets, and your own `headers()` exports or middleware — including a
+CDN-targeted one (`CDN-Cache-Control`, `Cloudflare-CDN-Cache-Control`,
+`Vercel-CDN-Cache-Control`, `Surrogate-Control`). Also untouched:
+non-`GET`/`HEAD` responses, protocol-switch (`101`) responses, and ISG
+documents.
+
+ISG is exempt deliberately. Those responses are stored and replayed by the
+platform — Vercel's prerender cache, the Node on-disk snapshot, Cloudflare's
+Cache API — so stamping `private, no-cache` would both defeat that cache and
+make a route's headers depend on whether its snapshot exists yet. ISG responses
+carry `public, max-age=0, must-revalidate` instead.
+
+To opt a route out, set your own policy:
+
+```typescript
+export function headers() {
+  return { "cache-control": "public, max-age=300" };
+}
+```
+
+---
+
 ## Markdown and the static fast path
 
 Routes that export `markdown` answer `Accept: text/markdown` with their raw
@@ -911,13 +943,32 @@ curl -X POST https://example.com/__pracht/revalidate \
 
 The body must include `paths` as an array of at most 64 concrete URL paths;
 larger batches are rejected with `400`. The endpoint returns JSON with
-`revalidated`, `skipped`, and `failed` path arrays. A path is skipped when it is
-not an ISG route, is not in the prerender manifest, or does not opt into
-`webhookRevalidate()`. A path lands in `failed` when regeneration did not
-produce cacheable 200 HTML (loader error, malformed manifest metadata,
-`Set-Cookie`, `Cache-Control: private`/`no-store`, cache write failure); the
-previously generated copy stays live, and the batch continues instead of
-aborting with a 500.
+`revalidated`, `skipped`, and `failed` path arrays plus a `details` array
+carrying the per-path reason:
+
+```json
+{
+  "revalidated": ["/pricing"],
+  "skipped": ["/blog", "/typo"],
+  "failed": [],
+  "details": [
+    { "path": "/pricing", "outcome": "revalidated" },
+    { "path": "/blog", "outcome": "skipped", "reason": "no_webhook_policy" },
+    { "path": "/typo", "outcome": "skipped", "reason": "not_a_route" }
+  ]
+}
+```
+
+Skip reasons are `not_a_route`, `not_isg`, `not_prerendered`, and
+`no_webhook_policy` — the last is the common one: a route with only a
+`timeRevalidate()` policy is not refreshable by webhook. A path lands in
+`failed` when regeneration did not produce cacheable 200 HTML (loader error,
+malformed manifest metadata, `Set-Cookie`, `Cache-Control: private`/`no-store`,
+cache write failure); the previously generated copy stays live, and the batch
+continues instead of aborting with a 500.
+
+The three path arrays are the stable contract and are unchanged; `details` is
+additive.
 
 Set `PRACHT_REVALIDATE_TOKEN` in the deployment environment. Auth uses a
 constant-time comparison and fails closed with `401` when the token is missing

--- a/docs/AGENT_TRUST.md
+++ b/docs/AGENT_TRUST.md
@@ -24,7 +24,8 @@ dispatch are dropped from the server bundle entirely (see
 Web Bot Auth is the emerging standard (implemented by major CDNs) where an
 agent signs its requests with [RFC 9421 HTTP Message
 Signatures](https://www.rfc-editor.org/rfc/rfc9421) and publishes its public
-keys in a well-known directory. Pracht implements the verifier side of:
+keys in a well-known directory. Pracht implements both sides — the verifier
+below, and the signer at [`@pracht/core/agent-auth`](#signing-requests-as-an-agent) — of:
 
 - [draft-meunier-web-bot-auth-architecture-02](https://www.ietf.org/archive/id/draft-meunier-web-bot-auth-architecture-02.html)
   — the protocol: covered components, signature parameters, the
@@ -572,8 +573,88 @@ example):
   and `confirm`; unresolvable references fail the scenario.
 - **Confirmation flow**: `confirm` sets the confirmation header without
   spelling out its name; raw `headers` still work for anything else.
+- **Signed agent identity**: a scenario-level `signAs` block signs every step
+  as a verified Web Bot Auth agent — the only way to reach a capability that
+  declares `agentPolicy: "require"`. Per-step `"sign": false` opts a step out,
+  so one scenario proves both halves of the policy:
+
+  ```jsonc
+  {
+    "name": "verified agent identity",
+    "signAs": {
+      "agent": "https://my-agent.example",
+      "privateKeyJwk": { "kty": "OKP", "crv": "Ed25519", "d": "…", "x": "…" }
+    },
+    "steps": [
+      { "capability": "agent.ping", "expect": { "ok": true } },
+      {
+        "capability": "agent.ping",
+        "sign": false,
+        "expect": { "ok": false, "status": 401, "errorCode": "agent_required" }
+      }
+    ]
+  }
+  ```
+
+  The signature covers `@authority` and carries a `created`/`expires` window,
+  so it is computed per request against the URL being called — which is why it
+  cannot be expressed as a static `headers` entry. `examples/basic/evals/agent-identity.eval.json`
+  is a working example. Keep real private keys out of the repo: read them from
+  the environment and write the scenario file in CI, or use a test-only key as
+  the example does.
 - Output: a human transcript (step, capability, outcome, status, latency,
   denial reasons) or `--json` for CI.
+
+## Signing requests as an agent
+
+Pracht ships the signer as well as the verifier, at `@pracht/core/agent-auth` —
+its own entry point, because nothing in a deployed app signs requests and the
+private-key path should not be bundled into a worker.
+
+```ts
+import { signAgentRequest, generateAgentKeyPair } from "@pracht/core/agent-auth";
+
+// One-time: mint a keypair. Publish `publicKeyJwk` in your key directory (or
+// pin it in the target app's `agents.webBotAuth.keys`); `keyId` is the RFC 8037
+// thumbprint both sides use to refer to it.
+const { keyId, privateKeyJwk, publicKeyJwk } = await generateAgentKeyPair();
+
+// Per request:
+const response = await fetch(
+  await signAgentRequest(new Request(url, { method: "POST", body }), {
+    agent: "https://my-agent.example",
+    privateKeyJwk,
+  }),
+);
+```
+
+`signAgentRequest()` returns a copy — the original request is untouched — and
+covers `@authority` and `signature-agent` by default, which is the covered-component
+set the Web Bot Auth draft specifies.
+
+> **Know what a signature binds.** Those two components bind the signature to a
+> *host*, not to a method, path, or body. Anyone who observes one signed request
+> can replay its headers against any other endpoint on the same origin until
+> `expires` passes (default 300 s). That is the draft's minimum, kept here for
+> interoperability — but if your agent talks to endpoints of differing
+> sensitivity, widen the coverage:
+>
+> ```ts
+> await signAgentRequest(request, {
+>   additionalComponents: ["@method", "@path"],
+>   agent, privateKeyJwk,
+> });
+> ```
+>
+> Pracht's verifier accepts any superset of the required components. Shorten
+> `lifetimeSeconds` too when the caller can re-sign cheaply. `additionalComponents` adds more (`"@method"`, `"@path"`,
+lowercase header names); `createAgentSignatureHeaders()` returns just the three
+headers when you need to attach them yourself.
+
+Because `@authority` is covered, a signature is bound to the host the request
+is actually delivered to. Signing `localhost:3000` while the server observes
+`app.example.com` — a Cloudflare custom-domain route under `wrangler dev` — will
+not verify. Sign [the authority the Worker sees](#preview-authority-with-custom-domain-routes).
 
 ## Not built yet
 
@@ -587,6 +668,7 @@ example):
   exactly-once commit, which the [approval store](#durable-approvals) now
   provides — unblocking this is a follow-up.
 - `pracht eval` speaking MCP instead of the HTTP projection.
+- RSA-PSS signing (the signer is Ed25519-only, matching the verifier).
 - Framework-level rate limiting, write-idempotency helpers, and result-size
   limits — see [operational
   hardening](#operational-hardening-what-the-framework-does-not-do-yet) for

--- a/docs/FRAMEWORK_PERMUTATION_AUDIT_2026-08-11-ADAPTERS.md
+++ b/docs/FRAMEWORK_PERMUTATION_AUDIT_2026-08-11-ADAPTERS.md
@@ -1,0 +1,875 @@
+# Framework permutation audit (deployment adapters) — 2026-08-11
+
+## Purpose
+
+A companion to
+[`FRAMEWORK_PERMUTATION_AUDIT_2026-08-11.md`](FRAMEWORK_PERMUTATION_AUDIT_2026-08-11.md),
+which covers render × hydration cross-products and the pages router. This pass
+runs the same question through the three deployment adapters instead: a
+full-surface dogfood of Pracht as both a human-facing and an agent-facing
+framework, run against the tree that landed all twelve findings of the
+[2026-08-10 audit](FRAMEWORK_PERMUTATION_AUDIT_2026-08-10.md). Every deployment
+adapter was exercised on both surfaces; scaffolding, both routers, all render and
+hydration modes, capabilities, remote MCP, Web Bot Auth, destructive confirmation,
+ISG revalidation, and the CLI were driven end to end.
+
+Goals, unchanged from the previous pass:
+
+- gaps between runtime behavior and `docs/` / `examples/docs`;
+- problems or confusing edges in the public API;
+- adoption footguns in scaffolding, local development, and deployment;
+- runtime and tooling bugs.
+
+This is an evidence report. Nothing in the workspace was changed to make a finding
+go away; the only repository writes were this file and temporary artifacts that
+were reverted (see [Reproduction notes](#reproduction-notes)).
+
+## Test baseline
+
+- Commit: `f840b1f` (`origin/main`, "Merge pull request #290")
+- Node.js: `v22.22.3`
+- Repository package manager: pnpm `11.3.0`
+- Generated-project toolchain: published `@pracht/*`, TypeScript `7.0.2`, Vite `8.2.1`
+- Host: macOS, local execution only
+
+No external Cloudflare or Vercel deployments were created. Cloudflare ran in the
+real local Workers runtime (`wrangler dev` against the built worker). Vercel was
+exercised by importing its Build Output API artifacts and invoking the generated
+handlers directly. The live documentation site was read over the public network
+but not modified.
+
+## Coverage
+
+### Deployment and interaction matrix
+
+| Adapter/workflow | Human surface | Agentic surface | Result |
+| --- | --- | --- | --- |
+| Node production server | SSR, SSG, ISG, SPA redirect, islands, API, auth middleware, route-state, markdown negotiation, 404 | llms.txt, capability HTTP, remote MCP, signed Web Bot Auth, prepare/commit, `pracht eval` | Passed |
+| Cloudflare Workers (workerd) | same probe set in the real runtime | same agentic probe set + `pracht eval` | Passed, with a trailing-slash divergence ([F-02](#f-02)) |
+| Vercel Build Output v3 | SSR, SSG, ISG, SPA redirect, API, auth middleware, route-state, markdown, 404 via the exported edge handler | llms.txt (static), capability HTTP, remote MCP, signed Web Bot Auth, prepare/commit | Passed except ISG webhook revalidation ([F-01](#f-01)) |
+| `pracht dev` (Node) | full route/API/banner surface, devtools at `/_pracht` | live llms.txt, capability HTTP, MCP, signed Web Bot Auth | Passed |
+| Showcase workflow | operator approval UI, admin API | two eval scenarios incl. human-approval gate | Passed |
+
+Node probes covered `/`, `/notes`, `/products/:id` (enumerated and un-enumerated),
+`/pricing`, `/gallery`, `/settings`, `/dashboard` (with and without session),
+a missing route, static assets, both route-state forms, `Accept: text/markdown`,
+`/llms.txt`, `/mcp`, all five capabilities, the destructive prepare/commit flow
+(including token replay and input-mismatch rejection), and
+`POST /__pracht/revalidate` (valid token, wrong token, unknown path, non-ISG
+route, oversized batch). Cloudflare and Vercel repeated the same set.
+
+### Render and hydration modes
+
+`examples/islands` was built for all three adapters (Node, Cloudflare, Vercel) and
+the prerendered output compared byte-for-byte across targets. `hydration: "none"`
+emits zero `<script>` tags and zero modulepreloads on every adapter; `islands`
+routes emit one bootstrap; `full` emits two. Output was identical across targets.
+
+### Scaffold matrix
+
+All 24 `create-pracht` combinations (adapter × router × template × agent tools)
+completed a dry run. Six representative projects were installed and built with
+pnpm 11 against the **published** packages:
+
+| Project | Adapter | Router | Template | Agent tools | install | build | `tsc --noEmit` |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| n1 | node | manifest | minimal | yes | ok | ok | ok |
+| cf1 | cf | manifest | minimal | yes | ok | ok | ok |
+| v1 | vercel | manifest | minimal | yes | ok | ok | ok |
+| np1 | node | pages | tailwind | no | ok | ok | ok |
+| cfp1 | cf | pages | minimal | no | ok | ok | ok |
+| vp1 | vercel | pages | tailwind | no | ok | ok | ok |
+
+The pnpm 11 `ERR_PNPM_IGNORED_BUILDS` blocker from the previous audit (F-04) is
+resolved: every project installed cleanly on the default happy path.
+
+### Repository checks
+
+- `pnpm run build`: passed.
+- `CI=1 pnpm run verify --skip-build`: passed (format, lint, generated types,
+  generated typecheck, workspace typecheck, unit tests, Playwright E2E), 67.3s.
+- `examples/showcase` `verify` and both eval scenarios: passed.
+- `examples/tsrx`, `examples/docs`, `examples/pages-router` graph commands and
+  builds: passed.
+
+## Remediation
+
+All findings were worked through after the audit. The findings below are kept in
+the present tense as observed at the baseline commit, so the original symptom and
+reproduction survive; this table records what actually changed.
+
+Two findings did not survive verification and are corrected rather than "fixed" —
+recorded here because a wrong finding is worse than no finding.
+
+| Finding | Status | Remediation |
+| --- | --- | --- |
+| [F-01](#f-01) | Fixed | Token read moved to `resolveRevalidationToken()` in `@pracht/core`, shared by all three adapters. The Vercel build E2E now asserts the emitted bundle contains no collapsed env reads *and* drives the built handler's revalidate endpoint with and without the token. |
+| [F-02](#f-02) | Fixed | `html_handling: "drop-trailing-slash"` added to the three example configs; `pracht verify` warns when a Cloudflare app with prerendered routes leaves it unset. |
+| [F-03](#f-03) | Fixed | `_pracht`/`__pracht` paths are excluded from llms.txt by default; `examples/basic` excludes its two auth-gated pages. |
+| [F-04](#f-04) | Fixed | Pages-router limitation table published on the public routing page, cross-linked from the capabilities and agent-trust pages, and named at the `create-pracht` router prompt. |
+| [F-05](#f-05) | Fixed | `product.tsx` throws `notFound()`; `/products/99` answers `404` with the app's not-found page on all three adapters. |
+| [F-06](#f-06) | Fixed | The 11 `lead:` fields are Markdown; the docs-site renderer converts code spans to `<code>` for HTML, and a test rejects HTML in `lead:`. |
+| [F-07](#f-07) | Fixed | New `@pracht/core/agent-auth` entry point (`signAgentRequest`, `createAgentSignatureHeaders`, `generateAgentKeyPair`) and a `signAs` block for `pracht eval`. `examples/basic/evals/agent-identity.eval.json` now covers both halves of `agentPolicy: "require"`. |
+| [F-08](#f-08) | Fixed | `preventHeuristicCaching` moved from the Cloudflare adapter into `@pracht/core` and is applied by Node and Vercel too; `docs/ADAPTERS.md` gained a shared section. |
+| [F-09](#f-09) | Fixed | `POST /__pracht/revalidate` gained a `details` array with per-path reasons, built through one shared `RevalidationReport`. `/pricing` in the example now opts into `webhookRevalidate()`. |
+| [F-10](#f-10) | Fixed | The build warns before overwriting a hand-authored `public/llms.txt`; `pracht llms` gained `--out` and a note distinguishing the two documents. |
+| [F-11](#f-11) | **Withdrawn** | Not reproducible on `main`. Both git call sites already silence stderr; the leak only occurs with the *published* `@pracht/cli@1.9.0`, which the audit invoked via `pnpm exec`. This is an instance of [F-15](#f-15), not a separate defect. |
+| [F-12](#f-12) | Fixed | `pracht verify` reports when no `.pracht/app-graph.json` exists instead of staying silent. |
+| [F-13](#f-13) | Partly withdrawn | The `.mcp.json` version-skew was real and is fixed (`npx --no-install pracht mcp`). The Dockerfile claim was **wrong** — it is already package-manager aware; the audit saw npm because it invoked the CLI without a package-manager user agent. The unconditional `pnpm-workspace.yaml` is **deliberate**, covered by a named test, and was left alone. |
+| [F-14](#f-14) | Partly fixed | `--no-budget-fail` help text corrected; `--tailwind` precedence documented in `--help`. The precedence itself is deliberate and tested, so it was documented rather than changed. |
+| [F-15](#f-15) | Unchanged | Release hygiene; resolved by publishing. |
+
+Two behaviours were reviewed and deliberately **not** changed, because each is
+covered by a test that names the intent: `create-pracht` writing an inert
+`pnpm-workspace.yaml` for npm/yarn/bun scaffolds (so a later `pnpm install` still
+has a build-script policy), and `--tailwind`/`--no-tailwind` taking precedence
+over `--template`. Both were changed during remediation and then reverted when
+those tests failed — the tests were right.
+
+### Adversarial review of the remediation
+
+Two independent review scopes — runtime/security, and docs/behaviour
+justification — were run against the remediation diff and found real defects in
+it. Everything below was introduced by the fixes above, not by the baseline:
+
+- **The Vercel `Cache-Control` default poisoned the ISG prerender cache.** The
+  generated entry wires `nodeListener = createVercelNodeListener(handle)` around
+  the very handler the stamp was added to, so every ISG regeneration was written
+  into Vercel's prerender cache as `private, no-cache` — and, because
+  `isCacheableISGResponse` rejects `private`, fired a "render this route as SSR
+  instead" warning the framework itself had caused. ISG responses are now exempt
+  on every adapter, with a regression test that fails when the guard is removed.
+- **Node ISG cold and warm hits disagreed** for the same reason: the cold render
+  was stamped while the on-disk hit kept `public, max-age=0, must-revalidate`.
+- **The Vercel webhook started acting where it used to skip.** `render` is
+  optional on a resolved route, and `entry.render !== undefined && … !== "isg"`
+  treated `undefined` as "proceed". Now a strict `!== "isg"`.
+- **Two false statements in the remediation's own docs.** The changeset claimed
+  scaffold behaviour that had been reverted, and the new `--help` line asserted
+  a `--tailwind` precedence that does not exist (the real rule is last-flag-wins,
+  measured). Both corrected.
+- **`signAgentRequest` did not leave the original request usable.**
+  `new Request(request)` disturbs the source body per the Fetch standard, so the
+  documented "the original is untouched" was false for any request with a body.
+  It now constructs from a `clone()`.
+- **Two ISG request-sanitization assertions were over-loosened** from `toEqual`
+  to `toMatchObject` by a bulk edit, weakening exactly the check that proves no
+  request-specific header reaches a shared-cache render. Restored.
+
+Also fixed from the same reviews: a broken `/docs/mcp` link, a changeset bump for
+a package with no changes, `CDN-Cache-Control` and friends not counting as an
+author-set policy, the revalidation `503` body missing `details`, and missing
+`keyId`/`agent`-URL validation in the signer.
+
+The signer's default covered-component set (`@authority` + `signature-agent`)
+was reviewed and deliberately **kept**: it is what the Web Bot Auth draft
+specifies, and widening it by default risks interop with other verifiers. The
+consequence — a captured signature is replayable against any endpoint on the
+same host until it expires — is now called out in `docs/AGENT_TRUST.md` with the
+`additionalComponents` remedy, rather than left implicit.
+
+The tree passes `CI=1 pnpm run verify` (build, format, lint, generated types,
+generated typecheck, workspace typecheck, unit tests, Playwright E2E) on top of
+`origin/main` at `8c1a9a7`.
+
+## Findings
+
+Severity reflects adoption impact and how likely a user is to mistake the failure
+for their own bug.
+
+---
+
+### F-01
+
+#### Vercel ISG webhook revalidation can never authenticate
+
+**Severity:** High &nbsp;·&nbsp; **Category:** Runtime bug (shipped in published packages)
+
+`POST /__pracht/revalidate` on the Vercel adapter answers `401 Unauthorized` for
+every request, no matter what `PRACHT_REVALIDATE_TOKEN` is set to. Webhook-based
+ISG revalidation is entirely non-functional on Vercel.
+
+The token lookup is written to survive bundling:
+
+```ts
+// packages/adapter-vercel/src/index.ts
+function getRuntimeRevalidationToken(): string | undefined {
+  const runtime = globalThis as typeof globalThis & {
+    process?: { env?: Record<string, string | undefined> };
+  };
+  return runtime.process?.env?.[PRACHT_REVALIDATE_TOKEN_ENV];
+}
+```
+
+The adapter's own `dist` is fine (`return globalThis.process?.env?.[...]`), but the
+**app** build's `process.env` define matches the member expression through the
+`globalThis` indirection and collapses it. In the emitted function bundle:
+
+```js
+// examples/basic/.vercel/output/functions/render.func/server.js
+function getRuntimeRevalidationToken() {
+	return {}?.[PRACHT_REVALIDATE_TOKEN_ENV];
+}
+```
+
+The function therefore always returns `undefined`, `readRevalidationRequest()`
+fails closed, and the endpoint answers `401`.
+
+Reproduction:
+
+```sh
+cd examples/basic
+PRACHT_ADAPTER=vercel pnpm exec pracht build
+PRACHT_REVALIDATE_TOKEN=t node --input-type=module -e '
+  const m = await import("./.vercel/output/functions/render.func/server.js");
+  const r = await m.default(new Request("https://x.test/__pracht/revalidate", {
+    method: "POST",
+    headers: { "content-type": "application/json", authorization: "Bearer t" },
+    body: JSON.stringify({ paths: ["/pricing"] }),
+  }), { waitUntil() {} });
+  console.log(r.status, await r.text());   // 401 {"error":"Unauthorized"}
+'
+```
+
+Causation was proven by editing that one line in the built bundle back to
+`globalThis.process?.env?.[...]` and re-running the same request: `200
+{"failed":[],"revalidated":[],"skipped":["/pricing"]}`.
+
+Scope:
+
+- Both emitted function types are affected — the Edge render function and the
+  Node ISG launcher (`pricing.func/server.js` contains the same collapsed call).
+- It reproduces against **published** packages. A `create-pracht --adapter=vercel`
+  project on `@pracht/adapter-vercel@0.2.8` emits `return {}[PRACHT_REVALIDATE_TOKEN_ENV]`
+  and answers `401`.
+- Node (`process.env[...]` directly) and Cloudflare (`env` binding) are unaffected
+  and were verified working.
+
+The rest of the framework already avoids this class of bug by reading through
+`serverEnv` — that is how `PRACHT_CONFIRMATION_SECRET` survives the same build
+(the destructive prepare/commit flow works correctly on Vercel).
+
+`docs/ADAPTERS.md` describes Vercel's runtime-versus-build-time token semantics in
+detail, which implies the runtime path authenticates. It cannot.
+
+**Suggested action:** read the token through `serverEnv` like the rest of the
+framework, and add an adapter integration test that drives the built Vercel bundle's
+revalidate endpoint with the env var set — a unit test against `src/` cannot catch
+this, because the defect is introduced by the app build.
+
+---
+
+### F-02
+
+#### Every checked-in Cloudflare example omits `html_handling`, including the docs site
+
+**Severity:** Medium &nbsp;·&nbsp; **Category:** Example/deployment footgun
+
+`docs/ADAPTERS.md` documents the trailing-slash divergence, says `create-pracht`
+writes `"html_handling": "drop-trailing-slash"`, and tells existing apps to add it.
+None of the three checked-in Cloudflare configs do:
+
+- `examples/basic/wrangler.jsonc`
+- `examples/cloudflare/wrangler.jsonc`
+- `examples/docs/wrangler.jsonc`
+
+Measured against the same build of `examples/basic`:
+
+| Request | Node | Cloudflare | Vercel |
+| --- | --- | --- | --- |
+| `GET /products/1` | `200` | `307 → /products/1/` | `200` |
+| `GET /pricing` | `200` | `307 → /pricing/` | `200` |
+
+The generated `llms.txt` emits the non-slash form, so an agent following it takes a
+redirect on every prerendered page — on Cloudflare only. This reproduces on the
+project's own production site:
+
+```
+$ curl -s -o /dev/null -w "%{http_code} -> %{redirect_url}\n" https://pracht.resynapse.dev/docs/routing
+307 -> https://pracht.resynapse.dev/docs/routing/
+```
+
+`create-pracht` gets this right, so only existing apps and the project's own
+examples are exposed — but the examples are what users copy, and the docs site is
+the reference deployment.
+
+**Suggested action:** add `"html_handling": "drop-trailing-slash"` to the three
+example configs, and consider a `pracht doctor` / `pracht verify` check that flags
+a Cloudflare app whose assets binding leaves `html_handling` at its default while
+the app has prerendered routes.
+
+---
+
+### F-03
+
+#### `examples/basic` publishes an llms.txt that lists endpoints agents cannot use
+
+**Severity:** Medium &nbsp;·&nbsp; **Category:** Example/agentic-surface gap
+
+The canonical example's generated `llms.txt` advertises:
+
+```
+## Pages
+- [/dashboard](/dashboard)
+- [/settings](/settings)
+
+## API
+- [/api/_pracht/image](/api/_pracht/image): GET, HEAD
+```
+
+Measured behavior for an anonymous agent following that index:
+
+| Listed URL | Actual response |
+| --- | --- |
+| `/dashboard` | `302 → /` (auth middleware) |
+| `/settings` | `302 → /` (auth middleware) |
+| `/api/_pracht/image` | framework-internal image endpoint, not an app API |
+
+The `llmsTxt.exclude` option exists and its own doc comment warns about precisely
+this — *"llms.txt invites agents to fetch every URL it lists, so exclude anything
+an anonymous agent cannot use — pages behind an auth middleware, internal
+tooling"* — but `examples/basic/vite.config.ts` does not use it. The example that
+demonstrates the agentic surface demonstrates the anti-pattern its own option
+documents.
+
+Separately, `/api/_pracht/*` is a framework-reserved namespace. Emitting it as an
+app API endpoint is noise in every app that uses `@pracht/image`, not just this
+one.
+
+**Suggested action:** set `llmsTxt: { exclude: ["/dashboard", "/settings"] }` in the
+example, and exclude the `/_pracht/**` reserved namespace from llms.txt by default
+rather than requiring every app to opt out of it.
+
+---
+
+### F-04
+
+#### The public docs never say the pages router has no agentic surface
+
+**Severity:** Medium &nbsp;·&nbsp; **Category:** Documentation gap / adoption footgun
+
+`docs/ROUTING.md` carries a precise comparison table:
+
+```
+| Capabilities | ❌ — and therefore no capability HTTP endpoints, no WebMCP,
+                    no remote MCP, no `pracht eval` |
+| defineApp({ constraints }), agents | ❌ |
+| Middleware | ❌ no registration seam |
+```
+
+That table exists only in the repository. On the public site, `examples/docs`
+mentions the pages-router limitation for **constraints** (agent-workflow.md) and
+offers a higher-order-function workaround for **middleware** (middleware.md,
+api-routes.md, recipes-logging.md) — but nowhere states that capabilities, WebMCP,
+remote MCP, Web Bot Auth, and `pracht eval` are unavailable. Grepping every public
+docs page for that combination returns nothing.
+
+`create-pracht` presents the two routers as equals:
+
+```
+Router:
+  1. Manifest (explicit routes.ts)
+  2. Pages (file-system routing)
+```
+
+The generated `AGENTS.md` *does* spell out the limitation for coding agents, so an
+agent working in the project is informed. A human choosing option 2 at the prompt
+is not, and neither is a reader of the public site. Capabilities are the product's
+headline bet; losing them should not be a discovery made later.
+
+Verified end to end: `pracht inspect capabilities` in `examples/pages-router`
+reports "No capabilities registered", and the plugin explicitly warns that
+`pagesDir` makes `appFile` ignored — so there is no seam to register them through.
+
+**Suggested action:** port the `docs/ROUTING.md` comparison table to the public
+routing page, cross-link it from the capabilities and agents pages, and add a
+one-line consequence note to the `create-pracht` router prompt.
+
+---
+
+### F-05
+
+#### The canonical example teaches `throw new Error` where the docs teach `notFound()`
+
+**Severity:** Medium &nbsp;·&nbsp; **Category:** Example contradicts documentation
+
+`examples/basic/src/routes/product.tsx`:
+
+```ts
+export function loader({ params }: LoaderArgs) {
+  const product = PRODUCTS.find((p) => p.id === params.productId);
+  if (!product) throw new Error("Product not found");
+  return product;
+}
+```
+
+`GET /products/99` — a dynamic SSG path `getStaticPaths()` did not enumerate, which
+correctly falls through to a server render — therefore answers:
+
+```
+500  content-type: text/plain; charset=utf-8
+Internal Server Error
+```
+
+on all three adapters, bypassing the app's `notFound` page entirely. The framework
+is behaving correctly; the example is wrong. `docs/DATA_LOADING.md` and
+`docs/ROUTING.md` both prescribe `throw notFound()` for exactly this case, and
+`notFound` is exported from `@pracht/core`.
+
+Un-enumerated dynamic paths are the single most common way a reader will exercise
+this route, and the example is the reference for "what does a loader do when the
+record is missing".
+
+**Suggested action:** use `throw notFound("Product not found")` in the example, and
+consider an `ErrorBoundary` export on the same route so both documented recovery
+paths are demonstrated.
+
+---
+
+### F-06
+
+#### The docs site's llms.txt contains raw HTML inside Markdown
+
+**Severity:** Medium &nbsp;·&nbsp; **Category:** Agentic-surface content bug
+
+`https://pracht.resynapse.dev/llms.txt` emits entries like:
+
+```
+- [Agent Skills](…/docs/agent-skills): pracht ships 28 Claude Code skills … seeded
+  into new apps by <code>create-pracht</code>, and pair with the built-in MCP server.
+- [Forms](…): Handle form submissions … using pracht's <code>&lt;Form&gt;</code> component …
+```
+
+llms.txt is Markdown. The descriptions come from the `lead:` frontmatter field of
+each docs page, and 11 of those fields contain literal `<code>` tags — one also
+contains HTML entities (`&lt;Form&gt;`). Every agent that reads the project's own
+agentic index gets markup noise and, in the `&lt;` case, double-escaped text.
+
+```sh
+$ grep -c '^lead:.*<code>' examples/docs/src/routes/docs/*.md | grep -v ':0' | wc -l
+11
+```
+
+This is the project's own showcase of the agentic web, so it is worth more than its
+raw severity.
+
+**Suggested action:** use backticks in `lead:` and let the HTML renderer convert
+them, or convert inline code to backticks in the llms.txt generator. A test that
+asserts the generated llms.txt contains no `<` would keep it fixed.
+
+---
+
+### F-07
+
+#### Nothing in the framework can sign a Web Bot Auth request, including `pracht eval`
+
+**Severity:** Medium &nbsp;·&nbsp; **Category:** API-surface / agentic-workflow gap
+
+Pracht ships the verifier (`verifyAgentSignature`, `defineApp({ agents.webBotAuth })`)
+and documents the wire format thoroughly, but ships no signer. Searching every
+package for RFC 9421 signing turns up nothing; the only working implementation in
+the repository is a private helper inside `e2e/capabilities.test.ts`.
+
+The consequence lands hardest on `pracht eval`, the framework's own agent-task
+harness. A scenario step accepts only static headers:
+
+```ts
+// packages/cli/src/eval-runner.ts
+headers?: Record<string, string>;
+```
+
+A Web Bot Auth signature covers `@authority` and carries `created`/`expires`
+timestamps, so it cannot be expressed as a static string. `agent.ping` in
+`examples/basic` declares `agentPolicy: "require"` and is therefore **unreachable
+by `pracht eval`** — the example's own eval file skips it, and the showcase's
+`agent.brief` step can only assert the `401 agent_required` rejection, never the
+success path.
+
+So the framework can prove the "unsigned callers are refused" half of agent trust
+in CI, but not the "verified agents are served" half — that is covered only by
+Playwright, using a helper that is not part of the public API.
+
+Verified working by hand: a signed request built from that e2e helper verifies
+correctly on Node, Cloudflare (workerd) and Vercel, returning
+`{"verified":true,"agentDomain":"test-agent.example",…}` and passing `agent.ping`.
+The capability is sound; the tooling around it is missing.
+
+**Suggested action:** export a signing helper (or a `@pracht/agent-client` test
+utility) and teach `pracht eval` a per-scenario `signAs: { jwk, keyId, agent }`
+block so `agentPolicy: "require"` capabilities become testable.
+
+---
+
+### F-08
+
+#### SSR and API responses carry no `Cache-Control` on Node and Vercel, but do on Cloudflare
+
+**Severity:** Medium &nbsp;·&nbsp; **Category:** Cross-adapter inconsistency
+
+Same app, same build, same route:
+
+| Route | Node | Cloudflare | Vercel |
+| --- | --- | --- | --- |
+| `/notes` (SSR) | *(no `Cache-Control`)* | `private, no-cache` | *(no `Cache-Control`)* |
+| `/api/health` | *(no `Cache-Control`)* | `private, no-cache` | *(no `Cache-Control`)* |
+| `/nope` (404) | *(no `Cache-Control`)* | `private, no-cache` | *(not measured)* |
+
+The Cloudflare adapter's `cache.ts` stamps `private, no-cache` on any GET/HEAD
+response that has no caching policy, with a well-argued comment: a shared cache
+that applies RFC 9111 heuristic freshness would otherwise store authenticated SSR
+pages, since `Cookie` is not part of the cache key. That reasoning is not
+Cloudflare-specific — it applies to any CDN or reverse proxy in front of a Node or
+Vercel deployment.
+
+Two consequences:
+
+1. The safety property is adapter-dependent, which cuts against "deploy anywhere".
+   An app hardened on Cloudflare loses the protection when it moves to Node.
+2. `docs/ADAPTERS.md` files that bullet under **"With the option on:"** in the
+   Workers Caching section, so it reads as gated on `cloudflareAdapter({ cache: true })`.
+   It is not — the stamping is unconditional (`applyDefaultCacheControl` runs on
+   every response), and was observed with the default adapter.
+
+**Suggested action:** decide whether the default belongs in the shared runtime
+rather than one adapter; either way, move the bullet out of the "with the option
+on" list and document the Node/Vercel gap in their adapter sections.
+
+---
+
+### F-09
+
+#### `POST /__pracht/revalidate` reports `skipped` with no reason
+
+**Severity:** Low &nbsp;·&nbsp; **Category:** Debuggability
+
+Three unrelated causes produce byte-identical output:
+
+```sh
+# route does not opt into webhookRevalidate()
+{"paths":["/pricing"]}      → {"failed":[],"revalidated":[],"skipped":["/pricing"]}
+# not an ISG route
+{"paths":["/notes"]}        → {"failed":[],"revalidated":[],"skipped":["/notes"]}
+# path does not exist at all (typo)
+{"paths":["/no-such-page"]} → {"failed":[],"revalidated":[],"skipped":["/no-such-page"]}
+```
+
+`docs/ADAPTERS.md` lists all three reasons, so the behavior is correct — but an
+operator wiring a CMS webhook gets a `200` with an unexplained skip and no way to
+tell a configuration mistake from a typo. `failed` has the same shape.
+
+This is compounded by the fact that **no route in `examples/basic` opts into
+`webhookRevalidate()`** — `/pricing` is `timeRevalidate(3600)` only — so the first
+thing a reader tries against the canonical example silently does nothing.
+
+**Suggested action:** return `skipped` as `{ path, reason }` objects
+(`not_isg` / `not_prerendered` / `no_webhook_policy`), and give the example a route
+with `revalidate: [timeRevalidate(...), webhookRevalidate()]`.
+
+---
+
+### F-10
+
+#### Two different documents compete for the name `llms.txt`, and one silently overwrites the other
+
+**Severity:** Low &nbsp;·&nbsp; **Category:** API-surface confusion / silent data loss
+
+`pracht llms --write` writes an **authoring guide for coding agents** (83 lines of
+framework conventions) to `./llms.txt` in the app root. The `llmsTxt` plugin option
+emits a completely different document — the **app's own agent index** — to
+`dist/client/llms.txt`, served at `/llms.txt`. Same filename, same project, two
+unrelated meanings, and the root copy is not gitignored.
+
+Separately, a hand-authored `public/llms.txt` is silently overwritten:
+
+```sh
+$ printf '# HAND WRITTEN\n' > public/llms.txt
+$ pnpm run build          # exit 0, no warning
+$ cat dist/client/llms.txt
+# n1
+## Pages
+- [/](/)
+```
+
+Nothing in `docs/LLMS_TXT.md` mentions the collision. A user who wants to hand-tune
+their index has no way to discover that the build discards it.
+
+**Suggested action:** warn (or fail) when `public/llms.txt` exists alongside
+`llmsTxt`, and rename the CLI output to something unambiguous
+(`pracht llms --write` → `AGENTS.md`-adjacent, or `--out <path>`).
+
+---
+
+### F-11
+
+#### `pracht plan` and `pracht report` leak raw git errors
+
+**Severity:** Low &nbsp;·&nbsp; **Category:** Polish
+
+> **Withdrawn on verification.** This does not reproduce on `main`: both git
+> call sites (`graph-snapshot.ts`, `verification-scope.ts`) already pass
+> `stdio: ["ignore", "pipe", "ignore"]` with a comment explaining exactly this.
+> The audit ran the command through `pnpm exec`, which resolves the *published*
+> `@pracht/cli@1.9.0` — where it does leak. Re-read as an instance of
+> [F-15](#f-15). The observation below is what the published CLI does.
+
+Outside a git repository, both commands print git's own error before their handled
+message:
+
+```
+$ pracht plan
+fatal: not a git repository (or any of the parent directories): .git
+Pracht plan (no baseline snapshot — every entry shows as added)
++ route /  render=ssg  shell=public  middleware=[]
+```
+
+The graceful path is already implemented; the child process's stderr just is not
+suppressed. Reproducible in any `create-pracht --no-git` project, and in CI systems
+that check out without `.git`.
+
+**Suggested action:** capture the git subprocess's stderr and discard it on the
+expected "not a repository" / "unknown revision" paths.
+
+---
+
+### F-12
+
+#### The app-graph snapshot is advertised in fresh projects but never created, and `verify` is silent about it
+
+**Severity:** Low &nbsp;·&nbsp; **Category:** Adoption gap
+
+A fresh scaffold ships this in `.gitignore`:
+
+```
+# Keep .pracht/app-graph.json committed — it is the `pracht plan` snapshot.
+```
+
+…but no `.pracht/` directory, and neither the published nor the current `pracht
+verify` mentions the snapshot at all in a project that lacks one:
+
+```
+$ pracht verify        # 9 OK lines, "No blocking issues found."
+$ pracht verify | grep -i snapshot
+(no mention)
+```
+
+By contrast `examples/showcase`, which has committed one, gets
+`OK  App graph snapshot .pracht/app-graph.json is up to date.` So the staleness
+guarantee described in `VISION_MVP.md` ("verify fails when the snapshot is stale")
+is real, but only for projects that already discovered `pracht plan --write`. A new
+project's `.gitignore` refers to a file that does not exist and nothing ever
+suggests creating it.
+
+`pracht plan` does print the hint, but only if the user runs `plan` — which they
+have no reason to do before they have a baseline.
+
+**Suggested action:** seed `.pracht/app-graph.json` during scaffolding (the graph
+is already computed at that point), or have `verify` emit an informational line
+when no snapshot exists.
+
+---
+
+### F-13
+
+#### Generated projects mix package managers
+
+**Severity:** Low &nbsp;·&nbsp; **Category:** Scaffolding polish
+
+> **Partly withdrawn on verification.** The Dockerfile claim below is wrong:
+> `createDockerfile(packageManager)` already emits pnpm/yarn/npm variants with
+> the matching lockfile and `corepack enable`. The audit saw npm because it
+> invoked `create-pracht` through `node …/bin/create-pracht.js`, which carries
+> no `npm_config_user_agent` — so npm detection was correct for that
+> invocation. Scaffolding under a pnpm agent emits `RUN pnpm install` and
+> `COPY package.json pnpm-lock.yaml* ./`.
+>
+> The unconditional `pnpm-workspace.yaml` is **deliberate**: a test named
+> "keeps the inert standalone pnpm policy for other package managers" asserts
+> it, so a user who scaffolds with npm and later runs `pnpm install` still has
+> a build-script policy for the edge adapters. Left unchanged.
+>
+> The `.mcp.json` version skew was real and is fixed.
+
+Every generated project — including Node, and regardless of the detected package
+manager — contains:
+
+- `pnpm-workspace.yaml` with `packages: ["."]` plus an `allowBuilds` policy. This
+  makes a standalone app a pnpm workspace **root**, which changes pnpm's behavior
+  and conflicts with nesting the app inside an existing monorepo. It is inert dead
+  weight for npm, yarn, and bun users.
+- a `Dockerfile` hardcoded to npm (`COPY package-lock.json*`, `RUN npm install`,
+  `npm prune --omit=dev`) even when the project was scaffolded with pnpm — the
+  lockfile is not copied and the image resolves fresh versions at build time.
+- `.mcp.json` pointing at `npx --yes @pracht/cli mcp`, i.e. floating `latest`
+  rather than the CLI version the project pins. The MCP server an agent talks to
+  can silently drift from the CLI the project builds with.
+
+The `allowBuilds` policy is the F-04 remediation and is genuinely needed for the
+edge adapters; the issue is that it is delivered through a file that has other
+semantics, and unconditionally.
+
+**Suggested action:** emit `pnpm-workspace.yaml` only for pnpm scaffolds that need
+it, template the `Dockerfile` per package manager, and point `.mcp.json` at the
+locally installed CLI.
+
+---
+
+### F-14
+
+#### Smaller API-surface and polish observations
+
+**Severity:** Low
+
+Grouped because each is small on its own.
+
+- **No `--config` or `--adapter` escape hatch on any CLI command.** `pracht build`
+  cannot select an adapter, so multi-target apps hand-roll
+  `process.env.PRACHT_ADAPTER` in `vite.config.ts` (as `examples/basic` does) with
+  no framework support or documentation for the pattern. Relatedly,
+  `docs/ADAPTERS.md`'s own local-preview workaround for custom-domain routes tells
+  users to run `npx wrangler dev --config wrangler.local.jsonc` — the documented
+  path requires abandoning `pracht preview`, because it does not forward `--config`.
+- **`--tailwind` / `--no-tailwind` silently override `--template`.**
+  `create-pracht --template=tailwind --no-tailwind` produces a minimal project with
+  no error and no warning. The precedence is undocumented in `--help`.
+- **`pracht build --no-budget-fail` help text describes the positive behavior under
+  the negative flag name:** `"Fail the build when a client JS budget is exceeded
+  (--no-budget-fail to disable)"`.
+- **`x-pracht-isg` is undocumented in `docs/ADAPTERS.md`** (it appears only in a
+  `REQUEST_FLOWS.md` diagram), and it is absent on Cloudflare when the build-time
+  snapshot answers from the assets binding — exactly the case an operator is most
+  likely to be debugging. Node stamps `fresh`/`stale` there.
+- **Generated `package.json` key order** puts `dependencies`/`devDependencies`
+  before `name`, and `tsconfig.json` is emitted with 4-space indentation while the
+  rest of the scaffold uses 2.
+
+---
+
+### F-15
+
+#### Release lag is user-visible because every scaffold installs the published CLI
+
+**Severity:** Low &nbsp;·&nbsp; **Category:** Release hygiene
+
+Two capabilities documented on `main` do not exist in the `@pracht/cli@1.9.0`
+currently on npm — which is exactly what `create-pracht` pins:
+
+| | published 1.9.0 | repo (also reports 1.9.0) |
+| --- | --- | --- |
+| `pracht generate capability` | `ERROR Unknown command capability` | works |
+| `pracht inspect routes` | `hydration=n/a`, no `shell=` | `hydration=full  shell=public` |
+
+`docs/CAPABILITIES.md:57` documents `pracht generate capability --name …` as
+available. A user following it in a freshly generated project gets an error.
+
+Both are covered by pending changesets, so this is the expected pre-release state
+rather than a defect — but it is worth recording that the repository's docs and the
+package a new user installs describe different command surfaces, and that the two
+report the same version string.
+
+**Suggested action:** none beyond releasing; optionally note "requires
+`@pracht/cli` ≥ x.y" beside newly added commands in the docs.
+
+---
+
+## Confirmed working
+
+Recorded so a future pass does not re-derive them. All were exercised directly, not
+inferred.
+
+- **Capability HTTP projection** is uniform across Node, Cloudflare (workerd), and
+  Vercel: `200` envelopes, `400 invalid_input` with JSON-pointer issue paths,
+  `404 unknown_capability`, `405 method_not_allowed`, `401 agent_required`.
+- **Destructive prepare/commit** works on all three adapters. Tokens bind to the
+  input (a token issued for `{"titlePrefix":"Render"}` is rejected with
+  `confirmation_invalid (input_mismatch)` when replayed against different input).
+  Replay within the TTL is possible and is explicitly documented as a stateless-HMAC
+  limitation with the approval-store remedy — not a defect.
+- **Remote MCP** is spec-clean: `initialize` negotiates down to the latest supported
+  version for unknown client versions, `MCP-Protocol-Version` response header
+  matches the negotiated version, a mismatched request header is rejected with
+  `400`, notifications return `202`, batching returns `-32600` with a clear message,
+  malformed JSON returns `-32700`, unknown tools list the known names, destructive
+  capabilities are absent from `tools/list` and rejected by `tools/call`, and
+  `isError` results carry structured `_meta` diagnostics.
+- **Web Bot Auth** verifies identically on Node, workerd, and the Vercel edge
+  handler, including `agentPolicy: "require"` enforcement and rejection of a
+  single-bit-flipped signature.
+- **Human-approval mode** in `examples/showcase` correctly distinguishes
+  "no confirmation secret" from "human approval mode without an authenticated
+  principal" — the shared `confirmation_unavailable` code carries a specific
+  message for each.
+- **Islands** produce byte-identical prerendered output on all three adapters;
+  `hydration: "none"` ships zero JavaScript.
+- **The `pracht dev` banner** reports routes, API methods, capabilities, effect
+  classes, exposures, HTTP paths, and the MCP endpoint. Re-exported API methods now
+  resolve correctly (previous audit's F-09).
+- **`/_pracht` devtools** is dev-only and correctly `404`s in production builds.
+- **Revalidation input validation** rejects >64 paths with `400` and a clear message,
+  and fails closed with `401` on a wrong token, on Node and Cloudflare.
+- **All 24 scaffold permutations** dry-run, and six representative projects install,
+  build, and typecheck against published packages under TypeScript 7 and Vite 8.2.
+- **The previous audit's F-01, F-04, F-08, and F-09** were re-tested and are fixed:
+  Cloudflare graph commands terminate, pnpm 11 installs cleanly, the public CLI page
+  covers all 13 commands, and the dev banner resolves re-exported methods.
+
+## Intentional limitations re-confirmed
+
+Unchanged from the previous audit and not treated as defects: Vercel has no faithful
+local preview; Node and Vercel cannot serve WebSocket upgrades through the adapter
+contract; remote MCP omits resources, prompts, OAuth, and streaming transports;
+destructive capabilities are deliberately unavailable over WebMCP and MCP; MCP Apps
+UI is unbuilt; Cloudflare Cache API locality and Workers Caching query cardinality
+are platform properties.
+
+Not exercised in this pass, and called out rather than assumed: `cloudflareAdapter({ cache: true })`
+edge-tier behavior (local `wrangler dev` does not faithfully emulate Workers
+Caching), and any behavior that requires a real Cloudflare or Vercel deployment.
+
+## Recommended order of work
+
+1. Fix the Vercel revalidation token read ([F-01](#f-01)) and add a built-bundle
+   integration test — it is the only functional runtime break, and it ships today.
+2. Correct the three example `wrangler.jsonc` files and the example llms.txt
+   exclusions ([F-02](#f-02), [F-03](#f-03)) — cheap, and they are what users copy.
+3. Fix `product.tsx` to use `notFound()` ([F-05](#f-05)) and strip HTML from the
+   docs `lead:` fields ([F-06](#f-06)).
+4. Publish the pages-router capability limitation on the public site and in the
+   scaffold prompt ([F-04](#f-04)).
+5. Ship a Web Bot Auth signer and teach `pracht eval` to use it ([F-07](#f-07)) —
+   without it, half of the agent-trust story is untestable in CI.
+6. Decide where the default `Cache-Control` belongs ([F-08](#f-08)).
+7. Work through the low-severity polish items ([F-09](#f-09)–[F-14](#f-14)).
+
+## Reproduction notes
+
+```sh
+pnpm install --frozen-lockfile && pnpm run build
+CI=1 pnpm run verify --skip-build
+
+# Node
+cd examples/basic && PRACHT_ADAPTER=node pnpm exec pracht build
+PORT=4599 PRACHT_CONFIRMATION_SECRET=… PRACHT_REVALIDATE_TOKEN=… node dist/server/server.js
+
+# Cloudflare (real workerd)
+PRACHT_ADAPTER=cloudflare pnpm exec pracht build
+pnpm exec wrangler dev --config wrangler.local.jsonc --port 4600 --inspector-port 9330
+
+# Vercel (invoke the generated handlers directly)
+PRACHT_ADAPTER=vercel pnpm exec pracht build
+node --input-type=module -e 'import("./.vercel/output/functions/render.func/server.js")…'
+
+# Scaffolds
+node packages/start/bin/create-pracht.js <dir> --adapter=… --router=… --template=… --yes
+
+pnpm exec pracht eval --url http://localhost:<port>
+pnpm --dir examples/showcase run eval
+```
+
+Temporary artifacts created during this audit and reverted afterwards: a
+`wrangler.local.jsonc` in `examples/basic` (custom-domain route removed so the
+Worker's request authority matches the preview URL — see the previous audit's
+F-07), a parameterized adapter selection in `examples/islands/vite.config.ts` with
+two `node_modules/@pracht/*` symlinks, a `public/llms.txt` and a root `llms.txt` in
+a generated project, and one patched line in a built Vercel bundle used to prove
+[F-01](#f-01)'s causation. `git status` is clean; generated projects live under
+`/tmp/pracht-audit`.

--- a/e2e/capabilities.test.ts
+++ b/e2e/capabilities.test.ts
@@ -580,7 +580,7 @@ test("MCP refuses GET, cross-origin, and cookie-authenticated requests", async (
 const repoRoot = resolve(fileURLToPath(new URL("..", import.meta.url)));
 const cliEntry = resolve(repoRoot, "packages/cli/bin/pracht.js");
 
-test("pracht eval runs the example scenario against the dev server", async () => {
+test("pracht eval runs the example scenarios against the dev server", async () => {
   const { stdout } = await execFileAsync(
     process.execPath,
     [cliEntry, "eval", "--url", capabilitiesUrl],
@@ -588,7 +588,17 @@ test("pracht eval runs the example scenario against the dev server", async () =>
   );
   expect(stdout).toContain("PASS  notes agent flow");
   expect(stdout).toContain("confirmation_required");
-  expect(stdout).toContain("1 scenario(s) passed, 0 failed");
+
+  // Both halves of the agent-trust policy, which only became expressible in a
+  // scenario once `signAs` shipped: a signed caller reaches a capability
+  // declaring `agentPolicy: "require"`, and an unsigned one is refused.
+  expect(stdout).toContain("PASS  verified agent identity");
+  expect(stdout).toContain("agent_required");
+
+  // Asserted on the failure count rather than a scenario total, so adding a
+  // scenario does not break this test.
+  expect(stdout).toMatch(/\d+ scenario\(s\) passed, 0 failed/);
+  expect(stdout).not.toContain("FAIL");
 });
 
 test("pracht eval --start launches the app, runs the scenario, and stops it", async () => {

--- a/e2e/node-build.test.ts
+++ b/e2e/node-build.test.ts
@@ -352,7 +352,15 @@ test("SSR-only builds keep static assets on the fast path for Markdown requests"
     const routesPath = resolve(exampleDir, "src/routes.ts");
     const routesSource = readFileSync(routesPath, "utf-8")
       .replaceAll('render: "ssg"', 'render: "ssr"')
-      .replace('render: "isg",\n        revalidate: timeRevalidate(3600),', 'render: "ssr",');
+      .replaceAll('render: "isg"', 'render: "ssr"')
+      // Matching on the render mode and stripping any `revalidate:` property
+      // keeps this working when the example's ISG policy changes shape. The
+      // assertions below fail loudly if it ever stops matching, instead of
+      // silently leaving prerendered routes in place.
+      .replace(/^[^\S\n]*revalidate: .*\n/gm, "");
+    expect(routesSource).not.toContain('render: "ssg"');
+    expect(routesSource).not.toContain('render: "isg"');
+    expect(routesSource).not.toContain("revalidate:");
     writeFileSync(routesPath, routesSource, "utf-8");
 
     buildExample(exampleDir, { PRACHT_ADAPTER: "node", PRACHT_ORIGIN: origin });

--- a/e2e/vercel-build.test.ts
+++ b/e2e/vercel-build.test.ts
@@ -194,6 +194,52 @@ test("pracht build emits a deployable Vercel Build Output setup", async () => {
     expect(functionSource).not.toContain("@pracht/core/env/server was imported in client code");
     // Vite keeps ownership of NODE_ENV inlining and its mode/NODE_ENV semantics.
     expect(functionSource).not.toContain("process.env.NODE_ENV");
+
+    // A single-use `globalThis.process.env` alias is inlined by the package
+    // bundler and then collapsed to `{}` by the app build's `process.env`
+    // define. That silently compiled the revalidation token read down to
+    // `return {}[PRACHT_REVALIDATE_TOKEN_ENV]`, so the webhook answered 401 for
+    // every request. Catch the whole class rather than the one call site.
+    const pricingFunctionSource = readFileSync(resolve(pricingFunctionDir, "server.js"), "utf-8");
+    for (const source of [functionSource, pricingFunctionSource]) {
+      // Block comments survive bundling and legitimately quote the broken form,
+      // so scan code only. Line comments are left alone: stripping them would
+      // also eat any `//` inside a string literal and hide a real match.
+      const code = source.replace(/\/\*[\s\S]*?\*\//g, "");
+      expect(code).not.toMatch(/\{\s*\}\s*\??\.?\[/);
+      expect(code).not.toMatch(/\(\s*\{\s*\}\s*\)\s*\??\./);
+    }
+
+    // Prove it functionally: the emitted edge handler must authenticate the
+    // documented bearer token, and must still fail closed without it.
+    const revalidateRequest = () =>
+      new Request("https://pracht-vercel.test/__pracht/revalidate", {
+        body: JSON.stringify({ paths: ["/pricing"] }),
+        headers: {
+          authorization: "Bearer e2e-revalidate-token",
+          "content-type": "application/json",
+        },
+        method: "POST",
+      });
+
+    const previousToken = process.env.PRACHT_REVALIDATE_TOKEN;
+    try {
+      process.env.PRACHT_REVALIDATE_TOKEN = "e2e-revalidate-token";
+      const authorized = await edgeHandler(revalidateRequest(), { waitUntil() {} });
+      expect(authorized.status).toBe(200);
+      // `/pricing` opts into `webhookRevalidate()`, so it is acted on rather
+      // than reported as skipped.
+      const body = await authorized.json();
+      expect(body.skipped).toEqual([]);
+      expect([...body.revalidated, ...body.failed]).toContain("/pricing");
+
+      delete process.env.PRACHT_REVALIDATE_TOKEN;
+      const unauthorized = await edgeHandler(revalidateRequest(), { waitUntil() {} });
+      expect(unauthorized.status).toBe(401);
+    } finally {
+      if (previousToken === undefined) delete process.env.PRACHT_REVALIDATE_TOKEN;
+      else process.env.PRACHT_REVALIDATE_TOKEN = previousToken;
+    }
   } finally {
     rmSync(tempDir, { force: true, recursive: true });
   }

--- a/examples/basic/evals/agent-identity.eval.json
+++ b/examples/basic/evals/agent-identity.eval.json
@@ -1,0 +1,41 @@
+{
+  "name": "verified agent identity",
+  "task": "A signed agent reaches a capability that requires Web Bot Auth; the same capability refuses the unsigned caller.",
+  "signAs": {
+    "agent": "https://test-agent.example",
+    "privateKeyJwk": {
+      "kty": "OKP",
+      "crv": "Ed25519",
+      "d": "JZlLQqnxH-0O_1mfnuqDBB1U5XgqETE5eiRXxXRhZNM",
+      "x": "s5n91rPm5ymJjl--scT4WWq7HE9kUdj-6sVe5r__xgc"
+    }
+  },
+  "steps": [
+    {
+      "capability": "agent.whoami",
+      "input": {},
+      "expect": {
+        "ok": true,
+        "status": 200,
+        "output": { "verified": true, "agentDomain": "test-agent.example" }
+      }
+    },
+    {
+      "capability": "agent.ping",
+      "input": {},
+      "expect": { "ok": true, "status": 200, "output": { "pong": true } }
+    },
+    {
+      "capability": "agent.ping",
+      "input": {},
+      "sign": false,
+      "expect": { "ok": false, "status": 401, "errorCode": "agent_required" }
+    },
+    {
+      "capability": "agent.whoami",
+      "input": {},
+      "sign": false,
+      "expect": { "ok": true, "status": 200, "output": { "verified": false } }
+    }
+  ]
+}

--- a/examples/basic/src/routes.ts
+++ b/examples/basic/src/routes.ts
@@ -1,4 +1,4 @@
-import { defineApp, group, route, timeRevalidate } from "@pracht/core";
+import { defineApp, group, route, timeRevalidate, webhookRevalidate } from "@pracht/core";
 import { cloudflareLoader, configureImage, passthroughLoader, vercelLoader } from "@pracht/image";
 
 declare const __PRACHT_IMAGE_BACKEND__: string;
@@ -70,7 +70,12 @@ export const app = defineApp({
       route("/pricing", () => import("./routes/pricing.tsx"), {
         id: "pricing",
         render: "isg",
-        revalidate: timeRevalidate(3600),
+        // Two policies on one route: the time window keeps the page fresh on
+        // its own, and the webhook policy lets an upstream change push an
+        // immediate refresh through `POST /__pracht/revalidate` (authenticated
+        // with PRACHT_REVALIDATE_TOKEN). Without `webhookRevalidate()` that
+        // endpoint reports the path as `skipped`.
+        revalidate: [timeRevalidate(3600), webhookRevalidate()],
         speculation: "prefetch",
       }),
       route("/gallery", () => import("./routes/gallery.tsx"), {

--- a/examples/basic/src/routes/product.tsx
+++ b/examples/basic/src/routes/product.tsx
@@ -1,3 +1,4 @@
+import { notFound } from "@pracht/core";
 import type { LoaderArgs, RouteComponentProps, RouteParams } from "@pracht/core";
 
 const PRODUCTS = [
@@ -12,7 +13,11 @@ export function getStaticPaths(): RouteParams[] {
 
 export function loader({ params }: LoaderArgs) {
   const product = PRODUCTS.find((p) => p.id === params.productId);
-  if (!product) throw new Error("Product not found");
+  // `getStaticPaths()` only enumerates the three prerendered products; any
+  // other id still reaches this loader at request time. `throw notFound()`
+  // renders the app's `notFound` page with a 404 — a bare `throw new Error`
+  // would surface as a 500 "Internal Server Error" instead.
+  if (!product) throw notFound("Product not found");
   return product;
 }
 

--- a/examples/basic/vite.config.ts
+++ b/examples/basic/vite.config.ts
@@ -38,6 +38,12 @@ export default defineConfig(async () => {
         llmsTxt: {
           title: "Pracht Example",
           description: "Example app for the pracht framework.",
+          // llms.txt is a list of URLs an agent is invited to fetch, so it must
+          // not advertise pages an anonymous agent cannot use. Both of these
+          // sit behind the `auth` middleware and answer 302 to `/`.
+          // Framework-reserved paths (`/api/_pracht/image`) are dropped
+          // automatically and need no entry here.
+          exclude: ["/dashboard", "/settings"],
         },
       }),
     ],

--- a/examples/basic/wrangler.jsonc
+++ b/examples/basic/wrangler.jsonc
@@ -13,6 +13,11 @@
   "assets": {
     "binding": "ASSETS",
     "directory": "dist/client",
+    // Without this, the assets binding answers `GET /guide` with a 307 to
+    // `/guide/`, so every prerendered route has a different canonical URL on
+    // Cloudflare than on Node and Vercel — and the generated llms.txt, which
+    // emits the non-slash form, sends agents through a redirect.
+    "html_handling": "drop-trailing-slash",
     "run_worker_first": true,
   },
 }

--- a/examples/cloudflare/wrangler.jsonc
+++ b/examples/cloudflare/wrangler.jsonc
@@ -9,6 +9,11 @@
   "assets": {
     "binding": "ASSETS",
     "directory": "dist/client",
+    // Without this, the assets binding answers `GET /guide` with a 307 to
+    // `/guide/`, so every prerendered route has a different canonical URL on
+    // Cloudflare than on Node and Vercel — and the generated llms.txt, which
+    // emits the non-slash form, sends agents through a redirect.
+    "html_handling": "drop-trailing-slash",
     "run_worker_first": true,
   },
   "kv_namespaces": [{ "binding": "MY_KV", "id": "abc123" }],

--- a/examples/docs/src/routes/docs/agent-skills.md
+++ b/examples/docs/src/routes/docs/agent-skills.md
@@ -1,6 +1,6 @@
 ---
 title: Agent Skills
-lead: pracht ships 28 Claude Code skills for scaffolding, auditing, testing, and deploying apps. They are published at stable URLs with a signed discovery manifest, seeded into new apps by <code>create-pracht</code>, and pair with the built-in MCP server.
+lead: pracht ships 28 Claude Code skills for scaffolding, auditing, testing, and deploying apps. They are published at stable URLs with a signed discovery manifest, seeded into new apps by `create-pracht`, and pair with the built-in MCP server.
 breadcrumb: Agent Skills
 prev:
   href: /docs/agent-workflow

--- a/examples/docs/src/routes/docs/agent-trust.md
+++ b/examples/docs/src/routes/docs/agent-trust.md
@@ -1,6 +1,6 @@
 ---
 title: Agent Trust
-lead: Who is calling, may they do this, and what happened? Verified agent identity with Web Bot Auth, a prepare/commit confirmation flow for destructive operations, structured audit events, and <code>pracht eval</code> to prove agent flows in CI.
+lead: Who is calling, may they do this, and what happened? Verified agent identity with Web Bot Auth, a prepare/commit confirmation flow for destructive operations, structured audit events, and `pracht eval` to prove agent flows in CI.
 breadcrumb: Agent Trust
 prev:
   href: /docs/capabilities
@@ -9,6 +9,23 @@ next:
   href: /docs/remote-mcp
   title: Remote MCP
 ---
+
+> **Manifest router only.** `defineApp({ agents })` is the configuration seam for Web Bot Auth, confirmation, and remote MCP, so none of it is available to [pages-router](/docs/routing#what-the-pages-router-does-not-have) apps.
+
+> **Signing requests as an agent.** Pracht ships the signer next to the verifier at `@pracht/core/agent-auth`:
+>
+> ```ts
+> import { signAgentRequest } from "@pracht/core/agent-auth";
+>
+> const response = await fetch(
+>   await signAgentRequest(new Request(url, { method: "POST", body }), {
+>     agent: "https://my-agent.example",
+>     privateKeyJwk,
+>   }),
+> );
+> ```
+>
+> `pracht eval` scenarios use the same identity through a `signAs` block, which is what lets a scenario cover an `agentPolicy: "require"` capability. The signature covers `@authority`, so sign the host the server actually sees.
 
 ## Three Questions
 
@@ -22,7 +39,8 @@ Exposing [capabilities](/docs/capabilities) to agents raises questions a schema 
 
 ## Web Bot Auth: Verified Agent Identity
 
-Agents sign requests with [RFC 9421 HTTP Message Signatures](https://www.rfc-editor.org/rfc/rfc9421) and publish Ed25519 public keys in a well-known directory — the emerging standard already deployed by major CDNs. pracht implements the verifier side; configuration lives in the manifest, and keys are public, so they are safe there:
+Agents sign requests with [RFC 9421 HTTP Message Signatures](https://www.rfc-editor.org/rfc/rfc9421) and publish Ed25519 public keys in a well-known directory — the emerging standard already deployed by major CDNs. pracht implements both sides — the verifier described here, and the signer at
+`@pracht/core/agent-auth` shown above; configuration lives in the manifest, and keys are public, so they are safe there:
 
 ```ts [src/routes.ts]
 export const app = defineApp({

--- a/examples/docs/src/routes/docs/agent-workflow.md
+++ b/examples/docs/src/routes/docs/agent-workflow.md
@@ -1,6 +1,6 @@
 ---
 title: AI-Assisted Authoring & Review
-lead: LLMs write plausible code; frameworks should make it provable. pracht turns intent into machine truth — declared constraints, a committed app-graph snapshot, semantic diffs with <code>pracht plan</code>, and PR reports assembled from real build output.
+lead: LLMs write plausible code; frameworks should make it provable. pracht turns intent into machine truth — declared constraints, a committed app-graph snapshot, semantic diffs with `pracht plan`, and PR reports assembled from real build output.
 breadcrumb: Agent Workflow
 prev:
   href: /docs/llms

--- a/examples/docs/src/routes/docs/api-routes.md
+++ b/examples/docs/src/routes/docs/api-routes.md
@@ -1,6 +1,6 @@
 ---
 title: API Routes
-lead: Standalone server endpoints that live alongside your pages. Export named HTTP method handlers or one default handler, then return <code>Response</code> objects directly.
+lead: Standalone server endpoints that live alongside your pages. Export named HTTP method handlers or one default handler, then return `Response` objects directly.
 breadcrumb: API Routes
 prev:
   href: /docs/data-loading

--- a/examples/docs/src/routes/docs/capabilities.md
+++ b/examples/docs/src/routes/docs/capabilities.md
@@ -10,6 +10,8 @@ next:
   title: Agent Trust
 ---
 
+> **Manifest router only.** Capabilities are registered through `defineApp({ capabilities })`, so apps using the [pages router](/docs/routing#what-the-pages-router-does-not-have) have no seam to declare them in — and therefore no capability HTTP endpoints, no WebMCP, no remote MCP, and no `pracht eval`. Ejecting to a manifest is a [one-time codegen](/docs/routing#ejecting-to-explicit-manifest).
+
 ## One Contract, Many Surfaces
 
 A capability is a typed, protocol-neutral application operation: JSON Schema input and output, an effect class (`read`, `write`, or `destructive`), optional named middleware, and a server-only `run()` function. From that single contract pracht generates:

--- a/examples/docs/src/routes/docs/cli.md
+++ b/examples/docs/src/routes/docs/cli.md
@@ -1,6 +1,6 @@
 ---
 title: CLI
-lead: The <code>@pracht/cli</code> package covers development, production builds, inspection, verification, evaluation, scaffolding, previews, and agent integrations.
+lead: The `@pracht/cli` package covers development, production builds, inspection, verification, evaluation, scaffolding, previews, and agent integrations.
 breadcrumb: CLI
 prev:
   href: /docs/env

--- a/examples/docs/src/routes/docs/images.md
+++ b/examples/docs/src/routes/docs/images.md
@@ -1,6 +1,6 @@
 ---
 title: Images
-lead: Use <code>@pracht/image</code> for responsive image markup, reserved layout space, and deployment-specific optimization loaders.
+lead: Use `@pracht/image` for responsive image markup, reserved layout space, and deployment-specific optimization loaders.
 breadcrumb: Images
 prev:
   href: /docs/styling

--- a/examples/docs/src/routes/docs/llms.md
+++ b/examples/docs/src/routes/docs/llms.md
@@ -1,6 +1,6 @@
 ---
 title: LLM Content Negotiation
-lead: Give AI agents first-class Markdown at the same URLs your readers use. pracht routes can negotiate on <code>Accept: text/markdown</code>, publish <code>/llms.txt</code>, and keep HTML as the browser default.
+lead: Give AI agents first-class Markdown at the same URLs your readers use. pracht routes can negotiate on `Accept: text/markdown`, publish `/llms.txt`, and keep HTML as the browser default.
 breadcrumb: LLMs
 prev:
   href: /docs/agents

--- a/examples/docs/src/routes/docs/recipes-forms.md
+++ b/examples/docs/src/routes/docs/recipes-forms.md
@@ -1,6 +1,6 @@
 ---
 title: Forms & Validation
-lead: Handle form submissions with progressive enhancement using pracht's <code>&lt;Form&gt;</code> component and API routes. Forms work without JavaScript and upgrade to fetch-based submissions when JS is available.
+lead: Handle form submissions with progressive enhancement using pracht's `<Form>` component and API routes. Forms work without JavaScript and upgrade to fetch-based submissions when JS is available.
 breadcrumb: Forms
 prev:
   href: /docs/recipes/csp

--- a/examples/docs/src/routes/docs/recipes-testing.md
+++ b/examples/docs/src/routes/docs/recipes-testing.md
@@ -1,6 +1,6 @@
 ---
 title: Testing
-lead: Test your pracht app at every level — unit test loaders and API routes with Vitest, run full E2E tests with Playwright to verify rendering, navigation, and hydration, and prove your agent surfaces with capability tests and <code>pracht eval</code>.
+lead: Test your pracht app at every level — unit test loaders and API routes with Vitest, run full E2E tests with Playwright to verify rendering, navigation, and hydration, and prove your agent surfaces with capability tests and `pracht eval`.
 breadcrumb: Testing
 prev:
   href: /docs/recipes/view-transitions

--- a/examples/docs/src/routes/docs/routing.md
+++ b/examples/docs/src/routes/docs/routing.md
@@ -1,6 +1,6 @@
 ---
 title: Routing
-lead: pracht uses a hybrid routing model: route modules live as files by convention, but their wiring — shells, middleware, render modes, and URL patterns — is declared explicitly in a single <code>src/routes.ts</code> manifest.
+lead: pracht uses a hybrid routing model: route modules live as files by convention, but their wiring — shells, middleware, render modes, and URL patterns — is declared explicitly in a single `src/routes.ts` manifest.
 breadcrumb: Routing
 prev:
   href: /docs/demo-comparison
@@ -247,17 +247,19 @@ For projects that prefer file-system routing — especially when migrating from 
 
 ### What the pages router does not have
 
-Auto-discovery replaces the manifest, so features registered through that manifest are unavailable:
+Auto-discovery replaces the manifest — and several features are registered *through* that manifest, so they are unavailable in `pagesDir` mode. Read this before choosing a router: `create-pracht` offers both, and they are not equivalent.
 
 | Feature | Pages router |
 | --- | --- |
-| Render and hydration modes, dynamic/catch-all routes, `getStaticPaths`, API routes | ✅ |
+| Render and hydration modes, dynamic/catch-all routes, `getStaticPaths`, API routes | ✅ via `RENDER_MODE` / `HYDRATION` / `REVALIDATE` exports |
 | Shells | one `_app.tsx`; no named shells or per-route assignment |
-| Route middleware | ❌ no registration seam |
-| [Capabilities](/docs/capabilities) | ❌ no capability HTTP endpoints, WebMCP, remote MCP, or `pracht eval` |
-| `defineApp({ constraints })`, `agents` | ❌ |
+| [Route middleware](/docs/middleware) | ❌ no registration seam — wrap API handlers in a higher-order function instead |
+| [Capabilities](/docs/capabilities) | ❌ no capability HTTP endpoints, [WebMCP](/docs/agents), [remote MCP](/docs/remote-mcp), or `pracht eval` |
+| [`defineApp({ constraints })`](/docs/agent-workflow), [`agents`](/docs/agent-trust) (Web Bot Auth) | ❌ |
 
-If the app needs any of these, [eject to an explicit manifest](#ejecting-to-explicit-manifest). The authoring MCP server and generated skills still work in pages mode; they do not add a runtime agent surface.
+In short: the pages router covers pages, but the runtime agent surface lives on `defineApp()`. If the app needs any of it, start with the manifest router — or [eject to one](#ejecting-to-explicit-manifest) later, which is a one-time codegen.
+
+The authoring MCP server and generated skills still work in pages mode; they do not add a runtime agent surface.
 
 ### Setup
 

--- a/examples/docs/src/routes/docs/shells.md
+++ b/examples/docs/src/routes/docs/shells.md
@@ -1,6 +1,6 @@
 ---
 title: Shells
-lead: Layout wrappers that surround route content. Shells are decoupled from URL structure — a flat route like <code>/settings</code> can share a shell with <code>/dashboard</code> without nesting.
+lead: Layout wrappers that surround route content. Shells are decoupled from URL structure — a flat route like `/settings` can share a shell with `/dashboard` without nesting.
 breadcrumb: Shells
 prev:
   href: /docs/middleware

--- a/examples/docs/vite-plugin-md.ts
+++ b/examples/docs/vite-plugin-md.ts
@@ -61,6 +61,29 @@ function esc(s: string): string {
   return s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
 }
 
+/**
+ * Render a one-line Markdown string (the frontmatter `lead`) to HTML.
+ *
+ * The lead is the single field that reaches two renderers: this one, and the
+ * llms.txt generator, which emits it verbatim into a Markdown document. Authors
+ * therefore write Markdown — `` `pracht eval` `` — and the code-span conversion
+ * happens here. Writing raw `<code>` in the source instead put literal HTML
+ * tags (and HTML entities like `&lt;Form&gt;`) into the published llms.txt.
+ *
+ * Everything outside a code span is escaped, so the lead can never inject
+ * markup.
+ */
+function renderLead(lead: string): string {
+  return lead
+    .split(/(`[^`]+`)/)
+    .map((part) =>
+      part.startsWith("`") && part.endsWith("`") && part.length > 2
+        ? `<code>${esc(part.slice(1, -1))}</code>`
+        : esc(part),
+    )
+    .join("");
+}
+
 function highlight(code: string): string {
   const out: string[] = [];
   let i = 0;
@@ -251,7 +274,7 @@ function buildDocPage(fm: Frontmatter, contentHtml: string): string {
 
   // Lead paragraph
   if (fm.lead) {
-    parts.push(`<p class="doc-lead">${fm.lead}</p>`);
+    parts.push(`<p class="doc-lead">${renderLead(fm.lead)}</p>`);
   }
 
   // Main content

--- a/examples/docs/wrangler.jsonc
+++ b/examples/docs/wrangler.jsonc
@@ -6,6 +6,11 @@
   "assets": {
     "binding": "ASSETS",
     "directory": "dist/client",
+    // Without this, the assets binding answers `GET /guide` with a 307 to
+    // `/guide/`, so every prerendered route has a different canonical URL on
+    // Cloudflare than on Node and Vercel — and the generated llms.txt, which
+    // emits the non-slash form, sends agents through a redirect.
+    "html_handling": "drop-trailing-slash",
     "run_worker_first": true,
   },
 }

--- a/packages/adapter-cloudflare/src/cache.ts
+++ b/packages/adapter-cloudflare/src/cache.ts
@@ -16,9 +16,14 @@
 import {
   getTimeRevalidateSeconds,
   isCacheableISGResponse,
-  isProtocolSwitchResponse,
   matchAppRoute,
+  preventHeuristicCaching,
 } from "@pracht/core/server";
+
+// Re-exported from its original home so `@pracht/adapter-cloudflare/cache`
+// keeps working; the implementation moved to @pracht/core so Node and Vercel
+// apply the identical default (see runtime-headers.ts).
+export { preventHeuristicCaching };
 import type { PrachtApp, ResolvedPrachtApp, ResolvedRoute } from "@pracht/core/server";
 
 export interface CloudflareWorkersCacheOptions {
@@ -161,44 +166,6 @@ export function applyWorkersCacheHeaders(
     statusText: response.statusText,
     headers,
   });
-}
-
-/**
- * Keep Workers Caching's heuristic freshness away from responses pracht did
- * not deliberately mark cacheable. When `"cache": { "enabled": true }` is
- * set in wrangler config, Cloudflare applies RFC 9111 heuristic caching to
- * 200 responses that carry no `Cache-Control` header (~2 hours), and
- * `Cookie` is not part of the cache key — SSR pages (including
- * authenticated ones) and API GET responses would be edge-cached
- * cross-user. Stamping `Cache-Control: private, no-cache` on GET/HEAD
- * responses that lack a caching policy makes heuristic caching impossible.
- *
- * Responses that already carry a `Cache-Control` (ISG responses stamped by
- * `applyWorkersCacheHeaders`, user-set policies via `headers()` exports or
- * middleware) pass through untouched.
- */
-export function preventHeuristicCaching(request: Request, response: Response): Response {
-  if (request.method !== "GET" && request.method !== "HEAD") return response;
-  // A WebSocket handshake carries no cacheable body, and the fallback branch
-  // below would destroy it: reconstructing the response drops the `webSocket`
-  // handle and the constructor rejects status 101 outright.
-  if (isProtocolSwitchResponse(response)) return response;
-  if (response.headers.has("cache-control")) return response;
-  if (response.headers.has("cloudflare-cdn-cache-control")) return response;
-
-  try {
-    response.headers.set("cache-control", "private, no-cache");
-    return response;
-  } catch {
-    // Immutable headers (e.g. a response passed through from `fetch`).
-    const headers = new Headers(response.headers);
-    headers.set("cache-control", "private, no-cache");
-    return new Response(response.body, {
-      status: response.status,
-      statusText: response.statusText,
-      headers,
-    });
-  }
 }
 
 export interface PurgeCacheOptions {

--- a/packages/adapter-cloudflare/src/runtime.ts
+++ b/packages/adapter-cloudflare/src/runtime.ts
@@ -4,27 +4,29 @@ import {
   createRevalidationSingleFlight,
   getTimeRevalidateSeconds,
   handlePrachtRequest,
-  hasWebhookRevalidate,
   type HandlePrachtRequestOptions,
   type ISGManifestEntry,
   isCacheableISGResponse,
   jsonResponse,
+  matchAppRoute,
   type ModuleRegistry,
   type MarkdownManifest,
   PRACHT_REVALIDATE_ENDPOINT,
   PRACHT_REVALIDATE_TOKEN_ENV,
   prefersMarkdown,
   type ResolvedApiRoute,
+  classifyRevalidationSkip,
   readRevalidationRequest,
+  RevalidationReport,
   routeSupportsMarkdown,
   setServerEnv,
   type PrachtApp,
+  preventHeuristicCaching,
 } from "@pracht/core/server";
 import {
   applyWorkersCacheHeaders,
   type CloudflareWorkersCacheOption,
   findCacheableIsgRoute,
-  preventHeuristicCaching,
   purgeCache,
   resolveWorkersCacheOptions,
 } from "./cache.ts";
@@ -130,6 +132,7 @@ export function createCloudflareFetchHandler<
       return handleCloudflareRevalidationEndpoint(
         request,
         env,
+        options.app,
         options.isgManifest ?? {},
         renderISGPage,
         Boolean(cacheOptions),
@@ -327,6 +330,7 @@ async function maybeServeISG<TEnv extends Record<string, unknown>>(
 async function handleCloudflareRevalidationEndpoint(
   request: Request,
   env: Record<string, unknown>,
+  app: PrachtApp,
   isgManifest: ISGManifest,
   renderISGPage: (pathname: string, originalRequest: Request) => Promise<Response>,
   edgeCacheEnabled: boolean,
@@ -352,15 +356,18 @@ async function handleCloudflareRevalidationEndpoint(
     );
   }
 
-  const revalidated: string[] = [];
-  const skipped: string[] = [];
-  const failed: string[] = [];
+  const report = new RevalidationReport();
 
   for (const pathname of parsed.paths) {
     try {
       const entry = isgManifest[pathname];
-      if (!entry || !hasWebhookRevalidate(entry.revalidate)) {
-        skipped.push(pathname);
+      const skip = classifyRevalidationSkip(
+        entry && { render: "isg", revalidate: entry.revalidate },
+        entry !== undefined,
+        matchAppRoute(app, pathname)?.route ?? null,
+      );
+      if (skip) {
+        report.skipped(pathname, skip);
         continue;
       }
 
@@ -368,7 +375,7 @@ async function handleCloudflareRevalidationEndpoint(
       // A failed regeneration keeps the existing cached copy and is reported
       // in `failed` instead of aborting the whole batch with a 500.
       if (await regenerateCloudflareISGPage(cache, cacheKey, pathname, request, renderISGPage)) {
-        revalidated.push(pathname);
+        report.revalidated(pathname);
         // Routes with both a time and a webhook policy are served through
         // Workers Caching when the `cache` option is on — the edge copy must
         // be purged too, or it keeps serving the old page until its TTL. A
@@ -382,15 +389,15 @@ async function handleCloudflareRevalidationEndpoint(
           }
         }
       } else {
-        failed.push(pathname);
+        report.failed(pathname, "regeneration_failed");
       }
     } catch (err) {
       console.error(`ISG webhook revalidation failed for ${pathname}:`, err);
-      failed.push(pathname);
+      report.failed(pathname, "regeneration_error");
     }
   }
 
-  return jsonResponse({ failed, revalidated, skipped });
+  return jsonResponse(report.toJSON());
 }
 
 /**

--- a/packages/adapter-cloudflare/test/runtime.test.ts
+++ b/packages/adapter-cloudflare/test/runtime.test.ts
@@ -528,6 +528,11 @@ describe("createCloudflareFetchHandler webhook revalidation", () => {
 
     expect(response.status).toBe(200);
     await expect(response.json()).resolves.toEqual({
+      details: [
+        { outcome: "revalidated", path: "/pricing" },
+        // Not in the ISG manifest: nothing cached for the webhook to refresh.
+        { outcome: "skipped", path: "/not-isg", reason: "not_a_route" },
+      ],
       failed: [],
       revalidated: ["/pricing"],
       skipped: ["/not-isg"],
@@ -561,7 +566,7 @@ describe("createCloudflareFetchHandler webhook revalidation", () => {
     );
 
     expect(response.status).toBe(200);
-    await expect(response.json()).resolves.toEqual({
+    await expect(response.json()).resolves.toMatchObject({
       failed: ["/malformed"],
       revalidated: ["/pricing"],
       skipped: [],
@@ -592,7 +597,7 @@ describe("createCloudflareFetchHandler webhook revalidation", () => {
     );
 
     expect(response.status).toBe(200);
-    await expect(response.json()).resolves.toEqual({
+    await expect(response.json()).resolves.toMatchObject({
       failed: ["/pricing"],
       revalidated: [],
       skipped: [],

--- a/packages/adapter-node/src/node-handler.ts
+++ b/packages/adapter-node/src/node-handler.ts
@@ -7,17 +7,20 @@ import {
   applyDefaultSecurityHeaders,
   getTimeRevalidateSeconds,
   handlePrachtRequest,
-  hasWebhookRevalidate,
+  classifyRevalidationSkip,
   type HandlePrachtRequestOptions,
   type ISGManifestEntry,
   isCacheableISGResponse,
   jsonResponse,
+  matchAppRoute,
   type ModuleRegistry,
   type MarkdownManifest,
   PRACHT_REVALIDATE_ENDPOINT,
-  PRACHT_REVALIDATE_TOKEN_ENV,
   prefersMarkdown,
+  preventHeuristicCaching,
   readRevalidationRequest,
+  RevalidationReport,
+  resolveRevalidationToken,
   type ResolvedApiRoute,
   type PrachtApp,
   routeSupportsMarkdown,
@@ -195,15 +198,16 @@ export function createNodeRequestHandler<TContext = unknown>(
       jsManifest: options.jsManifest,
     } satisfies HandlePrachtRequestOptions<TContext>);
 
-    if (
-      staticDir &&
+    const isIsgDocument =
+      staticDir !== undefined &&
       request.method === "GET" &&
       !isTransportRouteStateRequest &&
       url.pathname in isgManifest &&
       response.status === 200 &&
-      response.headers.get("content-type")?.includes("text/html") &&
-      isCacheableISGResponse(response)
-    ) {
+      (response.headers.get("content-type")?.includes("text/html") ?? false) &&
+      isCacheableISGResponse(response);
+
+    if (isIsgDocument) {
       const html = await response.clone().text();
       const htmlPath = resolveContainedPath(staticDir, url.pathname);
       if (htmlPath) {
@@ -212,7 +216,20 @@ export function createNodeRequestHandler<TContext = unknown>(
       }
     }
 
-    await writeWebResponse(res, response);
+    // Evaluated after the ISG snapshot decision above: stamping a
+    // `Cache-Control` first would make `isCacheableISGResponse()` reject the
+    // very response it was about to persist. A reverse proxy or CDN in front of
+    // a Node deployment can otherwise apply heuristic freshness to an
+    // authenticated SSR page — the same hazard the Cloudflare adapter guards.
+    //
+    // ISG documents are exempt. This response is the cold render of a page that
+    // every later request answers from disk with
+    // `public, max-age=0, must-revalidate`; stamping only the cold one would
+    // make a route's caching headers depend on whether its snapshot exists yet.
+    await writeWebResponse(
+      res,
+      isIsgDocument ? response : preventHeuristicCaching(request, response),
+    );
   };
 
   // `http.createServer(handler)` ignores the returned promise, so a rejection
@@ -358,48 +375,50 @@ async function handleRevalidationEndpoint<TContext>(
   isgManifest: Record<string, ISGManifestEntry>,
   contextArgs: NodeAdapterContextArgs,
 ): Promise<Response> {
-  const parsed = await readRevalidationRequest(request, process.env[PRACHT_REVALIDATE_TOKEN_ENV]);
+  const parsed = await readRevalidationRequest(request, resolveRevalidationToken());
   if (!parsed.ok) return parsed.response;
 
   if (!staticDir) {
+    // Built through the shared report so this reply has the same shape as every
+    // other one, `details` included, rather than the three legacy arrays alone.
+    const unavailable = new RevalidationReport();
+    for (const pathname of parsed.paths) unavailable.skipped(pathname, "not_prerendered");
     return jsonResponse(
-      {
-        error: "ISG revalidation requires a staticDir.",
-        failed: [],
-        revalidated: [],
-        skipped: parsed.paths,
-      },
+      { error: "ISG revalidation requires a staticDir.", ...unavailable.toJSON() },
       503,
     );
   }
 
-  const revalidated: string[] = [];
-  const skipped: string[] = [];
-  const failed: string[] = [];
+  const report = new RevalidationReport();
 
   for (const pathname of parsed.paths) {
     try {
       const entry = isgManifest[pathname];
       const htmlPath = resolveContainedPath(staticDir, pathname);
-      if (!entry || !htmlPath || !hasWebhookRevalidate(entry.revalidate)) {
-        skipped.push(pathname);
+      const skip = classifyRevalidationSkip(
+        entry && { render: "isg", revalidate: entry.revalidate },
+        htmlPath !== null,
+        matchAppRoute(options.app, pathname)?.route ?? null,
+      );
+      if (skip) {
+        report.skipped(pathname, skip);
         continue;
       }
 
       // A failed regeneration keeps the existing on-disk HTML and is reported
       // in `failed` instead of aborting the whole batch with a 500.
-      if (await regenerateISGPage(options, pathname, htmlPath, contextArgs)) {
-        revalidated.push(pathname);
+      if (await regenerateISGPage(options, pathname, htmlPath!, contextArgs)) {
+        report.revalidated(pathname);
       } else {
-        failed.push(pathname);
+        report.failed(pathname, "regeneration_failed");
       }
     } catch (err) {
       console.error(`ISG webhook revalidation failed for ${pathname}:`, err);
-      failed.push(pathname);
+      report.failed(pathname, "regeneration_error");
     }
   }
 
-  return jsonResponse({ failed, revalidated, skipped });
+  return jsonResponse(report.toJSON());
 }
 
 /**

--- a/packages/adapter-node/test/index.test.ts
+++ b/packages/adapter-node/test/index.test.ts
@@ -365,7 +365,7 @@ describe("createNodeRequestHandler", () => {
         method: "POST",
       });
       expect(valid.status).toBe(200);
-      await expect(valid.json()).resolves.toEqual({
+      await expect(valid.json()).resolves.toMatchObject({
         failed: [],
         revalidated: ["/pricing"],
         skipped: [],
@@ -438,7 +438,7 @@ describe("createNodeRequestHandler", () => {
       });
 
       expect(response.status).toBe(200);
-      await expect(response.json()).resolves.toEqual({
+      await expect(response.json()).resolves.toMatchObject({
         failed: ["/broken"],
         revalidated: [],
         skipped: ["/not-isg"],
@@ -508,7 +508,7 @@ describe("createNodeRequestHandler", () => {
       });
 
       expect(response.status).toBe(200);
-      await expect(response.json()).resolves.toEqual({
+      await expect(response.json()).resolves.toMatchObject({
         failed: ["/malformed"],
         revalidated: ["/pricing"],
         skipped: [],
@@ -854,5 +854,82 @@ describe("createNodeRequestHandler", () => {
       await new Promise((resolveTimer) => setTimeout(resolveTimer, 50));
       expect(unhandled).toEqual([]);
     });
+  });
+});
+
+describe("default cache-control (shared with the Cloudflare and Vercel adapters)", () => {
+  async function serve(
+    handlerOptions: Parameters<typeof createNodeRequestHandler>[0],
+    path: string,
+    init?: RequestInit,
+  ): Promise<Response> {
+    const handler = createNodeRequestHandler(handlerOptions);
+    const server = createServer((req: IncomingMessage, res: ServerResponse) => {
+      void handler(req, res);
+    });
+    servers.add(server);
+    server.listen(0, "127.0.0.1");
+    await once(server, "listening");
+    const address = server.address();
+    if (!address || typeof address === "string") throw new Error("Expected TCP server address");
+    return fetch(`http://127.0.0.1:${address.port}${path}`, init);
+  }
+
+  const app = defineApp({
+    routes: [route("/dash", "./routes/dash.tsx", { render: "ssr" })],
+  });
+  const registry = {
+    routeModules: {
+      "/src/routes/dash.tsx": async () => ({ default: () => null }),
+    },
+  };
+
+  // A reverse proxy or CDN in front of Node may heuristically cache a 200 that
+  // carries no Cache-Control, and Cookie is not part of its key. Cloudflare
+  // guarded this; Node and Vercel did not, so the protection disappeared when
+  // an app changed adapters.
+  it("stamps SSR documents that set no policy of their own", async () => {
+    const response = await serve({ app, canonicalOrigin: "https://app.test", registry }, "/dash");
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("cache-control")).toBe("private, no-cache");
+  });
+
+  it("leaves a route's own cache-control untouched", async () => {
+    const response = await serve(
+      {
+        app: defineApp({ routes: [route("/cached", "./routes/cached.tsx", { render: "ssr" })] }),
+        canonicalOrigin: "https://app.test",
+        registry: {
+          routeModules: {
+            "/src/routes/cached.tsx": async () => ({
+              default: () => null,
+              headers: () => ({ "cache-control": "public, max-age=600" }),
+            }),
+          },
+        },
+      },
+      "/cached",
+    );
+
+    expect(response.headers.get("cache-control")).toBe("public, max-age=600");
+  });
+
+  it("does not touch non-GET responses", async () => {
+    const response = await serve(
+      {
+        apiRoutes: resolveApiRoutes(["/src/api/echo.ts"]),
+        app: defineApp({ routes: [] }),
+        canonicalOrigin: "https://app.test",
+        registry: {
+          apiModules: { "/src/api/echo.ts": async () => ({ POST: () => Response.json({}) }) },
+        },
+      },
+      "/api/echo",
+      { body: "{}", headers: { "content-type": "application/json" }, method: "POST" },
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers.has("cache-control")).toBe(false);
   });
 });

--- a/packages/adapter-vercel/src/index.ts
+++ b/packages/adapter-vercel/src/index.ts
@@ -2,17 +2,20 @@ import type { PrachtAdapter } from "@pracht/vite-plugin";
 import {
   createISGRegenerationRequest,
   handlePrachtRequest,
-  hasWebhookRevalidate,
   type HandlePrachtRequestOptions,
   isCacheableISGResponse,
   isDangerousPrerenderHeader,
   jsonResponse,
+  classifyRevalidationSkip,
   matchAppRoute,
+  preventHeuristicCaching,
   type ModuleRegistry,
   PRACHT_REVALIDATE_ENDPOINT,
   PRACHT_REVALIDATE_TOKEN_ENV,
   type ResolvedApiRoute,
   readRevalidationRequest,
+  RevalidationReport,
+  resolveRevalidationToken,
   type PrachtApp,
 } from "@pracht/core/server";
 
@@ -83,7 +86,7 @@ export function createVercelEdgeHandler<
       ? await options.createContext({ request, context })
       : (context as unknown as TContext);
 
-    return handlePrachtRequest({
+    const response = await handlePrachtRequest({
       app: options.app,
       registry: options.registry,
       request,
@@ -95,7 +98,34 @@ export function createVercelEdgeHandler<
       cssManifest: options.cssManifest,
       jsManifest: options.jsManifest,
     } satisfies HandlePrachtRequestOptions<TContext>);
+
+    // Vercel's CDN, like any shared cache, may apply heuristic freshness to a
+    // 200 that carries no `Cache-Control` — and `Cookie` is not part of its
+    // cache key. Same default the Cloudflare adapter applies.
+    //
+    // Except on the ISG prerender path. The generated entry wires
+    // `nodeListener = createVercelNodeListener(handle)` around this very
+    // handler, so an ISG regeneration re-enters here. Stamping it would write
+    // `private, no-cache` into Vercel's prerender cache — killing the CDN layer
+    // for every ISG page — and would make `isCacheableISGResponse` false for
+    // every render, firing a "render this route as SSR instead" warning the
+    // framework itself caused. Vercel's `.prerender-config.json` owns caching
+    // on that path.
+    if (isIsgRegenerationContext(context)) return response;
+    return preventHeuristicCaching(request, response);
   };
+}
+
+/**
+ * Contexts minted by {@link createVercelNodeListener}, i.e. ISG prerender
+ * invocations. A `WeakSet` rather than a flag on the context object because the
+ * context is handed to application `createContext` factories, and this is
+ * adapter-internal bookkeeping they should not see or be able to forge.
+ */
+const isgRegenerationContexts = new WeakSet<object>();
+
+function isIsgRegenerationContext(context: unknown): boolean {
+  return typeof context === "object" && context !== null && isgRegenerationContexts.has(context);
 }
 
 /**
@@ -133,6 +163,9 @@ export function createVercelNodeListener(
         waitUntilTasks.push(task);
       },
     };
+    // Marks this invocation as an ISG regeneration so the edge handler skips
+    // its default `Cache-Control` — see `isIsgRegenerationContext`.
+    isgRegenerationContexts.add(context);
 
     try {
       const request = createNodeISGRequest(req);
@@ -297,14 +330,15 @@ async function handleVercelRevalidationEndpoint(
   const parsed = await readRevalidationRequest(request, token);
   if (!parsed.ok) return parsed.response;
 
-  const revalidated: string[] = [];
-  const skipped: string[] = [];
-  const failed: string[] = [];
+  const report = new RevalidationReport();
 
   for (const pathname of parsed.paths) {
     const match = matchAppRoute(app, pathname);
-    if (!match || match.route.render !== "isg" || !hasWebhookRevalidate(match.route.revalidate)) {
-      skipped.push(pathname);
+    // Vercel matches route patterns rather than a prerender manifest, so a
+    // matched ISG route always has somewhere to write.
+    const skip = classifyRevalidationSkip(match?.route, match !== null);
+    if (skip) {
+      report.skipped(pathname, skip);
       continue;
     }
 
@@ -321,7 +355,7 @@ async function handleVercelRevalidationEndpoint(
       });
 
       if (!response.ok) {
-        failed.push(pathname);
+        report.failed(pathname, `upstream_status_${response.status}`);
         continue;
       }
 
@@ -332,29 +366,29 @@ async function handleVercelRevalidationEndpoint(
       // (non-Vercel/test environments don't set it).
       const cacheStatus = response.headers.get("x-vercel-cache");
       if (cacheStatus === null || VERCEL_CACHE_REFRESH_STATUSES.has(cacheStatus.toUpperCase())) {
-        revalidated.push(pathname);
+        report.revalidated(pathname);
       } else {
         console.error(
           `ISG webhook revalidation failed for ${pathname}: x-vercel-cache was "${cacheStatus}" — ` +
             "the revalidation token did not match the build-time bypass token; " +
             `rebuild with ${PRACHT_REVALIDATE_TOKEN_ENV} set.`,
         );
-        failed.push(pathname);
+        report.failed(pathname, "prerender_cache_not_bypassed");
       }
     } catch (err) {
       console.error(`ISG webhook revalidation failed for ${pathname}:`, err);
-      failed.push(pathname);
+      report.failed(pathname, "regeneration_error");
     }
   }
 
-  return jsonResponse({ failed, revalidated, skipped });
+  return jsonResponse(report.toJSON());
 }
 
 function getRuntimeRevalidationToken(): string | undefined {
-  const runtime = globalThis as typeof globalThis & {
-    process?: { env?: Record<string, string | undefined> };
-  };
-  return runtime.process?.env?.[PRACHT_REVALIDATE_TOKEN_ENV];
+  // Must stay a call into @pracht/core: an inline `globalThis.process.env`
+  // read here is collapsed to `{}` by the app build's `process.env` define,
+  // which silently made this endpoint answer 401 for every request.
+  return resolveRevalidationToken();
 }
 
 /**

--- a/packages/adapter-vercel/test/index.test.ts
+++ b/packages/adapter-vercel/test/index.test.ts
@@ -1,6 +1,12 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { defineApp, route, timeRevalidate, webhookRevalidate } from "@pracht/core";
+import {
+  defineApp,
+  resolveApiRoutes,
+  route,
+  timeRevalidate,
+  webhookRevalidate,
+} from "@pracht/core";
 
 import {
   createVercelEdgeHandler,
@@ -237,7 +243,14 @@ describe("createVercelEdgeHandler webhook revalidation", () => {
     );
 
     expect(response.status).toBe(200);
+    // `details` names *why* each path was skipped: the legacy arrays alone made
+    // a route without a webhook policy indistinguishable from a typo.
     await expect(response.json()).resolves.toEqual({
+      details: [
+        { outcome: "revalidated", path: "/pricing" },
+        { outcome: "skipped", path: "/time-only", reason: "no_webhook_policy" },
+        { outcome: "skipped", path: "/unknown", reason: "not_a_route" },
+      ],
       failed: [],
       revalidated: ["/pricing"],
       skipped: ["/time-only", "/unknown"],
@@ -267,7 +280,7 @@ describe("createVercelEdgeHandler webhook revalidation", () => {
     const response = await handler(createWebhookRequest(["/pricing"], "secret"), {});
 
     expect(response.status).toBe(200);
-    await expect(response.json()).resolves.toEqual({
+    await expect(response.json()).resolves.toMatchObject({
       failed: ["/pricing"],
       revalidated: [],
       skipped: [],
@@ -292,7 +305,7 @@ describe("createVercelEdgeHandler webhook revalidation", () => {
     const response = await handler(createWebhookRequest(["/pricing"], "secret"), {});
 
     expect(response.status).toBe(200);
-    await expect(response.json()).resolves.toEqual({
+    await expect(response.json()).resolves.toMatchObject({
       failed: ["/pricing"],
       revalidated: [],
       skipped: [],
@@ -313,7 +326,7 @@ describe("createVercelEdgeHandler webhook revalidation", () => {
     const response = await handler(createWebhookRequest(["/pricing"], "secret"), {});
 
     expect(response.status).toBe(200);
-    await expect(response.json()).resolves.toEqual({
+    await expect(response.json()).resolves.toMatchObject({
       failed: [],
       revalidated: ["/pricing"],
       skipped: [],
@@ -331,10 +344,114 @@ describe("createVercelEdgeHandler webhook revalidation", () => {
     const response = await handler(createWebhookRequest(["/pricing"], "secret"), {});
 
     expect(response.status).toBe(200);
-    await expect(response.json()).resolves.toEqual({
+    await expect(response.json()).resolves.toMatchObject({
       failed: ["/pricing"],
       revalidated: [],
       skipped: [],
     });
+  });
+});
+
+describe("default cache-control (shared with the Node and Cloudflare adapters)", () => {
+  const app = defineApp({
+    routes: [route("/dash", "./routes/dash.tsx", { render: "ssr" })],
+  });
+  const registry = {
+    routeModules: { "/src/routes/dash.tsx": async () => ({ default: () => null }) },
+  };
+
+  it("stamps SSR documents that set no policy of their own", async () => {
+    const handler = createVercelEdgeHandler({ app, registry });
+    const response = await handler(new Request("https://app.example/dash"), {});
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("cache-control")).toBe("private, no-cache");
+  });
+
+  it("leaves a route's own cache-control untouched", async () => {
+    const handler = createVercelEdgeHandler({
+      app: defineApp({ routes: [route("/cached", "./routes/cached.tsx", { render: "ssr" })] }),
+      registry: {
+        routeModules: {
+          "/src/routes/cached.tsx": async () => ({
+            default: () => null,
+            headers: () => ({ "cache-control": "public, max-age=600" }),
+          }),
+        },
+      },
+    });
+    const response = await handler(new Request("https://app.example/cached"), {});
+
+    expect(response.headers.get("cache-control")).toBe("public, max-age=600");
+  });
+
+  // The generated entry wires `nodeListener = createVercelNodeListener(handle)`
+  // around the very handler that stamps, so an ISG regeneration re-enters it.
+  // Stamping there wrote `private, no-cache` into Vercel's prerender cache —
+  // killing the CDN layer for every ISG page — and made `isCacheableISGResponse`
+  // false for every render, firing a "render this route as SSR instead" warning
+  // the framework itself had caused.
+  it("does not stamp ISG prerender responses, which Vercel stores and replays", async () => {
+    const isgApp = defineApp({
+      routes: [
+        route("/pricing", "./routes/pricing.tsx", {
+          render: "isg",
+          revalidate: timeRevalidate(60),
+        }),
+      ],
+    });
+    const handle = createVercelEdgeHandler({
+      app: isgApp,
+      registry: {
+        routeModules: { "/src/routes/pricing.tsx": async () => ({ default: () => null }) },
+      },
+    });
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const listener = createVercelNodeListener(handle);
+
+    const headers: Record<string, string | string[]> = {};
+    await listener(
+      {
+        headers: { host: "app.example", "x-forwarded-proto": "https" },
+        method: "GET",
+        url: "/pricing",
+      },
+      {
+        end() {},
+        setHeader(key: string, value: string | string[]) {
+          headers[key] = value;
+        },
+        statusCode: 0,
+        write() {},
+      },
+    );
+
+    expect(headers["cache-control"]).toBeUndefined();
+    expect(warn).not.toHaveBeenCalled();
+
+    // The same handler still stamps on the ordinary edge path.
+    const edge = await handle(new Request("https://app.example/pricing"), {});
+    expect(edge.headers.get("cache-control")).toBe("private, no-cache");
+  });
+
+  it("does not touch non-GET responses", async () => {
+    const handler = createVercelEdgeHandler({
+      apiRoutes: resolveApiRoutes(["/src/api/echo.ts"]),
+      app: defineApp({ routes: [] }),
+      registry: {
+        apiModules: { "/src/api/echo.ts": async () => ({ POST: () => Response.json({}) }) },
+      },
+    });
+    const response = await handler(
+      new Request("https://app.example/api/echo", {
+        body: "{}",
+        headers: { "content-type": "application/json" },
+        method: "POST",
+      }),
+      {},
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers.has("cache-control")).toBe(false);
   });
 });

--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -49,8 +49,9 @@ export default defineCommand({
     "budget-fail": {
       type: "boolean",
       default: true,
-      description:
-        "Fail the build when a client JS budget is exceeded (--no-budget-fail to disable)",
+      // citty renders a `default: true` boolean under its negated name, so the
+      // description has to read correctly next to `--no-budget-fail`.
+      description: "Downgrade an exceeded client JS budget to a warning instead of failing",
     },
   },
   async run({ args }) {
@@ -214,6 +215,15 @@ export async function runBuild(root: string, options: BuildOptions = {}): Promis
     // The server module only exports generateLlmsTxt when the vite plugin's
     // `llmsTxt` option is enabled — disabled builds skip this entirely.
     if (typeof serverMod.generateLlmsTxt === "function") {
+      // Vite copies `public/` into the client output before this runs, so a
+      // hand-authored `public/llms.txt` is about to be overwritten. Silently
+      // discarding a file the user wrote is the worst outcome; say so.
+      if (existsSync(resolve(root, "public/llms.txt"))) {
+        log(
+          "\n  Warning: public/llms.txt is overwritten by the generated llms.txt.\n" +
+            "  Remove it, or disable the plugin's `llmsTxt` option to hand-author the file.",
+        );
+      }
       const llmsTxt: string = await serverMod.generateLlmsTxt();
       writeFileSync(resolve(clientDir, "llms.txt"), llmsTxt, "utf-8");
       log("\n  llms.txt → dist/client/llms.txt\n");

--- a/packages/cli/src/commands/llms.ts
+++ b/packages/cli/src/commands/llms.ts
@@ -1,9 +1,25 @@
-import { writeFileSync } from "node:fs";
+import { readFileSync, writeFileSync } from "node:fs";
 import { resolve } from "node:path";
 
 import { defineCommand } from "citty";
 
 import { AUTHORING_GUIDE } from "../authoring-guide.js";
+import { readProjectConfig } from "../project.js";
+
+/**
+ * Two different documents are called `llms.txt` in a pracht app:
+ *
+ * - this one — the framework's authoring guide, written for a coding agent
+ *   *editing* the app;
+ * - the one the vite plugin's `llmsTxt` option generates into
+ *   `dist/client/llms.txt` and serves at `/llms.txt` — the app's own index,
+ *   written for an agent *using* the deployed site.
+ *
+ * Writing the first into the project root next to a project that publishes the
+ * second is a genuine trap, so `--write` says so and `--out` exists to put the
+ * guide somewhere unambiguous.
+ */
+const DEFAULT_OUTPUT = "llms.txt";
 
 export default defineCommand({
   meta: {
@@ -13,17 +29,48 @@ export default defineCommand({
   args: {
     write: {
       type: "boolean",
-      description: "Write the guide to llms.txt in the app root",
+      description: `Write the guide to ${DEFAULT_OUTPUT} in the app root`,
+    },
+    out: {
+      type: "string",
+      description: `Write the guide to a specific path (implies --write; default ${DEFAULT_OUTPUT})`,
     },
   },
   async run({ args }) {
-    if (args.write) {
-      const filePath = resolve(process.cwd(), "llms.txt");
-      writeFileSync(filePath, AUTHORING_GUIDE, "utf-8");
-      console.log("Wrote llms.txt. Agents working in this app will pick up the conventions.");
+    const outPath = typeof args.out === "string" && args.out !== "" ? args.out : undefined;
+    if (!args.write && !outPath) {
+      console.log(AUTHORING_GUIDE);
       return;
     }
 
-    console.log(AUTHORING_GUIDE);
+    const target = outPath ?? DEFAULT_OUTPUT;
+    const filePath = resolve(process.cwd(), target);
+    writeFileSync(filePath, AUTHORING_GUIDE, "utf-8");
+    console.log(`Wrote ${target}. Agents working in this app will pick up the conventions.`);
+
+    if (outPath === undefined && projectPublishesItsOwnLlmsTxt()) {
+      console.log(
+        "\nNote: this app also generates a different llms.txt — its own agent-facing\n" +
+          "index — into dist/client/llms.txt via the plugin's `llmsTxt` option. The file\n" +
+          "just written is the framework authoring guide, not that index. Use\n" +
+          "`pracht llms --out AGENTS-pracht.md` to avoid the name collision.",
+      );
+    }
   },
 });
+
+/** Whether the app enables the vite plugin's `llmsTxt` option. */
+function projectPublishesItsOwnLlmsTxt(): boolean {
+  try {
+    const project = readProjectConfig(process.cwd());
+    if (!project.configFile) return false;
+    const source = readFileSync(project.configFile, "utf-8");
+    // A text probe, matching how the rest of the CLI reads the vite config
+    // without evaluating it. A false negative only costs the extra note.
+    return /\bllmsTxt\s*:/.test(source) && !/\bllmsTxt\s*:\s*false\b/.test(source);
+  } catch {
+    return false;
+  }
+}
+
+export { DEFAULT_OUTPUT as LLMS_GUIDE_DEFAULT_OUTPUT, projectPublishesItsOwnLlmsTxt };

--- a/packages/cli/src/eval-runner.ts
+++ b/packages/cli/src/eval-runner.ts
@@ -18,8 +18,17 @@
  *         "expect": { "ok": true, "errorCode": "...", "status": 200,
  *                     "output": { "notes": [] } }  // subset match
  *       }
- *     ]
+ *     ],
+ *     "signAs": {                              // optional Web Bot Auth identity
+ *       "agent": "https://my-agent.example",
+ *       "privateKeyJwk": { "kty": "OKP", "crv": "Ed25519", "d": "...", "x": "..." }
+ *     }
  *   }
+ *
+ * `signAs` signs every step with RFC 9421 HTTP Message Signatures, which is
+ * what a capability declaring `agentPolicy: "require"` demands. Per-step
+ * `"sign": false` opts a step out, so one scenario can prove both the signed
+ * and unsigned halves of an agent-trust policy.
  *
  * Reference syntax: a string value that is exactly `$steps[<index>].<path>`
  * is replaced with that value from an earlier step's result. The root object
@@ -30,6 +39,7 @@
 import { readdirSync, readFileSync, statSync } from "node:fs";
 import { join, resolve } from "node:path";
 import { capabilityHttpPath, CONFIRMATION_HEADER } from "@pracht/capabilities";
+import { createAgentSignatureHeaders, type AgentSigningJwk } from "@pracht/core/agent-auth";
 
 export interface EvalExpectation {
   ok?: boolean;
@@ -51,13 +61,34 @@ export interface EvalStep {
    * header without spelling out the header name.
    */
   confirm?: string;
+  /**
+   * Opt this step out of the scenario's `signAs` identity — for asserting that
+   * an `agentPolicy: "require"` capability rejects unsigned callers.
+   */
+  sign?: boolean;
   expect?: EvalExpectation;
+}
+
+/**
+ * Web Bot Auth identity used to sign every step of a scenario.
+ *
+ * The signature covers `@authority`, so it is computed per request against the
+ * URL actually being called — which is why this cannot be expressed as static
+ * `headers` and needed first-class support.
+ */
+export interface EvalSignAs {
+  agent: string;
+  privateKeyJwk: AgentSigningJwk;
+  keyId?: string;
+  lifetimeSeconds?: number;
 }
 
 export interface EvalScenario {
   name: string;
   task?: string;
   url?: string;
+  /** Sign every step (unless the step sets `"sign": false`) as this agent. */
+  signAs?: EvalSignAs;
   steps: EvalStep[];
 }
 
@@ -140,6 +171,25 @@ export function parseScenario(file: string): EvalScenario {
   for (const [index, step] of scenario.steps.entries()) {
     if (!step || typeof step !== "object" || typeof step.capability !== "string") {
       throw new Error(`step ${index} is missing a "capability" name`);
+    }
+  }
+  // Validated here rather than at first use: a malformed identity would
+  // otherwise surface as an unsigned request being rejected by the server,
+  // which reads like an application failure instead of a scenario bug.
+  if (scenario.signAs !== undefined) {
+    const signAs = scenario.signAs as Partial<EvalSignAs>;
+    if (!signAs || typeof signAs !== "object") {
+      throw new Error('"signAs" must be an object with "agent" and "privateKeyJwk"');
+    }
+    if (typeof signAs.agent !== "string" || signAs.agent === "") {
+      throw new Error('"signAs.agent" must be the agent\'s identity URL');
+    }
+    const jwk = signAs.privateKeyJwk as Partial<AgentSigningJwk> | undefined;
+    if (!jwk || jwk.kty !== "OKP" || jwk.crv !== "Ed25519") {
+      throw new Error('"signAs.privateKeyJwk" must be an Ed25519 OKP JWK');
+    }
+    if (typeof jwk.d !== "string" || typeof jwk.x !== "string") {
+      throw new Error('"signAs.privateKeyJwk" needs both "d" (private) and "x" (public)');
     }
   }
   return scenario as EvalScenario;
@@ -278,6 +328,30 @@ export async function runScenario(
 
     const path = step.path ?? capabilityHttpPath(step.capability);
     const url = new URL(path, options.baseUrl).toString();
+
+    // The signature covers `@authority` and a `created`/`expires` window, so it
+    // has to be produced per request against the concrete URL — the reason a
+    // signed step cannot be expressed with static `headers`.
+    if (scenario.signAs && step.sign !== false) {
+      try {
+        const signature = await createAgentSignatureHeaders(
+          new Request(url, { method: "POST" }),
+          scenario.signAs,
+        );
+        Object.assign(headers, signature);
+      } catch (error: unknown) {
+        return {
+          name: scenario.name,
+          file,
+          ok: false,
+          steps,
+          error: `could not sign step "${step.capability}": ${
+            error instanceof Error ? error.message : String(error)
+          }`,
+        };
+      }
+    }
+
     const started = performance.now();
     let status: number;
     let envelope: { ok?: unknown; data?: unknown; error?: { code?: unknown } };

--- a/packages/cli/src/verification-checks.ts
+++ b/packages/cli/src/verification-checks.ts
@@ -1,5 +1,5 @@
 import { dirname, resolve } from "node:path";
-import { existsSync, readFileSync } from "node:fs";
+import { existsSync, readFileSync, statSync } from "node:fs";
 
 import { formatBytes } from "./bundle-report.js";
 import { maskCommentsAndStrings } from "@pracht/capabilities/static";
@@ -22,7 +22,11 @@ import {
   type Check,
 } from "./verification-helpers.js";
 import { detectAdapterTarget } from "./commands/preview.js";
-import { findWranglerConfig, readWranglerMainEntries } from "./wrangler-config.js";
+import {
+  findWranglerConfig,
+  readWranglerAssetsHtmlHandling,
+  readWranglerMainEntries,
+} from "./wrangler-config.js";
 import {
   collectDuplicateRoutePaths,
   describePagesFile,
@@ -890,6 +894,7 @@ function collectCloudflareEntryCheck(project: ProjectConfig, root: string, check
   if (!configFile) return;
 
   const display = displayPath(root, configFile);
+  collectCloudflareTrailingSlashCheck(project, root, configFile, display, checks);
 
   for (const entry of readWranglerMainEntries(configFile)) {
     if (!normalizePath(entry.main).endsWith(SERVER_ENTRY_PATH)) continue;
@@ -904,4 +909,71 @@ function collectCloudflareEntryCheck(project: ProjectConfig, root: string, check
       ),
     );
   }
+}
+
+/**
+ * Cloudflare's assets binding defaults to `html_handling: "auto-trailing-slash"`,
+ * which answers `GET /guide` with a 307 to `/guide/`. Node and Vercel answer
+ * `200`, so the canonical URL of every prerendered route differs by adapter —
+ * and the generated `llms.txt` emits the non-slash form, sending agents through
+ * a redirect on Cloudflare only.
+ *
+ * `create-pracht` writes `"drop-trailing-slash"` into new Cloudflare scaffolds;
+ * this catches the apps that predate it. Warning-only and silent whenever
+ * anything is unproven: a TOML config, an unparsable file, no assets block, or
+ * an app with nothing prerendered to redirect.
+ */
+function collectCloudflareTrailingSlashCheck(
+  project: ProjectConfig,
+  root: string,
+  configFile: string,
+  display: string,
+  checks: Check[],
+): void {
+  const assets = readWranglerAssetsHtmlHandling(configFile);
+  if (!assets || assets.htmlHandling !== undefined) return;
+  if (!appHasPrerenderedRoutes(project, root)) return;
+
+  checks.push(
+    createCheck(
+      "warning",
+      `${display} does not set "assets.html_handling". Cloudflare's default redirects ` +
+        "every prerendered route to its trailing-slash form (307), so its canonical URL " +
+        'differs from Node and Vercel. Add "html_handling": "drop-trailing-slash" ' +
+        '(or "none" when you do your own routing).',
+    ),
+  );
+}
+
+/**
+ * Whether the app plausibly emits prerendered HTML. Proven from build output
+ * when there is any, and otherwise inferred from declared render modes — the
+ * same text-level heuristic the surrounding Cloudflare checks already accept,
+ * because the only consequence of being wrong is a suppressed suggestion.
+ */
+function appHasPrerenderedRoutes(project: ProjectConfig, root: string): boolean {
+  const clientDir = resolve(root, "dist/client");
+  if (existsSync(clientDir)) {
+    return listFilesRecursively(clientDir).some((file) => file.endsWith(".html"));
+  }
+
+  const sourceDir =
+    project.mode === "manifest"
+      ? resolveProjectPath(project.root, project.appFile)
+      : resolveProjectPath(project.root, project.pagesDir);
+  if (!existsSync(sourceDir)) return false;
+
+  const files = statSync(sourceDir).isDirectory()
+    ? listFilesRecursively(sourceDir).filter((file) => MODULE_SOURCE_RE.test(file))
+    : [sourceDir];
+
+  return files.some((file) => {
+    let source: string;
+    try {
+      source = readFileSync(file, "utf-8");
+    } catch {
+      return false;
+    }
+    return /["']ssg["']|["']isg["']/.test(source);
+  });
 }

--- a/packages/cli/src/verification-graph.ts
+++ b/packages/cli/src/verification-graph.ts
@@ -105,7 +105,20 @@ function collectSnapshotChecks(
   checks: Check[],
   snapshotExists: boolean,
 ): void {
-  if (!snapshotExists) return;
+  if (!snapshotExists) {
+    // Reported as `ok` rather than a warning: not having a snapshot is a valid
+    // state, it just means `pracht plan` has no baseline to diff against and
+    // the staleness guarantee is not in force. Staying silent left new projects
+    // with a `.gitignore` that talks about a file nothing ever creates.
+    checks.push(
+      createCheck(
+        "ok",
+        `No app graph snapshot yet — run \`pracht plan --write\` and commit ${GRAPH_SNAPSHOT_PATH} ` +
+          "to get incremental `pracht plan` diffs and snapshot-staleness verification.",
+      ),
+    );
+    return;
+  }
 
   const snapshot = readGraphSnapshotFromDisk(project.root);
   if (!snapshot) {

--- a/packages/cli/src/wrangler-config.ts
+++ b/packages/cli/src/wrangler-config.ts
@@ -42,6 +42,47 @@ export function readWranglerMainEntries(configFile: string): WranglerMainEntry[]
   return configFile.endsWith(".toml") ? readTomlMainEntries(source) : readJsonMainEntries(source);
 }
 
+/** What a wrangler config says about its assets binding's `html_handling`. */
+export interface WranglerAssetsHtmlHandling {
+  /** `undefined` when the key is absent, i.e. wrangler's `auto-trailing-slash`. */
+  htmlHandling: string | undefined;
+}
+
+/**
+ * The top-level `assets.html_handling` value, or `null` when it cannot be
+ * proven — an unreadable file, a parse failure, a TOML config (not parsed
+ * here), or no `assets` block at all.
+ *
+ * `null` means "unknown", never "fine": callers must stay silent on it rather
+ * than reporting a config they could not read.
+ */
+export function readWranglerAssetsHtmlHandling(
+  configFile: string,
+): WranglerAssetsHtmlHandling | null {
+  if (configFile.endsWith(".toml")) return null;
+
+  let source: string;
+  try {
+    source = readFileSync(configFile, "utf-8");
+  } catch {
+    return null;
+  }
+
+  let config: unknown;
+  try {
+    config = JSON.parse(stripJsonComments(source).replace(/,(\s*[}\]])/g, "$1"));
+  } catch {
+    return null;
+  }
+  if (!config || typeof config !== "object") return null;
+
+  const assets = (config as Record<string, unknown>).assets;
+  if (!assets || typeof assets !== "object") return null;
+
+  const htmlHandling = (assets as Record<string, unknown>).html_handling;
+  return { htmlHandling: typeof htmlHandling === "string" ? htmlHandling : undefined };
+}
+
 function readJsonMainEntries(source: string): WranglerMainEntry[] {
   let config: unknown;
   try {

--- a/packages/cli/test/docs-content.test.js
+++ b/packages/cli/test/docs-content.test.js
@@ -30,6 +30,30 @@ describe("documentation content", () => {
     expect(offenders).toEqual([]);
   });
 
+  // The `lead:` frontmatter is the one field with two renderers: the docs site
+  // injects it into HTML, and the llms.txt generator copies it verbatim into a
+  // Markdown document. Authoring it as HTML put literal `<code>` tags and
+  // `&lt;Form&gt;` entities into the published agent-facing index.
+  it("keeps doc lead frontmatter as Markdown, not HTML", () => {
+    const offenders = [];
+
+    for (const file of collectMarkdownAndTextFiles(["examples/docs/src/routes/docs"])) {
+      const source = readFileSync(resolve(repoRoot, file), "utf-8");
+      for (const line of source.split("\n")) {
+        if (!line.startsWith("lead:")) continue;
+        // Anything inside a code span is Markdown source, not markup — the
+        // renderers escape it. Only look at what is left.
+        const outsideCodeSpans = line.replaceAll(/`[^`]*`/g, "");
+        if (/<[a-zA-Z/]/.test(outsideCodeSpans)) offenders.push(`${file}: HTML tag in lead`);
+        if (/&[a-zA-Z]+;|&#\d+;/.test(outsideCodeSpans)) {
+          offenders.push(`${file}: HTML entity in lead`);
+        }
+      }
+    }
+
+    expect(offenders).toEqual([]);
+  });
+
   it("keeps the public CLI reference in sync with every shipped command", () => {
     const cliSource = readFileSync(resolve(repoRoot, "packages/cli/src/index.ts"), "utf-8");
     const publicReference = readFileSync(
@@ -46,6 +70,31 @@ describe("documentation content", () => {
     ).sort();
 
     expect(documentedCommands).toEqual(shippedCommands);
+  });
+
+  // The manifest-only limitation was documented in docs/ROUTING.md but never on
+  // the public site, so a reader choosing the pages router could not learn that
+  // it has no capability, MCP, or agent-trust surface until much later.
+  it("publishes the pages-router limitations on the public site", () => {
+    const routing = readFileSync(
+      resolve(repoRoot, "examples/docs/src/routes/docs/routing.md"),
+      "utf-8",
+    );
+    expect(routing).toContain("What the pages router does not have");
+    for (const feature of ["Capabilities", "Middleware", "WebMCP", "pracht eval", "constraints"]) {
+      expect(routing).toContain(feature);
+    }
+
+    // The two pages a reader lands on when they want the agent surface must
+    // point back at that table rather than silently assuming a manifest.
+    for (const file of [
+      "examples/docs/src/routes/docs/capabilities.md",
+      "examples/docs/src/routes/docs/agent-trust.md",
+    ]) {
+      const source = readFileSync(resolve(repoRoot, file), "utf-8");
+      expect(source).toContain("Manifest router only");
+      expect(source).toContain("/docs/routing#what-the-pages-router-does-not-have");
+    }
   });
 
   it("keeps high-risk adapter options in the public adapter guide", () => {

--- a/packages/cli/test/wrangler-config.test.ts
+++ b/packages/cli/test/wrangler-config.test.ts
@@ -6,6 +6,7 @@ import { afterEach, describe, expect, it } from "vitest";
 
 import {
   findWranglerConfig,
+  readWranglerAssetsHtmlHandling,
   readWranglerMainEntries,
   WRANGLER_CONFIG_FILES,
 } from "../src/wrangler-config.ts";
@@ -192,5 +193,47 @@ describe("readWranglerMainEntries", () => {
     expect(readWranglerMainEntries(file)).toEqual([
       { environment: null, main: "dist/server/worker.js" },
     ]);
+  });
+});
+
+describe("readWranglerAssetsHtmlHandling", () => {
+  it("reports an explicit html_handling value", () => {
+    const file = writeConfig(
+      "wrangler.jsonc",
+      `{
+        // Comment tolerated.
+        "assets": { "binding": "ASSETS", "html_handling": "drop-trailing-slash" },
+      }`,
+    );
+    expect(readWranglerAssetsHtmlHandling(file)).toEqual({
+      htmlHandling: "drop-trailing-slash",
+    });
+  });
+
+  it("reports an assets block that leaves html_handling at wrangler's default", () => {
+    const file = writeConfig(
+      "wrangler.jsonc",
+      `{ "assets": { "binding": "ASSETS", "directory": "dist/client" } }`,
+    );
+    expect(readWranglerAssetsHtmlHandling(file)).toEqual({ htmlHandling: undefined });
+  });
+
+  it("returns null — unknown, not fine — for shapes it cannot prove", () => {
+    // No assets block at all.
+    expect(
+      readWranglerAssetsHtmlHandling(writeConfig("wrangler.jsonc", `{ "main": "worker.js" }`)),
+    ).toBeNull();
+    // Unparsable.
+    expect(readWranglerAssetsHtmlHandling(writeConfig("wrangler.jsonc", "{ nope"))).toBeNull();
+    // TOML is not parsed here.
+    expect(readWranglerAssetsHtmlHandling(writeConfig("wrangler.toml", 'name = "app"'))).toBeNull();
+    // Missing file.
+    expect(readWranglerAssetsHtmlHandling(join(tmpdir(), "definitely-absent.jsonc"))).toBeNull();
+    // A non-string value is not an explicit setting.
+    expect(
+      readWranglerAssetsHtmlHandling(
+        writeConfig("wrangler.jsonc", `{ "assets": { "html_handling": 3 } }`),
+      ),
+    ).toEqual({ htmlHandling: undefined });
   });
 });

--- a/packages/framework/package.json
+++ b/packages/framework/package.json
@@ -63,6 +63,10 @@
       "types": "./dist/server.d.mts",
       "default": "./dist/server.mjs"
     },
+    "./agent-auth": {
+      "types": "./dist/agent-auth-sign.d.mts",
+      "default": "./dist/agent-auth-sign.mjs"
+    },
     "./islands-client": {
       "types": "./dist/islands-client.d.mts",
       "default": "./dist/islands-client.mjs"

--- a/packages/framework/src/agent-auth-sign.ts
+++ b/packages/framework/src/agent-auth-sign.ts
@@ -1,0 +1,319 @@
+/**
+ * Web Bot Auth: the *signing* side of RFC 9421 HTTP Message Signatures.
+ *
+ * `runtime-agent-auth.ts` verifies inbound agent requests. This module is its
+ * counterpart for outbound ones — what an agent, an eval scenario, or a test
+ * needs to actually reach a capability that declares `agentPolicy: "require"`.
+ *
+ * It lives behind its own entry point (`@pracht/core/agent-auth`) rather than
+ * on `@pracht/core/server` because nothing in a deployed app signs requests;
+ * bundling a private-key code path into every worker would be pure weight.
+ *
+ * Web-platform only (`crypto.subtle`, `Headers`), so it runs anywhere the
+ * verifier does: Node ≥ 20, Workers, and Vercel Edge.
+ *
+ * ```ts
+ * import { signAgentRequest } from "@pracht/core/agent-auth";
+ *
+ * const response = await fetch(
+ *   await signAgentRequest(new Request(url, { method: "POST", body }), {
+ *     agent: "https://my-agent.example",
+ *     privateKeyJwk: { crv: "Ed25519", d: "...", kty: "OKP", x: "..." },
+ *   }),
+ * );
+ * ```
+ */
+
+import { ed25519JwkThumbprint } from "./runtime-agent-auth.ts";
+
+/** Ed25519 private key in JWK form — the `d` (private) and `x` (public) pair. */
+export interface AgentSigningJwk {
+  kty: "OKP";
+  crv: "Ed25519";
+  /** Base64url private scalar. */
+  d: string;
+  /** Base64url public key. */
+  x: string;
+}
+
+export interface AgentSignatureOptions {
+  /**
+   * The agent's `Signature-Agent` identity — the HTTPS origin serving its key
+   * directory, e.g. `https://my-agent.example`. Sent as a quoted string and
+   * covered by the signature.
+   */
+  agent: string;
+  /** The agent's Ed25519 private key. */
+  privateKeyJwk: AgentSigningJwk;
+  /**
+   * `keyid`. Defaults to the RFC 8037 JWK thumbprint of `privateKeyJwk.x`,
+   * which is what the verifier and the key directory both expect — override
+   * only to reproduce a non-conforming peer.
+   */
+  keyId?: string;
+  /** Signature validity window in seconds. Default 300; the draft caps it at 24 h. */
+  lifetimeSeconds?: number;
+  /** `created` as a Unix timestamp in seconds. Defaults to now. */
+  createdAt?: number;
+  /** Signature label. Default `sig1`. */
+  label?: string;
+  /**
+   * Extra covered components beyond `@authority` and `signature-agent`, e.g.
+   * `["@method", "@path"]`. Header names must be lowercase.
+   */
+  additionalComponents?: readonly string[];
+  /** Optional `nonce` parameter. Pracht's verifier does not enforce uniqueness. */
+  nonce?: string;
+}
+
+/** The three headers a signed Web Bot Auth request carries. */
+export interface AgentSignatureHeaders {
+  "signature-agent": string;
+  "signature-input": string;
+  signature: string;
+}
+
+const REQUIRED_COMPONENTS = ["@authority", "signature-agent"] as const;
+const DEFAULT_LIFETIME_SECONDS = 300;
+const MAX_LIFETIME_SECONDS = 86_400;
+const WEB_BOT_AUTH_TAG = "web-bot-auth";
+const HEADER_CRLF_RE = /[\r\n]/;
+/** RFC 8941 key: lowercase alpha or `*` first, then alphanumerics and `_-.*`. */
+const SIGNATURE_LABEL_RE = /^[a-z*][a-z0-9_\-.*]*$/;
+
+const encoder = new TextEncoder();
+
+function bytesToBase64(bytes: Uint8Array): string {
+  let binary = "";
+  for (const byte of bytes) binary += String.fromCharCode(byte);
+  return btoa(binary);
+}
+
+/**
+ * RFC 8941 quoted string. Escaping matters: an agent identity containing a
+ * quote would otherwise produce a `Signature-Agent` header the verifier parses
+ * differently than the signer signed, which fails closed but confusingly.
+ */
+function quoteString(value: string): string {
+  return `"${value.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`;
+}
+
+/**
+ * The RFC 9421 signature base. Mirrors `buildSignatureBase()` in the verifier —
+ * the two must agree byte-for-byte or nothing verifies.
+ */
+function buildSigningBase(
+  request: Request,
+  components: readonly string[],
+  signatureAgent: string,
+  params: string,
+): string {
+  const url = new URL(request.url);
+  const lines: string[] = [];
+
+  for (const component of components) {
+    let value: string;
+    switch (component) {
+      case "@authority":
+        value = url.host.toLowerCase();
+        break;
+      case "@method":
+        value = request.method.toUpperCase();
+        break;
+      case "@scheme":
+        value = url.protocol.replace(/:$/, "");
+        break;
+      case "@target-uri":
+        value = request.url;
+        break;
+      case "@path":
+        value = url.pathname;
+        break;
+      case "@query":
+        value = url.search === "" ? "?" : url.search;
+        break;
+      case "signature-agent":
+        value = signatureAgent;
+        break;
+      default: {
+        if (component.startsWith("@")) {
+          throw new Error(
+            `[pracht] Cannot sign unsupported derived component ${JSON.stringify(component)}. ` +
+              'Supported: "@authority", "@method", "@scheme", "@target-uri", "@path", "@query".',
+          );
+        }
+        if (component !== component.toLowerCase()) {
+          throw new Error(
+            `[pracht] Covered header component ${JSON.stringify(component)} must be lowercase.`,
+          );
+        }
+        const headerValue = request.headers.get(component);
+        if (headerValue === null) {
+          throw new Error(
+            `[pracht] Cannot sign header component ${JSON.stringify(component)}: the request ` +
+              "does not carry it. Set the header before signing.",
+          );
+        }
+        value = headerValue.trim().replace(/[\r\n]+\s*/g, " ");
+      }
+    }
+    lines.push(`"${component}": ${value}`);
+  }
+
+  lines.push(`"@signature-params": ${params}`);
+  return lines.join("\n");
+}
+
+/**
+ * Build the `Signature-Agent`, `Signature-Input`, and `Signature` headers for
+ * `request`, without modifying it.
+ *
+ * The signature covers `@authority`, so it is bound to the host the request is
+ * actually delivered to. Signing `localhost:3000` and having the server observe
+ * `app.example.com` (a Cloudflare custom-domain route in `wrangler dev`, say)
+ * will not verify — sign the authority the server sees.
+ */
+export async function createAgentSignatureHeaders(
+  request: Request,
+  options: AgentSignatureOptions,
+): Promise<AgentSignatureHeaders> {
+  const { agent, privateKeyJwk } = options;
+  if (!agent) throw new Error("[pracht] signAgentRequest requires an `agent` identity.");
+  // RFC 8941 quoted strings cannot carry CR/LF, and `quoteString` only escapes
+  // quotes and backslashes. Left unchecked, an agent identity built from
+  // untrusted input could smuggle a newline into the `Signature-Agent` header.
+  if (HEADER_CRLF_RE.test(agent)) {
+    throw new Error("[pracht] signAgentRequest `agent` must not contain CR or LF.");
+  }
+  // The verifier derives the agent domain from this URL, so a scheme-less value
+  // produces a signature that verifies against nothing — silently, because
+  // Web Bot Auth fails closed. Reject it here where the cause is obvious.
+  let agentUrl: URL;
+  try {
+    agentUrl = new URL(agent);
+  } catch {
+    throw new Error(
+      `[pracht] signAgentRequest \`agent\` must be an absolute URL, got ${JSON.stringify(agent)}.`,
+    );
+  }
+  if (agentUrl.protocol !== "https:" && agentUrl.hostname !== "localhost") {
+    throw new Error(
+      `[pracht] signAgentRequest \`agent\` must be an https URL, got ${JSON.stringify(agent)}.`,
+    );
+  }
+  if (privateKeyJwk?.kty !== "OKP" || privateKeyJwk.crv !== "Ed25519" || !privateKeyJwk.d) {
+    throw new Error("[pracht] signAgentRequest requires an Ed25519 (OKP) private key JWK.");
+  }
+
+  const lifetime = options.lifetimeSeconds ?? DEFAULT_LIFETIME_SECONDS;
+  if (!Number.isFinite(lifetime) || lifetime <= 0 || lifetime > MAX_LIFETIME_SECONDS) {
+    throw new Error(
+      `[pracht] signAgentRequest lifetimeSeconds must be between 1 and ${MAX_LIFETIME_SECONDS}.`,
+    );
+  }
+
+  const created = Math.floor(options.createdAt ?? Date.now() / 1000);
+  const label = options.label ?? "sig1";
+  // The label is interpolated straight into two structured-field dictionaries.
+  // An unvalidated one could inject a second member (`sig1=…, evil`) whose
+  // parse the signer and verifier would disagree about.
+  if (!SIGNATURE_LABEL_RE.test(label)) {
+    throw new Error(
+      `[pracht] signAgentRequest label ${JSON.stringify(label)} is not a valid ` +
+        "RFC 8941 dictionary key.",
+    );
+  }
+  const keyId = options.keyId ?? (await ed25519JwkThumbprint(privateKeyJwk.x));
+  // `keyid` is a quoted string in two places; a quote or backslash in it would
+  // be escaped in one and re-parsed differently, yielding a signature the
+  // verifier silently rejects.
+  if (/["\\]/.test(keyId)) {
+    throw new Error(
+      `[pracht] signAgentRequest keyId ${JSON.stringify(keyId)} must not contain quotes or backslashes.`,
+    );
+  }
+  const signatureAgent = quoteString(agent);
+
+  // `@authority` and `signature-agent` are what the verifier requires; extras
+  // are appended in the caller's order and deduplicated.
+  const components = [
+    ...REQUIRED_COMPONENTS,
+    ...(options.additionalComponents ?? []).filter(
+      (component) =>
+        !REQUIRED_COMPONENTS.includes(component as (typeof REQUIRED_COMPONENTS)[number]),
+    ),
+  ];
+
+  const params =
+    `(${components.map((component) => quoteString(component)).join(" ")})` +
+    `;created=${created};expires=${created + lifetime}` +
+    `;keyid=${quoteString(keyId)};alg="ed25519"` +
+    (options.nonce === undefined ? "" : `;nonce=${quoteString(options.nonce)}`) +
+    `;tag="${WEB_BOT_AUTH_TAG}"`;
+
+  const base = buildSigningBase(request, components, signatureAgent, params);
+
+  const key = await crypto.subtle.importKey(
+    "jwk",
+    { crv: "Ed25519", d: privateKeyJwk.d, key_ops: ["sign"], kty: "OKP", x: privateKeyJwk.x },
+    { name: "Ed25519" },
+    false,
+    ["sign"],
+  );
+  const signature = new Uint8Array(await crypto.subtle.sign("Ed25519", key, encoder.encode(base)));
+
+  return {
+    signature: `${label}=:${bytesToBase64(signature)}:`,
+    "signature-agent": signatureAgent,
+    "signature-input": `${label}=${params}`,
+  };
+}
+
+/**
+ * Return a copy of `request` carrying Web Bot Auth signature headers.
+ *
+ * The original stays usable, including its body. That costs a `clone()`:
+ * `new Request(otherRequest)` *disturbs* the source per the Fetch standard, so
+ * the obvious one-liner would leave the caller holding a request whose body
+ * throws on read — surprising for anyone who signs and then also logs the
+ * payload. `clone()` throws if the body was already consumed, which is the
+ * right failure: there is nothing left to sign and send.
+ */
+export async function signAgentRequest(
+  request: Request,
+  options: AgentSignatureOptions,
+): Promise<Request> {
+  const headers = await createAgentSignatureHeaders(request, options);
+  const signed = new Request(request.bodyUsed ? request : request.clone());
+  for (const [name, value] of Object.entries(headers)) signed.headers.set(name, value);
+  return signed;
+}
+
+/**
+ * Generate an Ed25519 keypair for an agent: the private JWK to sign with, the
+ * public JWK to publish in a key directory, and the `keyid` thumbprint both
+ * sides use to refer to it.
+ */
+export async function generateAgentKeyPair(): Promise<{
+  keyId: string;
+  privateKeyJwk: AgentSigningJwk;
+  publicKeyJwk: { kty: "OKP"; crv: "Ed25519"; x: string };
+}> {
+  const pair = (await crypto.subtle.generateKey({ name: "Ed25519" }, true, [
+    "sign",
+    "verify",
+  ])) as CryptoKeyPair;
+  const privateJwk = (await crypto.subtle.exportKey("jwk", pair.privateKey)) as {
+    d?: string;
+    x?: string;
+  };
+  if (!privateJwk.d || !privateJwk.x) {
+    throw new Error("[pracht] Ed25519 key generation did not produce a usable JWK.");
+  }
+
+  return {
+    keyId: await ed25519JwkThumbprint(privateJwk.x),
+    privateKeyJwk: { crv: "Ed25519", d: privateJwk.d, kty: "OKP", x: privateJwk.x },
+    publicKeyJwk: { crv: "Ed25519", kty: "OKP", x: privateJwk.x },
+  };
+}

--- a/packages/framework/src/index.ts
+++ b/packages/framework/src/index.ts
@@ -166,6 +166,13 @@ export {
   PRACHT_REVALIDATE_TOKEN_ENV,
   PRACHT_REVALIDATE_TOKEN_HEADER,
   readRevalidationRequest,
+  resolveRevalidationToken,
+  RevalidationReport,
+  classifyRevalidationSkip,
+  type RevalidationDetail,
+  type RevalidationOutcome,
+  type RevalidationReportBody,
+  type RevalidationSkipReason,
   type RevalidationSingleFlight,
 } from "./revalidation.ts";
 export { PRACHT_GRAPH_ONLY_ENV } from "./runtime-constants.ts";

--- a/packages/framework/src/llms-txt.ts
+++ b/packages/framework/src/llms-txt.ts
@@ -55,6 +55,10 @@ export interface BuildLlmsTxtOptions {
    * matched against the emitted paths, so a prerendered instance of a dynamic
    * route (`/blog/hello-world`) is covered by `/blog/**`, and a capability is
    * excluded by its dispatch path (`/api/capabilities/**`).
+   *
+   * Framework-reserved paths (any `_pracht` or `__pracht` segment, such as the
+   * `@pracht/image` endpoint at `/api/_pracht/image`) are always omitted and
+   * do not need an entry here.
    */
   exclude?: readonly string[];
 }
@@ -77,10 +81,25 @@ interface LlmsTxtCapabilityEntry {
   effect: string;
 }
 
+/**
+ * Path segments pracht reserves for its own endpoints. `/api/_pracht/image` is
+ * the image-optimization handler the `@pracht/image` loaders post to, and
+ * `/__pracht/*` covers the revalidation webhook and devtools. They are
+ * framework plumbing, not part of the app's agent surface, so listing them
+ * invites agents to call endpoints that are not theirs to call. Users cannot
+ * be expected to exclude them by hand in every app.
+ */
+const RESERVED_PATH_SEGMENTS = new Set(["_pracht", "__pracht"]);
+
+function isReservedPath(path: string): boolean {
+  return path.split("/").some((segment) => RESERVED_PATH_SEGMENTS.has(segment));
+}
+
 export async function buildLlmsTxt(options: BuildLlmsTxtOptions): Promise<string> {
   const include = options.include ?? ["pages", "api", "capabilities"];
   const origin = options.origin?.replace(/\/$/, "") ?? "";
-  const isExcluded = createExcludeMatcher(options.exclude);
+  const excludesPattern = createExcludeMatcher(options.exclude);
+  const isExcluded = (path: string): boolean => isReservedPath(path) || excludesPattern(path);
 
   const lines: string[] = [`# ${options.title}`];
   if (options.description) {

--- a/packages/framework/src/revalidation.ts
+++ b/packages/framework/src/revalidation.ts
@@ -1,10 +1,143 @@
+import { serverEnv } from "./env-server.ts";
 import type { RouteRevalidate, RouteRevalidatePolicy } from "./types.ts";
 
 export const PRACHT_REVALIDATE_ENDPOINT = "/__pracht/revalidate";
 export const PRACHT_REVALIDATE_TOKEN_ENV = "PRACHT_REVALIDATE_TOKEN";
 export const PRACHT_REVALIDATE_TOKEN_HEADER = "x-pracht-revalidate-token";
 
+/**
+ * The configured webhook revalidation token, read through `serverEnv` so it
+ * resolves on every runtime pracht targets.
+ *
+ * Adapters must not reach for `process.env` (or `globalThis.process.env`)
+ * themselves. Vite defines `process.env` away in edge SSR builds, and a
+ * single-use local alias is inlined by the package bundler before Vite sees
+ * it — which silently compiled the Vercel adapter's read down to
+ * `return {}[PRACHT_REVALIDATE_TOKEN_ENV]` and made webhook revalidation
+ * unauthenticatable in production. `serverEnv` centralises that hazard behind
+ * one define-proof accessor that also picks up Cloudflare's request-scoped
+ * bindings.
+ */
+export function resolveRevalidationToken(): string | undefined {
+  try {
+    const token = serverEnv[PRACHT_REVALIDATE_TOKEN_ENV];
+    return typeof token === "string" && token !== "" ? token : undefined;
+  } catch {
+    // Cloudflare installs its bindings when a request enters the adapter.
+    // Before that there is intentionally no ambient environment.
+    return undefined;
+  }
+}
+
 const MAX_REVALIDATION_PATHS = 64;
+
+/**
+ * Why a revalidation webhook did not act on a path.
+ *
+ * The endpoint used to answer with bare path arrays, so a typo, a route that
+ * is not ISG, and a route that simply never opted into `webhookRevalidate()`
+ * were indistinguishable — an operator wiring a CMS got a `200` and silence.
+ */
+export type RevalidationSkipReason =
+  | "not_a_route"
+  | "not_isg"
+  | "not_prerendered"
+  | "no_webhook_policy";
+
+export type RevalidationOutcome = "revalidated" | "skipped" | "failed";
+
+export interface RevalidationDetail {
+  path: string;
+  outcome: RevalidationOutcome;
+  /** Present for `skipped`, and for `failed` when the cause is known. */
+  reason?: RevalidationSkipReason | string;
+}
+
+export interface RevalidationReportBody {
+  revalidated: string[];
+  skipped: string[];
+  failed: string[];
+  details: RevalidationDetail[];
+}
+
+/**
+ * Accumulates a revalidation batch's outcome.
+ *
+ * Shared by all three adapters so the wire shape cannot drift between them.
+ * The three legacy arrays are still emitted verbatim — existing webhook
+ * consumers keep working — with `details` carrying the per-path reason.
+ */
+export class RevalidationReport {
+  readonly #details: RevalidationDetail[] = [];
+
+  revalidated(path: string): void {
+    this.#details.push({ outcome: "revalidated", path });
+  }
+
+  skipped(path: string, reason: RevalidationSkipReason): void {
+    this.#details.push({ outcome: "skipped", path, reason });
+  }
+
+  failed(path: string, reason?: string): void {
+    this.#details.push(
+      reason === undefined
+        ? { outcome: "failed", path }
+        : {
+            outcome: "failed",
+            path,
+            reason,
+          },
+    );
+  }
+
+  toJSON(): RevalidationReportBody {
+    const pick = (outcome: RevalidationOutcome): string[] =>
+      this.#details.filter((detail) => detail.outcome === outcome).map((detail) => detail.path);
+
+    return {
+      details: this.#details,
+      failed: pick("failed"),
+      revalidated: pick("revalidated"),
+      skipped: pick("skipped"),
+    };
+  }
+}
+
+/**
+ * Classify why a webhook cannot refresh a path, or `null` when it can.
+ *
+ * `entry` is what the adapter can act on — a prerender-manifest entry for Node
+ * and Cloudflare, the matched app route for Vercel — and `prerendered` is
+ * whether there is a cached copy to refresh (an on-disk HTML file for Node, a
+ * manifest entry for Cloudflare; Vercel writes through the platform and passes
+ * `true`).
+ *
+ * `matchedRoute` only refines the *reason*, never the decision. Without it, a
+ * manifest-driven adapter reports every unknown path as `not_a_route` — so a
+ * real SSR route that simply is not ISG was indistinguishable from a typo,
+ * which is the confusion this whole field exists to remove. Pass `null` for
+ * "looked and found nothing", or omit it when the caller has no route table.
+ */
+export function classifyRevalidationSkip(
+  entry: { render?: string; revalidate?: RouteRevalidate } | undefined,
+  prerendered: boolean,
+  matchedRoute?: { render?: string } | null,
+): RevalidationSkipReason | null {
+  if (!entry) {
+    if (matchedRoute == null) return "not_a_route";
+    return matchedRoute.render === "isg" ? "not_prerendered" : "not_isg";
+  }
+  // Strict equality, not `!== undefined && !== "isg"`. `render` is optional on
+  // a resolved route and stays `undefined` when neither the route nor its group
+  // sets one, so treating `undefined` as "unknown, proceed" made the Vercel
+  // webhook act on a non-ISG route that merely declared `webhookRevalidate()` —
+  // where it previously skipped. Node and Cloudflare synthesize `"isg"` because
+  // their prerender manifests only ever contain ISG entries.
+  if (entry.render !== "isg") return "not_isg";
+  if (!prerendered) return "not_prerendered";
+  if (!hasWebhookRevalidate(entry.revalidate)) return "no_webhook_policy";
+  return null;
+}
 
 export interface ParsedRevalidationRequest {
   paths: string[];

--- a/packages/framework/src/runtime-headers.ts
+++ b/packages/framework/src/runtime-headers.ts
@@ -112,6 +112,63 @@ export function isProtocolSwitchResponse(response: Response): boolean {
   return response.status < 200 || (response as { webSocket?: unknown }).webSocket != null;
 }
 
+/**
+ * Headers that already express a CDN caching policy. Any of them means the
+ * author has decided; pracht adds nothing.
+ */
+const CDN_CACHE_CONTROL_HEADERS = [
+  "cache-control",
+  "cdn-cache-control",
+  "cloudflare-cdn-cache-control",
+  "surrogate-control",
+  "vercel-cdn-cache-control",
+] as const;
+
+/**
+ * Stamp `Cache-Control: private, no-cache` on GET/HEAD responses that carry no
+ * caching policy of their own.
+ *
+ * A shared cache in front of the app — Cloudflare's Workers Caching, a CDN, a
+ * reverse proxy — may apply RFC 9111 heuristic freshness to a `200` that has no
+ * `Cache-Control`, and `Cookie` is not part of its cache key. Without this, an
+ * authenticated SSR page or an API `GET` can be stored and replayed to another
+ * user. The hazard is a property of "shared cache in front of an origin", not
+ * of any one platform, so every adapter applies the same default: leaving it to
+ * Cloudflare alone meant an app hardened there silently lost the protection
+ * when it moved to Node or Vercel.
+ *
+ * Anything that set its own policy passes through untouched: ISG responses,
+ * route-state JSON, static assets, and user `headers()` exports or middleware.
+ */
+export function preventHeuristicCaching(request: Request, response: Response): Response {
+  if (request.method !== "GET" && request.method !== "HEAD") return response;
+  // A WebSocket handshake carries no cacheable body, and the fallback branch
+  // below would destroy it: reconstructing the response drops the `webSocket`
+  // handle and the constructor rejects status 101 outright.
+  if (isProtocolSwitchResponse(response)) return response;
+  // Any CDN-targeted policy counts as "the author decided". Honouring only
+  // Cloudflare's proprietary header would stamp `private, no-cache` on a
+  // response whose author deliberately set the vendor-neutral
+  // `CDN-Cache-Control` (RFC 9213) and left `Cache-Control` off on purpose.
+  for (const header of CDN_CACHE_CONTROL_HEADERS) {
+    if (response.headers.has(header)) return response;
+  }
+
+  try {
+    response.headers.set("cache-control", "private, no-cache");
+    return response;
+  } catch {
+    // Immutable headers (e.g. a response passed through from `fetch`).
+    const headers = new Headers(response.headers);
+    headers.set("cache-control", "private, no-cache");
+    return new Response(response.body, {
+      status: response.status,
+      statusText: response.statusText,
+      headers,
+    });
+  }
+}
+
 export function withDefaultSecurityHeaders(response: Response): Response {
   if (isProtocolSwitchResponse(response)) return response;
 

--- a/packages/framework/src/runtime.ts
+++ b/packages/framework/src/runtime.ts
@@ -1126,7 +1126,11 @@ function isHrefRouteDefinition(value: unknown): value is HrefRouteDefinition {
 
 // Public runtime surface — re-exported so `./runtime.ts` remains the
 // single import entry for the framework's runtime API.
-export { applyDefaultSecurityHeaders, isProtocolSwitchResponse } from "./runtime-headers.ts";
+export {
+  applyDefaultSecurityHeaders,
+  isProtocolSwitchResponse,
+  preventHeuristicCaching,
+} from "./runtime-headers.ts";
 export { formatServerTimingHeader, type PrachtPhaseTimings } from "./runtime-timing.ts";
 export {
   deserializeRouteError,

--- a/packages/framework/src/server.ts
+++ b/packages/framework/src/server.ts
@@ -45,6 +45,7 @@ export {
   formatServerTimingHeader,
   handlePrachtRequest,
   isProtocolSwitchResponse,
+  preventHeuristicCaching,
   PrachtRuntimeProvider,
 } from "./runtime.ts";
 export {
@@ -126,6 +127,13 @@ export {
   PRACHT_REVALIDATE_TOKEN_ENV,
   PRACHT_REVALIDATE_TOKEN_HEADER,
   readRevalidationRequest,
+  resolveRevalidationToken,
+  RevalidationReport,
+  classifyRevalidationSkip,
+  type RevalidationDetail,
+  type RevalidationOutcome,
+  type RevalidationReportBody,
+  type RevalidationSkipReason,
   type RevalidationSingleFlight,
 } from "./revalidation.ts";
 export { PRACHT_GRAPH_ONLY_ENV } from "./runtime-constants.ts";

--- a/packages/framework/test/agent-auth-sign.test.ts
+++ b/packages/framework/test/agent-auth-sign.test.ts
@@ -1,0 +1,167 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  createAgentSignatureHeaders,
+  generateAgentKeyPair,
+  signAgentRequest,
+} from "../src/agent-auth-sign.ts";
+import { verifyAgentSignature } from "../src/runtime-agent-auth.ts";
+
+// The e2e suite's test agent: a *public* key committed on purpose, paired here
+// with its private half so the signer can be verified against the real verifier.
+const TEST_JWK = {
+  crv: "Ed25519",
+  d: "JZlLQqnxH-0O_1mfnuqDBB1U5XgqETE5eiRXxXRhZNM",
+  kty: "OKP",
+  x: "s5n91rPm5ymJjl--scT4WWq7HE9kUdj-6sVe5r__xgc",
+} as const;
+const TEST_KEY_ID = "9zaO23t4-sitQq-zx7KAn4Q1Ds_W1PF07ozJfoP3H70";
+
+const config = {
+  keys: [{ agent: "test-agent.example", x: TEST_JWK.x }],
+  policy: "observe" as const,
+};
+
+function request(url = "https://app.example/api/capabilities/agent/ping"): Request {
+  return new Request(url, { method: "POST" });
+}
+
+describe("signAgentRequest", () => {
+  // The point of the whole module: what the signer produces is exactly what the
+  // verifier accepts. Anything less and the two drift silently.
+  it("produces a signature the framework's own verifier accepts", async () => {
+    const signed = await signAgentRequest(request(), {
+      agent: "https://test-agent.example",
+      privateKeyJwk: TEST_JWK,
+    });
+
+    await expect(verifyAgentSignature(signed, config)).resolves.toEqual({
+      agentDomain: "test-agent.example",
+      keyId: TEST_KEY_ID,
+      verified: true,
+    });
+  });
+
+  it("derives the RFC 8037 thumbprint as the default keyid", async () => {
+    const headers = await createAgentSignatureHeaders(request(), {
+      agent: "https://test-agent.example",
+      privateKeyJwk: TEST_JWK,
+    });
+
+    expect(headers["signature-input"]).toContain(`keyid="${TEST_KEY_ID}"`);
+    expect(headers["signature-input"]).toContain('tag="web-bot-auth"');
+    expect(headers["signature-input"]).toMatch(/^sig1=\("@authority" "signature-agent"\)/);
+    expect(headers["signature-agent"]).toBe('"https://test-agent.example"');
+    expect(headers.signature).toMatch(/^sig1=:[A-Za-z0-9+/=]+:$/);
+  });
+
+  it("leaves the original request untouched", async () => {
+    const original = request();
+    const signed = await signAgentRequest(original, {
+      agent: "https://test-agent.example",
+      privateKeyJwk: TEST_JWK,
+    });
+
+    expect(original.headers.get("signature")).toBeNull();
+    expect(signed.headers.get("signature")).not.toBeNull();
+  });
+
+  // `@authority` is covered, so a signature is bound to the host it was made
+  // for. This is the Cloudflare custom-domain preview trap in miniature.
+  it("does not verify against a different authority", async () => {
+    const signed = await signAgentRequest(request("https://app.example/x"), {
+      agent: "https://test-agent.example",
+      privateKeyJwk: TEST_JWK,
+    });
+    const replayed = new Request("https://other.example/x", {
+      headers: signed.headers,
+      method: "POST",
+    });
+
+    await expect(verifyAgentSignature(replayed, config)).resolves.toBeNull();
+  });
+
+  it("does not verify once expired", async () => {
+    const signed = await signAgentRequest(request(), {
+      agent: "https://test-agent.example",
+      // Created well outside the verifier's clock-skew allowance.
+      createdAt: Math.floor(Date.now() / 1000) - 10_000,
+      lifetimeSeconds: 60,
+      privateKeyJwk: TEST_JWK,
+    });
+
+    await expect(verifyAgentSignature(signed, config)).resolves.toBeNull();
+  });
+
+  it("signs additional covered components and still verifies", async () => {
+    const signed = await signAgentRequest(request("https://app.example/a/b?q=1"), {
+      additionalComponents: ["@method", "@path", "@query"],
+      agent: "https://test-agent.example",
+      privateKeyJwk: TEST_JWK,
+    });
+
+    expect(signed.headers.get("signature-input")).toContain('"@method" "@path" "@query"');
+    await expect(verifyAgentSignature(signed, config)).resolves.toMatchObject({ verified: true });
+  });
+
+  it("rejects inputs it cannot sign correctly", async () => {
+    const base = { agent: "https://test-agent.example", privateKeyJwk: TEST_JWK };
+
+    await expect(createAgentSignatureHeaders(request(), { ...base, agent: "" })).rejects.toThrow(
+      /requires an `agent` identity/,
+    );
+    await expect(
+      createAgentSignatureHeaders(request(), {
+        ...base,
+        privateKeyJwk: { ...TEST_JWK, d: "" },
+      }),
+    ).rejects.toThrow(/Ed25519 \(OKP\) private key/);
+    await expect(
+      createAgentSignatureHeaders(request(), { ...base, lifetimeSeconds: 0 }),
+    ).rejects.toThrow(/lifetimeSeconds/);
+    await expect(
+      createAgentSignatureHeaders(request(), { ...base, lifetimeSeconds: 90_000 }),
+    ).rejects.toThrow(/lifetimeSeconds/);
+    // A covered header the request does not carry would silently produce a
+    // signature nothing can verify.
+    await expect(
+      createAgentSignatureHeaders(request(), { ...base, additionalComponents: ["x-missing"] }),
+    ).rejects.toThrow(/does not carry it/);
+    await expect(
+      createAgentSignatureHeaders(request(), { ...base, additionalComponents: ["X-Upper"] }),
+    ).rejects.toThrow(/must be lowercase/);
+    await expect(
+      createAgentSignatureHeaders(request(), { ...base, additionalComponents: ["@unknown"] }),
+    ).rejects.toThrow(/unsupported derived component/);
+    // The label lands in two structured-field dictionaries verbatim; an
+    // injected one could add a second member the verifier reads differently.
+    await expect(
+      createAgentSignatureHeaders(request(), { ...base, label: 'sig1";x=1, evil' }),
+    ).rejects.toThrow(/not a valid/);
+    // `quoteString` escapes quotes and backslashes but not CR/LF.
+    await expect(
+      createAgentSignatureHeaders(request(), {
+        ...base,
+        agent: "https://a.example\r\nX-Injected: 1",
+      }),
+    ).rejects.toThrow(/must not contain CR or LF/);
+  });
+});
+
+describe("generateAgentKeyPair", () => {
+  it("produces a keypair whose signatures verify under its own thumbprint", async () => {
+    const { keyId, privateKeyJwk, publicKeyJwk } = await generateAgentKeyPair();
+
+    const signed = await signAgentRequest(request(), {
+      agent: "https://fresh-agent.example",
+      privateKeyJwk,
+    });
+
+    await expect(
+      verifyAgentSignature(signed, {
+        keys: [{ agent: "fresh-agent.example", x: publicKeyJwk.x }],
+        policy: "observe",
+      }),
+    ).resolves.toEqual({ agentDomain: "fresh-agent.example", keyId, verified: true });
+  });
+});

--- a/packages/framework/test/llms-txt.test.ts
+++ b/packages/framework/test/llms-txt.test.ts
@@ -301,3 +301,29 @@ describe("buildLlmsTxt capabilities", () => {
     expect(output).not.toContain("## Capabilities");
   });
 });
+
+describe("framework-reserved paths", () => {
+  it("never lists _pracht endpoints, with or without a user exclude list", async () => {
+    const app = resolveApp(
+      defineApp({ routes: [route("/", "./routes/home.tsx", { render: "ssg" })] }),
+    );
+    const apiRoutes = resolveApiRoutes(
+      ["/src/api/health.ts", "/src/api/_pracht/image.ts"],
+      "/src/api",
+    );
+    const registry: ModuleRegistry = {
+      apiModules: {
+        "/src/api/_pracht/image.ts": async () => ({ GET: () => new Response("") }),
+        "/src/api/health.ts": async () => ({ GET: () => new Response("") }),
+      },
+      routeModules: { "/src/routes/home.tsx": async () => ({}) },
+    };
+
+    for (const exclude of [undefined, ["/nothing-matches"]]) {
+      const output = await buildLlmsTxt({ apiRoutes, app, exclude, registry, title: "App" });
+      expect(output).toContain("/api/health");
+      // The @pracht/image handler is framework plumbing, not app API surface.
+      expect(output).not.toContain("_pracht");
+    }
+  });
+});

--- a/packages/framework/test/revalidation.test.ts
+++ b/packages/framework/test/revalidation.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 
 import {
   createRevalidationSingleFlight,
@@ -7,10 +7,13 @@ import {
   isAuthorizedRevalidationRequest,
   isCacheableISGResponse,
   normalizeRouteRevalidate,
+  classifyRevalidationSkip,
   readRevalidationRequest,
+  resolveRevalidationToken,
   timeRevalidate,
   webhookRevalidate,
 } from "@pracht/core";
+import { setServerEnv } from "@pracht/core/env/server";
 
 describe("revalidation policies", () => {
   it("supports combining time and webhook revalidation", () => {
@@ -226,5 +229,76 @@ describe("isCacheableISGResponse", () => {
       isCacheableISGResponse(new Response("x", { headers: { vary: "Accept, Authorization" } })),
     ).toBe(false);
     expect(isCacheableISGResponse(new Response("x", { headers: { vary: "*" } }))).toBe(false);
+  });
+});
+
+describe("resolveRevalidationToken", () => {
+  const previous = process.env.PRACHT_REVALIDATE_TOKEN;
+
+  afterEach(() => {
+    setServerEnv(undefined);
+    if (previous === undefined) delete process.env.PRACHT_REVALIDATE_TOKEN;
+    else process.env.PRACHT_REVALIDATE_TOKEN = previous;
+  });
+
+  it("reads the ambient process environment on Node-style runtimes", () => {
+    process.env.PRACHT_REVALIDATE_TOKEN = "from-process";
+    expect(resolveRevalidationToken()).toBe("from-process");
+  });
+
+  it("prefers installed platform bindings over the ambient environment", () => {
+    process.env.PRACHT_REVALIDATE_TOKEN = "from-process";
+    setServerEnv({ PRACHT_REVALIDATE_TOKEN: "from-binding" });
+    expect(resolveRevalidationToken()).toBe("from-binding");
+  });
+
+  it("treats a missing, empty, or non-string token as unconfigured", () => {
+    delete process.env.PRACHT_REVALIDATE_TOKEN;
+    expect(resolveRevalidationToken()).toBeUndefined();
+
+    setServerEnv({ PRACHT_REVALIDATE_TOKEN: "" });
+    expect(resolveRevalidationToken()).toBeUndefined();
+
+    setServerEnv({ PRACHT_REVALIDATE_TOKEN: 42 });
+    expect(resolveRevalidationToken()).toBeUndefined();
+  });
+
+  it("fails closed instead of throwing when no environment is available yet", () => {
+    // Mirrors Cloudflare before the first request installs its bindings.
+    setServerEnv(undefined);
+    const runtime = globalThis as Record<string, unknown>;
+    const realProcess = runtime.process;
+    try {
+      delete runtime.process;
+      expect(resolveRevalidationToken()).toBeUndefined();
+    } finally {
+      runtime.process = realProcess;
+    }
+  });
+});
+
+describe("classifyRevalidationSkip", () => {
+  const webhookEntry = { render: "isg", revalidate: [timeRevalidate(60), webhookRevalidate()] };
+
+  it("acts only when there is a prerendered entry with a webhook policy", () => {
+    expect(classifyRevalidationSkip(webhookEntry, true)).toBeNull();
+    expect(classifyRevalidationSkip({ render: "isg", revalidate: timeRevalidate(60) }, true)).toBe(
+      "no_webhook_policy",
+    );
+    expect(classifyRevalidationSkip(webhookEntry, false)).toBe("not_prerendered");
+  });
+
+  // Manifest-driven adapters (Node, Cloudflare) see no entry for a route that
+  // is not ISG. Without the matched route they reported every such path as
+  // `not_a_route`, so a real SSR route looked exactly like a typo.
+  it("distinguishes a real non-ISG route from a path that does not exist", () => {
+    expect(classifyRevalidationSkip(undefined, false, { render: "ssr" })).toBe("not_isg");
+    expect(classifyRevalidationSkip(undefined, false, null)).toBe("not_a_route");
+    expect(classifyRevalidationSkip(undefined, false)).toBe("not_a_route");
+  });
+
+  it("reports an ISG route with no cached copy as not_prerendered", () => {
+    // A dynamic ISG path getStaticPaths() never enumerated.
+    expect(classifyRevalidationSkip(undefined, false, { render: "isg" })).toBe("not_prerendered");
   });
 });

--- a/packages/framework/tsdown.config.ts
+++ b/packages/framework/tsdown.config.ts
@@ -11,6 +11,7 @@ export default defineConfig({
     "src/env-server.ts",
     "src/env-server.browser.ts",
     "src/server.ts",
+    "src/agent-auth-sign.ts",
     "src/islands-client.ts",
     "src/error-overlay.ts",
     "src/dev-404.ts",

--- a/packages/start/src/index.js
+++ b/packages/start/src/index.js
@@ -466,9 +466,13 @@ async function promptForAdapter(readline) {
 }
 
 async function promptForRouter(readline) {
+  // The two routers are not equivalent, and the difference is invisible until
+  // you reach for a manifest-only feature. Say so at the point of choosing.
   console.log("Router:");
-  console.log("  1. Manifest (explicit routes.ts)");
-  console.log("  2. Pages (file-system routing)");
+  console.log("  1. Manifest (explicit routes.ts) — supports middleware, capabilities,");
+  console.log("     MCP, Web Bot Auth, and constraints");
+  console.log("  2. Pages (file-system routing) — pages and API routes only; no");
+  console.log("     middleware, capabilities, MCP, or agent trust (eject later to add them)");
 
   while (true) {
     const answer = await readline.question("Router (1): ");
@@ -732,9 +736,13 @@ function createMcpConfig() {
       mcpServers: {
         pracht: {
           command: "npx",
-          // Not `npx pracht`: that resolves to a registry package literally
-          // named `pracht` whenever the local bin is not on the path.
-          args: ["--yes", "@pracht/cli", "mcp"],
+          // `--no-install` pins this to the `@pracht/cli` the project depends
+          // on. `--yes @pracht/cli` fetched the registry's latest instead, so
+          // the MCP server an agent talked to could describe a different CLI
+          // than the one the app builds with. Not bare `npx pracht` either:
+          // that resolves to a registry package literally named `pracht`
+          // whenever the local bin is missing — `--no-install` fails loudly.
+          args: ["--no-install", "pracht", "mcp"],
         },
       },
     },
@@ -1728,7 +1736,8 @@ Options:
   --adapter=node|cf|vercel     Choose hosting adapter (default: node)
   --router=manifest|pages      Choose routing system (default: manifest)
   --template=minimal|tailwind  Choose starter template (minimal, or minimal + Tailwind CSS)
-  --tailwind / --no-tailwind   Enable or disable Tailwind CSS wiring (default: prompt)
+  --tailwind / --no-tailwind   Enable or disable Tailwind CSS wiring (default: prompt).
+                               Sets the same thing as --template; the last one wins.
   --agent-tools / --no-agent-tools
                                Seed Claude Code skills and a pracht MCP config (default: prompt, yes)
   --no-git                     Skip git init and the initial commit

--- a/packages/start/test/index.test.js
+++ b/packages/start/test/index.test.js
@@ -735,9 +735,13 @@ describe("create-pracht", () => {
     const mcpConfig = JSON.parse(await readFile(join(targetDir, ".mcp.json"), "utf-8"));
     expect(mcpConfig.mcpServers.pracht).toEqual({
       command: "npx",
-      // Not `npx pracht`: that resolves to a registry package literally named
-      // `pracht` whenever the local bin is not on the path.
-      args: ["--yes", "@pracht/cli", "mcp"],
+      // Pinned to the project's own @pracht/cli. `--yes @pracht/cli` fetched
+      // the registry's latest instead, so the MCP server an agent talked to
+      // could describe a different CLI than the app builds with. Not bare
+      // `npx pracht` either: that resolves to a registry package literally
+      // named `pracht` whenever the local bin is missing, which `--no-install`
+      // turns into a loud failure.
+      args: ["--no-install", "pracht", "mcp"],
     });
 
     const skillFile = join(targetDir, ".claude/skills/add-auth/SKILL.md");

--- a/skills/configure-isg/SKILL.md
+++ b/skills/configure-isg/SKILL.md
@@ -95,9 +95,11 @@ curl -X POST https://example.com/__pracht/revalidate \
   or wrong. Providers that can't send bearer auth may use the
   `x-pracht-revalidate-token` header instead.
 - Body: `paths` array, max 64 entries (else `400`). Response reports
-  `revalidated` / `skipped` / `failed` arrays; failed paths keep serving the
-  previous copy. Regeneration is single-flighted per path and never replays
-  the caller's cookies/auth headers.
+  `revalidated` / `skipped` / `failed` arrays plus a `details` array naming why
+  each path was skipped (`not_a_route`, `not_isg`, `not_prerendered`,
+  `no_webhook_policy`) or failed — check `details` first when a webhook appears
+  to do nothing. Failed paths keep serving the previous copy. Regeneration is
+  single-flighted per path and never replays the caller's cookies/auth headers.
 
 ## Step 4: Adapter mechanics
 


### PR DESCRIPTION
## Summary

Fixes the 15 findings from a full-surface permutation audit that drove all three deployment adapters across both the human and agentic surfaces. Report: `docs/FRAMEWORK_PERMUTATION_AUDIT_2026-08-11-ADAPTERS.md` (companion to the render × hydration audit that landed in #291).

**Vercel ISG webhook revalidation could never authenticate.** The adapter read `PRACHT_REVALIDATE_TOKEN` through a `globalThis.process.env` alias written specifically to survive bundling. Because it was used *once*, tsdown inlined it, and the **app** build's `process.env` define then collapsed it:

```js
function getRuntimeRevalidationToken() { return {}[PRACHT_REVALIDATE_TOKEN_ENV]; }
```

So `POST /__pracht/revalidate` answered `401` for every request, on both the Edge render function and the Node ISG launcher — and it reproduces against published `@pracht/adapter-vercel@0.2.8`. The framework's own `serverEnv` survived only because its alias is used twice. The read now goes through a shared `resolveRevalidationToken()` in `@pracht/core`. A unit test against `src/` cannot catch this, so the Vercel build E2E asserts the emitted bundle contains no collapsed env reads **and** drives the built handler's endpoint with and without the token.

Also in this PR:

- **One default `Cache-Control` across adapters.** `preventHeuristicCaching` moved from the Cloudflare adapter into `@pracht/core`; Node and Vercel apply it too. A shared cache may otherwise heuristically store an authenticated SSR page, and `Cookie` is not part of its key — an app hardened on Cloudflare silently lost that when it moved. ISG documents and any author-set CDN policy are exempt.
- **A Web Bot Auth signer** at `@pracht/core/agent-auth`, plus `signAs` for `pracht eval`. Pracht verified RFC 9421 signatures but shipped no way to make one, so `agentPolicy: "require"` was unreachable from its own agent-task harness. `examples/basic` now covers both halves in an eval.
- **Revalidation webhooks explain themselves** — a `details` array with per-path reasons (`not_a_route`, `not_isg`, `not_prerendered`, `no_webhook_policy`), built through one shared `RevalidationReport`. The three legacy path arrays are unchanged.
- **llms.txt stops advertising what agents can't use** — `_pracht`/`__pracht` paths excluded by default; the example excludes its auth-gated pages.
- **Cloudflare trailing-slash divergence** — the three example `wrangler.jsonc` files set `html_handling`, and `pracht verify` now warns when a Cloudflare app with prerendered routes leaves it unset. This was live on `pracht.resynapse.dev`: every doc page 307'd while its own llms.txt pointed at the non-slash form.
- Docs: the pages-router manifest-only boundary on the public site, HTML removed from 11 `lead:` fields (it was leaking into the published llms.txt), and `notFound()` in the example's product loader (it threw a bare `Error` → 500).

### Two findings withdrawn on verification

`pracht plan` leaking git stderr and the Dockerfile "mixing package managers" were **wrong** — both only reproduce with the published CLI, or with the scaffolder invoked without a package-manager user agent. Marked withdrawn inline in the report rather than quietly dropped.

Two remediations were also **reverted**: gating `pnpm-workspace.yaml` on pnpm, and erroring on conflicting `--template`/`--tailwind`. Both broke tests that name the intent as deliberate. The tests were right; the precedence is documented in `--help` instead.

### Adversarial review

Two independent review scopes were run against the remediation and found real defects **in the fixes**, all corrected here: the Vercel cache-control default was poisoning the ISG prerender cache and firing a bogus "use SSR instead" warning on every regeneration; the webhook started acting on routes it used to skip; `signAgentRequest` disturbed the original request's body while the doc claimed otherwise; two ISG sanitization assertions were over-loosened by a bulk edit; and the changeset plus a new `--help` line contained statements that were simply false. Details in the report.

## Testing

- [x] `pnpm run verify` (build, format, lint, typecheck, test, e2e)

Additionally, each fix was proven end to end on real builds of all three adapters — Node production server, Cloudflare in real workerd via `wrangler dev`, and Vercel by invoking the generated Build Output v3 handlers:

| | Node | Cloudflare | Vercel |
| --- | --- | --- | --- |
| revalidate with / without token | 200 / 401 | 200 / 401 | **200** / 401 (was 401 / 401) |
| `GET /pricing`, `/products/1` | 200 | **200** (was 307) | 200 |
| `GET /products/99` | 404 page | 404 page | 404 page (was 500 text/plain) |
| SSR `Cache-Control` | `private, no-cache` | `private, no-cache` | `private, no-cache` |
| ISG keeps its own policy | yes | yes | yes |
| signed `agentPolicy: "require"` | 200 | 200 | unit + eval |

The Vercel ISG regression test was mutation-checked: it fails when the guard is removed. `examples/showcase` verify and both evals pass. A freshly generated scaffold installs, builds, and typechecks.

## Checklist

- [x] Docs updated if needed
- [x] Skills updated if needed
- [x] Changeset added if published packages changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)