### PR TITLE
Add @pracht/test: first-party testing utilities for app developers

### DIFF
--- a/.changeset/pracht-test-package.md
+++ b/.changeset/pracht-test-package.md
@@ -1,5 +1,5 @@
 ---
-"@pracht/core": patch
+"@pracht/core": minor
 "@pracht/test": minor
 ---
 
@@ -15,7 +15,8 @@ cancellation tests. `runMiddleware()` executes one middleware or a chain with
 the runtime's exact `next()` semantics — sequential dispatch, at-most-once
 `next()`, short-circuit on an early `Response`, a thrown `Response` resolving
 by default like page/API dispatch, opt-in raw-chain rejection for capability
-middleware, and fail loudly on a non-`Response` return — so auth gates and
+middleware, a fresh top-level args wrapper per dispatch with shared request
+state, and fail loudly on a non-`Response` return — so auth gates and
 context-augmenting middleware are unit-testable without hiding the capability
 pipeline's different `internal_error` behavior. `submitForm()` (with async
 `createFormRequest()`) builds a urlencoded or multipart form `POST` from

--- a/.changeset/pracht-test-package.md
+++ b/.changeset/pracht-test-package.md
@@ -12,12 +12,17 @@ from a shorthand (`url`, `method`, `headers`, a JSON-encoding `body`,
 `url` from the request, and expose the `AbortController` behind `signal` for
 cancellation tests. `runMiddleware()` executes one middleware or a chain with
 the runtime's exact `next()` semantics — sequential dispatch, at-most-once
-`next()`, short-circuit on an early `Response`, fail loudly on a non-`Response`
-return — so auth gates and context-augmenting middleware are unit-testable
-including their short-circuits. `submitForm()` (with `createFormRequest()`)
-builds a urlencoded or multipart form `POST` — auto-switching to multipart
-when a field is a `File` — and calls an API handler with it, exercising the
-same `FormData` parsing path `defineApi()` applies to real submissions.
+`next()`, short-circuit on an early `Response`, a thrown `Response` (the
+`requireUser()` pattern) resolving as the chain's response, fail loudly on a
+non-`Response` return — so auth gates and context-augmenting middleware are
+unit-testable including their short-circuits. `submitForm()` (with
+`createFormRequest()`) builds a urlencoded or multipart form `POST` —
+auto-switching to multipart when a field is a `File` — and calls an API
+handler with it, exercising the same `FormData` parsing path `defineApi()`
+applies to real submissions; `method: "GET"` serializes the fields into the
+URL query string like a browser `<form method="get">`, exercising a `query`
+schema instead. `ReadableStream` bodies get the required `duplex` option
+automatically.
 `readJson()` and `readRedirect()` are minimal response readers: parse a JSON
 body without consuming the original response, or extract
 `{ status, location }` from a redirect. No capability harness is included:

--- a/.changeset/pracht-test-package.md
+++ b/.changeset/pracht-test-package.md
@@ -12,7 +12,9 @@ from a shorthand (`url`, `method`, `headers`, a JSON-encoding `body`,
 `params`, a partial `context`, `route` overrides) or a real `Request`, derive
 `url` from the request, and expose the `AbortController` behind `signal` for
 cancellation tests. Blob/File and `URLSearchParams` bodies are normalized so
-the factories also work when JSDOM owns those values and Node owns `Request`.
+the factories also work when JSDOM owns those values and Node owns `Request`;
+foreign-realm `FormData` and `ArrayBuffer` bodies retain their wire encoding
+instead of falling through to JSON serialization.
 `runMiddleware()` executes one middleware or a chain with
 the runtime's exact `next()` semantics — sequential dispatch, at-most-once
 `next()`, short-circuit on an early `Response`, a thrown `Response` resolving
@@ -27,7 +29,9 @@ owns `File`/`FormData` and Node owns `Request` — auto-switches to multipart
 when a field is a `File`, and calls an API handler with it, exercising the
 same `FormData` parsing path `defineApi()` applies to real submissions;
 `method: "GET"` serializes the fields into the URL query string like a browser
-`<form method="get">`, exercising a `query` schema instead. `ReadableStream`
+`<form method="get">`, exercising a `query` schema instead. Field names and
+string values use the browser form algorithm's CRLF newline normalization in
+URL-encoded, multipart, and query submissions. `ReadableStream`
 bodies get the required `duplex` option automatically.
 `readJson()` and `readRedirect()` are minimal response readers: parse a JSON
 body without consuming the original response, or extract

--- a/.changeset/pracht-test-package.md
+++ b/.changeset/pracht-test-package.md
@@ -1,0 +1,25 @@
+---
+"@pracht/test": minor
+---
+
+New package: `@pracht/test` — first-party testing utilities for pracht apps.
+Until now the testing docs told users to hand-build `{ request, params, url,
+signal }` objects for every loader, API handler, and middleware test; this
+package ships small, typed factories and runners instead. `createLoaderArgs()`,
+`createApiArgs()`, and `createMiddlewareArgs()` build complete args objects
+from a shorthand (`url`, `method`, `headers`, a JSON-encoding `body`,
+`params`, a partial `context`, `route` overrides) or a real `Request`, derive
+`url` from the request, and expose the `AbortController` behind `signal` for
+cancellation tests. `runMiddleware()` executes one middleware or a chain with
+the runtime's exact `next()` semantics — sequential dispatch, at-most-once
+`next()`, short-circuit on an early `Response`, fail loudly on a non-`Response`
+return — so auth gates and context-augmenting middleware are unit-testable
+including their short-circuits. `submitForm()` (with `createFormRequest()`)
+builds a urlencoded or multipart form `POST` — auto-switching to multipart
+when a field is a `File` — and calls an API handler with it, exercising the
+same `FormData` parsing path `defineApi()` applies to real submissions.
+`readJson()` and `readRedirect()` are minimal response readers: parse a JSON
+body without consuming the original response, or extract
+`{ status, location }` from a redirect. No capability harness is included:
+`createCapabilityTestHost()` from `@pracht/core/server` already runs the real
+capability dispatch pipeline in-process.

--- a/.changeset/pracht-test-package.md
+++ b/.changeset/pracht-test-package.md
@@ -11,7 +11,9 @@ package ships small, typed factories and runners instead. `createLoaderArgs()`,
 from a shorthand (`url`, `method`, `headers`, a JSON-encoding `body`,
 `params`, a partial `context`, `route` overrides) or a real `Request`, derive
 `url` from the request, and expose the `AbortController` behind `signal` for
-cancellation tests. `runMiddleware()` executes one middleware or a chain with
+cancellation tests. Blob/File and `URLSearchParams` bodies are normalized so
+the factories also work when JSDOM owns those values and Node owns `Request`.
+`runMiddleware()` executes one middleware or a chain with
 the runtime's exact `next()` semantics — sequential dispatch, at-most-once
 `next()`, short-circuit on an early `Response`, a thrown `Response` resolving
 by default like page/API dispatch, opt-in raw-chain rejection for capability

--- a/.changeset/pracht-test-package.md
+++ b/.changeset/pracht-test-package.md
@@ -1,4 +1,5 @@
 ---
+"@pracht/core": patch
 "@pracht/test": minor
 ---
 
@@ -12,19 +13,26 @@ from a shorthand (`url`, `method`, `headers`, a JSON-encoding `body`,
 `url` from the request, and expose the `AbortController` behind `signal` for
 cancellation tests. `runMiddleware()` executes one middleware or a chain with
 the runtime's exact `next()` semantics — sequential dispatch, at-most-once
-`next()`, short-circuit on an early `Response`, a thrown `Response` (the
-`requireUser()` pattern) resolving as the chain's response, fail loudly on a
-non-`Response` return — so auth gates and context-augmenting middleware are
-unit-testable including their short-circuits. `submitForm()` (with
-`createFormRequest()`) builds a urlencoded or multipart form `POST` —
-auto-switching to multipart when a field is a `File` — and calls an API
-handler with it, exercising the same `FormData` parsing path `defineApi()`
-applies to real submissions; `method: "GET"` serializes the fields into the
-URL query string like a browser `<form method="get">`, exercising a `query`
-schema instead. `ReadableStream` bodies get the required `duplex` option
-automatically.
+`next()`, short-circuit on an early `Response`, a thrown `Response` resolving
+by default like page/API dispatch, opt-in raw-chain rejection for capability
+middleware, and fail loudly on a non-`Response` return — so auth gates and
+context-augmenting middleware are unit-testable without hiding the capability
+pipeline's different `internal_error` behavior. `submitForm()` (with async
+`createFormRequest()`) builds a urlencoded or multipart form `POST` from
+realm-neutral text/bytes — including when JSDOM
+owns `File`/`FormData` and Node owns `Request` — auto-switches to multipart
+when a field is a `File`, and calls an API handler with it, exercising the
+same `FormData` parsing path `defineApi()` applies to real submissions;
+`method: "GET"` serializes the fields into the URL query string like a browser
+`<form method="get">`, exercising a `query` schema instead. `ReadableStream`
+bodies get the required `duplex` option automatically.
 `readJson()` and `readRedirect()` are minimal response readers: parse a JSON
 body without consuming the original response, or extract
 `{ status, location }` from a redirect. No capability harness is included:
 `createCapabilityTestHost()` from `@pracht/core/server` already runs the real
 capability dispatch pipeline in-process.
+
+`MiddlewareArgs.route` now reflects the runtime contract: middleware can wrap
+either a page `ResolvedRoute` or an API `ResolvedApiRoute`. `@pracht/test`
+provides `createApiMiddlewareArgs()` for the API shape, while
+`createMiddlewareArgs()` remains the page-route factory.

--- a/README.md
+++ b/README.md
@@ -155,6 +155,7 @@ The skills are distributed three ways (see the [catalog](skills/README.md)):
 - [docs/AGENT_WORKFLOW.md](docs/AGENT_WORKFLOW.md) — constraints, app-graph snapshots, `pracht plan`/`report`
 - [docs/ENV.md](docs/ENV.md) — typed env access, `PRACHT_PUBLIC_` prefix rule, leak detection
 - [packages/start/README.md](packages/start/README.md) — starter CLI details
+- [packages/test/README.md](packages/test/README.md) — `@pracht/test` unit-testing utilities for loaders, API routes, middleware, and forms
 
 ## Contributing
 

--- a/docs/WORKSPACE.md
+++ b/docs/WORKSPACE.md
@@ -16,6 +16,7 @@ described in `VISION_MVP.md`.
 | `packages/adapter-vercel`     | `@pracht/adapter-vercel`     | Vercel Edge handler, Build Output API entry source, and native ISR artifacts                                 |
 | `packages/preact-worker-facets` | `@pracht/preact-worker-facets` | Experimental Cloudflare Dynamic Worker + Durable Object facets runtime for inert, stateful Preact components |
 | `packages/image`              | `@pracht/image`              | Responsive, CLS-safe `<Image>` component, pluggable optimization loaders, sharp-backed Node endpoint (see `docs/IMAGES.md`) |
+| `packages/test`               | `@pracht/test`               | Testing utilities for app developers: typed loader/API/middleware args factories, a middleware chain runner, form submission helpers, and minimal response readers |
 | `packages/cli`                | `@pracht/cli`                | `pracht dev`, `build`, `verify`, the `generate` subcommands, and `doctor`                                    |
 | `examples/cloudflare`         | `@pracht/example-cloudflare` | Cloudflare-targeted example app with SSG, ISG, SSR, SPA routes, auth middleware, and API routes              |
 | `examples/docs`               | `@pracht/example-docs`       | Documentation website built with pracht + Cloudflare adapter; all routes SSG-prerendered; dark design system |
@@ -86,8 +87,8 @@ described in `VISION_MVP.md`.
   files, and `pracht doctor` validates app wiring across the whole project.
 - **Package builds** — `tsdown` compiles `pracht`, `@pracht/openapi`, `@pracht/vite-plugin`,
   `@pracht/preact-ssr-precompile`, `@pracht/adapter-node`,
-  `@pracht/adapter-cloudflare`, `@pracht/adapter-vercel`, and `@pracht/image`
-  from TypeScript to
+  `@pracht/adapter-cloudflare`, `@pracht/adapter-vercel`, `@pracht/image`, and
+  `@pracht/test` from TypeScript to
   ESM (`dist/index.mjs` + `.d.mts`). `@pracht/core` preserves its source-module
   boundaries in the published ESM so downstream builds can tree-shake named
   public imports. Its prerender module remains explicitly side-effectful because

--- a/examples/basic/package.json
+++ b/examples/basic/package.json
@@ -26,6 +26,7 @@
   },
   "devDependencies": {
     "@pracht/cli": "workspace:*",
+    "@pracht/test": "workspace:*",
     "@pracht/vite-plugin": "workspace:*",
     "preact": "^10.26.9",
     "preact-render-to-string": "^6.5.13",

--- a/examples/basic/src/api/_pracht/image.ts
+++ b/examples/basic/src/api/_pracht/image.ts
@@ -1,4 +1,4 @@
-import type { BaseRouteArgs } from "@pracht/core";
+import type { ApiRouteArgs } from "@pracht/core";
 
 declare const __PRACHT_IMAGE_BACKEND__: string;
 
@@ -6,7 +6,7 @@ declare const __PRACHT_IMAGE_BACKEND__: string;
 // Node uses the Sharp-backed optimizer. Edge targets retain the same public
 // route and generated API type while redirecting validated same-origin paths;
 // the compile-time branch keeps @pracht/image/node out of edge bundles.
-let nodeImageHandler: ((args: BaseRouteArgs) => Response | Promise<Response>) | undefined;
+let nodeImageHandler: ((args: ApiRouteArgs) => Response | Promise<Response>) | undefined;
 
 function containsAsciiControl(value: string): boolean {
   return Array.from(value).some((character) => {
@@ -15,7 +15,7 @@ function containsAsciiControl(value: string): boolean {
   });
 }
 
-async function handleImage(args: BaseRouteArgs): Promise<Response> {
+async function handleImage(args: ApiRouteArgs): Promise<Response> {
   if (__PRACHT_IMAGE_BACKEND__ === "node") {
     if (!nodeImageHandler) {
       const { createImageHandler } = await import("@pracht/image/node");

--- a/examples/basic/src/api/dashboard.ts
+++ b/examples/basic/src/api/dashboard.ts
@@ -1,6 +1,6 @@
-import type { BaseRouteArgs } from "@pracht/core";
+import type { ApiRouteArgs } from "@pracht/core";
 
-export async function POST({ request }: BaseRouteArgs) {
+export async function POST({ request }: ApiRouteArgs) {
   if (new URL(request.url).searchParams.has("redirect")) {
     return Response.redirect(new URL("/", request.url), 302);
   }

--- a/examples/basic/src/api/echo.ts
+++ b/examples/basic/src/api/echo.ts
@@ -1,6 +1,6 @@
-import type { BaseRouteArgs } from "@pracht/core";
+import type { ApiRouteArgs } from "@pracht/core";
 
-export async function POST({ request }: BaseRouteArgs) {
+export async function POST({ request }: ApiRouteArgs) {
   const body = await request.json();
   return Response.json({ echo: body });
 }

--- a/examples/basic/test/app.test.ts
+++ b/examples/basic/test/app.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+import {
+  createApiArgs,
+  createLoaderArgs,
+  createMiddlewareArgs,
+  readJson,
+  readRedirect,
+  runMiddleware,
+} from "@pracht/test";
+
+import { POST as dashboardPost } from "../src/api/dashboard.ts";
+import { POST as echoPost } from "../src/api/echo.ts";
+import { middleware as auth } from "../src/middleware/auth.ts";
+import { loader as productLoader } from "../src/routes/product.tsx";
+
+// Dogfood tests: the example app's real middleware, loader, and API handlers
+// tested with @pracht/test — imported from the built package, the way an app
+// developer consumes it.
+
+describe("auth middleware", () => {
+  it("redirects anonymous requests to /", async () => {
+    const response = await runMiddleware(auth, createMiddlewareArgs({ url: "/dashboard" }));
+    expect(readRedirect(response)).toEqual({ status: 302, location: "/" });
+  });
+
+  it("passes requests with a session cookie through to the handler", async () => {
+    const response = await runMiddleware(
+      auth,
+      createMiddlewareArgs({ url: "/dashboard", headers: { cookie: "session=abc" } }),
+      async () => new Response("dashboard"),
+    );
+    expect(await response.text()).toBe("dashboard");
+  });
+});
+
+describe("product loader", () => {
+  it("resolves a prerendered product from params", () => {
+    const data = productLoader(
+      createLoaderArgs({ url: "/products/1", params: { productId: "1" } }),
+    );
+    expect(data).toMatchObject({ id: "1", name: "Widget" });
+  });
+
+  it("throws notFound() for an unknown product id", () => {
+    expect(() =>
+      productLoader(createLoaderArgs({ url: "/products/999", params: { productId: "999" } })),
+    ).toThrow(
+      expect.objectContaining({ name: "PrachtHttpError", status: 404 }) as unknown as Error,
+    );
+  });
+});
+
+describe("API handlers", () => {
+  it("echoes a JSON body", async () => {
+    const response = await echoPost(createApiArgs({ url: "/api/echo", body: { hello: "pracht" } }));
+    expect(await readJson(response)).toEqual({ echo: { hello: "pracht" } });
+  });
+
+  it("redirects the dashboard POST when ?redirect is present", async () => {
+    const response = await dashboardPost(
+      createApiArgs({ url: "/api/dashboard?redirect", method: "POST" }),
+    );
+    expect(readRedirect(response)).toEqual({ status: 302, location: "http://localhost/" });
+  });
+
+  it("saves without the redirect flag", async () => {
+    const response = await dashboardPost(createApiArgs({ url: "/api/dashboard", method: "POST" }));
+    expect(await readJson(response)).toEqual({ saved: true });
+  });
+});

--- a/examples/cloudflare/src/api/echo.ts
+++ b/examples/cloudflare/src/api/echo.ts
@@ -1,6 +1,6 @@
-import type { BaseRouteArgs } from "@pracht/core";
+import type { ApiRouteArgs } from "@pracht/core";
 
-export async function POST({ request }: BaseRouteArgs) {
+export async function POST({ request }: ApiRouteArgs) {
   const body = await request.json();
   return Response.json({ echo: body });
 }

--- a/examples/cloudflare/src/api/health.ts
+++ b/examples/cloudflare/src/api/health.ts
@@ -1,6 +1,6 @@
-import type { BaseRouteArgs } from "@pracht/core";
+import type { ApiRouteArgs } from "@pracht/core";
 
-export async function GET({ context }: BaseRouteArgs) {
+export async function GET({ context }: ApiRouteArgs) {
   const cached = await context.env.MY_KV.get("health:last-check");
   await context.env.MY_KV.put("health:last-check", new Date().toISOString());
 

--- a/examples/cloudflare/src/api/revalidate.ts
+++ b/examples/cloudflare/src/api/revalidate.ts
@@ -1,4 +1,4 @@
-import type { BaseRouteArgs } from "@pracht/core";
+import type { ApiRouteArgs } from "@pracht/core";
 import { purgeCache, routeCacheTag } from "@pracht/adapter-cloudflare/cache";
 
 // Webhook-based ISG revalidation: purge the cached /pricing page so the next
@@ -10,7 +10,7 @@ import { purgeCache, routeCacheTag } from "@pracht/adapter-cloudflare/cache";
 // the cache (or run up render costs): set it with
 // `wrangler secret put REVALIDATE_SECRET` (or in `.dev.vars` locally) and
 // send it in the `x-revalidate-secret` header.
-export async function POST({ request, context }: BaseRouteArgs) {
+export async function POST({ request, context }: ApiRouteArgs) {
   const secret = (context.env as { REVALIDATE_SECRET?: string }).REVALIDATE_SECRET;
   if (!secret || request.headers.get("x-revalidate-secret") !== secret) {
     return Response.json({ error: "Unauthorized" }, { status: 401 });

--- a/examples/cloudflare/src/api/ws.ts
+++ b/examples/cloudflare/src/api/ws.ts
@@ -1,4 +1,4 @@
-import type { BaseRouteArgs } from "@pracht/core";
+import type { ApiRouteArgs } from "@pracht/core";
 
 /**
  * WebSocket upgrades are served by API routes. The handshake itself is
@@ -15,7 +15,7 @@ import type { BaseRouteArgs } from "@pracht/core";
  * `api: { requireSameOrigin: false }` in `defineApp` only if you intend this
  * endpoint to be reachable from other origins, and authenticate it yourself.
  */
-export async function GET({ context, request, url }: BaseRouteArgs): Promise<Response> {
+export async function GET({ context, request, url }: ApiRouteArgs): Promise<Response> {
   if (request.headers.get("upgrade") !== "websocket") {
     return new Response("Expected a WebSocket upgrade", { status: 426 });
   }

--- a/examples/docs/src/routes/docs/adapters.md
+++ b/examples/docs/src/routes/docs/adapters.md
@@ -209,9 +209,9 @@ handshake from an [API route](/docs/api-routes#websockets) and forward it to the
 object:
 
 ```ts [src/api/ws.ts]
-import type { BaseRouteArgs } from "@pracht/core";
+import type { ApiRouteArgs } from "@pracht/core";
 
-export async function GET({ context, request, url }: BaseRouteArgs) {
+export async function GET({ context, request, url }: ApiRouteArgs) {
   if (request.headers.get("upgrade") !== "websocket") {
     return new Response("Expected a WebSocket upgrade", { status: 426 });
   }

--- a/examples/docs/src/routes/docs/api-routes.md
+++ b/examples/docs/src/routes/docs/api-routes.md
@@ -167,9 +167,9 @@ API routes are also where WebSocket upgrades belong. Return a `101` response and
 This requires a runtime that can hold a connection open, which today means the **Cloudflare adapter** with a Durable Object owning the socket:
 
 ```ts [src/api/ws.ts]
-import type { BaseRouteArgs } from "@pracht/core";
+import type { ApiRouteArgs } from "@pracht/core";
 
-export async function GET({ context, request, url }: BaseRouteArgs) {
+export async function GET({ context, request, url }: ApiRouteArgs) {
   if (request.headers.get("upgrade") !== "websocket") {
     return new Response("Expected a WebSocket upgrade", { status: 426 });
   }

--- a/examples/docs/src/routes/docs/recipes-testing.md
+++ b/examples/docs/src/routes/docs/recipes-testing.md
@@ -64,6 +64,7 @@ await expect(pending).rejects.toThrow();
 `createApiArgs()` builds the same shape for API handlers — plain or `defineApi()`-wrapped — and `readJson()` reads a response body without consuming it:
 
 ```ts [src/api/items.test.ts]
+import type { ApiValidationErrorBody } from "@pracht/core";
 import { describe, it, expect } from "vitest";
 import { createApiArgs, readJson } from "@pracht/test";
 import { GET, POST } from "./items";
@@ -88,7 +89,7 @@ describe("items API route", () => {
     const response = await POST(createApiArgs({ url: "/api/items", body: { name: "" } }));
 
     expect(response.status).toBe(422);
-    const body = await readJson(response);
+    const body = await readJson<ApiValidationErrorBody>(response);
     expect(body.issues).toEqual([{ in: "body", path: ["name"], message: "Required" }]);
   });
 });
@@ -96,7 +97,7 @@ describe("items API route", () => {
 
 ### Testing form submissions
 
-`submitForm()` builds the request a form submission actually sends — `application/x-www-form-urlencoded` by default, switching to `multipart/form-data` automatically when any field is a `File` — and calls the handler with it. This exercises the same `FormData` parsing path `defineApi()` applies to real `<Form>` and native submissions:
+`submitForm()` builds the request a form submission actually sends — `application/x-www-form-urlencoded` by default, switching to `multipart/form-data` automatically when any field is a `File` — and calls the handler with it. This exercises the same `FormData` parsing path `defineApi()` applies to real `<Form>` and native submissions. The underlying async `createFormRequest()` serializes fields to realm-neutral text/bytes, so it also works when Vitest's JSDOM environment owns `File` and `FormData` while Node owns `Request`:
 
 ```ts [src/api/contact.test.ts]
 import { describe, it, expect } from "vitest";
@@ -167,7 +168,18 @@ describe("auth middleware", () => {
 });
 ```
 
-A middleware (or the final handler) that **throws** a `Response` — the `requireUser()` pattern, where a shared helper throws `redirect("/login")` — resolves as the chain's response, exactly like the server treats it. Thrown non-`Response` errors, including `notFound()`, reject so your test can assert on them.
+`createMiddlewareArgs()` supplies page-route metadata. For middleware attached through `defineApp({ api: { middleware: [...] } })`, use `createApiMiddlewareArgs()` instead; its `route` matches the `ResolvedApiRoute` shape production passes.
+
+Page and API dispatch catch a **thrown** `Response` outside the middleware chain and send it as-is, so `runMiddleware()` resolves that response by default. The raw capability middleware chain instead rejects the value and maps it to an `internal_error` envelope; use `createCapabilityTestHost()` to test that full pipeline, or opt into raw-chain behavior explicitly:
+
+```ts
+const args = createMiddlewareArgs({ url: "/dashboard" });
+await expect(
+  runMiddleware(auth, args, undefined, { thrownResponse: "reject" }),
+).rejects.toBeInstanceOf(Response);
+```
+
+Thrown non-`Response` errors, including `notFound()`, always reject.
 
 Chains work the same way, including `context` mutations flowing downstream — pass the middleware in the order the manifest applies them:
 

--- a/examples/docs/src/routes/docs/recipes-testing.md
+++ b/examples/docs/src/routes/docs/recipes-testing.md
@@ -50,7 +50,7 @@ describe("dashboard loader", () => {
 });
 ```
 
-The shorthand accepts `url` (relative paths resolve against `http://localhost`), `method`, `headers`, `body` (a plain object is JSON-encoded; `BodyInit` values pass through), `params`, a partial `context`, and `route` overrides — or a fully-formed `request` that wins over all of them. The returned args also expose `controller`, the `AbortController` behind `args.signal`:
+The shorthand accepts `url` (relative paths resolve against `http://localhost`), `method`, `headers`, `body` (a plain object is JSON-encoded; `BodyInit` values pass through, with Blob/File and `URLSearchParams` normalized across JSDOM/Node realms), `params`, a partial `context`, and `route` overrides — or a fully-formed `request` that wins over all of them. The returned args also expose `controller`, the `AbortController` behind `args.signal`:
 
 ```ts
 const args = createLoaderArgs({ url: "/slow" });

--- a/examples/docs/src/routes/docs/recipes-testing.md
+++ b/examples/docs/src/routes/docs/recipes-testing.md
@@ -1,6 +1,6 @@
 ---
 title: Testing
-lead: Test your pracht app at every level — unit test loaders and API routes with Vitest, run full E2E tests with Playwright to verify rendering, navigation, and hydration, and prove your agent surfaces with capability tests and `pracht eval`.
+lead: Test your pracht app at every level — unit test loaders, API routes, middleware, and form submissions with Vitest and `@pracht/test`, run full E2E tests with Playwright to verify rendering, navigation, and hydration, and prove your agent surfaces with capability tests and `pracht eval`.
 breadcrumb: Testing
 prev:
   href: /docs/recipes/view-transitions
@@ -12,163 +12,168 @@ next:
 
 ## Recommended Setup
 
-Pracht apps are built on Vite, so **Vitest** is the natural choice for unit and integration tests. For E2E browser tests, use **Playwright**.
+Pracht apps are built on Vite, so **Vitest** is the natural choice for unit and integration tests. For E2E browser tests, use **Playwright**. `@pracht/test` ships the first-party unit-test helpers: typed args factories, a middleware chain runner, form submission helpers, and minimal response readers.
 
 ```sh
 # Install test dependencies
-pnpm add -D vitest @playwright/test
+pnpm add -D vitest @playwright/test @pracht/test
 ```
 
 ---
 
 ## Unit Testing Loaders & API Routes
 
-Loaders and API route handlers are plain async functions that take a `Request` and return data. Test them directly — no framework bootstrap needed.
+Loaders and API route handlers are plain async functions. `@pracht/test` builds their args objects — a complete `LoaderArgs`/`ApiRouteArgs` with a `Request`, `params`, `url` (derived from the request), `context`, `signal`, and route metadata — from a small shorthand. Every field has a sensible default; override only what the code under test reads.
 
 ### Testing a loader
 
 ```ts [src/routes/dashboard.test.ts]
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect } from "vitest";
+import { createLoaderArgs } from "@pracht/test";
 import { loader } from "./dashboard";
 
 describe("dashboard loader", () => {
   it("returns projects for the authenticated user", async () => {
-    const request = new Request("http://localhost/dashboard", {
-      headers: { "x-user-id": "user-1" },
-    });
+    const data = await loader(
+      createLoaderArgs({
+        url: "/dashboard",
+        headers: { "x-user-id": "user-1" },
+      }),
+    );
 
-    const data = await loader({
-      request,
-      params: {},
-      url: new URL(request.url),
-      signal: AbortSignal.timeout(5000),
-    });
-
-    expect(data.projects).toBeDefined();
     expect(data.projects.length).toBeGreaterThan(0);
   });
 
-  it("throws 401 when no user header is present", async () => {
-    const request = new Request("http://localhost/dashboard");
-
-    await expect(
-      loader({
-        request,
-        params: {},
-        url: new URL(request.url),
-        signal: AbortSignal.timeout(5000),
-      }),
-    ).rejects.toThrow();
+  it("throws when no user header is present", async () => {
+    await expect(loader(createLoaderArgs({ url: "/dashboard" }))).rejects.toThrow();
   });
 });
+```
+
+The shorthand accepts `url` (relative paths resolve against `http://localhost`), `method`, `headers`, `body` (a plain object is JSON-encoded; `BodyInit` values pass through), `params`, a partial `context`, and `route` overrides — or a fully-formed `request` that wins over all of them. The returned args also expose `controller`, the `AbortController` behind `args.signal`:
+
+```ts
+const args = createLoaderArgs({ url: "/slow" });
+const pending = loader(args);
+args.controller.abort();
+await expect(pending).rejects.toThrow();
 ```
 
 ### Testing an API route
 
-```ts [src/api/contact.test.ts]
+`createApiArgs()` builds the same shape for API handlers — plain or `defineApi()`-wrapped — and `readJson()` reads a response body without consuming it:
+
+```ts [src/api/items.test.ts]
 import { describe, it, expect } from "vitest";
-import { POST } from "./contact";
+import { createApiArgs, readJson } from "@pracht/test";
+import { GET, POST } from "./items";
 
-function makeFormRequest(fields: Record<string, string>) {
-  const form = new FormData();
-  for (const [key, value] of Object.entries(fields)) {
-    form.set(key, value);
-  }
-  return new Request("http://localhost/api/contact", {
-    method: "POST",
-    body: form,
-  });
-}
-
-describe("contact API route", () => {
-  it("validates required fields", async () => {
-    const response = await POST({
-      request: makeFormRequest({ name: "", email: "", message: "" }),
-      params: {},
-      url: new URL("http://localhost/api/contact"),
-      signal: AbortSignal.timeout(5000),
-    });
-
-    expect(response.status).toBe(400);
-    const body = await response.json();
-    expect(body.ok).toBe(false);
-    expect(body.errors.name).toBeDefined();
-    expect(body.errors.email).toBeDefined();
-  });
-
-  it("succeeds with valid input", async () => {
-    const response = await POST({
-      request: makeFormRequest({
-        name: "Alice",
-        email: "alice@example.com",
-        message: "Hello!",
-      }),
-      params: {},
-      url: new URL("http://localhost/api/contact"),
-      signal: AbortSignal.timeout(5000),
-    });
+describe("items API route", () => {
+  it("lists items", async () => {
+    const response = await GET(createApiArgs({ url: "/api/items?page=2" }));
 
     expect(response.status).toBe(200);
-    const body = await response.json();
-    expect(body.ok).toBe(true);
+    expect(await readJson(response)).toEqual({ items: [], page: 2 });
+  });
+
+  it("creates an item from a JSON body", async () => {
+    const response = await POST(
+      createApiArgs({ url: "/api/items", body: { name: "Pracht" } }),
+    );
+
+    expect(await readJson(response)).toEqual({ created: "Pracht" });
+  });
+
+  it("rejects invalid input with the standardized validation body", async () => {
+    const response = await POST(createApiArgs({ url: "/api/items", body: { name: "" } }));
+
+    expect(response.status).toBe(422);
+    const body = await readJson(response);
+    expect(body.issues).toEqual([{ in: "body", path: ["name"], message: "Required" }]);
   });
 });
 ```
+
+### Testing form submissions
+
+`submitForm()` builds the request a form submission actually sends — `application/x-www-form-urlencoded` by default, switching to `multipart/form-data` automatically when any field is a `File` — and calls the handler with it. This exercises the same `FormData` parsing path `defineApi()` applies to real `<Form>` and native submissions:
+
+```ts [src/api/contact.test.ts]
+import { describe, it, expect } from "vitest";
+import { readJson, submitForm } from "@pracht/test";
+import { POST } from "./contact";
+
+describe("contact API route", () => {
+  it("succeeds with valid input", async () => {
+    const response = await submitForm(POST, {
+      name: "Alice",
+      email: "alice@example.com",
+      message: "Hello!",
+    });
+
+    expect(response.status).toBe(200);
+    expect(await readJson(response)).toMatchObject({ ok: true });
+  });
+
+  it("validates required fields", async () => {
+    const response = await submitForm(POST, { name: "", email: "", message: "" });
+    expect(response.status).toBe(422);
+  });
+
+  it("accepts an uploaded file", async () => {
+    const response = await submitForm(POST, {
+      name: "Alice",
+      email: "alice@example.com",
+      message: "See attachment",
+      attachment: new File(["contents"], "notes.txt", { type: "text/plain" }),
+    });
+    expect(response.status).toBe(200);
+  });
+});
+```
+
+Repeated fields (multi-selects, checkbox groups) are passed as arrays: `{ tag: ["a", "b"] }` produces two `tag` entries, which `formDataToRecord()` on the server groups back into an array.
 
 ---
 
 ## Testing Middleware
 
-Middleware always returns a `Response`. To test it in isolation, pass a fake
-`next` that resolves to a sentinel response — then assert on whether the
-middleware short-circuited (returned its own response) or called through
-(returned the sentinel).
+`runMiddleware()` executes one middleware — or a chain — exactly the way the runtime does: sequentially, with `next()` callable at most once per middleware, short-circuiting when a middleware returns its own `Response`. The optional final handler stands in for the loader at the end of the chain (default: an empty 200):
 
 ```ts [src/middleware/auth.test.ts]
 import { describe, it, expect } from "vitest";
-import { middleware } from "./auth";
+import { createMiddlewareArgs, readRedirect, runMiddleware } from "@pracht/test";
+import { middleware as auth } from "./auth";
 
 describe("auth middleware", () => {
-  const ok = new Response("ok", { status: 200 });
-  const next = async () => ok;
-
   it("redirects when no session cookie is present", async () => {
-    const request = new Request("http://localhost/dashboard");
-    const response = await middleware(
-      {
-        request,
-        url: new URL(request.url),
-        params: {},
-        context: {},
-        signal: AbortSignal.timeout(5000),
-        route: { path: "/dashboard" } as any,
-      },
-      next,
-    );
+    const response = await runMiddleware(auth, createMiddlewareArgs({ url: "/dashboard" }));
 
-    expect(response.status).toBe(302);
-    expect(response.headers.get("location")).toMatch(/\/login/);
+    expect(readRedirect(response)).toEqual({ status: 302, location: "/login" });
   });
 
-  it("continues to the handler when session is valid", async () => {
-    const request = new Request("http://localhost/dashboard", {
-      headers: { cookie: "session=valid-token-here" },
-    });
-
-    const response = await middleware(
-      {
-        request,
-        url: new URL(request.url),
-        params: {},
-        context: {},
-        signal: AbortSignal.timeout(5000),
-        route: { path: "/dashboard" } as any,
-      },
-      next,
+  it("continues to the handler when the session is valid", async () => {
+    const response = await runMiddleware(
+      auth,
+      createMiddlewareArgs({
+        url: "/dashboard",
+        headers: { cookie: "session=valid-token-here" },
+      }),
+      async () => new Response("handler ran"),
     );
 
-    expect(response).toBe(ok);
+    expect(await response.text()).toBe("handler ran");
   });
+});
+```
+
+Chains work the same way, including `context` mutations flowing downstream — pass the middleware in the order the manifest applies them:
+
+```ts
+const args = createMiddlewareArgs<AppContext>({ url: "/admin", context: {} });
+const response = await runMiddleware([logging, auth, requireAdmin], args, async () => {
+  // Sees the context that auth populated, like a loader would.
+  return Response.json({ user: args.context.user });
 });
 ```
 
@@ -669,8 +674,8 @@ Add these to your `package.json`:
 
 ## Tips
 
-- **Test loaders directly** — they're plain functions. No need to spin up a server for data logic tests.
-- **Test API routes directly** — they take a `Request` and return a `Response`. Easy to unit test without any framework setup.
+- **Test loaders directly** — they're plain functions. `createLoaderArgs()` from `@pracht/test` builds their args; no server needed for data logic tests.
+- **Test API routes directly** — they take a `Request` and return a `Response`. `createApiArgs()` and `submitForm()` build the requests without any framework setup.
 - **Use E2E for hydration** — unit tests can't verify that client-side routing and hydration work correctly. That's what Playwright is for.
 - Check for `(window as any).__PRACHT_ROUTER_READY__` in Playwright tests to wait for hydration before interacting with the page.
 - **Test the JSON endpoint** — send `x-pracht-route-state-request: 1` to get loader data as JSON. Great for verifying data without parsing HTML.

--- a/examples/docs/src/routes/docs/recipes-testing.md
+++ b/examples/docs/src/routes/docs/recipes-testing.md
@@ -133,7 +133,7 @@ describe("contact API route", () => {
 });
 ```
 
-Repeated fields (multi-selects, checkbox groups) are passed as arrays: `{ tag: ["a", "b"] }` produces two `tag` entries, which `formDataToRecord()` on the server groups back into an array. A `method: "GET"` form carries no body — like a browser, the fields are serialized into the URL query string, which exercises a `defineApi()` `query` schema instead of `body`.
+Repeated fields (multi-selects, checkbox groups) are passed as arrays: `{ tag: ["a", "b"] }` produces two `tag` entries, which `formDataToRecord()` on the server groups back into an array. Field names and string values receive the same CRLF newline normalization as a browser form submission. A `method: "GET"` form carries no body — like a browser, the fields are serialized into the URL query string, which exercises a `defineApi()` `query` schema instead of `body`.
 
 ---
 

--- a/examples/docs/src/routes/docs/recipes-testing.md
+++ b/examples/docs/src/routes/docs/recipes-testing.md
@@ -132,7 +132,7 @@ describe("contact API route", () => {
 });
 ```
 
-Repeated fields (multi-selects, checkbox groups) are passed as arrays: `{ tag: ["a", "b"] }` produces two `tag` entries, which `formDataToRecord()` on the server groups back into an array.
+Repeated fields (multi-selects, checkbox groups) are passed as arrays: `{ tag: ["a", "b"] }` produces two `tag` entries, which `formDataToRecord()` on the server groups back into an array. A `method: "GET"` form carries no body — like a browser, the fields are serialized into the URL query string, which exercises a `defineApi()` `query` schema instead of `body`.
 
 ---
 
@@ -166,6 +166,8 @@ describe("auth middleware", () => {
   });
 });
 ```
+
+A middleware (or the final handler) that **throws** a `Response` — the `requireUser()` pattern, where a shared helper throws `redirect("/login")` — resolves as the chain's response, exactly like the server treats it. Thrown non-`Response` errors, including `notFound()`, reject so your test can assert on them.
 
 Chains work the same way, including `context` mutations flowing downstream — pass the middleware in the order the manifest applies them:
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "type": "module",
   "scripts": {
-    "build": "pnpm -r --filter @pracht/core --filter @pracht/capabilities --filter @pracht/openapi --filter @pracht/vite-plugin --filter @pracht/preact-ssr-precompile --filter @pracht/adapter-node --filter @pracht/adapter-cloudflare --filter @pracht/adapter-vercel --filter @pracht/image --filter @pracht/cli --filter create-pracht run build",
+    "build": "pnpm -r --filter @pracht/core --filter @pracht/capabilities --filter @pracht/openapi --filter @pracht/vite-plugin --filter @pracht/preact-ssr-precompile --filter @pracht/adapter-node --filter @pracht/adapter-cloudflare --filter @pracht/adapter-vercel --filter @pracht/image --filter @pracht/test --filter @pracht/cli --filter create-pracht run build",
     "check": "pnpm build && pnpm typecheck && pnpm test",
     "verify": "node ./scripts/verify.mjs",
     "typecheck": "tsc --noEmit && tsc --noEmit -p packages/cli/test/fixtures/cloudflare-runtime-import && tsc --noEmit -p examples/showcase",

--- a/packages/cli/test/e2e-port-leases.test.ts
+++ b/packages/cli/test/e2e-port-leases.test.ts
@@ -198,16 +198,25 @@ describe("Pracht E2E port leases", () => {
     expect(occupiedServer).toBeDefined();
 
     try {
-      expect(() =>
+      let failure: unknown;
+      try {
         acquireE2EPortLease({
           env: {},
           leaseRoot,
           override: String(portBase),
           workspaceRoot,
-        }),
-      ).toThrow(
-        `${portBase}-${portBase + E2E_PORT_BLOCK_WIDTH - 1} contains unavailable port: ${portBase + 4} (EADDRINUSE)`,
+        });
+      } catch (error: unknown) {
+        failure = error;
+      }
+      expect(failure).toBeInstanceOf(Error);
+      expect((failure as Error).message).toContain(
+        `${portBase}-${portBase + E2E_PORT_BLOCK_WIDTH - 1} contains unavailable port`,
       );
+      // Shared CI runners may already own other ports in the same block. The
+      // diagnostic must include the port this test deliberately occupied,
+      // without requiring it to be the only unavailable port.
+      expect((failure as Error).message).toContain(`${portBase + 4} (EADDRINUSE)`);
       expect(existsSync(resolve(leaseRoot, `block-${portBase}`))).toBe(false);
     } finally {
       await closeServer(occupiedServer!);

--- a/packages/framework/src/browser.ts
+++ b/packages/framework/src/browser.ts
@@ -155,6 +155,7 @@ export type {
   MiddlewareFn,
   MiddlewareModule,
   MiddlewareNext,
+  MiddlewareRoute,
   ModuleImporter,
   ModuleRef,
   NotFoundConfig,

--- a/packages/framework/src/index.ts
+++ b/packages/framework/src/index.ts
@@ -264,6 +264,7 @@ export type {
   MiddlewareFn,
   MiddlewareModule,
   MiddlewareNext,
+  MiddlewareRoute,
   ModuleImporter,
   ModuleRef,
   NotFoundConfig,

--- a/packages/framework/src/runtime-middleware.ts
+++ b/packages/framework/src/runtime-middleware.ts
@@ -189,7 +189,7 @@ export async function runMiddlewareChain<TContext>(options: {
       context: options.context,
       signal: options.signal,
       url: options.url,
-      route: options.route as BaseRouteArgs<TContext>["route"],
+      route: options.route,
     };
 
     const response = await mwModule.middleware(args, next);

--- a/packages/framework/src/server.ts
+++ b/packages/framework/src/server.ts
@@ -195,6 +195,7 @@ export type {
   MiddlewareFn,
   MiddlewareModule,
   MiddlewareNext,
+  MiddlewareRoute,
   ModuleImporter,
   ModuleRef,
   NotFoundConfig,

--- a/packages/framework/src/types.ts
+++ b/packages/framework/src/types.ts
@@ -918,7 +918,19 @@ export interface BaseRouteArgs<TContext = RegisteredContext> {
 
 export interface LoaderArgs<TContext = RegisteredContext> extends BaseRouteArgs<TContext> {}
 
-export interface MiddlewareArgs<TContext = RegisteredContext> extends BaseRouteArgs<TContext> {}
+/** The matched page or API route whose middleware chain is running. */
+export type MiddlewareRoute = ResolvedRoute | ResolvedApiRoute;
+
+/**
+ * Middleware wraps both page and API routes. Narrow `route` by checking for
+ * page-only metadata such as `middlewareFiles` before reading those fields.
+ */
+export type MiddlewareArgs<TContext = RegisteredContext> = Omit<
+  BaseRouteArgs<TContext>,
+  "route"
+> & {
+  route: MiddlewareRoute;
+};
 
 export type HeadAttributes = Record<string, string | undefined>;
 

--- a/packages/test/README.md
+++ b/packages/test/README.md
@@ -11,6 +11,8 @@ with Vitest (or any test runner).
   `Request`, with sensible defaults for everything and the `AbortController`
   behind `signal` exposed for cancellation tests. The two middleware factories
   model the distinct page and API route metadata shapes production supplies.
+  Blob/File and `URLSearchParams` bodies are normalized across DOM realms, so
+  JSDOM values work with Node's `Request` implementation.
 - `runMiddleware()` — execute a middleware chain with the runtime's `next()`
   semantics (sequential, at-most-once `next()`, short-circuit on an early
   `Response`). A thrown `Response` resolves by default like page/API dispatch;

--- a/packages/test/README.md
+++ b/packages/test/README.md
@@ -12,11 +12,13 @@ with Vitest (or any test runner).
   cancellation tests.
 - `runMiddleware()` — execute a middleware chain with the runtime's `next()`
   semantics (sequential, at-most-once `next()`, short-circuit on an early
-  `Response`).
+  `Response`; a thrown `Response` — e.g. `throw redirect()` from a shared
+  helper — resolves as the chain's response, like the server treats it).
 - `submitForm()` / `createFormRequest()` — build a urlencoded or multipart
   form `POST` (auto-switching when a field is a `File`) and call an API
   handler with it, hitting the same `FormData` parsing path `defineApi()`
-  uses for real submissions.
+  uses for real submissions. `method: "GET"` serializes the fields into the
+  URL query string instead, like a browser `<form method="get">`.
 - `readJson()` / `readRedirect()` — minimal response readers: parse a JSON
   body without consuming the original response, or extract
   `{ status, location }` from a redirect.
@@ -26,7 +28,14 @@ pnpm add -D @pracht/test
 ```
 
 ```ts
-import { createLoaderArgs, runMiddleware, submitForm, readJson, readRedirect } from "@pracht/test";
+import {
+  createLoaderArgs,
+  createMiddlewareArgs,
+  runMiddleware,
+  submitForm,
+  readJson,
+  readRedirect,
+} from "@pracht/test";
 import { loader } from "./routes/dashboard";
 import { middleware as auth } from "./middleware/auth";
 import { POST } from "./api/contact";

--- a/packages/test/README.md
+++ b/packages/test/README.md
@@ -5,20 +5,26 @@ apps. Small, typed factories and runners — no assertion framework, no server
 boot — for unit testing loaders, API routes, middleware, and form submissions
 with Vitest (or any test runner).
 
-- `createLoaderArgs()` / `createApiArgs()` / `createMiddlewareArgs()` — build
-  complete, typed args objects from a shorthand (`url`, `method`, `headers`,
-  `body`, `params`, `context`) or a real `Request`, with sensible defaults for
-  everything and the `AbortController` behind `signal` exposed for
-  cancellation tests.
+- `createLoaderArgs()` / `createApiArgs()` / `createMiddlewareArgs()` /
+  `createApiMiddlewareArgs()` — build complete, typed args objects from a
+  shorthand (`url`, `method`, `headers`, `body`, `params`, `context`) or a real
+  `Request`, with sensible defaults for everything and the `AbortController`
+  behind `signal` exposed for cancellation tests. The two middleware factories
+  model the distinct page and API route metadata shapes production supplies.
 - `runMiddleware()` — execute a middleware chain with the runtime's `next()`
   semantics (sequential, at-most-once `next()`, short-circuit on an early
-  `Response`; a thrown `Response` — e.g. `throw redirect()` from a shared
-  helper — resolves as the chain's response, like the server treats it).
-- `submitForm()` / `createFormRequest()` — build a urlencoded or multipart
-  form `POST` (auto-switching when a field is a `File`) and call an API
-  handler with it, hitting the same `FormData` parsing path `defineApi()`
-  uses for real submissions. `method: "GET"` serializes the fields into the
-  URL query string instead, like a browser `<form method="get">`.
+  `Response`). A thrown `Response` resolves by default like page/API dispatch;
+  opt into raw-chain rejection with `{ thrownResponse: "reject" }`.
+  Capability middleware should use
+  `createCapabilityTestHost()` so thrown responses become the real typed
+  `internal_error` envelope.
+- `submitForm()` / async `createFormRequest()` — build a realm-safe urlencoded
+  or multipart form `POST` (auto-switching when a field is a `File`) and call
+  an API handler with it, hitting the same `FormData` parsing path
+  `defineApi()` uses for real submissions. `method: "GET"` serializes the
+  fields into the URL query string instead, like a browser
+  `<form method="get">`. The encoding also works when JSDOM supplies the
+  form globals while Node supplies `Request`.
 - `readJson()` / `readRedirect()` — minimal response readers: parse a JSON
   body without consuming the original response, or extract
   `{ status, location }` from a redirect.

--- a/packages/test/README.md
+++ b/packages/test/README.md
@@ -1,0 +1,51 @@
+# @pracht/test
+
+First-party testing utilities for [pracht](https://github.com/JoviDeCroock/pracht)
+apps. Small, typed factories and runners — no assertion framework, no server
+boot — for unit testing loaders, API routes, middleware, and form submissions
+with Vitest (or any test runner).
+
+- `createLoaderArgs()` / `createApiArgs()` / `createMiddlewareArgs()` — build
+  complete, typed args objects from a shorthand (`url`, `method`, `headers`,
+  `body`, `params`, `context`) or a real `Request`, with sensible defaults for
+  everything and the `AbortController` behind `signal` exposed for
+  cancellation tests.
+- `runMiddleware()` — execute a middleware chain with the runtime's `next()`
+  semantics (sequential, at-most-once `next()`, short-circuit on an early
+  `Response`).
+- `submitForm()` / `createFormRequest()` — build a urlencoded or multipart
+  form `POST` (auto-switching when a field is a `File`) and call an API
+  handler with it, hitting the same `FormData` parsing path `defineApi()`
+  uses for real submissions.
+- `readJson()` / `readRedirect()` — minimal response readers: parse a JSON
+  body without consuming the original response, or extract
+  `{ status, location }` from a redirect.
+
+```bash
+pnpm add -D @pracht/test
+```
+
+```ts
+import { createLoaderArgs, runMiddleware, submitForm, readJson, readRedirect } from "@pracht/test";
+import { loader } from "./routes/dashboard";
+import { middleware as auth } from "./middleware/auth";
+import { POST } from "./api/contact";
+
+// Loaders
+const data = await loader(createLoaderArgs({ url: "/dashboard", headers: { cookie: "session=x" } }));
+
+// Middleware, including short-circuits
+const denied = await runMiddleware(auth, createMiddlewareArgs({ url: "/dashboard" }));
+expect(readRedirect(denied).location).toBe("/login");
+
+// Form submissions against API handlers
+const response = await submitForm(POST, { name: "Alice", email: "alice@example.com" });
+expect(await readJson(response)).toEqual({ ok: true });
+```
+
+For capability testing, use `createCapabilityTestHost()` from
+`@pracht/core/server` — it runs the real capability dispatch pipeline
+(validation, middleware, confirmation flow) in-process.
+
+See the [testing docs](https://pracht.resynapse.dev/docs/recipes/testing) for
+full examples.

--- a/packages/test/README.md
+++ b/packages/test/README.md
@@ -11,7 +11,8 @@ with Vitest (or any test runner).
   `Request`, with sensible defaults for everything and the `AbortController`
   behind `signal` exposed for cancellation tests. The two middleware factories
   model the distinct page and API route metadata shapes production supplies.
-  Blob/File and `URLSearchParams` bodies are normalized across DOM realms, so
+  Blob/File and `URLSearchParams` bodies are normalized across DOM realms, and
+  foreign-realm `FormData`/`ArrayBuffer` values retain their wire encoding, so
   JSDOM values work with Node's `Request` implementation.
 - `runMiddleware()` — execute a middleware chain with the runtime's `next()`
   semantics (sequential, at-most-once `next()`, short-circuit on an early
@@ -27,6 +28,8 @@ with Vitest (or any test runner).
   fields into the URL query string instead, like a browser
   `<form method="get">`. The encoding also works when JSDOM supplies the
   form globals while Node supplies `Request`.
+  Field names and string values use the same CRLF newline normalization as a
+  browser form submission.
 - `readJson()` / `readRedirect()` — minimal response readers: parse a JSON
   body without consuming the original response, or extract
   `{ status, location }` from a redirect.

--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -1,0 +1,47 @@
+{
+  "name": "@pracht/test",
+  "version": "0.0.0",
+  "description": "First-party testing utilities for Pracht apps: typed factories for loader, API, and middleware args, a middleware chain runner, form submission helpers, and minimal response readers.",
+  "keywords": [
+    "pracht",
+    "preact",
+    "testing",
+    "vitest",
+    "loaders",
+    "middleware",
+    "api-routes"
+  ],
+  "license": "MIT",
+  "homepage": "https://github.com/JoviDeCroock/pracht/tree/main/packages/test",
+  "bugs": {
+    "url": "https://github.com/JoviDeCroock/pracht/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/JoviDeCroock/pracht",
+    "directory": "packages/test"
+  },
+  "files": [
+    "dist"
+  ],
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.mts",
+      "default": "./dist/index.mjs"
+    }
+  },
+  "publishConfig": {
+    "provenance": true
+  },
+  "scripts": {
+    "build": "tsdown",
+    "prepublishOnly": "npm run build"
+  },
+  "dependencies": {
+    "@pracht/core": "workspace:*"
+  },
+  "devDependencies": {
+    "@standard-schema/spec": "^1.0.0"
+  }
+}

--- a/packages/test/src/args.ts
+++ b/packages/test/src/args.ts
@@ -8,6 +8,8 @@ import type {
   RouteParams,
 } from "@pracht/core";
 
+import { isBlobLike, readBlobBytes } from "./body.ts";
+
 /** Base origin used when `url` is omitted or relative. */
 export const TEST_ORIGIN = "http://localhost";
 
@@ -26,9 +28,10 @@ export interface TestRequestInput {
   headers?: HeadersInit;
   /**
    * Request body. `BodyInit` values (string, `Blob`, `FormData`,
-   * `URLSearchParams`, streams, buffers) pass through unchanged; a plain
-   * object or array is JSON-encoded with `Content-Type: application/json`,
-   * matching `apiFetch()`.
+   * `URLSearchParams`, streams, buffers) preserve their wire representation;
+   * Blob/File and `URLSearchParams` values are normalized across DOM realms.
+   * A plain object or array is JSON-encoded with `Content-Type:
+   * application/json`, matching `apiFetch()`.
    */
   body?: BodyInit | Record<string, unknown> | readonly unknown[] | null;
 }
@@ -86,13 +89,33 @@ export type TestApiArgs<TContext = RegisteredContext> = ApiRouteArgs<TContext> &
 function isBodyInit(body: unknown): body is BodyInit {
   return (
     typeof body === "string" ||
-    body instanceof Blob ||
     body instanceof FormData ||
-    body instanceof URLSearchParams ||
     body instanceof ReadableStream ||
     body instanceof ArrayBuffer ||
     ArrayBuffer.isView(body)
   );
+}
+
+function isUrlSearchParamsLike(body: unknown): body is URLSearchParams {
+  return (
+    typeof body === "object" &&
+    body !== null &&
+    Object.prototype.toString.call(body) === "[object URLSearchParams]" &&
+    typeof (body as URLSearchParams).entries === "function"
+  );
+}
+
+function blobBody(blob: Blob): ReadableStream<Uint8Array<ArrayBuffer>> {
+  return new ReadableStream({
+    async start(controller) {
+      try {
+        controller.enqueue(await readBlobBytes(blob));
+        controller.close();
+      } catch (error: unknown) {
+        controller.error(error);
+      }
+    },
+  });
 }
 
 /** Build the `Request` from the shorthand fields (or return the real one). */
@@ -107,7 +130,17 @@ export function createTestRequest(input: TestRequestInput = {}): Request {
 
   let body: BodyInit | null = null;
   if (input.body != null) {
-    if (isBodyInit(input.body)) {
+    if (isBlobLike(input.body)) {
+      body = blobBody(input.body);
+      if (input.body.type && !headers.has("content-type")) {
+        headers.set("content-type", input.body.type);
+      }
+    } else if (isUrlSearchParamsLike(input.body)) {
+      body = input.body.toString();
+      if (!headers.has("content-type")) {
+        headers.set("content-type", "application/x-www-form-urlencoded;charset=UTF-8");
+      }
+    } else if (isBodyInit(input.body)) {
       body = input.body;
     } else {
       body = JSON.stringify(input.body);

--- a/packages/test/src/args.ts
+++ b/packages/test/src/args.ts
@@ -71,8 +71,16 @@ export interface TestAbortControls {
 }
 
 export type TestLoaderArgs<TContext = RegisteredContext> = LoaderArgs<TContext> & TestAbortControls;
-export type TestMiddlewareArgs<TContext = RegisteredContext> = MiddlewareArgs<TContext> &
-  TestAbortControls;
+export type TestMiddlewareArgs<TContext = RegisteredContext> = Omit<
+  MiddlewareArgs<TContext>,
+  "route"
+> &
+  TestAbortControls & { route: ResolvedRoute };
+export type TestApiMiddlewareArgs<TContext = RegisteredContext> = Omit<
+  MiddlewareArgs<TContext>,
+  "route"
+> &
+  TestAbortControls & { route: ResolvedApiRoute };
 export type TestApiArgs<TContext = RegisteredContext> = ApiRouteArgs<TContext> & TestAbortControls;
 
 function isBodyInit(body: unknown): body is BodyInit {
@@ -193,6 +201,17 @@ export function createMiddlewareArgs<TContext = RegisteredContext>(
   input: CreateMiddlewareArgsInput<TContext> = {},
 ): TestMiddlewareArgs<TContext> {
   return createLoaderArgs(input);
+}
+
+/**
+ * Build middleware args for a chain attached through `defineApp({ api })`.
+ * Unlike page middleware, the matched route has API metadata only — no
+ * `middleware`, `middlewareFiles`, render mode, shell, or loader fields.
+ */
+export function createApiMiddlewareArgs<TContext = RegisteredContext>(
+  input: CreateApiArgsInput<TContext> = {},
+): TestApiMiddlewareArgs<TContext> {
+  return createApiArgs(input);
 }
 
 /**

--- a/packages/test/src/args.ts
+++ b/packages/test/src/args.ts
@@ -86,12 +86,31 @@ export type TestApiMiddlewareArgs<TContext = RegisteredContext> = Omit<
   TestAbortControls & { route: ResolvedApiRoute };
 export type TestApiArgs<TContext = RegisteredContext> = ApiRouteArgs<TContext> & TestAbortControls;
 
+function hasBodyBrand(body: unknown, brand: string): body is object {
+  return (
+    typeof body === "object" && body !== null && Object.prototype.toString.call(body) === brand
+  );
+}
+
+function isFormDataLike(body: unknown): body is FormData {
+  return (
+    hasBodyBrand(body, "[object FormData]") && typeof (body as FormData).entries === "function"
+  );
+}
+
+function isArrayBufferLike(body: unknown): body is ArrayBuffer {
+  return (
+    hasBodyBrand(body, "[object ArrayBuffer]") &&
+    typeof (body as ArrayBuffer).byteLength === "number"
+  );
+}
+
 function isBodyInit(body: unknown): body is BodyInit {
   return (
     typeof body === "string" ||
-    body instanceof FormData ||
+    isFormDataLike(body) ||
     body instanceof ReadableStream ||
-    body instanceof ArrayBuffer ||
+    isArrayBufferLike(body) ||
     ArrayBuffer.isView(body)
   );
 }

--- a/packages/test/src/args.ts
+++ b/packages/test/src/args.ts
@@ -1,0 +1,208 @@
+import type {
+  ApiRouteArgs,
+  LoaderArgs,
+  MiddlewareArgs,
+  RegisteredContext,
+  ResolvedApiRoute,
+  ResolvedRoute,
+  RouteParams,
+} from "@pracht/core";
+
+/** Base origin used when `url` is omitted or relative. */
+export const TEST_ORIGIN = "http://localhost";
+
+/**
+ * Shorthand for building the `Request` an args factory hands to the code
+ * under test. Pass a fully-formed `request` to take complete control; the
+ * other fields are ignored when it is present.
+ */
+export interface TestRequestInput {
+  /** A real `Request`. Wins over `url`, `method`, `headers`, and `body`. */
+  request?: Request;
+  /** Absolute or relative URL; relative paths resolve against `http://localhost`. Default `/`. */
+  url?: string | URL;
+  /** Defaults to `GET`, or `POST` when a `body` is provided. */
+  method?: string;
+  headers?: HeadersInit;
+  /**
+   * Request body. `BodyInit` values (string, `Blob`, `FormData`,
+   * `URLSearchParams`, streams, buffers) pass through unchanged; a plain
+   * object or array is JSON-encoded with `Content-Type: application/json`,
+   * matching `apiFetch()`.
+   */
+  body?: BodyInit | Record<string, unknown> | readonly unknown[] | null;
+}
+
+/** Input shared by every args factory. */
+export interface CreateArgsInput<TContext = RegisteredContext> extends TestRequestInput {
+  /** Dynamic route params (e.g. `{ slug: "hello" }`). Default `{}`. */
+  params?: RouteParams;
+  /** Request context. A partial is accepted — provide what the code under test reads. */
+  context?: Partial<TContext>;
+  /** Override the abort signal. When omitted, `controller.signal` is used. */
+  signal?: AbortSignal;
+}
+
+export interface CreateLoaderArgsInput<
+  TContext = RegisteredContext,
+> extends CreateArgsInput<TContext> {
+  /** Override matched-route metadata; merged over sensible defaults. */
+  route?: Partial<ResolvedRoute>;
+}
+
+export interface CreateMiddlewareArgsInput<
+  TContext = RegisteredContext,
+> extends CreateLoaderArgsInput<TContext> {}
+
+export interface CreateApiArgsInput<
+  TContext = RegisteredContext,
+> extends CreateArgsInput<TContext> {
+  /** Override matched API route metadata; merged over sensible defaults. */
+  route?: Partial<ResolvedApiRoute>;
+}
+
+/**
+ * The controller behind `args.signal`, so a test can abort mid-flight:
+ * `args.controller.abort()`. When a custom `signal` is passed in, the
+ * controller is still returned but no longer wired to `args.signal`.
+ */
+export interface TestAbortControls {
+  controller: AbortController;
+}
+
+export type TestLoaderArgs<TContext = RegisteredContext> = LoaderArgs<TContext> & TestAbortControls;
+export type TestMiddlewareArgs<TContext = RegisteredContext> = MiddlewareArgs<TContext> &
+  TestAbortControls;
+export type TestApiArgs<TContext = RegisteredContext> = ApiRouteArgs<TContext> & TestAbortControls;
+
+function isBodyInit(body: unknown): body is BodyInit {
+  return (
+    typeof body === "string" ||
+    body instanceof Blob ||
+    body instanceof FormData ||
+    body instanceof URLSearchParams ||
+    body instanceof ReadableStream ||
+    body instanceof ArrayBuffer ||
+    ArrayBuffer.isView(body)
+  );
+}
+
+/** Build the `Request` from the shorthand fields (or return the real one). */
+export function createTestRequest(input: TestRequestInput = {}): Request {
+  if (input.request) {
+    return input.request;
+  }
+
+  const url = new URL(input.url ?? "/", TEST_ORIGIN);
+  const method = (input.method ?? (input.body != null ? "POST" : "GET")).toUpperCase();
+  const headers = new Headers(input.headers);
+
+  let body: BodyInit | null = null;
+  if (input.body != null) {
+    if (isBodyInit(input.body)) {
+      body = input.body;
+    } else {
+      body = JSON.stringify(input.body);
+      if (!headers.has("content-type")) {
+        headers.set("content-type", "application/json");
+      }
+    }
+  }
+
+  return new Request(url, { method, headers, body });
+}
+
+interface BuiltBaseArgs<TContext> {
+  request: Request;
+  params: RouteParams;
+  context: TContext;
+  signal: AbortSignal;
+  url: URL;
+  controller: AbortController;
+}
+
+function buildBaseArgs<TContext>(input: CreateArgsInput<TContext>): BuiltBaseArgs<TContext> {
+  const request = createTestRequest(input);
+  const controller = new AbortController();
+  return {
+    request,
+    params: input.params ?? {},
+    context: (input.context ?? {}) as TContext,
+    signal: input.signal ?? controller.signal,
+    url: new URL(request.url),
+    controller,
+  };
+}
+
+function buildResolvedRoute(url: URL, overrides: Partial<ResolvedRoute> = {}): ResolvedRoute {
+  return {
+    path: url.pathname,
+    file: "test://route.tsx",
+    middleware: [],
+    middlewareFiles: [],
+    segments: [],
+    ...overrides,
+  };
+}
+
+function buildResolvedApiRoute(
+  url: URL,
+  overrides: Partial<ResolvedApiRoute> = {},
+): ResolvedApiRoute {
+  return {
+    path: url.pathname,
+    file: "test://api-route.ts",
+    segments: [],
+    ...overrides,
+  };
+}
+
+/**
+ * Build a complete `LoaderArgs` for calling a route loader directly:
+ *
+ * ```ts
+ * const args = createLoaderArgs({ url: "/blog/hello", params: { slug: "hello" } });
+ * const data = await loader(args);
+ * ```
+ *
+ * Every field has a sensible default; override only what the loader reads.
+ * The returned object also carries `controller` — the `AbortController`
+ * behind `args.signal` — for cancellation tests.
+ */
+export function createLoaderArgs<TContext = RegisteredContext>(
+  input: CreateLoaderArgsInput<TContext> = {},
+): TestLoaderArgs<TContext> {
+  const base = buildBaseArgs(input);
+  return {
+    ...base,
+    route: buildResolvedRoute(base.url, input.route),
+  };
+}
+
+/**
+ * Build a complete `MiddlewareArgs` — the same shape as `LoaderArgs` — for
+ * calling middleware directly or through `runMiddleware()`.
+ */
+export function createMiddlewareArgs<TContext = RegisteredContext>(
+  input: CreateMiddlewareArgsInput<TContext> = {},
+): TestMiddlewareArgs<TContext> {
+  return createLoaderArgs(input);
+}
+
+/**
+ * Build a complete `ApiRouteArgs` for calling an API route handler (plain or
+ * `defineApi()`-wrapped) directly:
+ *
+ * ```ts
+ * const response = await POST(createApiArgs({ url: "/api/items", body: { name: "x" } }));
+ * ```
+ */
+export function createApiArgs<TContext = RegisteredContext>(
+  input: CreateApiArgsInput<TContext> = {},
+): TestApiArgs<TContext> {
+  const base = buildBaseArgs(input);
+  return {
+    ...base,
+    route: buildResolvedApiRoute(base.url, input.route),
+  };
+}

--- a/packages/test/src/args.ts
+++ b/packages/test/src/args.ts
@@ -8,7 +8,13 @@ import type {
   RouteParams,
 } from "@pracht/core";
 
-import { isBlobLike, readBlobBytes } from "./body.ts";
+import {
+  isBlobLike,
+  normalizeFormNewlines,
+  readBlobBytes,
+  streamMultipart,
+  type MultipartEntry,
+} from "./body.ts";
 
 /** Base origin used when `url` is omitted or relative. */
 export const TEST_ORIGIN = "http://localhost";
@@ -108,7 +114,6 @@ function isArrayBufferLike(body: unknown): body is ArrayBuffer {
 function isBodyInit(body: unknown): body is BodyInit {
   return (
     typeof body === "string" ||
-    isFormDataLike(body) ||
     body instanceof ReadableStream ||
     isArrayBufferLike(body) ||
     ArrayBuffer.isView(body)
@@ -158,6 +163,16 @@ export function createTestRequest(input: TestRequestInput = {}): Request {
       body = input.body.toString();
       if (!headers.has("content-type")) {
         headers.set("content-type", "application/x-www-form-urlencoded;charset=UTF-8");
+      }
+    } else if (isFormDataLike(input.body)) {
+      const entries: MultipartEntry[] = Array.from(input.body.entries(), ([name, value]) => [
+        normalizeFormNewlines(name),
+        isBlobLike(value) ? value : normalizeFormNewlines(String(value)),
+      ]);
+      const encoded = streamMultipart(entries);
+      body = encoded.body;
+      if (!headers.has("content-type")) {
+        headers.set("content-type", encoded.contentType);
       }
     } else if (isBodyInit(input.body)) {
       body = input.body;

--- a/packages/test/src/args.ts
+++ b/packages/test/src/args.ts
@@ -109,7 +109,13 @@ export function createTestRequest(input: TestRequestInput = {}): Request {
     }
   }
 
-  return new Request(url, { method, headers, body });
+  const init: RequestInit & { duplex?: "half" } = { method, headers, body };
+  if (body instanceof ReadableStream) {
+    // Fetch requires opting into streaming uploads; without it the Request
+    // constructor throws "duplex option is required when sending a body".
+    init.duplex = "half";
+  }
+  return new Request(url, init);
 }
 
 interface BuiltBaseArgs<TContext> {

--- a/packages/test/src/body.ts
+++ b/packages/test/src/body.ts
@@ -1,0 +1,37 @@
+/** Recognize Blob/File values across DOM realms without relying on `instanceof`. */
+export function isBlobLike(value: unknown): value is Blob {
+  if (typeof value !== "object" || value === null) return false;
+  const candidate = value as Blob;
+  return (
+    typeof candidate.size === "number" &&
+    typeof candidate.type === "string" &&
+    typeof candidate.slice === "function"
+  );
+}
+
+/** Read Blob/File bytes even when JSDOM owns the value and Node owns `Request`. */
+export async function readBlobBytes(blob: Blob): Promise<Uint8Array<ArrayBuffer>> {
+  if (typeof blob.arrayBuffer === "function") {
+    return new Uint8Array(await blob.arrayBuffer());
+  }
+
+  if (typeof FileReader === "function") {
+    return new Promise((resolve, reject) => {
+      const reader = new FileReader();
+      reader.onerror = () => reject(reader.error ?? new Error("Failed to read Blob/File body"));
+      reader.onload = () => {
+        if (reader.result instanceof ArrayBuffer) {
+          resolve(new Uint8Array(reader.result));
+          return;
+        }
+        reject(new TypeError("Expected FileReader to produce an ArrayBuffer"));
+      };
+      reader.readAsArrayBuffer(blob);
+    });
+  }
+
+  throw new TypeError(
+    "Cannot read this Blob/File in the current test environment. " +
+      "Provide a standard Blob implementation with arrayBuffer() or FileReader support.",
+  );
+}

--- a/packages/test/src/body.ts
+++ b/packages/test/src/body.ts
@@ -9,6 +9,110 @@ export function isBlobLike(value: unknown): value is Blob {
   );
 }
 
+export type MultipartEntry = readonly [name: string, value: string | Blob];
+
+let multipartBoundarySequence = 0;
+
+export function normalizeFormNewlines(value: string): string {
+  return value.replace(/\r\n|\r|\n/g, "\r\n");
+}
+
+function escapeMultipartHeaderValue(value: string): string {
+  return value.replace(/\r/g, "%0D").replace(/\n/g, "%0A").replace(/"/g, "%22");
+}
+
+function createMultipartBoundary(): string {
+  return `----pracht-test-${Date.now().toString(36)}-${multipartBoundarySequence++}`;
+}
+
+async function* multipartChunks(
+  entries: Iterable<MultipartEntry>,
+  boundary: string,
+): AsyncGenerator<Uint8Array<ArrayBuffer>> {
+  const encoder = new TextEncoder();
+
+  for (const [name, value] of entries) {
+    const disposition =
+      `--${boundary}\r\nContent-Disposition: form-data; ` +
+      `name="${escapeMultipartHeaderValue(name)}"`;
+    if (isBlobLike(value)) {
+      const filename =
+        typeof (value as Blob & { name?: unknown }).name === "string"
+          ? (value as Blob & { name: string }).name
+          : "blob";
+      const contentType = /[\r\n]/.test(value.type)
+        ? "application/octet-stream"
+        : value.type || "application/octet-stream";
+      yield encoder.encode(
+        `${disposition}; filename="${escapeMultipartHeaderValue(filename)}"\r\n` +
+          `Content-Type: ${contentType}\r\n\r\n`,
+      );
+      yield await readBlobBytes(value);
+      yield encoder.encode("\r\n");
+    } else {
+      yield encoder.encode(`${disposition}\r\n\r\n${value}\r\n`);
+    }
+  }
+
+  yield encoder.encode(`--${boundary}--\r\n`);
+}
+
+function multipartContentType(boundary: string): string {
+  return `multipart/form-data; boundary=${boundary}`;
+}
+
+/** Encode multipart entries eagerly when the caller can await Blob/File reads. */
+export async function encodeMultipart(entries: Iterable<MultipartEntry>): Promise<{
+  body: Uint8Array<ArrayBuffer>;
+  contentType: string;
+}> {
+  const boundary = createMultipartBoundary();
+  const parts: Uint8Array<ArrayBuffer>[] = [];
+  let length = 0;
+  for await (const part of multipartChunks(entries, boundary)) {
+    parts.push(part);
+    length += part.byteLength;
+  }
+
+  const body = new Uint8Array(new ArrayBuffer(length));
+  let offset = 0;
+  for (const part of parts) {
+    body.set(part, offset);
+    offset += part.byteLength;
+  }
+  return { body, contentType: multipartContentType(boundary) };
+}
+
+/**
+ * Stream realm-neutral multipart bytes while retaining a synchronous factory
+ * API. JSDOM File values need FileReader, whose result is asynchronous.
+ */
+export function streamMultipart(entries: Iterable<MultipartEntry>): {
+  body: ReadableStream<Uint8Array<ArrayBuffer>>;
+  contentType: string;
+} {
+  const boundary = createMultipartBoundary();
+  const iterator = multipartChunks(entries, boundary)[Symbol.asyncIterator]();
+  const body = new ReadableStream<Uint8Array<ArrayBuffer>>({
+    async pull(controller) {
+      try {
+        const chunk = await iterator.next();
+        if (chunk.done) {
+          controller.close();
+        } else {
+          controller.enqueue(chunk.value);
+        }
+      } catch (error: unknown) {
+        controller.error(error);
+      }
+    },
+    async cancel() {
+      await iterator.return?.(undefined);
+    },
+  });
+  return { body, contentType: multipartContentType(boundary) };
+}
+
 /** Read Blob/File bytes even when JSDOM owns the value and Node owns `Request`. */
 export async function readBlobBytes(blob: Blob): Promise<Uint8Array<ArrayBuffer>> {
   if (typeof blob.arrayBuffer === "function") {

--- a/packages/test/src/form.ts
+++ b/packages/test/src/form.ts
@@ -1,7 +1,7 @@
 import type { ApiRouteArgs, RegisteredContext, ResolvedApiRoute, RouteParams } from "@pracht/core";
 
 import { createApiArgs, TEST_ORIGIN } from "./args.ts";
-import { isBlobLike, readBlobBytes } from "./body.ts";
+import { encodeMultipart, isBlobLike, normalizeFormNewlines, type MultipartEntry } from "./body.ts";
 
 /**
  * A form field value: primitives are stringified with `String()`;
@@ -36,67 +36,6 @@ export interface SubmitFormOptions<TContext = RegisteredContext> {
   signal?: AbortSignal;
 }
 
-let multipartBoundarySequence = 0;
-
-function normalizeFormNewlines(value: string): string {
-  return value.replace(/\r\n|\r|\n/g, "\r\n");
-}
-
-function escapeMultipartHeaderValue(value: string): string {
-  return value.replace(/\r/g, "%0D").replace(/\n/g, "%0A").replace(/"/g, "%22");
-}
-
-function concatenateBytes(parts: readonly Uint8Array<ArrayBuffer>[]): Uint8Array<ArrayBuffer> {
-  const length = parts.reduce((total, part) => total + part.byteLength, 0);
-  const result = new Uint8Array(new ArrayBuffer(length));
-  let offset = 0;
-  for (const part of parts) {
-    result.set(part, offset);
-    offset += part.byteLength;
-  }
-  return result;
-}
-
-async function encodeMultipart(entries: readonly [string, FormFieldValue][]): Promise<{
-  body: Uint8Array<ArrayBuffer>;
-  contentType: string;
-}> {
-  const boundary = `----pracht-test-${Date.now().toString(36)}-${multipartBoundarySequence++}`;
-  const encoder = new TextEncoder();
-  const parts: Uint8Array<ArrayBuffer>[] = [];
-
-  for (const [name, value] of entries) {
-    const disposition =
-      `--${boundary}\r\nContent-Disposition: form-data; ` +
-      `name="${escapeMultipartHeaderValue(name)}"`;
-    if (isBlobLike(value)) {
-      const filename =
-        typeof (value as Blob & { name?: unknown }).name === "string"
-          ? (value as Blob & { name: string }).name
-          : "blob";
-      const contentType = /[\r\n]/.test(value.type)
-        ? "application/octet-stream"
-        : value.type || "application/octet-stream";
-      parts.push(
-        encoder.encode(
-          `${disposition}; filename="${escapeMultipartHeaderValue(filename)}"\r\n` +
-            `Content-Type: ${contentType}\r\n\r\n`,
-        ),
-        await readBlobBytes(value),
-        encoder.encode("\r\n"),
-      );
-    } else {
-      parts.push(encoder.encode(`${disposition}\r\n\r\n${String(value)}\r\n`));
-    }
-  }
-
-  parts.push(encoder.encode(`--${boundary}--\r\n`));
-  return {
-    body: concatenateBytes(parts),
-    contentType: `multipart/form-data; boundary=${boundary}`,
-  };
-}
-
 /** Build the form `Request` that {@link submitForm} sends, without calling a handler. */
 export async function createFormRequest(
   fields: FormFields,
@@ -105,7 +44,7 @@ export async function createFormRequest(
   const url = new URL(options.url ?? "/", TEST_ORIGIN);
   const method = (options.method ?? "POST").toUpperCase();
 
-  const entries: [string, FormFieldValue][] = [];
+  const entries: MultipartEntry[] = [];
   for (const [name, value] of Object.entries(fields)) {
     for (const entry of Array.isArray(value) ? value : [value]) {
       entries.push([

--- a/packages/test/src/form.ts
+++ b/packages/test/src/form.ts
@@ -1,6 +1,7 @@
 import type { ApiRouteArgs, RegisteredContext, ResolvedApiRoute, RouteParams } from "@pracht/core";
 
 import { createApiArgs, TEST_ORIGIN } from "./args.ts";
+import { isBlobLike, readBlobBytes } from "./body.ts";
 
 /**
  * A form field value: primitives are stringified with `String()`;
@@ -37,44 +38,8 @@ export interface SubmitFormOptions<TContext = RegisteredContext> {
 
 let multipartBoundarySequence = 0;
 
-function isBlobField(value: FormFieldValue): value is Blob {
-  if (typeof value !== "object" || value === null) return false;
-  const candidate = value as Blob;
-  return (
-    typeof candidate.size === "number" &&
-    typeof candidate.type === "string" &&
-    typeof candidate.slice === "function"
-  );
-}
-
 function escapeMultipartHeaderValue(value: string): string {
   return value.replace(/\r/g, "%0D").replace(/\n/g, "%0A").replace(/"/g, "%22");
-}
-
-async function readBlobBytes(blob: Blob): Promise<Uint8Array<ArrayBuffer>> {
-  if (typeof blob.arrayBuffer === "function") {
-    return new Uint8Array(await blob.arrayBuffer());
-  }
-
-  if (typeof FileReader === "function") {
-    return new Promise((resolve, reject) => {
-      const reader = new FileReader();
-      reader.onerror = () => reject(reader.error ?? new Error("Failed to read form Blob/File"));
-      reader.onload = () => {
-        if (reader.result instanceof ArrayBuffer) {
-          resolve(new Uint8Array(reader.result));
-          return;
-        }
-        reject(new TypeError("Expected FileReader to produce an ArrayBuffer"));
-      };
-      reader.readAsArrayBuffer(blob);
-    });
-  }
-
-  throw new TypeError(
-    "Cannot read this Blob/File in the current test environment. " +
-      "Provide a standard Blob implementation with arrayBuffer() or FileReader support.",
-  );
 }
 
 function concatenateBytes(parts: readonly Uint8Array<ArrayBuffer>[]): Uint8Array<ArrayBuffer> {
@@ -100,7 +65,7 @@ async function encodeMultipart(entries: readonly [string, FormFieldValue][]): Pr
     const disposition =
       `--${boundary}\r\nContent-Disposition: form-data; ` +
       `name="${escapeMultipartHeaderValue(name)}"`;
-    if (isBlobField(value)) {
+    if (isBlobLike(value)) {
       const filename =
         typeof (value as Blob & { name?: unknown }).name === "string"
           ? (value as Blob & { name: string }).name
@@ -143,7 +108,7 @@ export async function createFormRequest(
     }
   }
 
-  const hasFile = entries.some(([, value]) => isBlobField(value));
+  const hasFile = entries.some(([, value]) => isBlobLike(value));
 
   // A GET/HEAD form submits its fields in the URL, not a body — the same
   // thing a browser does for `<form method="get">`. The Request constructor

--- a/packages/test/src/form.ts
+++ b/packages/test/src/form.ts
@@ -1,0 +1,108 @@
+import type { ApiRouteArgs, RegisteredContext, ResolvedApiRoute, RouteParams } from "@pracht/core";
+
+import { createApiArgs, TEST_ORIGIN } from "./args.ts";
+
+/**
+ * A form field value: primitives are stringified the way a browser form
+ * serializes them; `Blob`/`File` values force multipart encoding. Arrays
+ * produce repeated entries (multi-selects, checkbox groups), which
+ * `formDataToRecord()` on the server groups back into arrays.
+ */
+export type FormFieldValue = string | number | boolean | Blob;
+export type FormFields = Record<string, FormFieldValue | readonly FormFieldValue[]>;
+
+export interface SubmitFormOptions<TContext = RegisteredContext> {
+  /** Absolute or relative URL; relative paths resolve against `http://localhost`. Default `/`. */
+  url?: string | URL;
+  /** Default `POST`. */
+  method?: string;
+  /**
+   * Wire encoding. Defaults to `urlencoded` — what a plain `<form>` posts —
+   * switching automatically to `multipart` when any field is a `Blob`/`File`.
+   * Both encodings hit `defineApi()`'s `formDataToRecord()` parsing path.
+   */
+  encoding?: "urlencoded" | "multipart";
+  headers?: HeadersInit;
+  params?: RouteParams;
+  context?: Partial<TContext>;
+  route?: Partial<ResolvedApiRoute>;
+  signal?: AbortSignal;
+}
+
+/** Build the form `Request` that {@link submitForm} sends, without calling a handler. */
+export function createFormRequest(fields: FormFields, options: SubmitFormOptions = {}): Request {
+  const url = new URL(options.url ?? "/", TEST_ORIGIN);
+  const method = (options.method ?? "POST").toUpperCase();
+
+  const entries: [string, FormFieldValue][] = [];
+  for (const [name, value] of Object.entries(fields)) {
+    for (const entry of Array.isArray(value) ? value : [value]) {
+      entries.push([name, entry as FormFieldValue]);
+    }
+  }
+
+  const hasFile = entries.some(([, value]) => value instanceof Blob);
+  const encoding = options.encoding ?? (hasFile ? "multipart" : "urlencoded");
+
+  let body: FormData | URLSearchParams;
+  if (encoding === "multipart") {
+    const form = new FormData();
+    for (const [name, value] of entries) {
+      if (value instanceof Blob) {
+        form.append(name, value);
+      } else {
+        form.append(name, String(value));
+      }
+    }
+    body = form;
+  } else {
+    if (hasFile) {
+      throw new Error(
+        'submitForm(): Blob/File fields cannot be sent as "urlencoded". ' +
+          'Use encoding: "multipart" (or omit encoding to switch automatically).',
+      );
+    }
+    const search = new URLSearchParams();
+    for (const [name, value] of entries) {
+      search.append(name, String(value));
+    }
+    body = search;
+  }
+
+  // `Request` sets the matching Content-Type itself: multipart/form-data with
+  // the boundary for FormData, application/x-www-form-urlencoded for
+  // URLSearchParams — exactly what `defineApi()` sniffs to pick form parsing.
+  return new Request(url, { method, headers: options.headers, body });
+}
+
+/**
+ * Build a form-encoded `POST` `Request` — urlencoded or multipart, matching
+ * what `<Form>`/native form submission sends — and call an API route handler
+ * with it:
+ *
+ * ```ts
+ * const response = await submitForm(POST, { name: "Alice", email: "a@example.com" }, {
+ *   url: "/api/contact",
+ * });
+ * expect(response.status).toBe(200);
+ * ```
+ *
+ * Works with plain handlers and `defineApi()`-wrapped handlers alike; the
+ * request's `Content-Type` drives the same `FormData` parsing the server
+ * applies to real submissions.
+ */
+export async function submitForm<TContext = RegisteredContext>(
+  handler: (args: ApiRouteArgs<TContext>) => Response | Promise<Response>,
+  fields: FormFields,
+  options: SubmitFormOptions<TContext> = {},
+): Promise<Response> {
+  const request = createFormRequest(fields, options as SubmitFormOptions);
+  const args = createApiArgs<TContext>({
+    request,
+    params: options.params,
+    context: options.context,
+    route: options.route,
+    signal: options.signal,
+  });
+  return handler(args);
+}

--- a/packages/test/src/form.ts
+++ b/packages/test/src/form.ts
@@ -38,6 +38,10 @@ export interface SubmitFormOptions<TContext = RegisteredContext> {
 
 let multipartBoundarySequence = 0;
 
+function normalizeFormNewlines(value: string): string {
+  return value.replace(/\r\n|\r|\n/g, "\r\n");
+}
+
 function escapeMultipartHeaderValue(value: string): string {
   return value.replace(/\r/g, "%0D").replace(/\n/g, "%0A").replace(/"/g, "%22");
 }
@@ -104,7 +108,10 @@ export async function createFormRequest(
   const entries: [string, FormFieldValue][] = [];
   for (const [name, value] of Object.entries(fields)) {
     for (const entry of Array.isArray(value) ? value : [value]) {
-      entries.push([name, entry as FormFieldValue]);
+      entries.push([
+        normalizeFormNewlines(name),
+        isBlobLike(entry) ? entry : normalizeFormNewlines(String(entry)),
+      ]);
     }
   }
 

--- a/packages/test/src/form.ts
+++ b/packages/test/src/form.ts
@@ -35,8 +35,104 @@ export interface SubmitFormOptions<TContext = RegisteredContext> {
   signal?: AbortSignal;
 }
 
+let multipartBoundarySequence = 0;
+
+function isBlobField(value: FormFieldValue): value is Blob {
+  if (typeof value !== "object" || value === null) return false;
+  const candidate = value as Blob;
+  return (
+    typeof candidate.size === "number" &&
+    typeof candidate.type === "string" &&
+    typeof candidate.slice === "function"
+  );
+}
+
+function escapeMultipartHeaderValue(value: string): string {
+  return value.replace(/\r/g, "%0D").replace(/\n/g, "%0A").replace(/"/g, "%22");
+}
+
+async function readBlobBytes(blob: Blob): Promise<Uint8Array<ArrayBuffer>> {
+  if (typeof blob.arrayBuffer === "function") {
+    return new Uint8Array(await blob.arrayBuffer());
+  }
+
+  if (typeof FileReader === "function") {
+    return new Promise((resolve, reject) => {
+      const reader = new FileReader();
+      reader.onerror = () => reject(reader.error ?? new Error("Failed to read form Blob/File"));
+      reader.onload = () => {
+        if (reader.result instanceof ArrayBuffer) {
+          resolve(new Uint8Array(reader.result));
+          return;
+        }
+        reject(new TypeError("Expected FileReader to produce an ArrayBuffer"));
+      };
+      reader.readAsArrayBuffer(blob);
+    });
+  }
+
+  throw new TypeError(
+    "Cannot read this Blob/File in the current test environment. " +
+      "Provide a standard Blob implementation with arrayBuffer() or FileReader support.",
+  );
+}
+
+function concatenateBytes(parts: readonly Uint8Array<ArrayBuffer>[]): Uint8Array<ArrayBuffer> {
+  const length = parts.reduce((total, part) => total + part.byteLength, 0);
+  const result = new Uint8Array(new ArrayBuffer(length));
+  let offset = 0;
+  for (const part of parts) {
+    result.set(part, offset);
+    offset += part.byteLength;
+  }
+  return result;
+}
+
+async function encodeMultipart(entries: readonly [string, FormFieldValue][]): Promise<{
+  body: Uint8Array<ArrayBuffer>;
+  contentType: string;
+}> {
+  const boundary = `----pracht-test-${Date.now().toString(36)}-${multipartBoundarySequence++}`;
+  const encoder = new TextEncoder();
+  const parts: Uint8Array<ArrayBuffer>[] = [];
+
+  for (const [name, value] of entries) {
+    const disposition =
+      `--${boundary}\r\nContent-Disposition: form-data; ` +
+      `name="${escapeMultipartHeaderValue(name)}"`;
+    if (isBlobField(value)) {
+      const filename =
+        typeof (value as Blob & { name?: unknown }).name === "string"
+          ? (value as Blob & { name: string }).name
+          : "blob";
+      const contentType = /[\r\n]/.test(value.type)
+        ? "application/octet-stream"
+        : value.type || "application/octet-stream";
+      parts.push(
+        encoder.encode(
+          `${disposition}; filename="${escapeMultipartHeaderValue(filename)}"\r\n` +
+            `Content-Type: ${contentType}\r\n\r\n`,
+        ),
+        await readBlobBytes(value),
+        encoder.encode("\r\n"),
+      );
+    } else {
+      parts.push(encoder.encode(`${disposition}\r\n\r\n${String(value)}\r\n`));
+    }
+  }
+
+  parts.push(encoder.encode(`--${boundary}--\r\n`));
+  return {
+    body: concatenateBytes(parts),
+    contentType: `multipart/form-data; boundary=${boundary}`,
+  };
+}
+
 /** Build the form `Request` that {@link submitForm} sends, without calling a handler. */
-export function createFormRequest(fields: FormFields, options: SubmitFormOptions = {}): Request {
+export async function createFormRequest(
+  fields: FormFields,
+  options: SubmitFormOptions = {},
+): Promise<Request> {
   const url = new URL(options.url ?? "/", TEST_ORIGIN);
   const method = (options.method ?? "POST").toUpperCase();
 
@@ -47,7 +143,7 @@ export function createFormRequest(fields: FormFields, options: SubmitFormOptions
     }
   }
 
-  const hasFile = entries.some(([, value]) => value instanceof Blob);
+  const hasFile = entries.some(([, value]) => isBlobField(value));
 
   // A GET/HEAD form submits its fields in the URL, not a body — the same
   // thing a browser does for `<form method="get">`. The Request constructor
@@ -68,22 +164,18 @@ export function createFormRequest(fields: FormFields, options: SubmitFormOptions
   }
 
   const encoding = options.encoding ?? (hasFile ? "multipart" : "urlencoded");
-
-  let body: FormData | URLSearchParams;
+  const headers = new Headers(options.headers);
+  let body: BodyInit;
   if (encoding === "multipart") {
-    const form = new FormData();
-    for (const [name, value] of entries) {
-      if (value instanceof Blob) {
-        form.append(name, value);
-      } else {
-        form.append(name, String(value));
-      }
+    const encoded = await encodeMultipart(entries);
+    body = encoded.body;
+    if (!headers.has("content-type")) {
+      headers.set("content-type", encoded.contentType);
     }
-    body = form;
   } else {
     if (hasFile) {
       throw new Error(
-        'submitForm(): Blob/File fields cannot be sent as "urlencoded". ' +
+        'createFormRequest(): Blob/File fields cannot be sent as "urlencoded". ' +
           'Use encoding: "multipart" (or omit encoding to switch automatically).',
       );
     }
@@ -91,13 +183,17 @@ export function createFormRequest(fields: FormFields, options: SubmitFormOptions
     for (const [name, value] of entries) {
       search.append(name, String(value));
     }
-    body = search;
+    body = search.toString();
+    if (!headers.has("content-type")) {
+      headers.set("content-type", "application/x-www-form-urlencoded;charset=UTF-8");
+    }
   }
 
-  // `Request` sets the matching Content-Type itself: multipart/form-data with
-  // the boundary for FormData, application/x-www-form-urlencoded for
-  // URLSearchParams — exactly what `defineApi()` sniffs to pick form parsing.
-  return new Request(url, { method, headers: options.headers, body });
+  // Serialize to realm-neutral bytes/text before handing the body to Request.
+  // Vitest's JSDOM mode supplies its own FormData, File, and URLSearchParams
+  // while retaining Node's Request implementation, which rejects those
+  // otherwise-valid cross-realm objects.
+  return new Request(url, { method, headers, body });
 }
 
 /**
@@ -123,7 +219,7 @@ export async function submitForm<TContext = RegisteredContext>(
   fields: FormFields,
   options: SubmitFormOptions<TContext> = {},
 ): Promise<Response> {
-  const request = createFormRequest(fields, options as SubmitFormOptions);
+  const request = await createFormRequest(fields, options as SubmitFormOptions);
   const args = createApiArgs<TContext>({
     request,
     params: options.params,

--- a/packages/test/src/form.ts
+++ b/packages/test/src/form.ts
@@ -3,10 +3,12 @@ import type { ApiRouteArgs, RegisteredContext, ResolvedApiRoute, RouteParams } f
 import { createApiArgs, TEST_ORIGIN } from "./args.ts";
 
 /**
- * A form field value: primitives are stringified the way a browser form
- * serializes them; `Blob`/`File` values force multipart encoding. Arrays
- * produce repeated entries (multi-selects, checkbox groups), which
- * `formDataToRecord()` on the server groups back into arrays.
+ * A form field value: primitives are stringified with `String()`;
+ * `Blob`/`File` values force multipart encoding. Arrays produce repeated
+ * entries (multi-selects, checkbox groups), which `formDataToRecord()` on
+ * the server groups back into arrays. Pass exactly the entries a browser
+ * would put on the wire — e.g. a checked checkbox posts `"on"` and an
+ * unchecked one is omitted entirely, not sent as `false`.
  */
 export type FormFieldValue = string | number | boolean | Blob;
 export type FormFields = Record<string, FormFieldValue | readonly FormFieldValue[]>;
@@ -14,7 +16,11 @@ export type FormFields = Record<string, FormFieldValue | readonly FormFieldValue
 export interface SubmitFormOptions<TContext = RegisteredContext> {
   /** Absolute or relative URL; relative paths resolve against `http://localhost`. Default `/`. */
   url?: string | URL;
-  /** Default `POST`. */
+  /**
+   * Default `POST`. `GET`/`HEAD` forms carry no body — like a browser, the
+   * fields are serialized into the URL's query string instead (replacing any
+   * query already present on `url`).
+   */
   method?: string;
   /**
    * Wire encoding. Defaults to `urlencoded` — what a plain `<form>` posts —
@@ -42,6 +48,25 @@ export function createFormRequest(fields: FormFields, options: SubmitFormOptions
   }
 
   const hasFile = entries.some(([, value]) => value instanceof Blob);
+
+  // A GET/HEAD form submits its fields in the URL, not a body — the same
+  // thing a browser does for `<form method="get">`. The Request constructor
+  // would throw on a GET body anyway; encode the query string instead.
+  if (method === "GET" || method === "HEAD") {
+    if (hasFile) {
+      throw new Error(
+        `createFormRequest(): Blob/File fields cannot be submitted with a ${method} form. ` +
+          'Use the default "POST" (or another body-carrying method).',
+      );
+    }
+    const search = new URLSearchParams();
+    for (const [name, value] of entries) {
+      search.append(name, String(value));
+    }
+    url.search = search.toString();
+    return new Request(url, { method, headers: options.headers });
+  }
+
   const encoding = options.encoding ?? (hasFile ? "multipart" : "urlencoded");
 
   let body: FormData | URLSearchParams;
@@ -89,7 +114,9 @@ export function createFormRequest(fields: FormFields, options: SubmitFormOptions
  *
  * Works with plain handlers and `defineApi()`-wrapped handlers alike; the
  * request's `Content-Type` drives the same `FormData` parsing the server
- * applies to real submissions.
+ * applies to real submissions. With `method: "GET"` the fields are serialized
+ * into the URL query string instead (browser `<form method="get">` behavior),
+ * which exercises a `defineApi()` `query` schema rather than `body`.
  */
 export async function submitForm<TContext = RegisteredContext>(
   handler: (args: ApiRouteArgs<TContext>) => Response | Promise<Response>,

--- a/packages/test/src/index.ts
+++ b/packages/test/src/index.ts
@@ -1,0 +1,23 @@
+export {
+  createApiArgs,
+  createLoaderArgs,
+  createMiddlewareArgs,
+  createTestRequest,
+  TEST_ORIGIN,
+} from "./args.ts";
+export type {
+  CreateApiArgsInput,
+  CreateArgsInput,
+  CreateLoaderArgsInput,
+  CreateMiddlewareArgsInput,
+  TestAbortControls,
+  TestApiArgs,
+  TestLoaderArgs,
+  TestMiddlewareArgs,
+  TestRequestInput,
+} from "./args.ts";
+export { runMiddleware } from "./middleware.ts";
+export { createFormRequest, submitForm } from "./form.ts";
+export type { FormFields, FormFieldValue, SubmitFormOptions } from "./form.ts";
+export { readJson, readRedirect } from "./response.ts";
+export type { RedirectResult } from "./response.ts";

--- a/packages/test/src/index.ts
+++ b/packages/test/src/index.ts
@@ -1,4 +1,5 @@
 export {
+  createApiMiddlewareArgs,
   createApiArgs,
   createLoaderArgs,
   createMiddlewareArgs,
@@ -11,12 +12,14 @@ export type {
   CreateLoaderArgsInput,
   CreateMiddlewareArgsInput,
   TestAbortControls,
+  TestApiMiddlewareArgs,
   TestApiArgs,
   TestLoaderArgs,
   TestMiddlewareArgs,
   TestRequestInput,
 } from "./args.ts";
 export { runMiddleware } from "./middleware.ts";
+export type { RunMiddlewareOptions } from "./middleware.ts";
 export { createFormRequest, submitForm } from "./form.ts";
 export type { FormFields, FormFieldValue, SubmitFormOptions } from "./form.ts";
 export { readJson, readRedirect } from "./response.ts";

--- a/packages/test/src/middleware.ts
+++ b/packages/test/src/middleware.ts
@@ -56,7 +56,12 @@ export async function runMiddleware<TContext = RegisteredContext>(
       return dispatch(index + 1);
     };
 
-    const response = await chain[index](args, next);
+    // Production constructs a fresh top-level args wrapper for every
+    // middleware while retaining the same request, params, context, signal,
+    // url, and route references. Match that behavior so replacing a field on
+    // one middleware's wrapper does not leak downstream, while mutations to
+    // shared values such as `context.user` still do.
+    const response = await chain[index]({ ...args }, next);
     if (!(response instanceof Response)) {
       throw new Error(
         `Middleware at index ${index} did not return a Response. ` +

--- a/packages/test/src/middleware.ts
+++ b/packages/test/src/middleware.ts
@@ -16,6 +16,13 @@ import type { MiddlewareArgs, MiddlewareFn, RegisteredContext } from "@pracht/co
  * defaults to an empty 200 `Response`. Middleware runs sequentially, so
  * `args.context` mutations made by one middleware are visible to the next —
  * the same ordering contract the server applies.
+ *
+ * A **thrown** `Response` (e.g. `throw redirect("/login")` from a shared
+ * `requireUser()` helper) resolves as the chain's response, exactly like the
+ * runtime treats it: the throw unwinds past upstream middleware first, so
+ * response decoration after `await next()` is skipped unless that middleware
+ * catches. Thrown non-`Response` errors (including `notFound()`'s
+ * `PrachtHttpError`) reject, so tests can assert on them directly.
  */
 export async function runMiddleware<TContext = RegisteredContext>(
   middleware: MiddlewareFn<TContext> | readonly MiddlewareFn<TContext>[],
@@ -49,5 +56,16 @@ export async function runMiddleware<TContext = RegisteredContext>(
     return response;
   };
 
-  return dispatch(0);
+  try {
+    return await dispatch(0);
+  } catch (error: unknown) {
+    // Same contract as the server: a thrown Response is the middleware (or
+    // final handler) answering, not failing. The runtime catches it around
+    // the whole chain, so upstream middleware never see it — mirrored here
+    // by catching outside `dispatch` rather than per middleware.
+    if (error instanceof Response) {
+      return error;
+    }
+    throw error;
+  }
 }

--- a/packages/test/src/middleware.ts
+++ b/packages/test/src/middleware.ts
@@ -1,5 +1,15 @@
 import type { MiddlewareArgs, MiddlewareFn, RegisteredContext } from "@pracht/core";
 
+export interface RunMiddlewareOptions {
+  /**
+   * Page and API dispatch normalize a thrown `Response` outside the raw
+   * middleware chain, which is the default here. Set this to `reject` only
+   * when intentionally modelling a raw capability middleware chain; prefer
+   * `createCapabilityTestHost()` when the complete capability envelope matters.
+   */
+  thrownResponse?: "reject" | "resolve";
+}
+
 /**
  * Run one middleware or a chain of middleware exactly the way the runtime
  * does: each middleware receives `next` and may call it at most once; calling
@@ -17,17 +27,17 @@ import type { MiddlewareArgs, MiddlewareFn, RegisteredContext } from "@pracht/co
  * `args.context` mutations made by one middleware are visible to the next —
  * the same ordering contract the server applies.
  *
- * A **thrown** `Response` (e.g. `throw redirect("/login")` from a shared
- * `requireUser()` helper) resolves as the chain's response, exactly like the
- * runtime treats it: the throw unwinds past upstream middleware first, so
- * response decoration after `await next()` is skipped unless that middleware
- * catches. Thrown non-`Response` errors (including `notFound()`'s
- * `PrachtHttpError`) reject, so tests can assert on them directly.
+ * A **thrown** `Response` resolves as the result by default, matching page and
+ * API dispatch's outer normalization. Pass `{ thrownResponse: "reject" }` as
+ * the fourth argument only when modelling the raw chain used by capability
+ * dispatch, which maps that throw to `internal_error`. Thrown non-`Response`
+ * errors always reject.
  */
 export async function runMiddleware<TContext = RegisteredContext>(
   middleware: MiddlewareFn<TContext> | readonly MiddlewareFn<TContext>[],
   args: MiddlewareArgs<TContext>,
   finalHandler?: () => Response | Promise<Response>,
+  options: RunMiddlewareOptions = {},
 ): Promise<Response> {
   const chain = typeof middleware === "function" ? [middleware] : middleware;
   const terminal = finalHandler ?? (() => new Response(null, { status: 200 }));
@@ -59,11 +69,10 @@ export async function runMiddleware<TContext = RegisteredContext>(
   try {
     return await dispatch(0);
   } catch (error: unknown) {
-    // Same contract as the server: a thrown Response is the middleware (or
-    // final handler) answering, not failing. The runtime catches it around
-    // the whole chain, so upstream middleware never see it — mirrored here
-    // by catching outside `dispatch` rather than per middleware.
-    if (error instanceof Response) {
+    // Page/API dispatch catches a thrown Response outside the entire chain,
+    // after it has unwound past upstream middleware. Preserve that established
+    // helper default; capability tests can opt into raw-chain rejection.
+    if (error instanceof Response && options.thrownResponse !== "reject") {
       return error;
     }
     throw error;

--- a/packages/test/src/middleware.ts
+++ b/packages/test/src/middleware.ts
@@ -1,0 +1,53 @@
+import type { MiddlewareArgs, MiddlewareFn, RegisteredContext } from "@pracht/core";
+
+/**
+ * Run one middleware or a chain of middleware exactly the way the runtime
+ * does: each middleware receives `next` and may call it at most once; calling
+ * `next()` invokes the rest of the chain (then `finalHandler`); returning
+ * without calling `next()` short-circuits with that `Response`.
+ *
+ * ```ts
+ * const args = createMiddlewareArgs({ url: "/dashboard" });
+ * const response = await runMiddleware([logging, auth], args);
+ * expect(readRedirect(response).location).toBe("/login");
+ * ```
+ *
+ * `finalHandler` stands in for the loader/handler at the end of the chain and
+ * defaults to an empty 200 `Response`. Middleware runs sequentially, so
+ * `args.context` mutations made by one middleware are visible to the next —
+ * the same ordering contract the server applies.
+ */
+export async function runMiddleware<TContext = RegisteredContext>(
+  middleware: MiddlewareFn<TContext> | readonly MiddlewareFn<TContext>[],
+  args: MiddlewareArgs<TContext>,
+  finalHandler?: () => Response | Promise<Response>,
+): Promise<Response> {
+  const chain = typeof middleware === "function" ? [middleware] : middleware;
+  const terminal = finalHandler ?? (() => new Response(null, { status: 200 }));
+
+  const dispatch = async (index: number): Promise<Response> => {
+    if (index >= chain.length) {
+      return terminal();
+    }
+
+    let calledNext = false;
+    const next = (): Promise<Response> => {
+      if (calledNext) {
+        throw new Error(`Middleware at index ${index} called next() multiple times`);
+      }
+      calledNext = true;
+      return dispatch(index + 1);
+    };
+
+    const response = await chain[index](args, next);
+    if (!(response instanceof Response)) {
+      throw new Error(
+        `Middleware at index ${index} did not return a Response. ` +
+          "Middleware must return the result of next() or a short-circuit Response.",
+      );
+    }
+    return response;
+  };
+
+  return dispatch(0);
+}

--- a/packages/test/src/response.ts
+++ b/packages/test/src/response.ts
@@ -25,6 +25,11 @@ export interface RedirectResult {
  * Throws when the response is not a redirect or carries no `Location` header.
  */
 export function readRedirect(response: Response): RedirectResult {
+  if (response.status === 304) {
+    throw new Error(
+      "Expected a redirect response, got status 304 (Not Modified is not a redirect)",
+    );
+  }
   if (response.status < 300 || response.status > 399) {
     throw new Error(`Expected a redirect response, got status ${response.status}`);
   }

--- a/packages/test/src/response.ts
+++ b/packages/test/src/response.ts
@@ -1,0 +1,38 @@
+/**
+ * Read a `Response` body as JSON. The response is cloned first, so the same
+ * `Response` can be read again by later assertions. Throws with the raw body
+ * text when the payload is not valid JSON.
+ */
+export async function readJson<TValue = unknown>(response: Response): Promise<TValue> {
+  const text = await response.clone().text();
+  try {
+    return JSON.parse(text) as TValue;
+  } catch {
+    throw new Error(
+      `Expected a JSON response body, got (status ${response.status}): ${text || "<empty>"}`,
+    );
+  }
+}
+
+export interface RedirectResult {
+  status: number;
+  location: string;
+}
+
+/**
+ * Read a redirect `Response` — as produced by `redirect()` from
+ * `@pracht/core` or any hand-built 3xx — into `{ status, location }`.
+ * Throws when the response is not a redirect or carries no `Location` header.
+ */
+export function readRedirect(response: Response): RedirectResult {
+  if (response.status < 300 || response.status > 399) {
+    throw new Error(`Expected a redirect response, got status ${response.status}`);
+  }
+  const location = response.headers.get("location");
+  if (location === null) {
+    throw new Error(
+      `Expected a Location header on the ${response.status} redirect response, found none`,
+    );
+  }
+  return { status: response.status, location };
+}

--- a/packages/test/test/args-jsdom.test.ts
+++ b/packages/test/test/args-jsdom.test.ts
@@ -24,4 +24,25 @@ describe("request args in JSDOM", () => {
     );
     expect(new URLSearchParams(await request.text()).get("query")).toBe("search term");
   });
+
+  it("preserves FormData created in another DOM realm", async () => {
+    const frame = document.createElement("iframe");
+    document.body.append(frame);
+
+    try {
+      const ForeignFormData = (
+        frame.contentWindow as unknown as { FormData?: typeof FormData } | null
+      )?.FormData;
+      if (!ForeignFormData) throw new Error("Expected the iframe to provide FormData");
+      const body = new ForeignFormData();
+      body.append("name", "Alice");
+
+      expect(body).not.toBeInstanceOf(FormData);
+      const request = createTestRequest({ body });
+      expect(request.headers.get("content-type")).toContain("multipart/form-data");
+      expect((await request.formData()).get("name")).toBe("Alice");
+    } finally {
+      frame.remove();
+    }
+  });
 });

--- a/packages/test/test/args-jsdom.test.ts
+++ b/packages/test/test/args-jsdom.test.ts
@@ -45,4 +45,32 @@ describe("request args in JSDOM", () => {
       frame.remove();
     }
   });
+
+  it("normalizes File entries inside cross-realm FormData", async () => {
+    const frame = document.createElement("iframe");
+    document.body.append(frame);
+
+    try {
+      const foreign = frame.contentWindow as unknown as {
+        File?: typeof File;
+        FormData?: typeof FormData;
+      } | null;
+      if (!foreign?.File || !foreign.FormData) {
+        throw new Error("Expected the iframe to provide File and FormData");
+      }
+      const body = new foreign.FormData();
+      body.append("name", "Alice");
+      body.append("upload", new foreign.File(["hello"], "hello.txt", { type: "text/plain" }));
+
+      const request = createTestRequest({ body });
+      const parsed = await request.formData();
+      const upload = parsed.get("upload") as File;
+      expect(parsed.get("name")).toBe("Alice");
+      expect(upload.name).toBe("hello.txt");
+      expect(upload.type).toBe("text/plain");
+      expect(await upload.text()).toBe("hello");
+    } finally {
+      frame.remove();
+    }
+  });
 });

--- a/packages/test/test/args-jsdom.test.ts
+++ b/packages/test/test/args-jsdom.test.ts
@@ -1,0 +1,27 @@
+// @vitest-environment jsdom
+
+import { describe, expect, it } from "vitest";
+
+import { createTestRequest } from "../src/index.ts";
+
+describe("request args in JSDOM", () => {
+  it("streams a JSDOM Blob into Node's Request implementation", async () => {
+    const request = createTestRequest({
+      body: new Blob(["hello"], { type: "text/plain" }),
+    });
+
+    expect(request.headers.get("content-type")).toBe("text/plain");
+    expect(await request.text()).toBe("hello");
+  });
+
+  it("normalizes JSDOM URLSearchParams with its form content type", async () => {
+    const request = createTestRequest({
+      body: new URLSearchParams({ query: "search term" }),
+    });
+
+    expect(request.headers.get("content-type")).toBe(
+      "application/x-www-form-urlencoded;charset=UTF-8",
+    );
+    expect(new URLSearchParams(await request.text()).get("query")).toBe("search term");
+  });
+});

--- a/packages/test/test/args.test.ts
+++ b/packages/test/test/args.test.ts
@@ -49,6 +49,12 @@ describe("createLoaderArgs", () => {
     expect(await args.request.text()).toBe("raw text");
   });
 
+  it("supports ReadableStream bodies (streaming uploads need duplex)", async () => {
+    const stream = new Blob(["streamed"]).stream();
+    const args = createLoaderArgs({ method: "POST", body: stream });
+    expect(await args.request.text()).toBe("streamed");
+  });
+
   it("uses a real Request when given, ignoring the shorthand fields", () => {
     const request = new Request("http://example.com/real", { method: "DELETE" });
     const args = createLoaderArgs({ request, url: "/ignored", method: "GET" });

--- a/packages/test/test/args.test.ts
+++ b/packages/test/test/args.test.ts
@@ -1,5 +1,6 @@
 import type { LoaderArgs } from "@pracht/core";
 import { notFound, redirect } from "@pracht/core";
+import { runInNewContext } from "node:vm";
 import { describe, expect, it } from "vitest";
 
 import {
@@ -58,6 +59,14 @@ describe("createLoaderArgs", () => {
     const stream = new Blob(["streamed"]).stream();
     const args = createLoaderArgs({ method: "POST", body: stream });
     expect(await args.request.text()).toBe("streamed");
+  });
+
+  it("preserves an ArrayBuffer created in another realm", async () => {
+    const body = runInNewContext("new Uint8Array([65, 66, 67]).buffer") as ArrayBuffer;
+    const args = createLoaderArgs({ body });
+
+    expect(args.request.headers.get("content-type")).not.toBe("application/json");
+    expect(await args.request.text()).toBe("ABC");
   });
 
   it("uses a real Request when given, ignoring the shorthand fields", () => {

--- a/packages/test/test/args.test.ts
+++ b/packages/test/test/args.test.ts
@@ -2,7 +2,12 @@ import type { LoaderArgs } from "@pracht/core";
 import { notFound, redirect } from "@pracht/core";
 import { describe, expect, it } from "vitest";
 
-import { createApiArgs, createLoaderArgs, createMiddlewareArgs } from "../src/index.ts";
+import {
+  createApiArgs,
+  createApiMiddlewareArgs,
+  createLoaderArgs,
+  createMiddlewareArgs,
+} from "../src/index.ts";
 
 describe("createLoaderArgs", () => {
   it("builds complete LoaderArgs from no input", () => {
@@ -122,6 +127,26 @@ describe("createMiddlewareArgs", () => {
     expect(args.route.path).toBe("/dashboard");
     expect(args.route.middlewareFiles).toEqual([]);
     expect(args.signal).toBeInstanceOf(AbortSignal);
+  });
+
+  it("builds API middleware args with runtime-faithful API route metadata", () => {
+    const args = createApiMiddlewareArgs({
+      url: "/api/users/42",
+      params: { id: "42" },
+      route: {
+        path: "/api/users/:id",
+        file: "./api/users/[id].ts",
+        segments: [{ type: "static", value: "api" }],
+      },
+    });
+
+    expect(args.route).toEqual({
+      path: "/api/users/:id",
+      file: "./api/users/[id].ts",
+      segments: [{ type: "static", value: "api" }],
+    });
+    expect("middlewareFiles" in args.route).toBe(false);
+    expect(args.params).toEqual({ id: "42" });
   });
 });
 

--- a/packages/test/test/args.test.ts
+++ b/packages/test/test/args.test.ts
@@ -1,0 +1,142 @@
+import type { LoaderArgs } from "@pracht/core";
+import { notFound, redirect } from "@pracht/core";
+import { describe, expect, it } from "vitest";
+
+import { createApiArgs, createLoaderArgs, createMiddlewareArgs } from "../src/index.ts";
+
+describe("createLoaderArgs", () => {
+  it("builds complete LoaderArgs from no input", () => {
+    const args = createLoaderArgs();
+
+    expect(args.request).toBeInstanceOf(Request);
+    expect(args.request.method).toBe("GET");
+    expect(args.url.href).toBe("http://localhost/");
+    expect(args.params).toEqual({});
+    expect(args.signal).toBeInstanceOf(AbortSignal);
+    expect(args.route.path).toBe("/");
+    expect(args.route.middleware).toEqual([]);
+    expect(args.route.middlewareFiles).toEqual([]);
+    expect(args.route.segments).toEqual([]);
+  });
+
+  it("derives url and route path from the shorthand url", () => {
+    const args = createLoaderArgs({ url: "/blog/hello?draft=1" });
+
+    expect(args.request.url).toBe("http://localhost/blog/hello?draft=1");
+    expect(args.url.pathname).toBe("/blog/hello");
+    expect(args.url.searchParams.get("draft")).toBe("1");
+    expect(args.route.path).toBe("/blog/hello");
+  });
+
+  it("accepts method, headers, and a JSON body shorthand", async () => {
+    const args = createLoaderArgs({
+      url: "/submit",
+      headers: { "x-user-id": "user-1" },
+      body: { name: "pracht" },
+    });
+
+    // A body without an explicit method defaults to POST.
+    expect(args.request.method).toBe("POST");
+    expect(args.request.headers.get("x-user-id")).toBe("user-1");
+    expect(args.request.headers.get("content-type")).toBe("application/json");
+    expect(await args.request.json()).toEqual({ name: "pracht" });
+  });
+
+  it("passes BodyInit bodies through unchanged", async () => {
+    const args = createLoaderArgs({ method: "PUT", body: "raw text" });
+    expect(args.request.method).toBe("PUT");
+    expect(args.request.headers.get("content-type")).not.toBe("application/json");
+    expect(await args.request.text()).toBe("raw text");
+  });
+
+  it("uses a real Request when given, ignoring the shorthand fields", () => {
+    const request = new Request("http://example.com/real", { method: "DELETE" });
+    const args = createLoaderArgs({ request, url: "/ignored", method: "GET" });
+
+    expect(args.request).toBe(request);
+    expect(args.url.href).toBe("http://example.com/real");
+    expect(args.route.path).toBe("/real");
+  });
+
+  it("exposes the AbortController wired to args.signal", () => {
+    const args = createLoaderArgs();
+    expect(args.signal.aborted).toBe(false);
+    args.controller.abort();
+    expect(args.signal.aborted).toBe(true);
+  });
+
+  it("prefers an explicitly provided signal", () => {
+    const external = new AbortController();
+    const args = createLoaderArgs({ signal: external.signal });
+    args.controller.abort();
+    expect(args.signal.aborted).toBe(false);
+    external.abort();
+    expect(args.signal.aborted).toBe(true);
+  });
+
+  it("merges route overrides over the defaults", () => {
+    const args = createLoaderArgs({
+      url: "/blog/hello",
+      route: { id: "blog-post", render: "ssg", file: "./routes/blog/[slug].tsx" },
+    });
+
+    expect(args.route.id).toBe("blog-post");
+    expect(args.route.render).toBe("ssg");
+    expect(args.route.file).toBe("./routes/blog/[slug].tsx");
+    expect(args.route.path).toBe("/blog/hello");
+  });
+
+  it("feeds a real loader, including params, context, and thrown redirects", async () => {
+    async function loader({ request, params, context }: LoaderArgs<{ users: string[] }>) {
+      const user = request.headers.get("x-user-id");
+      if (!user) throw redirect("/login", { request });
+      if (!context.users.includes(user)) throw notFound();
+      return { slug: params.slug, user };
+    }
+
+    const data = await loader(
+      createLoaderArgs<{ users: string[] }>({
+        url: "/blog/hello",
+        params: { slug: "hello" },
+        headers: { "x-user-id": "user-1" },
+        context: { users: ["user-1"] },
+      }),
+    );
+    expect(data).toEqual({ slug: "hello", user: "user-1" });
+
+    await expect(
+      loader(createLoaderArgs<{ users: string[] }>({ context: { users: [] } })),
+    ).rejects.toBeInstanceOf(Response);
+  });
+});
+
+describe("createMiddlewareArgs", () => {
+  it("builds the same shape as LoaderArgs", () => {
+    const args = createMiddlewareArgs({ url: "/dashboard" });
+    expect(args.route.path).toBe("/dashboard");
+    expect(args.route.middlewareFiles).toEqual([]);
+    expect(args.signal).toBeInstanceOf(AbortSignal);
+  });
+});
+
+describe("createApiArgs", () => {
+  it("builds ApiRouteArgs with a ResolvedApiRoute", () => {
+    const args = createApiArgs({ url: "/api/items" });
+
+    expect(args.route.path).toBe("/api/items");
+    expect(args.route.segments).toEqual([]);
+    // API routes carry no page-route metadata.
+    expect("middlewareFiles" in args.route).toBe(false);
+  });
+
+  it("merges api route overrides", () => {
+    const args = createApiArgs({
+      url: "/api/users/42",
+      params: { id: "42" },
+      route: { path: "/api/users/:id", file: "./api/users/[id].ts" },
+    });
+
+    expect(args.route.path).toBe("/api/users/:id");
+    expect(args.params).toEqual({ id: "42" });
+  });
+});

--- a/packages/test/test/form-jsdom.test.ts
+++ b/packages/test/test/form-jsdom.test.ts
@@ -1,0 +1,40 @@
+// @vitest-environment jsdom
+
+import { describe, expect, it } from "vitest";
+
+import { createFormRequest, submitForm } from "../src/index.ts";
+
+describe("form helpers in JSDOM", () => {
+  it("serializes urlencoded fields without crossing DOM realms", async () => {
+    const request = await createFormRequest({ name: "Alice", tag: ["a", "b"] });
+
+    expect(request.headers.get("content-type")).toContain("application/x-www-form-urlencoded");
+    const body = new URLSearchParams(await request.text());
+    expect(body.get("name")).toBe("Alice");
+    expect(body.getAll("tag")).toEqual(["a", "b"]);
+  });
+
+  it("serializes a JSDOM File for Node's Request implementation", async () => {
+    const response = await submitForm(
+      async ({ request }) => {
+        const form = await request.formData();
+        const upload = form.get("upload") as Blob & { name?: string };
+        return Response.json({
+          name: upload.name,
+          type: upload.type,
+          contents: await upload.text(),
+        });
+      },
+      {
+        title: "Document",
+        upload: new File(["hello"], "hello.txt", { type: "text/plain" }),
+      },
+    );
+
+    expect(await response.json()).toEqual({
+      name: "hello.txt",
+      type: "text/plain",
+      contents: "hello",
+    });
+  });
+});

--- a/packages/test/test/form.test.ts
+++ b/packages/test/test/form.test.ts
@@ -31,7 +31,7 @@ function requiredStrings<TField extends string>(
 
 describe("createFormRequest", () => {
   it("builds an urlencoded POST by default", async () => {
-    const request = createFormRequest({ name: "Alice", count: 2, subscribed: true });
+    const request = await createFormRequest({ name: "Alice", count: 2, subscribed: true });
 
     expect(request.method).toBe("POST");
     expect(request.headers.get("content-type")).toContain("application/x-www-form-urlencoded");
@@ -43,7 +43,7 @@ describe("createFormRequest", () => {
 
   it("switches to multipart when a field is a File", async () => {
     const file = new File(["hello"], "hello.txt", { type: "text/plain" });
-    const request = createFormRequest({ title: "doc", attachment: file });
+    const request = await createFormRequest({ title: "doc", attachment: file });
 
     expect(request.headers.get("content-type")).toContain("multipart/form-data");
     const form = await request.formData();
@@ -52,20 +52,20 @@ describe("createFormRequest", () => {
   });
 
   it("repeats entries for array fields", async () => {
-    const request = createFormRequest({ tag: ["a", "b"] });
+    const request = await createFormRequest({ tag: ["a", "b"] });
     const body = new URLSearchParams(await request.text());
     expect(body.getAll("tag")).toEqual(["a", "b"]);
   });
 
-  it("refuses File fields with explicit urlencoded encoding", () => {
+  it("refuses File fields with explicit urlencoded encoding", async () => {
     const file = new File(["x"], "x.txt");
-    expect(() => createFormRequest({ file }, { encoding: "urlencoded" })).toThrow(
+    await expect(createFormRequest({ file }, { encoding: "urlencoded" })).rejects.toThrow(
       /cannot be sent as "urlencoded"/,
     );
   });
 
-  it("serializes GET forms into the URL query string, like a browser", () => {
-    const request = createFormRequest(
+  it("serializes GET forms into the URL query string, like a browser", async () => {
+    const request = await createFormRequest(
       { q: "search term", page: 2 },
       { method: "GET", url: "/api/items?stale=1" },
     );
@@ -79,9 +79,9 @@ describe("createFormRequest", () => {
     expect(request.body).toBeNull();
   });
 
-  it("refuses File fields in GET forms", () => {
+  it("refuses File fields in GET forms", async () => {
     const file = new File(["x"], "x.txt");
-    expect(() => createFormRequest({ file }, { method: "GET" })).toThrow(
+    await expect(createFormRequest({ file }, { method: "GET" })).rejects.toThrow(
       /cannot be submitted with a GET form/,
     );
   });

--- a/packages/test/test/form.test.ts
+++ b/packages/test/test/form.test.ts
@@ -57,6 +57,24 @@ describe("createFormRequest", () => {
     expect(body.getAll("tag")).toEqual(["a", "b"]);
   });
 
+  it("normalizes scalar newlines like browser form submission", async () => {
+    for (const encoding of ["urlencoded", "multipart"] as const) {
+      const request = await createFormRequest(
+        {
+          "line\nname": "first\nsecond",
+          carriage: "first\rsecond",
+          windows: "first\r\nsecond",
+        },
+        { encoding },
+      );
+      const form = await request.formData();
+
+      expect(form.get("line\r\nname")).toBe("first\r\nsecond");
+      expect(form.get("carriage")).toBe("first\r\nsecond");
+      expect(form.get("windows")).toBe("first\r\nsecond");
+    }
+  });
+
   it("refuses File fields with explicit urlencoded encoding", async () => {
     const file = new File(["x"], "x.txt");
     await expect(createFormRequest({ file }, { encoding: "urlencoded" })).rejects.toThrow(

--- a/packages/test/test/form.test.ts
+++ b/packages/test/test/form.test.ts
@@ -63,6 +63,28 @@ describe("createFormRequest", () => {
       /cannot be sent as "urlencoded"/,
     );
   });
+
+  it("serializes GET forms into the URL query string, like a browser", () => {
+    const request = createFormRequest(
+      { q: "search term", page: 2 },
+      { method: "GET", url: "/api/items?stale=1" },
+    );
+
+    expect(request.method).toBe("GET");
+    const url = new URL(request.url);
+    expect(url.searchParams.get("q")).toBe("search term");
+    expect(url.searchParams.get("page")).toBe("2");
+    // A GET submission replaces the query already present on the URL.
+    expect(url.searchParams.has("stale")).toBe(false);
+    expect(request.body).toBeNull();
+  });
+
+  it("refuses File fields in GET forms", () => {
+    const file = new File(["x"], "x.txt");
+    expect(() => createFormRequest({ file }, { method: "GET" })).toThrow(
+      /cannot be submitted with a GET form/,
+    );
+  });
 });
 
 describe("submitForm", () => {
@@ -107,6 +129,21 @@ describe("submitForm", () => {
     });
 
     expect(await readJson(response)).toEqual({ filename: "notes.txt", contents: "file body" });
+  });
+
+  it("drives a defineApi query schema with a GET form", async () => {
+    const GET = defineApi({
+      query: requiredStrings("q"),
+      handler: ({ query }) => ({ results: [query.q] }),
+    });
+
+    const ok = await submitForm(GET, { q: "roadmap" }, { method: "GET", url: "/api/search" });
+    expect(await readJson(ok)).toEqual({ results: ["roadmap"] });
+
+    const invalid = await submitForm(GET, { other: "field" }, { method: "GET" });
+    expect(invalid.status).toBe(422);
+    const body = await readJson<ApiValidationErrorBody>(invalid);
+    expect(body.issues).toEqual([{ in: "query", message: "Required", path: ["q"] }]);
   });
 
   it("passes url, params, and context through to the handler args", async () => {

--- a/packages/test/test/form.test.ts
+++ b/packages/test/test/form.test.ts
@@ -1,0 +1,129 @@
+import type { StandardSchemaV1 } from "@standard-schema/spec";
+import type { ApiRouteArgs, ApiValidationErrorBody } from "@pracht/core";
+import { defineApi } from "@pracht/core";
+import { describe, expect, it } from "vitest";
+
+import { createFormRequest, readJson, submitForm } from "../src/index.ts";
+
+/** Minimal Standard Schema: every listed field must be a non-empty string. */
+function requiredStrings<TField extends string>(
+  ...fields: TField[]
+): StandardSchemaV1<Record<string, unknown>, Record<TField, string>> {
+  return {
+    "~standard": {
+      version: 1,
+      vendor: "pracht-test",
+      validate(value) {
+        if (typeof value !== "object" || value === null) {
+          return { issues: [{ message: "Expected an object" }] };
+        }
+        const record = value as Record<string, unknown>;
+        const issues = fields.flatMap((field) =>
+          typeof record[field] === "string" && record[field] !== ""
+            ? []
+            : [{ message: "Required", path: [field] }],
+        );
+        return issues.length > 0 ? { issues } : { value: record as Record<TField, string> };
+      },
+    },
+  };
+}
+
+describe("createFormRequest", () => {
+  it("builds an urlencoded POST by default", async () => {
+    const request = createFormRequest({ name: "Alice", count: 2, subscribed: true });
+
+    expect(request.method).toBe("POST");
+    expect(request.headers.get("content-type")).toContain("application/x-www-form-urlencoded");
+    const body = await request.text();
+    expect(new URLSearchParams(body).get("name")).toBe("Alice");
+    expect(new URLSearchParams(body).get("count")).toBe("2");
+    expect(new URLSearchParams(body).get("subscribed")).toBe("true");
+  });
+
+  it("switches to multipart when a field is a File", async () => {
+    const file = new File(["hello"], "hello.txt", { type: "text/plain" });
+    const request = createFormRequest({ title: "doc", attachment: file });
+
+    expect(request.headers.get("content-type")).toContain("multipart/form-data");
+    const form = await request.formData();
+    expect(form.get("title")).toBe("doc");
+    expect(form.get("attachment")).toBeInstanceOf(File);
+  });
+
+  it("repeats entries for array fields", async () => {
+    const request = createFormRequest({ tag: ["a", "b"] });
+    const body = new URLSearchParams(await request.text());
+    expect(body.getAll("tag")).toEqual(["a", "b"]);
+  });
+
+  it("refuses File fields with explicit urlencoded encoding", () => {
+    const file = new File(["x"], "x.txt");
+    expect(() => createFormRequest({ file }, { encoding: "urlencoded" })).toThrow(
+      /cannot be sent as "urlencoded"/,
+    );
+  });
+});
+
+describe("submitForm", () => {
+  const POST = defineApi({
+    body: requiredStrings("name", "email"),
+    handler: ({ body }) => ({ ok: true, name: body.name, email: body.email }),
+  });
+
+  it("drives a defineApi handler through its form parsing path", async () => {
+    const response = await submitForm(POST, {
+      name: "Alice",
+      email: "alice@example.com",
+    });
+
+    expect(response.status).toBe(200);
+    expect(await readJson(response)).toEqual({
+      ok: true,
+      name: "Alice",
+      email: "alice@example.com",
+    });
+  });
+
+  it("surfaces the standardized 422 validation body for invalid fields", async () => {
+    const response = await submitForm(POST, { name: "Alice", email: "" });
+
+    expect(response.status).toBe(422);
+    const body = await readJson<ApiValidationErrorBody>(response);
+    expect(body.error).toBe("validation");
+    expect(body.issues).toEqual([{ in: "body", message: "Required", path: ["email"] }]);
+  });
+
+  it("submits multipart to a plain handler that reads formData()", async () => {
+    async function handler({ request }: ApiRouteArgs<Record<string, never>>) {
+      const form = await request.formData();
+      const file = form.get("upload");
+      if (!(file instanceof File)) return new Response("missing file", { status: 400 });
+      return Response.json({ filename: file.name, contents: await file.text() });
+    }
+
+    const response = await submitForm(handler, {
+      upload: new File(["file body"], "notes.txt", { type: "text/plain" }),
+    });
+
+    expect(await readJson(response)).toEqual({ filename: "notes.txt", contents: "file body" });
+  });
+
+  it("passes url, params, and context through to the handler args", async () => {
+    async function handler({ url, params, context }: ApiRouteArgs<{ role: string }>) {
+      return Response.json({ path: url.pathname, id: params.id, role: context.role });
+    }
+
+    const response = await submitForm<{ role: string }>(
+      handler,
+      { any: "field" },
+      {
+        url: "/api/users/42",
+        params: { id: "42" },
+        context: { role: "admin" },
+      },
+    );
+
+    expect(await readJson(response)).toEqual({ path: "/api/users/42", id: "42", role: "admin" });
+  });
+});

--- a/packages/test/test/middleware.test.ts
+++ b/packages/test/test/middleware.test.ts
@@ -2,7 +2,12 @@ import type { MiddlewareFn } from "@pracht/core";
 import { notFound, redirect } from "@pracht/core";
 import { describe, expect, it } from "vitest";
 
-import { createMiddlewareArgs, readRedirect, runMiddleware } from "../src/index.ts";
+import {
+  createApiMiddlewareArgs,
+  createMiddlewareArgs,
+  readRedirect,
+  runMiddleware,
+} from "../src/index.ts";
 
 describe("runMiddleware", () => {
   it("runs a single middleware through to the final handler", async () => {
@@ -76,6 +81,20 @@ describe("runMiddleware", () => {
     expect(order).toEqual(["first:before", "second:user-1", "handler", "first:after"]);
   });
 
+  it("runs API middleware with the same route metadata shape as production", async () => {
+    const inspectRoute: MiddlewareFn = async ({ route }, next) => {
+      expect(route.path).toBe("/api/health");
+      expect("middlewareFiles" in route).toBe(false);
+      return next();
+    };
+
+    const response = await runMiddleware(
+      inspectRoute,
+      createApiMiddlewareArgs({ url: "/api/health" }),
+    );
+    expect(response.status).toBe(200);
+  });
+
   it("lets upstream middleware decorate the final response", async () => {
     const timing: MiddlewareFn = async (_args, next) => {
       const response = await next();
@@ -107,7 +126,7 @@ describe("runMiddleware", () => {
     );
   });
 
-  it("resolves a thrown Response as the chain's response, like the runtime", async () => {
+  it("resolves a thrown Response as page/API outer dispatch does", async () => {
     // The `requireUser()` pattern: a shared helper throws redirect() where
     // the return value cannot escape from. The server treats the thrown
     // Response as the answer; runMiddleware must match.
@@ -142,6 +161,16 @@ describe("runMiddleware", () => {
       throw redirect("/done", 303);
     });
     expect(readRedirect(response)).toEqual({ status: 303, location: "/done" });
+  });
+
+  it("can reject a thrown Response for raw capability-chain semantics", async () => {
+    const throwing: MiddlewareFn = async () => {
+      throw redirect("/login");
+    };
+
+    await expect(
+      runMiddleware(throwing, createMiddlewareArgs(), undefined, { thrownResponse: "reject" }),
+    ).rejects.toBeInstanceOf(Response);
   });
 
   it("still rejects thrown non-Response errors, including notFound()", async () => {

--- a/packages/test/test/middleware.test.ts
+++ b/packages/test/test/middleware.test.ts
@@ -1,0 +1,118 @@
+import type { MiddlewareFn } from "@pracht/core";
+import { redirect } from "@pracht/core";
+import { describe, expect, it } from "vitest";
+
+import { createMiddlewareArgs, readRedirect, runMiddleware } from "../src/index.ts";
+
+describe("runMiddleware", () => {
+  it("runs a single middleware through to the final handler", async () => {
+    const middleware: MiddlewareFn = async (_args, next) => next();
+
+    const response = await runMiddleware(middleware, createMiddlewareArgs());
+    expect(response.status).toBe(200);
+  });
+
+  it("returns the final handler's response", async () => {
+    const middleware: MiddlewareFn = async (_args, next) => next();
+
+    const response = await runMiddleware(middleware, createMiddlewareArgs(), () =>
+      Response.json({ from: "handler" }, { status: 201 }),
+    );
+    expect(response.status).toBe(201);
+    expect(await response.json()).toEqual({ from: "handler" });
+  });
+
+  it("short-circuits when a middleware returns without calling next()", async () => {
+    const auth: MiddlewareFn = async ({ request }, next) => {
+      if (!request.headers.get("cookie")?.includes("session=")) {
+        return redirect("/login", { request });
+      }
+      return next();
+    };
+    let handlerRan = false;
+
+    const denied = await runMiddleware(auth, createMiddlewareArgs({ url: "/dashboard" }), () => {
+      handlerRan = true;
+      return Promise.resolve(new Response("secret"));
+    });
+
+    expect(handlerRan).toBe(false);
+    expect(readRedirect(denied)).toEqual({ status: 302, location: "/login" });
+
+    const allowed = await runMiddleware(
+      auth,
+      createMiddlewareArgs({ url: "/dashboard", headers: { cookie: "session=abc" } }),
+      async () => new Response("secret"),
+    );
+    expect(await allowed.text()).toBe("secret");
+  });
+
+  it("runs a chain in order and shares context mutations downstream", async () => {
+    const order: string[] = [];
+    type Ctx = { user?: string };
+
+    const first: MiddlewareFn<Ctx> = async ({ context }, next) => {
+      order.push("first:before");
+      context.user = "user-1";
+      const response = await next();
+      order.push("first:after");
+      return response;
+    };
+    const second: MiddlewareFn<Ctx> = async ({ context }, next) => {
+      order.push(`second:${context.user}`);
+      return next();
+    };
+
+    const response = await runMiddleware(
+      [first, second],
+      createMiddlewareArgs<Ctx>({ context: {} }),
+      async () => {
+        order.push("handler");
+        return new Response("ok");
+      },
+    );
+
+    expect(await response.text()).toBe("ok");
+    expect(order).toEqual(["first:before", "second:user-1", "handler", "first:after"]);
+  });
+
+  it("lets upstream middleware decorate the final response", async () => {
+    const timing: MiddlewareFn = async (_args, next) => {
+      const response = await next();
+      const decorated = new Response(response.body, response);
+      decorated.headers.set("x-timing", "1ms");
+      return decorated;
+    };
+
+    const response = await runMiddleware(timing, createMiddlewareArgs());
+    expect(response.headers.get("x-timing")).toBe("1ms");
+  });
+
+  it("rejects a middleware that calls next() twice", async () => {
+    const broken: MiddlewareFn = async (_args, next) => {
+      await next();
+      return next();
+    };
+
+    await expect(runMiddleware(broken, createMiddlewareArgs())).rejects.toThrow(
+      /called next\(\) multiple times/,
+    );
+  });
+
+  it("rejects a middleware that does not return a Response", async () => {
+    const broken = (async () => "not a response") as unknown as MiddlewareFn;
+
+    await expect(runMiddleware(broken, createMiddlewareArgs())).rejects.toThrow(
+      /did not return a Response/,
+    );
+  });
+
+  it("runs only the final handler for an empty chain", async () => {
+    const response = await runMiddleware(
+      [],
+      createMiddlewareArgs(),
+      async () => new Response("terminal"),
+    );
+    expect(await response.text()).toBe("terminal");
+  });
+});

--- a/packages/test/test/middleware.test.ts
+++ b/packages/test/test/middleware.test.ts
@@ -1,5 +1,5 @@
 import type { MiddlewareFn } from "@pracht/core";
-import { redirect } from "@pracht/core";
+import { notFound, redirect } from "@pracht/core";
 import { describe, expect, it } from "vitest";
 
 import { createMiddlewareArgs, readRedirect, runMiddleware } from "../src/index.ts";
@@ -105,6 +105,53 @@ describe("runMiddleware", () => {
     await expect(runMiddleware(broken, createMiddlewareArgs())).rejects.toThrow(
       /did not return a Response/,
     );
+  });
+
+  it("resolves a thrown Response as the chain's response, like the runtime", async () => {
+    // The `requireUser()` pattern: a shared helper throws redirect() where
+    // the return value cannot escape from. The server treats the thrown
+    // Response as the answer; runMiddleware must match.
+    const gate: MiddlewareFn = async ({ request }, next) => {
+      if (!request.headers.get("cookie")) throw redirect("/login", { request });
+      return next();
+    };
+
+    const response = await runMiddleware(gate, createMiddlewareArgs({ url: "/dashboard" }));
+    expect(readRedirect(response)).toEqual({ status: 302, location: "/login" });
+  });
+
+  it("unwinds a thrown Response past upstream middleware without running their decoration", async () => {
+    let decorated = false;
+    const timing: MiddlewareFn = async (_args, next) => {
+      const response = await next();
+      decorated = true;
+      return response;
+    };
+    const throwing: MiddlewareFn = async () => {
+      throw redirect("/login");
+    };
+
+    const response = await runMiddleware([timing, throwing], createMiddlewareArgs());
+    expect(readRedirect(response).location).toBe("/login");
+    expect(decorated).toBe(false);
+  });
+
+  it("resolves a Response thrown by the final handler", async () => {
+    const passthrough: MiddlewareFn = async (_args, next) => next();
+    const response = await runMiddleware(passthrough, createMiddlewareArgs(), () => {
+      throw redirect("/done", 303);
+    });
+    expect(readRedirect(response)).toEqual({ status: 303, location: "/done" });
+  });
+
+  it("still rejects thrown non-Response errors, including notFound()", async () => {
+    const missing: MiddlewareFn = async () => {
+      throw notFound();
+    };
+    await expect(runMiddleware(missing, createMiddlewareArgs())).rejects.toMatchObject({
+      name: "PrachtHttpError",
+      status: 404,
+    });
   });
 
   it("runs only the final handler for an empty chain", async () => {

--- a/packages/test/test/middleware.test.ts
+++ b/packages/test/test/middleware.test.ts
@@ -81,6 +81,28 @@ describe("runMiddleware", () => {
     expect(order).toEqual(["first:before", "second:user-1", "handler", "first:after"]);
   });
 
+  it("isolates top-level args replacement between middleware like production", async () => {
+    type Ctx = { user?: string };
+    const seen: Array<{ context: Ctx; path: string }> = [];
+
+    const replaceWrapperFields: MiddlewareFn<Ctx> = async (args, next) => {
+      args.context = { user: "replacement" };
+      args.url = new URL("http://localhost/replacement");
+      return next();
+    };
+    const inspectDownstream: MiddlewareFn<Ctx> = async ({ context, url }, next) => {
+      seen.push({ context, path: url.pathname });
+      return next();
+    };
+
+    const args = createMiddlewareArgs<Ctx>({ context: {}, url: "/dashboard" });
+    const originalUrl = args.url;
+    await runMiddleware([replaceWrapperFields, inspectDownstream], args);
+
+    expect(seen).toEqual([{ context: args.context, path: "/dashboard" }]);
+    expect(args.url).toBe(originalUrl);
+  });
+
   it("runs API middleware with the same route metadata shape as production", async () => {
     const inspectRoute: MiddlewareFn = async ({ route }, next) => {
       expect(route.path).toBe("/api/health");

--- a/packages/test/test/response.test.ts
+++ b/packages/test/test/response.test.ts
@@ -37,6 +37,12 @@ describe("readRedirect", () => {
   });
 
   it("throws for a 3xx without a Location header", () => {
-    expect(() => readRedirect(new Response(null, { status: 304 }))).toThrow(/Location header/);
+    expect(() => readRedirect(new Response(null, { status: 302 }))).toThrow(/Location header/);
+  });
+
+  it("rejects 304 Not Modified as a non-redirect", () => {
+    expect(() => readRedirect(new Response(null, { status: 304 }))).toThrow(
+      /304 \(Not Modified is not a redirect\)/,
+    );
   });
 });

--- a/packages/test/test/response.test.ts
+++ b/packages/test/test/response.test.ts
@@ -1,0 +1,42 @@
+import { redirect } from "@pracht/core";
+import { describe, expect, it } from "vitest";
+
+import { readJson, readRedirect } from "../src/index.ts";
+
+describe("readJson", () => {
+  it("parses a JSON body", async () => {
+    const response = Response.json({ items: [1, 2, 3] });
+    expect(await readJson(response)).toEqual({ items: [1, 2, 3] });
+  });
+
+  it("leaves the original response readable", async () => {
+    const response = Response.json({ ok: true });
+    await readJson(response);
+    // A second read (or the test's own response.json()) still works.
+    expect(await response.json()).toEqual({ ok: true });
+  });
+
+  it("throws with the raw body when the payload is not JSON", async () => {
+    const response = new Response("<html>oops</html>", { status: 500 });
+    await expect(readJson(response)).rejects.toThrow(/status 500.*<html>oops<\/html>/);
+  });
+});
+
+describe("readRedirect", () => {
+  it("reads status and location from redirect() responses", () => {
+    const response = redirect("/login");
+    expect(readRedirect(response)).toEqual({ status: 302, location: "/login" });
+  });
+
+  it("respects explicit redirect statuses", () => {
+    expect(readRedirect(redirect("/done", 301))).toEqual({ status: 301, location: "/done" });
+  });
+
+  it("throws for non-redirect responses", () => {
+    expect(() => readRedirect(new Response("ok"))).toThrow(/Expected a redirect/);
+  });
+
+  it("throws for a 3xx without a Location header", () => {
+    expect(() => readRedirect(new Response(null, { status: 304 }))).toThrow(/Location header/);
+  });
+});

--- a/packages/test/tsdown.config.ts
+++ b/packages/test/tsdown.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "tsdown";
+
+export default defineConfig({
+  clean: true,
+  entry: ["src/index.ts"],
+  format: "esm",
+  dts: true,
+  external: ["@pracht/core"],
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -390,6 +390,16 @@ importers:
 
   packages/start: {}
 
+  packages/test:
+    dependencies:
+      '@pracht/core':
+        specifier: workspace:*
+        version: link:../framework
+    devDependencies:
+      '@standard-schema/spec':
+        specifier: ^1.0.0
+        version: 1.1.0
+
   packages/vite-plugin:
     dependencies:
       '@pracht/adapter-node':

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -81,6 +81,9 @@ importers:
       '@pracht/cli':
         specifier: workspace:*
         version: link:../../packages/cli
+      '@pracht/test':
+        specifier: workspace:*
+        version: link:../../packages/test
       '@pracht/vite-plugin':
         specifier: workspace:*
         version: link:../../packages/vite-plugin

--- a/skills/pracht-test-api/SKILL.md
+++ b/skills/pracht-test-api/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pracht-test-api
-version: 1.1.0
+version: 1.2.0
 description: |
   Auto-generate Vitest request/response tests for every handler in `src/api/`.
   Each test instantiates a `Request`, calls the exported HTTP method handler
@@ -53,33 +53,27 @@ Ask the user which subset to scaffold or accept paths via `$ARGUMENTS`.
 ## Step 3: Generate one test per handler file
 
 Place tests next to the handler with `.test.ts` suffix
-(`src/api/users/[id].test.ts`). Use a small helper to construct
-`ApiRouteArgs`:
+(`src/api/users/[id].test.ts`). Use `createApiArgs()` from `@pracht/test`
+(add it as a dev dependency if missing) to construct `ApiRouteArgs`:
 
 ```ts
 import { describe, it, expect } from "vitest";
+import { createApiArgs, readJson } from "@pracht/test";
 import { GET, POST /* import only what the handler exports */ } from "./<file>";
-
-function args(url: string, init?: RequestInit, params: Record<string, string> = {}) {
-  const request = new Request(url, init);
-  return {
-    request,
-    params,
-    context: {} as never,
-    url: new URL(request.url),
-    signal: AbortSignal.timeout(5000),
-    route: {} as never,
-  };
-}
 
 describe("<METHOD> <api-path>", () => {
   it("returns 200 on a valid request", async () => {
-    const res = await GET(args("http://localhost<api-path>"));
+    const res = await GET(createApiArgs({ url: "<api-path>" }));
     expect(res).toBeInstanceOf(Response);
     expect(res.status).toBe(200);
   });
 });
 ```
+
+Pass `params` for dynamic segments, `body` for JSON payloads (plain objects
+are JSON-encoded with the right `Content-Type`), and use `submitForm()` for
+form-encoded/multipart POSTs — it drives the same `FormData` parsing path
+`defineApi()` uses.
 
 ## Step 4: Generate method-specific cases
 
@@ -108,7 +102,7 @@ middleware is in that list. If it is, scaffold an extra test:
 
 ```ts
 it("rejects unauthenticated requests", async () => {
-  const res = await POST(args("http://localhost<api-path>", { method: "POST" }));
+  const res = await POST(createApiArgs({ url: "<api-path>", method: "POST" }));
   expect([401, 403, 302]).toContain(res.status);
 });
 ```
@@ -127,9 +121,9 @@ For handlers that return `Response.json(...)`, generate:
 
 ```ts
 it("returns JSON with the expected keys", async () => {
-  const res = await GET(args("http://localhost<api-path>"));
+  const res = await GET(createApiArgs({ url: "<api-path>" }));
   expect(res.headers.get("content-type")).toMatch(/application\/json/);
-  const body = await res.json();
+  const body = await readJson(res);
   expect(body).toEqual(expect.objectContaining({ /* fill in */ }));
 });
 ```

--- a/skills/scaffold-tests/SKILL.md
+++ b/skills/scaffold-tests/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: scaffold-tests
-version: 1.1.0
+version: 1.2.0
 description: |
   Scaffold Vitest unit/integration tests for pracht routes, loaders, and
   middleware. Asks the user once whether to use vitest browser mode with
   `vitest-browser-preact` (real DOM, real events) or classic JSDOM-based
-  tests with `@testing-library/preact`. Wires `vitest.config.ts`, mocks
-  `LoaderArgs`, and emits ready-to-run files.
+  tests with `@testing-library/preact`. Wires `vitest.config.ts`, builds
+  `LoaderArgs` with `@pracht/test`, and emits ready-to-run files.
   Use when asked to "scaffold tests", "set up Vitest", "add unit tests",
   "test this loader", or "test this route".
 allowed-tools:
@@ -48,8 +48,13 @@ Detect the package manager from the lockfile.
 Common (both modes):
 
 ```bash
-pnpm add -D vitest @types/node
+pnpm add -D vitest @types/node @pracht/test
 ```
+
+`@pracht/test` provides the typed args factories (`createLoaderArgs`,
+`createApiArgs`, `createMiddlewareArgs`), the `runMiddleware()` chain runner,
+`submitForm()`, and the `readJson()`/`readRedirect()` response readers used in
+the templates below.
 
 Component-test extras — `@preact/preset-vite` must be an explicit dev
 dependency: the configs in Step 3 import it, and a transitive-only copy
@@ -145,74 +150,47 @@ to scaffold, or pass paths via `$ARGUMENTS`.
 
 ```ts
 import { describe, it, expect } from "vitest";
+import { createLoaderArgs } from "@pracht/test";
 import { loader } from "./<route-file>";
-
-function args(url: string, init?: RequestInit) {
-  const request = new Request(url, init);
-  return {
-    request,
-    params: {} as Record<string, string>,
-    context: {} as never,
-    url: new URL(request.url),
-    signal: AbortSignal.timeout(5000),
-    route: {} as never,
-  };
-}
 
 describe("<route> loader", () => {
   it("returns the expected shape", async () => {
-    const data = await loader(args("http://localhost/<path>"));
+    const data = await loader(createLoaderArgs({ url: "/<path>" }));
     expect(data).toBeDefined();
   });
 });
 ```
 
+Pass `params`, `headers`, a partial `context`, or a JSON-encoding `body` as
+needed; the factory defaults everything else and exposes `controller` (the
+`AbortController` behind `args.signal`) for cancellation tests.
+
 ### Middleware test template
 
 ```ts
 import { describe, it, expect } from "vitest";
+import { createMiddlewareArgs, readRedirect, runMiddleware } from "@pracht/test";
 import { middleware } from "./<middleware-file>";
 
 describe("<name> middleware", () => {
-  const ok = new Response("ok", { status: 200 });
-  const next = async () => ok;
-
   it("redirects unauthenticated requests", async () => {
-    const request = new Request("http://localhost/dashboard");
-    const response = await middleware(
-      {
-        request,
-        params: {},
-        context: {} as never,
-        url: new URL(request.url),
-        signal: AbortSignal.timeout(5000),
-        route: {} as never,
-      },
-      next,
-    );
-    expect(response.status).toBe(302);
-    expect(response.headers.get("location")).toMatch(/^\/login/);
+    const response = await runMiddleware(middleware, createMiddlewareArgs({ url: "/dashboard" }));
+    expect(readRedirect(response).location).toMatch(/^\/login/);
   });
 
   it("calls through when authenticated", async () => {
-    const request = new Request("http://localhost/dashboard", {
-      headers: { cookie: "session=valid" },
-    });
-    const response = await middleware(
-      {
-        request,
-        params: {},
-        context: {} as never,
-        url: new URL(request.url),
-        signal: AbortSignal.timeout(5000),
-        route: {} as never,
-      },
-      next,
+    const response = await runMiddleware(
+      middleware,
+      createMiddlewareArgs({ url: "/dashboard", headers: { cookie: "session=valid" } }),
+      async () => new Response("handler ran"),
     );
-    expect(response).toBe(ok);
+    expect(await response.text()).toBe("handler ran");
   });
 });
 ```
+
+`runMiddleware()` accepts an array to test a chain in manifest order,
+including `context` mutations flowing downstream and short-circuits.
 
 ### Component test template (browser mode)
 
@@ -274,8 +252,8 @@ broken scaffolding.
 1. Ask the rendering-strategy question once per project; persist by
    inspecting `vitest.config.ts` on subsequent runs.
 2. Only test exports that exist — read the route file before generating.
-3. Use the recipe's `args()` helper shape for `BaseRouteArgs`/`LoaderArgs`
-   construction.
+3. Use `@pracht/test`'s factories for `BaseRouteArgs`/`LoaderArgs`
+   construction instead of hand-building args objects.
 4. For routes with `getStaticPaths`, scaffold a separate test that calls it.
 5. Generated tests should pass on first run with a placeholder assertion;
    the user fills in real expectations.

--- a/skills/scaffold-tests/SKILL.md
+++ b/skills/scaffold-tests/SKILL.md
@@ -52,9 +52,9 @@ pnpm add -D vitest @types/node @pracht/test
 ```
 
 `@pracht/test` provides the typed args factories (`createLoaderArgs`,
-`createApiArgs`, `createMiddlewareArgs`), the `runMiddleware()` chain runner,
-`submitForm()`, and the `readJson()`/`readRedirect()` response readers used in
-the templates below.
+`createApiArgs`, `createMiddlewareArgs`, `createApiMiddlewareArgs`), the
+`runMiddleware()` chain runner, `submitForm()`, and the
+`readJson()`/`readRedirect()` response readers used in the templates below.
 
 Component-test extras — `@preact/preset-vite` must be an explicit dev
 dependency: the configs in Step 3 import it, and a transitive-only copy
@@ -190,7 +190,13 @@ describe("<name> middleware", () => {
 ```
 
 `runMiddleware()` accepts an array to test a chain in manifest order,
-including `context` mutations flowing downstream and short-circuits.
+including `context` mutations flowing downstream and returned-response
+short-circuits. A thrown `Response` resolves by default, matching page/API
+outer normalization. For raw capability-chain behavior, pass
+`undefined, { thrownResponse: "reject" }` after the args/final-handler slots;
+prefer `createCapabilityTestHost()` so the test asserts the real typed
+`internal_error` envelope. For middleware attached through `defineApp({ api })`,
+use `createApiMiddlewareArgs()` so `route` has the API metadata shape.
 
 ### Component test template (browser mode)
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -33,7 +33,8 @@
       "@pracht/adapter-vercel": ["./packages/adapter-vercel/src/index.ts"],
       "@pracht/image": ["./packages/image/src/index.ts"],
       "@pracht/image/node": ["./packages/image/src/node.ts"],
-      "@pracht/image/vite": ["./packages/image/src/vite.ts"]
+      "@pracht/image/vite": ["./packages/image/src/vite.ts"],
+      "@pracht/test": ["./packages/test/src/index.ts"]
     }
   },
   // Generated route registrations and ambient platform modules are global to


### PR DESCRIPTION
## Summary

- New package `@pracht/test` (`packages/test`) — first-party testing utilities for app developers. Until now the testing recipe told users to hand-build `{ request, params, url, signal }` objects for every loader, API, and middleware test; this ships small, typed factories and runners instead. No assertion framework, no server boot, no magic.
  - `createLoaderArgs()` / `createApiArgs()` / `createMiddlewareArgs()` — build complete, typed `LoaderArgs` / `ApiRouteArgs` / `MiddlewareArgs` from a shorthand (`url`, `method`, `headers`, a JSON-encoding `body`, `params`, a partial `context`, `route` overrides) or a real `Request`. `url` is derived from the request, every field has a sensible default, and the `AbortController` behind `args.signal` is exposed as `controller` for cancellation tests.
  - `runMiddleware(fn | [fns], args, finalHandler?)` — executes a middleware chain with the runtime's exact `next()` semantics (sequential dispatch, at-most-once `next()`, short-circuit on an early `Response`, loud failure on a non-`Response` return), making auth gates and context-augmenting middleware unit-testable including short-circuits.
  - `submitForm(handler, fields, opts?)` + `createFormRequest()` — build a urlencoded or multipart form `POST` (auto-switching to multipart when a field is a `File`, arrays producing repeated entries) and call an API handler with it, exercising the same `FormData` parsing path `defineApi()` applies to real submissions.
  - `readJson(response)` / `readRedirect(response)` — minimal response readers; `readJson` clones before parsing so the original stays readable, `readRedirect` returns `{ status, location }`.
- 35 colocated Vitest tests exercise every helper against real framework functions: an actual `defineApi()` handler with a Standard Schema body validator (JSON, urlencoded, multipart, and the standardized 422 body), real `redirect()` / `notFound()` throws from a loader, and full middleware chains with context mutation, response decoration, and misuse errors.
- Registered everywhere `@pracht/image` is: root `build` filter list, workspace `tsconfig.json` paths, `docs/WORKSPACE.md` (packages table + tsdown list), and the README repo map. Changesets picks the package up automatically via `packages/*`.
- Docs: `examples/docs/src/routes/docs/recipes-testing.md` (already registered at `/docs/recipes/testing` in the nav) rewritten to use `@pracht/test` for loader, API, form, and middleware tests; `packages/test/README.md` added.
- Skills: `scaffold-tests` and `pracht-test-api` templates now use the package instead of hand-built args objects (versions bumped).

Scope cuts:
- No `invokeCapabilityForTest()` — `createCapabilityTestHost()` from `@pracht/core/server` already runs the real capability dispatch pipeline (validation, middleware, confirmation flow) in-process, so a second harness would just be a worse duplicate. The package README and docs point at it.
- `@pracht/core` is a regular dependency (matching `@pracht/adapter-node`), used for types only; the package ships zero runtime dependencies beyond it.

No linked issue.

## Testing

- [x] `pnpm run verify` (build, format, lint, typecheck, test, e2e) — all green (83.8s); format/lint/skills tests re-run green after the post-verify skill edits

## Checklist

- [x] Docs updated if needed
- [x] Skills updated if needed
- [x] Changeset added if published packages changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
