### PR TITLE
Serve static markdown as text/markdown; widen preact peer range to allow 11.x

### DIFF
--- a/.changeset/preact-11-peer-range.md
+++ b/.changeset/preact-11-peer-range.md
@@ -1,0 +1,20 @@
+---
+"@pracht/core": patch
+"@pracht/image": patch
+"@pracht/preact-ssr-precompile": patch
+---
+
+Widen the `preact` peer range to accept 11.x prereleases.
+
+The peer was `^10.0.0` (`^10.26.0` for the precompiler), so installing pracht
+alongside `preact@11.0.0-beta.x` or `11.0.0-rc.0` printed peer warnings on
+every install even though nothing was actually broken. The range is now
+`^10.0.0 || ^11.0.0-0`, matching what `preact-render-to-string` already
+declares.
+
+The only preact internals pracht touches are the `options` hooks in the
+dev-only hydration-mismatch warning, which is installed behind
+`import.meta.env.DEV` and degrades to silence if the hooks it taps are never
+called. The SSR precompiler's `jsxTemplate` / `jsxAttr` / `jsxEscape` helpers
+are still exported from `preact/jsx-runtime` in 11. CI still runs against
+preact 10 — 11 is permitted, not yet verified.

--- a/.changeset/static-markdown-mime.md
+++ b/.changeset/static-markdown-mime.md
@@ -1,0 +1,19 @@
+---
+"@pracht/adapter-node": patch
+"@pracht/vite-plugin": patch
+---
+
+Static markdown is served as `text/markdown`, in dev and in production.
+
+`@pracht/adapter-node`'s MIME table had no `.md` entry, so a markdown file in
+the static output was served as `application/octet-stream` — browsers offered
+it as a download and agents fetching it got a content type they had no reason
+to parse. Apps publishing a skills catalog or docs corpus as plain files had to
+route it through middleware to set the header by hand. `.md` and `.markdown`
+now map to `text/markdown; charset=utf-8`, and `.txt` gained the `charset=utf-8`
+it was missing (it matters for `llms.txt` with non-ASCII content).
+
+The dev server had the matching gap from the other side: `.md` was not in its
+static-asset extension list, so `pracht dev` handed those requests to the SSR
+router and answered 404 for a file that existed in `public/`. Markdown now
+resolves the same way in both.

--- a/docs/ADAPTERS.md
+++ b/docs/ADAPTERS.md
@@ -869,6 +869,15 @@ and hashed assets are never re-rendered because a client sent an odd `Accept`.
 The build emits an empty manifest for SSR-only apps too, so public files keep
 the same guarantee even when the app has no prerendered documents.
 
+A `.md` file in `public/` is a different thing entirely: it is a plain static
+asset, copied to `dist/client/` by the build and served by content type, not by
+negotiation. Those files answer every request the same way: the Node adapter
+sends `Content-Type: text/markdown; charset=utf-8`, and on Cloudflare and Vercel
+the platform's own asset layer types the file (the `ASSETS` binding and the
+static rewrite respectively, neither of which the adapter intercepts). This is
+the route to take for a corpus that is markdown all the way down (a skills
+catalog, a docs mirror); no middleware is needed to correct the header.
+
 Vercel reaches the same outcome through its routing table rather than adapter
 code, because the platform serves prerendered files before any function runs.
 The build emits an `Accept`-conditional route to the render function, ahead of

--- a/e2e/node-build.test.ts
+++ b/e2e/node-build.test.ts
@@ -355,6 +355,10 @@ test("SSR-only builds keep static assets on the fast path for Markdown requests"
       .replace('render: "isg",\n        revalidate: timeRevalidate(3600),', 'render: "ssr",');
     writeFileSync(routesPath, routesSource, "utf-8");
 
+    // A markdown file published as a plain static asset — the shape a skills
+    // catalog or docs corpus takes, distinct from a route's `markdown` export.
+    writeFileSync(resolve(exampleDir, "public/skill.md"), "# Skill\n", "utf-8");
+
     buildExample(exampleDir, { PRACHT_ADAPTER: "node", PRACHT_ORIGIN: origin });
 
     expect(
@@ -378,6 +382,11 @@ test("SSR-only builds keep static assets on the fast path for Markdown requests"
     expect(response.status).toBe(200);
     expect(response.headers.get("content-type")).toContain("text/plain");
     await expect(response.text()).resolves.toContain("User-agent");
+
+    const markdown = await fetch(`${origin}/skill.md`);
+    expect(markdown.status).toBe(200);
+    expect(markdown.headers.get("content-type")).toBe("text/markdown; charset=utf-8");
+    await expect(markdown.text()).resolves.toContain("# Skill");
   } finally {
     if (server) {
       server.kill("SIGTERM");

--- a/packages/adapter-node/src/node-static.ts
+++ b/packages/adapter-node/src/node-static.ts
@@ -20,7 +20,9 @@ const MIME_TYPES: Record<string, string> = {
   ".woff2": "font/woff2",
   ".ttf": "font/ttf",
   ".otf": "font/otf",
-  ".txt": "text/plain",
+  ".txt": "text/plain; charset=utf-8",
+  ".md": "text/markdown; charset=utf-8",
+  ".markdown": "text/markdown; charset=utf-8",
   ".xml": "application/xml",
   ".webmanifest": "application/manifest+json",
 };

--- a/packages/adapter-node/test/static-mime.test.ts
+++ b/packages/adapter-node/test/static-mime.test.ts
@@ -1,0 +1,46 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { resolveStaticFile } from "../src/node-static.ts";
+
+const tempDirs: string[] = [];
+
+function makeStaticDir(files: Record<string, string>): string {
+  const root = mkdtempSync(join(tmpdir(), "pracht-adapter-node-mime-"));
+  tempDirs.push(root);
+  const staticDir = join(root, "client");
+  mkdirSync(staticDir, { recursive: true });
+  for (const [name, contents] of Object.entries(files)) {
+    writeFileSync(join(staticDir, name), contents, "utf-8");
+  }
+  return staticDir;
+}
+
+afterEach(() => {
+  while (tempDirs.length > 0) {
+    const dir = tempDirs.pop();
+    if (dir) rmSync(dir, { force: true, recursive: true });
+  }
+});
+
+describe("static content types", () => {
+  it.each([
+    ["skill.md", "text/markdown; charset=utf-8"],
+    ["skill.markdown", "text/markdown; charset=utf-8"],
+    ["llms.txt", "text/plain; charset=utf-8"],
+  ])("serves %s as %s", async (file, contentType) => {
+    const staticDir = makeStaticDir({ [file]: "# hello" });
+
+    const result = await resolveStaticFile(staticDir, `/${file}`);
+    expect(result?.contentType).toBe(contentType);
+  });
+
+  it("falls back to application/octet-stream for unknown extensions", async () => {
+    const staticDir = makeStaticDir({ "archive.tar": "binary" });
+
+    const result = await resolveStaticFile(staticDir, "/archive.tar");
+    expect(result?.contentType).toBe("application/octet-stream");
+  });
+});

--- a/packages/framework/package.json
+++ b/packages/framework/package.json
@@ -93,7 +93,7 @@
     "preact-suspense": "^0.3.0"
   },
   "peerDependencies": {
-    "preact": "^10.0.0",
+    "preact": "^10.0.0 || ^11.0.0-0",
     "preact-render-to-string": "^6.0.0"
   }
 }

--- a/packages/image/package.json
+++ b/packages/image/package.json
@@ -44,7 +44,7 @@
     "prepublishOnly": "npm run build"
   },
   "peerDependencies": {
-    "preact": "^10.0.0",
+    "preact": "^10.0.0 || ^11.0.0-0",
     "sharp": "^0.33.0 || ^0.34.0"
   },
   "peerDependenciesMeta": {

--- a/packages/preact-ssr-precompile/package.json
+++ b/packages/preact-ssr-precompile/package.json
@@ -43,7 +43,7 @@
     "prepublishOnly": "npm run build"
   },
   "peerDependencies": {
-    "preact": "^10.26.0",
+    "preact": "^10.26.0 || ^11.0.0-0",
     "preact-render-to-string": "^6.5.13",
     "vite": "^8.0.0"
   },

--- a/packages/vite-plugin/src/plugin-dev-ssr.ts
+++ b/packages/vite-plugin/src/plugin-dev-ssr.ts
@@ -759,6 +759,8 @@ const DEV_ASSET_EXTENSIONS = new Set([
   ".js",
   ".json",
   ".map",
+  ".markdown",
+  ".md",
   ".mjs",
   ".pdf",
   ".png",

--- a/packages/vite-plugin/test/dev-middleware.test.ts
+++ b/packages/vite-plugin/test/dev-middleware.test.ts
@@ -199,6 +199,15 @@ describe("shouldBypassDevSSR", () => {
         method: "GET",
       }),
     ).toBe(true);
+
+    // Static markdown (skill catalogs, llms.txt companions) is an asset in dev
+    // too, so `pracht dev` matches what the adapters serve in production.
+    expect(
+      shouldBypassDevSSR("/skills/add-auth.md", {
+        headers: { accept: "*/*" },
+        method: "GET",
+      }),
+    ).toBe(true);
   });
 
   it("serves the dev 404 page for unmatched HTML navigations only", () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -324,7 +324,7 @@ importers:
         specifier: ^1.0.0
         version: 1.1.0
       preact:
-        specifier: ^10.0.0
+        specifier: ^10.0.0 || ^11.0.0-0
         version: 10.29.1
       preact-render-to-string:
         specifier: ^6.0.0
@@ -336,7 +336,7 @@ importers:
   packages/image:
     dependencies:
       preact:
-        specifier: ^10.0.0
+        specifier: ^10.0.0 || ^11.0.0-0
         version: 10.29.1
     devDependencies:
       sharp:
@@ -346,7 +346,7 @@ importers:
   packages/preact-ssr-precompile:
     dependencies:
       preact:
-        specifier: ^10.26.0
+        specifier: ^10.26.0 || ^11.0.0-0
         version: 10.29.1
       preact-render-to-string:
         specifier: ^6.5.13


### PR DESCRIPTION
## Summary

- `@pracht/adapter-node`'s MIME table had no `.md` entry, so markdown in the static output was served as `application/octet-stream`; `.md`/`.markdown` now map to `text/markdown; charset=utf-8`, and `.txt` gained the `charset=utf-8` it was missing.
- The dev server had the matching gap from the other side — `.md` was absent from `DEV_ASSET_EXTENSIONS`, so `pracht dev` handed those requests to the SSR router and answered 404 for a file that existed in `public/`.
- The `preact` peer range was `^10.0.0`, which printed peer warnings on every install alongside preact 11 prereleases; it is now `^10.0.0 || ^11.0.0-0` (matching what `preact-render-to-string` declares) across `@pracht/core`, `@pracht/image`, and `@pracht/preact-ssr-precompile`.
- The only preact internals pracht touches are the `options` hooks in the dev-only hydration-mismatch warning, which degrades to silence, and the precompiler's `jsxTemplate`/`jsxAttr`/`jsxEscape` helpers, still exported from `preact/jsx-runtime` in 11 — but CI still runs against preact 10, so 11 is permitted rather than verified.
- Both gaps were reported from an app that had to work around them; no linked issue.

## Testing

- [x] `pnpm run verify` (build, format, lint, typecheck, test, e2e)

Unit coverage in a new `packages/adapter-node/test/static-mime.test.ts` and the dev-middleware bypass test, plus an end-to-end assertion in `e2e/node-build.test.ts` that boots the built Node server and fetches a `public/` markdown file (checked against a sentinel value to confirm it is not passing vacuously).

## Checklist

- [x] Docs updated if needed — `docs/ADAPTERS.md` documents the static-asset path next to the `markdown`-export negotiation it is easy to confuse it with
- [x] Skills updated if needed — N/A, no skill covers static asset content types
- [x] Changeset added if published packages changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)