### PR TITLE
Add response compression to the Node adapter

### DIFF
--- a/.changeset/node-adapter-compression.md
+++ b/.changeset/node-adapter-compression.md
@@ -12,11 +12,14 @@ written), while static assets and (re)generated ISG documents are compressed
 once per file version at higher quality and served from an in-memory LRU.
 Concurrent first requests share one in-flight compression, while
 byte/concurrency limits send excess cold paths through streaming compression.
-Successful ISG writes explicitly invalidate their prior compressed cache
-generation and validators, including same-size rewrites on
-coarse-timestamp filesystems.
+Successful ISG writes are published as an atomic file replacement and
+explicitly invalidate their prior compressed cache generation and validators,
+including same-size rewrites on coarse-timestamp filesystems after a handler
+restart or in a sibling worker. Date-only validation is conservatively
+bypassed for mutable compressed ISG snapshots.
 Compressible responses always carry
-`Vary: Accept-Encoding` (merged with existing `Vary` members), encoded
+`Vary: Accept-Encoding` (merged with existing `Vary` members), including on
+application-generated `304` responses, encoded
 variants get their own collision-resistant weak ETag so conditional
 revalidation never crosses encodings or aliases a later application-provided
 identity validator (including when applications provide strong identity
@@ -29,9 +32,9 @@ as `GET` (including buffered compressed lengths), and already-encoded
 responses, `Cache-Control: no-transform`, Range/204/304 responses, binary
 media, integrity-protected responses, and bodies under 1 KiB (when the size is
 known) are left untouched. Identity `Content-Length` values are removed before
-streaming an encoded static response, cancellation failures cannot replace a
-valid conditional `304` with a `500`, and a body failure before the first byte
-clears staged compression metadata before the adapter returns its unencoded
-500 fallback.
+streaming an encoded static response, Range requests retain their conditional
+headers, cancellation failures cannot replace a valid conditional `304` with
+a `500`, and a body failure before the first byte clears staged compression
+metadata before the adapter returns its unencoded 500 fallback.
 Disable with `nodeAdapter({ compression: false })` — recommended when a reverse
 proxy or CDN in front of the server already compresses responses.

--- a/.changeset/node-adapter-compression.md
+++ b/.changeset/node-adapter-compression.md
@@ -12,6 +12,9 @@ written), while static assets and (re)generated ISG documents are compressed
 once per file version at higher quality and served from an in-memory LRU.
 Concurrent first requests share one in-flight compression, while
 byte/concurrency limits send excess cold paths through streaming compression.
+Content-derived ISG validator hashing has matching admission limits; an
+overloaded response omits its ETag instead of queuing unbounded whole-file
+reads, while concurrent requests for the same snapshot share one hash.
 Successful ISG writes are published as an atomic file replacement and
 explicitly invalidate their prior local compressed cache generation. Public
 ISG validators are content-derived so handlers and deployment replicas agree

--- a/.changeset/node-adapter-compression.md
+++ b/.changeset/node-adapter-compression.md
@@ -13,7 +13,8 @@ once per file version at higher quality and served from an in-memory LRU.
 Concurrent first requests share one in-flight compression, while
 byte/concurrency limits send excess cold paths through streaming compression.
 Successful ISG writes explicitly invalidate their prior compressed cache
-generation, including same-size rewrites on coarse-timestamp filesystems.
+generation and validators, including same-size rewrites on
+coarse-timestamp filesystems.
 Compressible responses always carry
 `Vary: Accept-Encoding` (merged with existing `Vary` members), encoded
 variants get their own weak ETag so conditional revalidation never crosses
@@ -21,8 +22,8 @@ encodings (including when applications provide strong identity validators),
 dynamic `If-None-Match` and `If-Modified-Since` validation runs after
 representation selection (with ETag precedence) and supports commas inside
 quoted opaque tags, static `.wasm` files are served as compressible
-`application/wasm`, `HEAD` uses
-the same negotiated representation metadata as `GET`, and already-encoded
+`application/wasm`, `HEAD` uses the same negotiated representation metadata
+as `GET` (including buffered compressed lengths), and already-encoded
 responses, `Cache-Control: no-transform`, Range/204/304 responses, binary
 media, integrity-protected responses, and bodies under 1 KiB (when the size is
 known) are left untouched. Identity `Content-Length` values are removed before

--- a/.changeset/node-adapter-compression.md
+++ b/.changeset/node-adapter-compression.md
@@ -32,16 +32,17 @@ variants get their own collision-resistant weak ETag so conditional
 revalidation never crosses encodings or aliases a later application-provided
 identity validator (including when applications provide strong identity
 validators or use the adapter's reserved ETag namespace),
-dynamic `If-None-Match` and `If-Modified-Since` validation runs after
-representation selection (with ETag precedence) and supports commas inside
-quoted opaque tags, static `.wasm` files are served as compressible
-`application/wasm`, `HEAD` uses the same negotiated representation metadata
-as `GET` (including buffered compressed lengths), and already-encoded
+dynamic `If-None-Match` and `If-Modified-Since` validation runs for every
+successful response after representation selection (with ETag precedence) and
+supports commas inside quoted opaque tags, static `.wasm` files are served as
+compressible `application/wasm`, `HEAD` uses the same negotiated representation
+metadata as `GET` (including buffered compressed lengths), and already-encoded
 responses, `Cache-Control: no-transform`, Range/204/304 responses, binary
 media, integrity-protected responses, and bodies under 1 KiB (when the size is
 known) are left untouched. Identity `Content-Length` values are removed before
-streaming an encoded static response, Range requests retain their conditional
-headers, cancellation failures cannot replace a valid conditional `304` with
+streaming an encoded static response, requests carrying `Range` retain their
+conditional headers and remain identity-encoded even when answered with a full
+`200`, cancellation failures cannot replace a valid conditional `304` with
 a `500`, and a body failure before the first byte clears staged compression
 metadata before the adapter returns its unencoded 500 fallback.
 Disable with `nodeAdapter({ compression: false })` — recommended when a reverse

--- a/.changeset/node-adapter-compression.md
+++ b/.changeset/node-adapter-compression.md
@@ -13,10 +13,14 @@ once per file version at higher quality and served from an in-memory LRU.
 Concurrent first requests share one in-flight compression, while
 byte/concurrency limits send excess cold paths through streaming compression.
 Successful ISG writes are published as an atomic file replacement and
-explicitly invalidate their prior compressed cache generation and validators,
-including same-size rewrites on coarse-timestamp filesystems after a handler
-restart or in a sibling worker. Date-only validation is conservatively
-bypassed for mutable compressed ISG snapshots.
+explicitly invalidate their prior local compressed cache generation. Public
+validators derive only from the replacement's durable file identity so sibling
+handlers agree on the ETag, including for same-size rewrites on
+coarse-timestamp filesystems and after a handler restart. Static response reads
+stay bound to the same open file version that supplied their size and validator,
+so a concurrent replacement cannot bypass the cold-work budget or mix new
+bytes with old metadata. Date-only validation is conservatively bypassed for
+mutable compressed ISG snapshots.
 Compressible responses always carry
 `Vary: Accept-Encoding` (merged with existing `Vary` members), including on
 application-generated `304` responses, encoded

--- a/.changeset/node-adapter-compression.md
+++ b/.changeset/node-adapter-compression.md
@@ -12,6 +12,8 @@ written), while static assets and (re)generated ISG documents are compressed
 once per file version at higher quality and served from an in-memory LRU.
 Concurrent first requests share one in-flight compression, while
 byte/concurrency limits send excess cold paths through streaming compression.
+Successful ISG writes explicitly invalidate their prior compressed cache
+generation, including same-size rewrites on coarse-timestamp filesystems.
 Compressible responses always carry
 `Vary: Accept-Encoding` (merged with existing `Vary` members), encoded
 variants get their own weak ETag so conditional revalidation never crosses

--- a/.changeset/node-adapter-compression.md
+++ b/.changeset/node-adapter-compression.md
@@ -9,15 +9,17 @@ with `node:zlib`: dynamic documents, route-state JSON, and other compressible
 text types stream through a zlib transform that flushes per written chunk (so
 SSE and other incrementally produced bodies are delivered as they are
 written), while static assets and (re)generated ISG documents are compressed
-once per file version at higher quality — concurrent first requests share one
-in-flight compression — and served from an in-memory LRU. Compressible
-responses always carry
+once per file version at higher quality and served from an in-memory LRU.
+Concurrent first requests share one in-flight compression, while
+byte/concurrency limits send excess cold paths through streaming compression.
+Compressible responses always carry
 `Vary: Accept-Encoding` (merged with existing `Vary` members), encoded
 variants get their own weak ETag so conditional revalidation never crosses
 encodings (including when applications provide strong identity validators),
-dynamic `If-None-Match` validation runs after representation selection and
-supports commas inside quoted opaque tags, static `.wasm` files are served as
-compressible `application/wasm`, `HEAD` uses
+dynamic `If-None-Match` and `If-Modified-Since` validation runs after
+representation selection (with ETag precedence) and supports commas inside
+quoted opaque tags, static `.wasm` files are served as compressible
+`application/wasm`, `HEAD` uses
 the same negotiated representation metadata as `GET`, and already-encoded
 responses, `Cache-Control: no-transform`, Range/204/304 responses, binary
 media, integrity-protected responses, and bodies under 1 KiB (when the size is

--- a/.changeset/node-adapter-compression.md
+++ b/.changeset/node-adapter-compression.md
@@ -3,18 +3,20 @@
 ---
 
 Add response compression to the Node adapter. Responses are negotiated against
-`Accept-Encoding` (highest q-value wins per RFC 9110, brotli preferred on
-ties) and compressed with `node:zlib`: dynamic documents, route-state JSON,
-and other compressible text types stream through a zlib transform that flushes
-per written chunk (so SSE and other incrementally produced bodies are
-delivered as they are written), while static assets and (re)generated ISG
-documents are compressed once per file version at higher quality — concurrent
-first requests share one in-flight compression — and served from an in-memory
-LRU. Compressible responses always carry
+`Accept-Encoding` (highest q-value wins per RFC 9110, including an explicitly
+higher `identity` preference, with brotli preferred on ties) and compressed
+with `node:zlib`: dynamic documents, route-state JSON, and other compressible
+text types stream through a zlib transform that flushes per written chunk (so
+SSE and other incrementally produced bodies are delivered as they are
+written), while static assets and (re)generated ISG documents are compressed
+once per file version at higher quality — concurrent first requests share one
+in-flight compression — and served from an in-memory LRU. Compressible
+responses always carry
 `Vary: Accept-Encoding` (merged with existing `Vary` members), encoded
 variants get their own weak ETag so conditional revalidation never crosses
-encodings, and already-encoded responses, `Cache-Control: no-transform`,
-Range/204/304 responses, binary media, and bodies under 1 KiB (when the size
-is known) are left untouched. Disable with `nodeAdapter({ compression: false })`
-— recommended when a reverse proxy or CDN in front of the server already
-compresses responses.
+encodings, dynamic variant ETags revalidate through the adapter, `HEAD` uses
+the same negotiated representation metadata as `GET`, and already-encoded
+responses, `Cache-Control: no-transform`, Range/204/304 responses, binary
+media, and bodies under 1 KiB (when the size is known) are left untouched.
+Disable with `nodeAdapter({ compression: false })` — recommended when a reverse
+proxy or CDN in front of the server already compresses responses.

--- a/.changeset/node-adapter-compression.md
+++ b/.changeset/node-adapter-compression.md
@@ -14,7 +14,10 @@ in-flight compression — and served from an in-memory LRU. Compressible
 responses always carry
 `Vary: Accept-Encoding` (merged with existing `Vary` members), encoded
 variants get their own weak ETag so conditional revalidation never crosses
-encodings, dynamic variant ETags revalidate through the adapter, `HEAD` uses
+encodings (including when applications provide strong identity validators),
+dynamic `If-None-Match` validation runs after representation selection and
+supports commas inside quoted opaque tags, static `.wasm` files are served as
+compressible `application/wasm`, `HEAD` uses
 the same negotiated representation metadata as `GET`, and already-encoded
 responses, `Cache-Control: no-transform`, Range/204/304 responses, binary
 media, integrity-protected responses, and bodies under 1 KiB (when the size is

--- a/.changeset/node-adapter-compression.md
+++ b/.changeset/node-adapter-compression.md
@@ -17,8 +17,10 @@ generation and validators, including same-size rewrites on
 coarse-timestamp filesystems.
 Compressible responses always carry
 `Vary: Accept-Encoding` (merged with existing `Vary` members), encoded
-variants get their own weak ETag so conditional revalidation never crosses
-encodings (including when applications provide strong identity validators),
+variants get their own collision-resistant weak ETag so conditional
+revalidation never crosses encodings or aliases a later application-provided
+identity validator (including when applications provide strong identity
+validators or use the adapter's reserved ETag namespace),
 dynamic `If-None-Match` and `If-Modified-Since` validation runs after
 representation selection (with ETag precedence) and supports commas inside
 quoted opaque tags, static `.wasm` files are served as compressible
@@ -27,7 +29,8 @@ as `GET` (including buffered compressed lengths), and already-encoded
 responses, `Cache-Control: no-transform`, Range/204/304 responses, binary
 media, integrity-protected responses, and bodies under 1 KiB (when the size is
 known) are left untouched. Identity `Content-Length` values are removed before
-streaming an encoded static response, and a body failure before the first byte
+streaming an encoded static response, cancellation failures cannot replace a
+valid conditional `304` with a `500`, and a body failure before the first byte
 clears staged compression metadata before the adapter returns its unencoded
 500 fallback.
 Disable with `nodeAdapter({ compression: false })` — recommended when a reverse

--- a/.changeset/node-adapter-compression.md
+++ b/.changeset/node-adapter-compression.md
@@ -14,13 +14,14 @@ Concurrent first requests share one in-flight compression, while
 byte/concurrency limits send excess cold paths through streaming compression.
 Successful ISG writes are published as an atomic file replacement and
 explicitly invalidate their prior local compressed cache generation. Public
-validators derive only from the replacement's durable file identity so sibling
-handlers agree on the ETag, including for same-size rewrites on
-coarse-timestamp filesystems and after a handler restart. Static response reads
-stay bound to the same open file version that supplied their size and validator,
-so a concurrent replacement cannot bypass the cold-work budget or mix new
-bytes with old metadata. Date-only validation is conservatively bypassed for
-mutable compressed ISG snapshots.
+ISG validators are content-derived so handlers and deployment replicas agree
+on the ETag without exposing replica-local device, inode, or ctime metadata,
+including for same-size rewrites on coarse-timestamp filesystems and after a
+handler restart. Filesystem identity remains private to compression-cache keys.
+Static response reads stay bound to the same open file version that supplied
+their size and validator, so a concurrent replacement cannot bypass the
+cold-work budget or mix new bytes with old metadata. Date-only validation is
+conservatively bypassed for mutable compressed ISG snapshots.
 Compressible responses always carry
 `Vary: Accept-Encoding` (merged with existing `Vary` members), including on
 application-generated `304` responses, encoded

--- a/.changeset/node-adapter-compression.md
+++ b/.changeset/node-adapter-compression.md
@@ -1,0 +1,17 @@
+---
+"@pracht/adapter-node": minor
+---
+
+Add response compression to the Node adapter. Responses are negotiated against
+`Accept-Encoding` (brotli preferred, then gzip, honoring q-values) and
+compressed with `node:zlib`: dynamic documents, route-state JSON, and other
+compressible text types stream through a zlib transform, while static assets
+and (re)generated ISG documents are compressed once per file version at higher
+quality and served from an in-memory LRU. Compressible responses always carry
+`Vary: Accept-Encoding` (merged with existing `Vary` members), encoded
+variants get their own weak ETag so conditional revalidation never crosses
+encodings, and already-encoded responses, `Cache-Control: no-transform`,
+Range/204/304 responses, binary media, and bodies under 1 KiB (when the size
+is known) are left untouched. Disable with `nodeAdapter({ compression: false })`
+— recommended when a reverse proxy or CDN in front of the server already
+compresses responses.

--- a/.changeset/node-adapter-compression.md
+++ b/.changeset/node-adapter-compression.md
@@ -3,11 +3,14 @@
 ---
 
 Add response compression to the Node adapter. Responses are negotiated against
-`Accept-Encoding` (brotli preferred, then gzip, honoring q-values) and
-compressed with `node:zlib`: dynamic documents, route-state JSON, and other
-compressible text types stream through a zlib transform, while static assets
-and (re)generated ISG documents are compressed once per file version at higher
-quality and served from an in-memory LRU. Compressible responses always carry
+`Accept-Encoding` (highest q-value wins per RFC 9110, brotli preferred on
+ties) and compressed with `node:zlib`: dynamic documents, route-state JSON,
+and other compressible text types stream through a zlib transform that flushes
+per written chunk (so SSE and other incrementally produced bodies are
+delivered as they are written), while static assets and (re)generated ISG
+documents are compressed once per file version at higher quality — concurrent
+first requests share one in-flight compression — and served from an in-memory
+LRU. Compressible responses always carry
 `Vary: Accept-Encoding` (merged with existing `Vary` members), encoded
 variants get their own weak ETag so conditional revalidation never crosses
 encodings, and already-encoded responses, `Cache-Control: no-transform`,

--- a/.changeset/node-adapter-compression.md
+++ b/.changeset/node-adapter-compression.md
@@ -32,9 +32,10 @@ variants get their own collision-resistant weak ETag so conditional
 revalidation never crosses encodings or aliases a later application-provided
 identity validator (including when applications provide strong identity
 validators or use the adapter's reserved ETag namespace),
-dynamic `If-None-Match` and `If-Modified-Since` validation runs for every
-successful response after representation selection (with ETag precedence) and
-supports commas inside quoted opaque tags, static `.wasm` files are served as
+encoded dynamic requests run `If-Match`, `If-None-Match`, and
+`If-Modified-Since` validation after representation selection, with strong
+`If-Match` comparison and RFC precondition precedence, and support commas
+inside quoted opaque tags, static `.wasm` files are served as
 compressible `application/wasm`, `HEAD` uses the same negotiated representation
 metadata as `GET` (including buffered compressed lengths), and already-encoded
 responses, `Cache-Control: no-transform`, Range/204/304 responses, binary

--- a/.changeset/node-adapter-compression.md
+++ b/.changeset/node-adapter-compression.md
@@ -17,6 +17,10 @@ variants get their own weak ETag so conditional revalidation never crosses
 encodings, dynamic variant ETags revalidate through the adapter, `HEAD` uses
 the same negotiated representation metadata as `GET`, and already-encoded
 responses, `Cache-Control: no-transform`, Range/204/304 responses, binary
-media, and bodies under 1 KiB (when the size is known) are left untouched.
+media, integrity-protected responses, and bodies under 1 KiB (when the size is
+known) are left untouched. Identity `Content-Length` values are removed before
+streaming an encoded static response, and a body failure before the first byte
+clears staged compression metadata before the adapter returns its unencoded
+500 fallback.
 Disable with `nodeAdapter({ compression: false })` — recommended when a reverse
 proxy or CDN in front of the server already compresses responses.

--- a/docs/ADAPTERS.md
+++ b/docs/ADAPTERS.md
@@ -165,18 +165,24 @@ that manifest.
 ### Response compression
 
 The Node adapter compresses responses by default, negotiated against the
-request's `Accept-Encoding` header (brotli preferred, then gzip, honoring
-q-values and `*` wildcards, all via `node:zlib`):
+request's `Accept-Encoding` header (the acceptable coding with the highest
+q-value wins per RFC 9110, brotli preferred on ties and in unweighted lists
+like `gzip, deflate, br`; `*` wildcards and `q=0` exclusions honored, all via
+`node:zlib`):
 
 - **Dynamic responses** — SSR/ISG documents, route-state JSON, API responses
-  with compressible types — stream through a zlib transform (brotli quality 4),
-  so compression adds no buffering to the response path.
+  with compressible types — stream through a zlib transform (brotli quality 4)
+  that flushes per written chunk, so incrementally produced bodies such as
+  `text/event-stream` (SSE) reach the client as each event is written instead
+  of sitting in the compressor's buffer until the stream ends.
 - **Static assets and ISG snapshots** up to 1 MiB are compressed once per file
   version at higher quality and kept in a byte-bounded in-memory LRU
   (32 MiB) keyed by path + size + mtime, so hashed assets and regenerated ISG
-  HTML pay the compression cost once. Larger files stream through zlib per
-  request. This is runtime compression rather than build-time precompression;
-  it also covers ISG documents rewritten on disk after the build.
+  HTML pay the compression cost once — concurrent first requests to the same
+  file share a single in-flight compression. Larger files stream through zlib
+  per request. This is runtime compression rather than build-time
+  precompression; it also covers ISG documents rewritten on disk after the
+  build.
 
 What gets compressed: `text/*`, `application/json`, `application/javascript`,
 `application/xml`, `application/wasm`, and any `+json`/`+xml` structured

--- a/docs/ADAPTERS.md
+++ b/docs/ADAPTERS.md
@@ -191,7 +191,11 @@ syntax type (`image/svg+xml`, `application/manifest+json`, ...). Binary media
 
 What is never touched: responses that already carry a `Content-Encoding`,
 `Cache-Control: no-transform` responses, 1xx/204/205/206/304 statuses, Range
-responses, and bodies under 1 KiB when the size is known.
+responses, integrity-protected responses (`Content-Digest`, `Repr-Digest`,
+legacy `Digest`/`Content-MD5`), and bodies under 1 KiB when the size is known.
+Because those integrity fields depend on the selected content encoding, the
+adapter preserves their identity representation rather than forwarding a
+digest that no longer matches the bytes on the wire.
 
 Correctness guarantees:
 
@@ -206,6 +210,8 @@ Correctness guarantees:
 - `HEAD` advertises the same negotiated `Content-Encoding` and variant ETag as
   the corresponding `GET` while omitting the body (and compressed length when
   it is not already known).
+- If a dynamic body fails before any bytes are written, the adapter discards
+  its staged compression metadata and returns an unencoded, non-cacheable 500.
 
 **Behind a reverse proxy:** when nginx, Caddy, Cloudflare, or another
 CDN/proxy in front of the Node server already compresses responses, disable

--- a/docs/ADAPTERS.md
+++ b/docs/ADAPTERS.md
@@ -210,9 +210,12 @@ Correctness guarantees:
 - Compressible responses always carry `Vary: Accept-Encoding`, merged with any
   existing `Vary` members (e.g. `x-pracht-route-state-request`), even when the
   response goes out identity-encoded — so shared caches key on the encoding.
-- Encoded variants get their own weak ETag (the encoding is folded into the
-  tag, e.g. `W/"1a2f-18c-br"`), so `If-None-Match` revalidation can never
-  answer an identity request with a cached brotli body or vice versa. Strong
+- Encoded variants get their own collision-resistant weak ETag (a SHA-256
+  digest of the identity tag and encoding, e.g. `W/"pracht-br-..."`), so
+  an encoded validator cannot alias an application-provided identity tag; an
+  identity tag that enters the adapter's reserved namespace is escaped. Thus
+  `If-None-Match` revalidation can never answer an identity request with a
+  cached brotli body or vice versa. Strong
   application ETags are weakened because streaming compression bytes can vary
   with chunk boundaries. The adapter evaluates dynamic `If-None-Match` and
   `If-Modified-Since` only after selecting the outgoing representation

--- a/docs/ADAPTERS.md
+++ b/docs/ADAPTERS.md
@@ -230,12 +230,14 @@ Correctness guarantees:
   `If-None-Match` revalidation can never answer an identity request with a
   cached brotli body or vice versa. Strong
   application ETags are weakened because streaming compression bytes can vary
-  with chunk boundaries. The adapter evaluates dynamic `If-None-Match` and
-  `If-Modified-Since` only after selecting the outgoing representation
-  (`If-None-Match` takes precedence), including valid quoted opaque tags that
-  contain commas, so application-level identity validation cannot short-circuit
-  an encoded request with a cross-encoding `304`. Range requests retain their
-  original validators because their `206` responses are never transformed.
+  with chunk boundaries. For every successful dynamic response, the adapter
+  evaluates `If-None-Match` and `If-Modified-Since` only after selecting the
+  outgoing representation (`If-None-Match` takes precedence), including valid
+  quoted opaque tags that contain commas, so application-level identity
+  validation cannot short-circuit an encoded request with a cross-encoding
+  `304`. Requests carrying `Range` retain their original validators and remain
+  identity-encoded even when the application ignores the range and returns a
+  full `200`; `206` responses are likewise never transformed.
 - `HEAD` advertises the same negotiated `Content-Encoding`, variant ETag, and
   buffered compressed `Content-Length` as the corresponding `GET` while
   omitting the body (streamed compressed lengths remain unknown).

--- a/docs/ADAPTERS.md
+++ b/docs/ADAPTERS.md
@@ -181,9 +181,14 @@ wildcards, and `q=0` exclusions are honored, all via `node:zlib`):
   assets and regenerated ISG HTML pay the compression cost once — concurrent
   first requests to the same file share a single in-flight compression.
   Successful ISG writes are published as an atomic file replacement and
-  advance the in-process generation explicitly, so even same-size rewrites on
-  coarse-timestamp filesystems cannot reuse stale compressed bytes or
-  validators after a handler restart or in a sibling worker. Date-only
+  therefore receive a new durable file identity; public validators use only
+  that shared identity so sibling handlers advertise the same ETag, while each
+  handler advances its own cache generation to discard prior compressed bytes.
+  The response reads through the same open file handle that supplied its size
+  and validator, so a concurrent replacement cannot be admitted under stale
+  metadata or bypass the cold-work byte budget. Even same-size rewrites on
+  coarse-timestamp filesystems therefore remain distinct after a handler
+  restart or in a sibling worker. Date-only
   revalidation is conservatively bypassed for mutable ISG snapshots while
   compression is enabled because an HTTP date cannot identify such a
   generation. Whole-file cold work is bounded by both bytes and concurrency;

--- a/docs/ADAPTERS.md
+++ b/docs/ADAPTERS.md
@@ -193,9 +193,12 @@ wildcards, and `q=0` exclusions are honored, all via `node:zlib`):
   restart or in a sibling worker. Date-only
   revalidation is conservatively bypassed for mutable ISG snapshots while
   compression is enabled because an HTTP date cannot identify such a
-  generation. Whole-file cold work is bounded by both bytes and concurrency;
-  excess distinct files, and all larger files, stream through zlib instead of
-  queuing another buffered compression. This is runtime compression rather
+  generation. Whole-file cold work is bounded by both bytes and concurrency,
+  including content-derived validator hashing. Concurrent requests for the
+  same snapshot share one hash; when the validator budget is full, the response
+  safely omits its ETag instead of queuing another whole-file read. Excess
+  distinct compression jobs, and all larger files, stream through zlib instead
+  of queuing another buffered compression. This is runtime compression rather
   than build-time precompression; it also covers ISG documents rewritten on
   disk after the build.
 

--- a/docs/ADAPTERS.md
+++ b/docs/ADAPTERS.md
@@ -181,9 +181,11 @@ wildcards, and `q=0` exclusions are honored, all via `node:zlib`):
   and regenerated ISG HTML pay the compression cost once — concurrent first
   requests to the same file share a single in-flight compression. Successful
   ISG writes advance that generation explicitly, so even same-size rewrites on
-  coarse-timestamp filesystems cannot reuse stale compressed bytes. Whole-file
-  cold work is bounded by both bytes and concurrency; excess distinct files,
-  and all larger files, stream through zlib instead of queuing another buffered
+  coarse-timestamp filesystems cannot reuse stale compressed bytes or
+  validators; date-only revalidation is bypassed after such a write when the
+  filesystem timestamp cannot distinguish the generations. Whole-file cold
+  work is bounded by both bytes and concurrency; excess distinct files, and
+  all larger files, stream through zlib instead of queuing another buffered
   compression. This is runtime compression rather than build-time
   precompression; it also covers ISG documents rewritten on disk after the
   build.
@@ -217,9 +219,9 @@ Correctness guarantees:
   (`If-None-Match` takes precedence), including valid quoted opaque tags that
   contain commas, so application-level identity validation cannot short-circuit
   an encoded request with a cross-encoding `304`.
-- `HEAD` advertises the same negotiated `Content-Encoding` and variant ETag as
-  the corresponding `GET` while omitting the body (and compressed length when
-  it is not already known).
+- `HEAD` advertises the same negotiated `Content-Encoding`, variant ETag, and
+  buffered compressed `Content-Length` as the corresponding `GET` while
+  omitting the body (streamed compressed lengths remain unknown).
 - If a dynamic body fails before any bytes are written, the adapter discards
   its staged compression metadata and returns an unencoded, non-cacheable 500.
 

--- a/docs/ADAPTERS.md
+++ b/docs/ADAPTERS.md
@@ -177,18 +177,20 @@ wildcards, and `q=0` exclusions are honored, all via `node:zlib`):
   of sitting in the compressor's buffer until the stream ends.
 - **Static assets and ISG snapshots** up to 1 MiB are compressed once per file
   version at higher quality and kept in a byte-bounded in-memory LRU
-  (32 MiB) keyed by path + write generation + size + mtime, so hashed assets
-  and regenerated ISG HTML pay the compression cost once — concurrent first
-  requests to the same file share a single in-flight compression. Successful
-  ISG writes advance that generation explicitly, so even same-size rewrites on
+  (32 MiB) keyed by path + durable file identity + write generation, so hashed
+  assets and regenerated ISG HTML pay the compression cost once — concurrent
+  first requests to the same file share a single in-flight compression.
+  Successful ISG writes are published as an atomic file replacement and
+  advance the in-process generation explicitly, so even same-size rewrites on
   coarse-timestamp filesystems cannot reuse stale compressed bytes or
-  validators; date-only revalidation is bypassed after such a write when the
-  filesystem timestamp cannot distinguish the generations. Whole-file cold
-  work is bounded by both bytes and concurrency; excess distinct files, and
-  all larger files, stream through zlib instead of queuing another buffered
-  compression. This is runtime compression rather than build-time
-  precompression; it also covers ISG documents rewritten on disk after the
-  build.
+  validators after a handler restart or in a sibling worker. Date-only
+  revalidation is conservatively bypassed for mutable ISG snapshots while
+  compression is enabled because an HTTP date cannot identify such a
+  generation. Whole-file cold work is bounded by both bytes and concurrency;
+  excess distinct files, and all larger files, stream through zlib instead of
+  queuing another buffered compression. This is runtime compression rather
+  than build-time precompression; it also covers ISG documents rewritten on
+  disk after the build.
 
 What gets compressed: `text/*`, `application/json`, `application/javascript`,
 `application/xml`, `application/wasm`, and any `+json`/`+xml` structured
@@ -209,7 +211,8 @@ Correctness guarantees:
 
 - Compressible responses always carry `Vary: Accept-Encoding`, merged with any
   existing `Vary` members (e.g. `x-pracht-route-state-request`), even when the
-  response goes out identity-encoded — so shared caches key on the encoding.
+  response goes out identity-encoded or the application answers a conditional
+  request with `304` — so shared caches keep keying on the encoding.
 - Encoded variants get their own collision-resistant weak ETag (a SHA-256
   digest of the identity tag and encoding, e.g. `W/"pracht-br-..."`), so
   an encoded validator cannot alias an application-provided identity tag; an
@@ -221,7 +224,8 @@ Correctness guarantees:
   `If-Modified-Since` only after selecting the outgoing representation
   (`If-None-Match` takes precedence), including valid quoted opaque tags that
   contain commas, so application-level identity validation cannot short-circuit
-  an encoded request with a cross-encoding `304`.
+  an encoded request with a cross-encoding `304`. Range requests retain their
+  original validators because their `206` responses are never transformed.
 - `HEAD` advertises the same negotiated `Content-Encoding`, variant ETag, and
   buffered compressed `Content-Length` as the corresponding `GET` while
   omitting the body (streamed compressed lengths remain unknown).

--- a/docs/ADAPTERS.md
+++ b/docs/ADAPTERS.md
@@ -181,9 +181,11 @@ wildcards, and `q=0` exclusions are honored, all via `node:zlib`):
   assets and regenerated ISG HTML pay the compression cost once — concurrent
   first requests to the same file share a single in-flight compression.
   Successful ISG writes are published as an atomic file replacement and
-  therefore receive a new durable file identity; public validators use only
-  that shared identity so sibling handlers advertise the same ETag, while each
-  handler advances its own cache generation to discard prior compressed bytes.
+  therefore receive a new durable file identity. That identity remains private
+  to local compression-cache keys; public ISG validators are content-derived,
+  so sibling handlers and deployment replicas advertise the same ETag for the
+  same snapshot while each handler advances its own cache generation to
+  discard prior compressed bytes.
   The response reads through the same open file handle that supplied its size
   and validator, so a concurrent replacement cannot be admitted under stale
   metadata or bypass the cold-work byte budget. Even same-size rewrites on

--- a/docs/ADAPTERS.md
+++ b/docs/ADAPTERS.md
@@ -167,8 +167,8 @@ that manifest.
 The Node adapter compresses responses by default, negotiated against the
 request's `Accept-Encoding` header (the acceptable coding with the highest
 q-value wins per RFC 9110, brotli preferred on ties and in unweighted lists
-like `gzip, deflate, br`; `*` wildcards and `q=0` exclusions honored, all via
-`node:zlib`):
+like `gzip, deflate, br`; an explicitly higher `identity` preference, `*`
+wildcards, and `q=0` exclusions are honored, all via `node:zlib`):
 
 - **Dynamic responses** — SSR/ISG documents, route-state JSON, API responses
   with compressible types — stream through a zlib transform (brotli quality 4)
@@ -201,7 +201,11 @@ Correctness guarantees:
 - Encoded variants get their own weak ETag (the encoding is folded into the
   tag, e.g. `W/"1a2f-18c-br"`), so `If-None-Match` revalidation can never
   answer an identity request with a cached brotli body or vice versa. The
+  adapter evaluates those derived validators for dynamic responses, and the
   `304` path keeps working per variant.
+- `HEAD` advertises the same negotiated `Content-Encoding` and variant ETag as
+  the corresponding `GET` while omitting the body (and compressed length when
+  it is not already known).
 
 **Behind a reverse proxy:** when nginx, Caddy, Cloudflare, or another
 CDN/proxy in front of the Node server already compresses responses, disable

--- a/docs/ADAPTERS.md
+++ b/docs/ADAPTERS.md
@@ -82,6 +82,7 @@ The adapter factory calls the entry module generator internally to create a virt
 | `trustProxy`    | `boolean`            | Honor forwarded headers for URL construction (default: `false`) |
 | `canonicalOrigin` | `string`           | Fixed public origin for `request.url`; ignores request Host values |
 | `maxBodySize`   | `number`             | Maximum request body size in bytes (default: 1 MiB)             |
+| `compression`   | `boolean`            | Brotli/gzip response compression via `Accept-Encoding` (default: `true`) |
 
 ### Trusted proxy configuration
 
@@ -158,6 +159,54 @@ that manifest.
   `<link>` tags into server-rendered HTML.
 - **Response headers**: preserves multiple `Set-Cookie` headers from framework
   responses by writing them as an array to Node's `ServerResponse`.
+- **Response compression**: brotli/gzip content negotiation on every response
+  path — see below.
+
+### Response compression
+
+The Node adapter compresses responses by default, negotiated against the
+request's `Accept-Encoding` header (brotli preferred, then gzip, honoring
+q-values and `*` wildcards, all via `node:zlib`):
+
+- **Dynamic responses** — SSR/ISG documents, route-state JSON, API responses
+  with compressible types — stream through a zlib transform (brotli quality 4),
+  so compression adds no buffering to the response path.
+- **Static assets and ISG snapshots** up to 1 MiB are compressed once per file
+  version at higher quality and kept in a byte-bounded in-memory LRU
+  (32 MiB) keyed by path + size + mtime, so hashed assets and regenerated ISG
+  HTML pay the compression cost once. Larger files stream through zlib per
+  request. This is runtime compression rather than build-time precompression;
+  it also covers ISG documents rewritten on disk after the build.
+
+What gets compressed: `text/*`, `application/json`, `application/javascript`,
+`application/xml`, `application/wasm`, and any `+json`/`+xml` structured
+syntax type (`image/svg+xml`, `application/manifest+json`, ...). Binary media
+(images, fonts, video) is never re-compressed.
+
+What is never touched: responses that already carry a `Content-Encoding`,
+`Cache-Control: no-transform` responses, 1xx/204/205/206/304 statuses, Range
+responses, and bodies under 1 KiB when the size is known.
+
+Correctness guarantees:
+
+- Compressible responses always carry `Vary: Accept-Encoding`, merged with any
+  existing `Vary` members (e.g. `x-pracht-route-state-request`), even when the
+  response goes out identity-encoded — so shared caches key on the encoding.
+- Encoded variants get their own weak ETag (the encoding is folded into the
+  tag, e.g. `W/"1a2f-18c-br"`), so `If-None-Match` revalidation can never
+  answer an identity request with a cached brotli body or vice versa. The
+  `304` path keeps working per variant.
+
+**Behind a reverse proxy:** when nginx, Caddy, Cloudflare, or another
+CDN/proxy in front of the Node server already compresses responses, disable
+the adapter's compression so the body is not compressed twice and the proxy
+can apply its own policy:
+
+```typescript
+nodeAdapter({ compression: false });
+// or for custom entries:
+createNodeRequestHandler({ app, registry, staticDir, compression: false });
+```
 
 ### WebSockets
 

--- a/docs/ADAPTERS.md
+++ b/docs/ADAPTERS.md
@@ -177,13 +177,16 @@ wildcards, and `q=0` exclusions are honored, all via `node:zlib`):
   of sitting in the compressor's buffer until the stream ends.
 - **Static assets and ISG snapshots** up to 1 MiB are compressed once per file
   version at higher quality and kept in a byte-bounded in-memory LRU
-  (32 MiB) keyed by path + size + mtime, so hashed assets and regenerated ISG
-  HTML pay the compression cost once — concurrent first requests to the same
-  file share a single in-flight compression. Whole-file cold work is bounded
-  by both bytes and concurrency; excess distinct files, and all larger files,
-  stream through zlib instead of queuing another buffered compression. This is
-  runtime compression rather than build-time precompression; it also covers
-  ISG documents rewritten on disk after the build.
+  (32 MiB) keyed by path + write generation + size + mtime, so hashed assets
+  and regenerated ISG HTML pay the compression cost once — concurrent first
+  requests to the same file share a single in-flight compression. Successful
+  ISG writes advance that generation explicitly, so even same-size rewrites on
+  coarse-timestamp filesystems cannot reuse stale compressed bytes. Whole-file
+  cold work is bounded by both bytes and concurrency; excess distinct files,
+  and all larger files, stream through zlib instead of queuing another buffered
+  compression. This is runtime compression rather than build-time
+  precompression; it also covers ISG documents rewritten on disk after the
+  build.
 
 What gets compressed: `text/*`, `application/json`, `application/javascript`,
 `application/xml`, `application/wasm`, and any `+json`/`+xml` structured

--- a/docs/ADAPTERS.md
+++ b/docs/ADAPTERS.md
@@ -179,10 +179,11 @@ wildcards, and `q=0` exclusions are honored, all via `node:zlib`):
   version at higher quality and kept in a byte-bounded in-memory LRU
   (32 MiB) keyed by path + size + mtime, so hashed assets and regenerated ISG
   HTML pay the compression cost once — concurrent first requests to the same
-  file share a single in-flight compression. Larger files stream through zlib
-  per request. This is runtime compression rather than build-time
-  precompression; it also covers ISG documents rewritten on disk after the
-  build.
+  file share a single in-flight compression. Whole-file cold work is bounded
+  by both bytes and concurrency; excess distinct files, and all larger files,
+  stream through zlib instead of queuing another buffered compression. This is
+  runtime compression rather than build-time precompression; it also covers
+  ISG documents rewritten on disk after the build.
 
 What gets compressed: `text/*`, `application/json`, `application/javascript`,
 `application/xml`, `application/wasm`, and any `+json`/`+xml` structured
@@ -208,10 +209,11 @@ Correctness guarantees:
   tag, e.g. `W/"1a2f-18c-br"`), so `If-None-Match` revalidation can never
   answer an identity request with a cached brotli body or vice versa. Strong
   application ETags are weakened because streaming compression bytes can vary
-  with chunk boundaries. The adapter evaluates dynamic `If-None-Match` only
-  after selecting the outgoing representation, including valid quoted opaque
-  tags that contain commas, so application-level identity validation cannot
-  short-circuit an encoded request with a cross-encoding `304`.
+  with chunk boundaries. The adapter evaluates dynamic `If-None-Match` and
+  `If-Modified-Since` only after selecting the outgoing representation
+  (`If-None-Match` takes precedence), including valid quoted opaque tags that
+  contain commas, so application-level identity validation cannot short-circuit
+  an encoded request with a cross-encoding `304`.
 - `HEAD` advertises the same negotiated `Content-Encoding` and variant ETag as
   the corresponding `GET` while omitting the body (and compressed length when
   it is not already known).

--- a/docs/ADAPTERS.md
+++ b/docs/ADAPTERS.md
@@ -230,12 +230,14 @@ Correctness guarantees:
   `If-None-Match` revalidation can never answer an identity request with a
   cached brotli body or vice versa. Strong
   application ETags are weakened because streaming compression bytes can vary
-  with chunk boundaries. For every successful dynamic response, the adapter
-  evaluates `If-None-Match` and `If-Modified-Since` only after selecting the
-  outgoing representation (`If-None-Match` takes precedence), including valid
-  quoted opaque tags that contain commas, so application-level identity
-  validation cannot short-circuit an encoded request with a cross-encoding
-  `304`. Requests carrying `Range` retain their original validators and remain
+  with chunk boundaries. For encoded dynamic requests, the adapter evaluates
+  `If-Match` with strong comparison, then `If-None-Match` and
+  `If-Modified-Since`, only after selecting the outgoing representation.
+  `If-Match` takes precedence over `If-Unmodified-Since`, and `If-None-Match`
+  takes precedence over `If-Modified-Since`. Valid quoted opaque tags can
+  contain commas. Application-level identity validation therefore cannot
+  short-circuit an encoded request with a cross-encoding `200` or `304`.
+  Requests carrying `Range` retain their original validators and remain
   identity-encoded even when the application ignores the range and returns a
   full `200`; `206` responses are likewise never transformed.
 - `HEAD` advertises the same negotiated `Content-Encoding`, variant ETag, and

--- a/docs/ADAPTERS.md
+++ b/docs/ADAPTERS.md
@@ -187,7 +187,9 @@ wildcards, and `q=0` exclusions are honored, all via `node:zlib`):
 What gets compressed: `text/*`, `application/json`, `application/javascript`,
 `application/xml`, `application/wasm`, and any `+json`/`+xml` structured
 syntax type (`image/svg+xml`, `application/manifest+json`, ...). Binary media
-(images, fonts, video) is never re-compressed.
+(images, fonts, video) is never re-compressed. Static `.wasm` assets are served
+as `application/wasm`, so they follow the same compression path as dynamic
+WebAssembly responses.
 
 What is never touched: responses that already carry a `Content-Encoding`,
 `Cache-Control: no-transform` responses, 1xx/204/205/206/304 statuses, Range
@@ -204,9 +206,12 @@ Correctness guarantees:
   response goes out identity-encoded — so shared caches key on the encoding.
 - Encoded variants get their own weak ETag (the encoding is folded into the
   tag, e.g. `W/"1a2f-18c-br"`), so `If-None-Match` revalidation can never
-  answer an identity request with a cached brotli body or vice versa. The
-  adapter evaluates those derived validators for dynamic responses, and the
-  `304` path keeps working per variant.
+  answer an identity request with a cached brotli body or vice versa. Strong
+  application ETags are weakened because streaming compression bytes can vary
+  with chunk boundaries. The adapter evaluates dynamic `If-None-Match` only
+  after selecting the outgoing representation, including valid quoted opaque
+  tags that contain commas, so application-level identity validation cannot
+  short-circuit an encoded request with a cross-encoding `304`.
 - `HEAD` advertises the same negotiated `Content-Encoding` and variant ETag as
   the corresponding `GET` while omitting the body (and compressed length when
   it is not already known).

--- a/e2e/node-build.test.ts
+++ b/e2e/node-build.test.ts
@@ -322,6 +322,34 @@ test("pracht build emits a deployable Node server entry", async () => {
 
     // HTML responses should have conservative cache headers
     expect(homeResponse.headers.get("cache-control")).toBe("public, max-age=0, must-revalidate");
+
+    // Responses are compressed by Accept-Encoding negotiation: brotli is
+    // preferred, the compressed variant varies on Accept-Encoding, and its
+    // ETag never collides with the identity variant's. (fetch decompresses
+    // transparently, so the body assertions stay readable.)
+    const compressedHome = await fetch(`http://127.0.0.1:${port}/`, {
+      headers: { "accept-encoding": "gzip, br" },
+    });
+    expect(compressedHome.status).toBe(200);
+    expect(compressedHome.headers.get("content-encoding")).toBe("br");
+    expect(compressedHome.headers.get("vary")).toContain("Accept-Encoding");
+    expect(compressedHome.headers.get("etag")).toContain("-br");
+    await expect(compressedHome.text()).resolves.toContain(
+      "Pracht starts with an explicit app manifest.",
+    );
+
+    const compressedAsset = await fetch(`http://127.0.0.1:${port}${assetMatch![1]}`, {
+      headers: { "accept-encoding": "gzip" },
+    });
+    expect(compressedAsset.status).toBe(200);
+    expect(compressedAsset.headers.get("content-encoding")).toBe("gzip");
+    expect(compressedAsset.headers.get("vary")).toContain("Accept-Encoding");
+
+    const compressedRouteState = await fetch(`http://127.0.0.1:${port}/pricing`, {
+      headers: { "accept-encoding": "br", "x-pracht-route-state-request": "1" },
+    });
+    expect(compressedRouteState.status).toBe(200);
+    expect(compressedRouteState.headers.get("content-encoding")).toBe("br");
   } finally {
     if (server) {
       server.kill("SIGTERM");

--- a/examples/docs/src/routes/docs/adapters.md
+++ b/examples/docs/src/routes/docs/adapters.md
@@ -482,8 +482,9 @@ compressible text types (`text/*`, JSON, JavaScript, SVG, and other
 `+json`/`+xml` types) stream through `node:zlib` with per-chunk flushing, so
 streamed bodies such as SSE are delivered incrementally; static assets and ISG
 snapshots are compressed once per file version and served from an in-memory
-LRU. Successful ISG writes use an atomic file replacement whose durable
-identity gives every sibling handler the same updated validator, while local
+LRU. Successful ISG writes use an atomic file replacement whose filesystem
+identity stays private to local cache keys; content-derived public validators
+remain stable across sibling handlers and deployment replicas, while local
 cache generations discard old compressed bytes. Each response reads through
 the same open file handle that supplied its size and validator, so a concurrent
 replacement cannot mix bytes with stale metadata or bypass the cold-work byte

--- a/examples/docs/src/routes/docs/adapters.md
+++ b/examples/docs/src/routes/docs/adapters.md
@@ -499,11 +499,13 @@ streaming compression. Static WebAssembly is served as `application/wasm`
 and follows that static compression path. Compressible responses carry
 `Vary: Accept-Encoding` (merged with existing `Vary` values), including on an
 application-generated `304`; encoded variants use their own collision-resistant
-weak ETag, and dynamic `If-None-Match` / `If-Modified-Since` validation runs
-after the adapter selects the representation so identity and encoded validators
-cannot cross. Range requests retain their original validators because their
-`206` responses are never transformed. `HEAD` advertises the same negotiated
-metadata as `GET`, including buffered compressed lengths.
+weak ETag, and dynamic `If-None-Match` / `If-Modified-Since` validation runs for
+every successful response after the adapter selects the representation so
+identity and encoded validators cannot cross. Requests carrying `Range` retain
+their original validators and remain identity-encoded even when the application
+returns a full `200`; `206` responses are likewise never transformed. `HEAD`
+advertises the same negotiated metadata as `GET`, including buffered compressed
+lengths.
 Already-encoded responses, `Cache-Control: no-transform`, Range/`204`/`304`
 responses, integrity-protected responses (`Content-Digest`, `Repr-Digest`,
 legacy `Digest`/`Content-MD5`), binary media, and bodies under 1 KiB when their

--- a/examples/docs/src/routes/docs/adapters.md
+++ b/examples/docs/src/routes/docs/adapters.md
@@ -482,11 +482,13 @@ compressible text types (`text/*`, JSON, JavaScript, SVG, and other
 `+json`/`+xml` types) stream through `node:zlib` with per-chunk flushing, so
 streamed bodies such as SSE are delivered incrementally; static assets and ISG
 snapshots are compressed once per file version and served from an in-memory
-LRU. Static WebAssembly is served as `application/wasm` and follows that static
-compression path. Compressible responses carry `Vary: Accept-Encoding` (merged
-with existing `Vary` values), encoded variants use their own weak ETag, and dynamic
-`If-None-Match` validation runs after the adapter selects the representation so
-identity and encoded validators cannot cross. `HEAD` advertises the same
+LRU. Buffered cold work is byte- and concurrency-bounded, with excess distinct
+files falling back to streaming compression. Static WebAssembly is served as
+`application/wasm` and follows that static compression path. Compressible
+responses carry `Vary: Accept-Encoding` (merged with existing `Vary` values),
+encoded variants use their own weak ETag, and dynamic `If-None-Match` /
+`If-Modified-Since` validation runs after the adapter selects the representation
+so identity and encoded validators cannot cross. `HEAD` advertises the same
 negotiated metadata as `GET`.
 Already-encoded responses, `Cache-Control: no-transform`, Range/`204`/`304`
 responses, integrity-protected responses (`Content-Digest`, `Repr-Digest`,

--- a/examples/docs/src/routes/docs/adapters.md
+++ b/examples/docs/src/routes/docs/adapters.md
@@ -473,6 +473,26 @@ trusted reverse proxy that overwrites `Forwarded` or `X-Forwarded-*` headers.
 Never enable it on a directly reachable server; `canonicalOrigin` is safer
 when the public origin is fixed.
 
+### Response compression
+
+Responses are compressed by default via `Accept-Encoding` negotiation —
+brotli preferred, then gzip. Dynamic documents, route-state JSON, and other
+compressible text types (`text/*`, JSON, JavaScript, SVG, and other
+`+json`/`+xml` types) stream through `node:zlib`; static assets and ISG
+snapshots are compressed once per file version and served from an in-memory
+LRU. Compressible responses carry `Vary: Accept-Encoding` (merged with
+existing `Vary` values) and encoded variants use their own ETag, so
+conditional revalidation never crosses encodings. Already-encoded responses,
+`Cache-Control: no-transform`, Range/`204`/`304` responses, binary media, and
+bodies under 1 KiB are never compressed.
+
+When a reverse proxy or CDN in front of the server already compresses
+responses, disable the adapter's compression and let the proxy own it:
+
+```ts [vite.config.ts]
+nodeAdapter({ compression: false });
+```
+
 ### Deploy
 
 ```sh

--- a/examples/docs/src/routes/docs/adapters.md
+++ b/examples/docs/src/routes/docs/adapters.md
@@ -492,8 +492,10 @@ budget. This covers same-size rewrites on coarse-timestamp filesystems and
 revalidation after a handler restart or in a sibling worker. Date-only
 validation is conservatively bypassed for mutable ISG snapshots while
 compression is enabled. Buffered cold work is byte- and concurrency-bounded,
-with excess distinct files falling back to streaming compression. Static
-WebAssembly is served as `application/wasm`
+including content-derived validator hashing; same-snapshot requests share one
+hash, and an overloaded response safely omits its ETag instead of queuing an
+unbounded whole-file read. Excess distinct compression jobs fall back to
+streaming compression. Static WebAssembly is served as `application/wasm`
 and follows that static compression path. Compressible responses carry
 `Vary: Accept-Encoding` (merged with existing `Vary` values), including on an
 application-generated `304`; encoded variants use their own collision-resistant

--- a/examples/docs/src/routes/docs/adapters.md
+++ b/examples/docs/src/routes/docs/adapters.md
@@ -486,7 +486,10 @@ LRU. Compressible responses carry `Vary: Accept-Encoding` (merged with existing
 `Vary` values), encoded variants use their own ETag with adapter-level dynamic
 revalidation, and `HEAD` advertises the same negotiated metadata as `GET`.
 Already-encoded responses, `Cache-Control: no-transform`, Range/`204`/`304`
-responses, binary media, and bodies under 1 KiB are never compressed.
+responses, integrity-protected responses (`Content-Digest`, `Repr-Digest`,
+legacy `Digest`/`Content-MD5`), binary media, and bodies under 1 KiB are never
+compressed. If a dynamic body fails before sending bytes, the fallback 500 is
+sent without the abandoned response's compression metadata.
 
 When a reverse proxy or CDN in front of the server already compresses
 responses, disable the adapter's compression and let the proxy own it:

--- a/examples/docs/src/routes/docs/adapters.md
+++ b/examples/docs/src/routes/docs/adapters.md
@@ -482,17 +482,21 @@ compressible text types (`text/*`, JSON, JavaScript, SVG, and other
 `+json`/`+xml` types) stream through `node:zlib` with per-chunk flushing, so
 streamed bodies such as SSE are delivered incrementally; static assets and ISG
 snapshots are compressed once per file version and served from an in-memory
-LRU. Successful ISG writes explicitly invalidate the old compressed version
-and validator, including same-size rewrites on coarse-timestamp filesystems;
-date-only validation is bypassed when the timestamp cannot distinguish those
-generations. Buffered cold work is byte- and concurrency-bounded, with excess
-distinct files falling back to streaming compression. Static WebAssembly is served as `application/wasm`
-and follows that static compression path. Compressible
-responses carry `Vary: Accept-Encoding` (merged with existing `Vary` values),
-encoded variants use their own collision-resistant weak ETag, and dynamic `If-None-Match` /
-`If-Modified-Since` validation runs after the adapter selects the representation
-so identity and encoded validators cannot cross. `HEAD` advertises the same
-negotiated metadata as `GET`, including buffered compressed lengths.
+LRU. Successful ISG writes use an atomic file replacement and explicitly
+invalidate the old compressed version and validator, including same-size
+rewrites on coarse-timestamp filesystems and revalidation after a handler
+restart or in a sibling worker. Date-only validation is conservatively
+bypassed for mutable ISG snapshots while compression is enabled. Buffered cold
+work is byte- and concurrency-bounded, with excess distinct files falling back
+to streaming compression. Static WebAssembly is served as `application/wasm`
+and follows that static compression path. Compressible responses carry
+`Vary: Accept-Encoding` (merged with existing `Vary` values), including on an
+application-generated `304`; encoded variants use their own collision-resistant
+weak ETag, and dynamic `If-None-Match` / `If-Modified-Since` validation runs
+after the adapter selects the representation so identity and encoded validators
+cannot cross. Range requests retain their original validators because their
+`206` responses are never transformed. `HEAD` advertises the same negotiated
+metadata as `GET`, including buffered compressed lengths.
 Already-encoded responses, `Cache-Control: no-transform`, Range/`204`/`304`
 responses, integrity-protected responses (`Content-Digest`, `Repr-Digest`,
 legacy `Digest`/`Content-MD5`), binary media, and bodies under 1 KiB when their

--- a/examples/docs/src/routes/docs/adapters.md
+++ b/examples/docs/src/routes/docs/adapters.md
@@ -489,7 +489,7 @@ generations. Buffered cold work is byte- and concurrency-bounded, with excess
 distinct files falling back to streaming compression. Static WebAssembly is served as `application/wasm`
 and follows that static compression path. Compressible
 responses carry `Vary: Accept-Encoding` (merged with existing `Vary` values),
-encoded variants use their own weak ETag, and dynamic `If-None-Match` /
+encoded variants use their own collision-resistant weak ETag, and dynamic `If-None-Match` /
 `If-Modified-Since` validation runs after the adapter selects the representation
 so identity and encoded validators cannot cross. `HEAD` advertises the same
 negotiated metadata as `GET`, including buffered compressed lengths.

--- a/examples/docs/src/routes/docs/adapters.md
+++ b/examples/docs/src/routes/docs/adapters.md
@@ -482,13 +482,17 @@ compressible text types (`text/*`, JSON, JavaScript, SVG, and other
 `+json`/`+xml` types) stream through `node:zlib` with per-chunk flushing, so
 streamed bodies such as SSE are delivered incrementally; static assets and ISG
 snapshots are compressed once per file version and served from an in-memory
-LRU. Successful ISG writes use an atomic file replacement and explicitly
-invalidate the old compressed version and validator, including same-size
-rewrites on coarse-timestamp filesystems and revalidation after a handler
-restart or in a sibling worker. Date-only validation is conservatively
-bypassed for mutable ISG snapshots while compression is enabled. Buffered cold
-work is byte- and concurrency-bounded, with excess distinct files falling back
-to streaming compression. Static WebAssembly is served as `application/wasm`
+LRU. Successful ISG writes use an atomic file replacement whose durable
+identity gives every sibling handler the same updated validator, while local
+cache generations discard old compressed bytes. Each response reads through
+the same open file handle that supplied its size and validator, so a concurrent
+replacement cannot mix bytes with stale metadata or bypass the cold-work byte
+budget. This covers same-size rewrites on coarse-timestamp filesystems and
+revalidation after a handler restart or in a sibling worker. Date-only
+validation is conservatively bypassed for mutable ISG snapshots while
+compression is enabled. Buffered cold work is byte- and concurrency-bounded,
+with excess distinct files falling back to streaming compression. Static
+WebAssembly is served as `application/wasm`
 and follows that static compression path. Compressible responses carry
 `Vary: Accept-Encoding` (merged with existing `Vary` values), including on an
 application-generated `304`; encoded variants use their own collision-resistant

--- a/examples/docs/src/routes/docs/adapters.md
+++ b/examples/docs/src/routes/docs/adapters.md
@@ -482,9 +482,11 @@ compressible text types (`text/*`, JSON, JavaScript, SVG, and other
 `+json`/`+xml` types) stream through `node:zlib` with per-chunk flushing, so
 streamed bodies such as SSE are delivered incrementally; static assets and ISG
 snapshots are compressed once per file version and served from an in-memory
-LRU. Buffered cold work is byte- and concurrency-bounded, with excess distinct
-files falling back to streaming compression. Static WebAssembly is served as
-`application/wasm` and follows that static compression path. Compressible
+LRU. Successful ISG writes explicitly invalidate the old compressed version,
+including same-size rewrites on coarse-timestamp filesystems. Buffered cold
+work is byte- and concurrency-bounded, with excess distinct files falling back
+to streaming compression. Static WebAssembly is served as `application/wasm`
+and follows that static compression path. Compressible
 responses carry `Vary: Accept-Encoding` (merged with existing `Vary` values),
 encoded variants use their own weak ETag, and dynamic `If-None-Match` /
 `If-Modified-Since` validation runs after the adapter selects the representation
@@ -492,9 +494,10 @@ so identity and encoded validators cannot cross. `HEAD` advertises the same
 negotiated metadata as `GET`.
 Already-encoded responses, `Cache-Control: no-transform`, Range/`204`/`304`
 responses, integrity-protected responses (`Content-Digest`, `Repr-Digest`,
-legacy `Digest`/`Content-MD5`), binary media, and bodies under 1 KiB are never
-compressed. If a dynamic body fails before sending bytes, the fallback 500 is
-sent without the abandoned response's compression metadata.
+legacy `Digest`/`Content-MD5`), binary media, and bodies under 1 KiB when their
+size is known are never compressed. If a dynamic body fails before sending
+bytes, the fallback 500 is sent without the abandoned response's compression
+metadata.
 
 When a reverse proxy or CDN in front of the server already compresses
 responses, disable the adapter's compression and let the proxy own it:

--- a/examples/docs/src/routes/docs/adapters.md
+++ b/examples/docs/src/routes/docs/adapters.md
@@ -482,9 +482,12 @@ compressible text types (`text/*`, JSON, JavaScript, SVG, and other
 `+json`/`+xml` types) stream through `node:zlib` with per-chunk flushing, so
 streamed bodies such as SSE are delivered incrementally; static assets and ISG
 snapshots are compressed once per file version and served from an in-memory
-LRU. Compressible responses carry `Vary: Accept-Encoding` (merged with existing
-`Vary` values), encoded variants use their own ETag with adapter-level dynamic
-revalidation, and `HEAD` advertises the same negotiated metadata as `GET`.
+LRU. Static WebAssembly is served as `application/wasm` and follows that static
+compression path. Compressible responses carry `Vary: Accept-Encoding` (merged
+with existing `Vary` values), encoded variants use their own weak ETag, and dynamic
+`If-None-Match` validation runs after the adapter selects the representation so
+identity and encoded validators cannot cross. `HEAD` advertises the same
+negotiated metadata as `GET`.
 Already-encoded responses, `Cache-Control: no-transform`, Range/`204`/`304`
 responses, integrity-protected responses (`Content-Digest`, `Repr-Digest`,
 legacy `Digest`/`Content-MD5`), binary media, and bodies under 1 KiB are never

--- a/examples/docs/src/routes/docs/adapters.md
+++ b/examples/docs/src/routes/docs/adapters.md
@@ -476,16 +476,17 @@ when the public origin is fixed.
 ### Response compression
 
 Responses are compressed by default via `Accept-Encoding` negotiation — the
-highest q-value wins, brotli preferred on ties. Dynamic documents, route-state
-JSON, and other compressible text types (`text/*`, JSON, JavaScript, SVG, and
-other `+json`/`+xml` types) stream through `node:zlib` with per-chunk
-flushing, so streamed bodies such as SSE are delivered incrementally; static
-assets and ISG snapshots are compressed once per file version and served from
-an in-memory LRU. Compressible responses carry `Vary: Accept-Encoding` (merged with
-existing `Vary` values) and encoded variants use their own ETag, so
-conditional revalidation never crosses encodings. Already-encoded responses,
-`Cache-Control: no-transform`, Range/`204`/`304` responses, binary media, and
-bodies under 1 KiB are never compressed.
+highest q-value wins (including an explicitly higher `identity` preference),
+with brotli preferred on ties. Dynamic documents, route-state JSON, and other
+compressible text types (`text/*`, JSON, JavaScript, SVG, and other
+`+json`/`+xml` types) stream through `node:zlib` with per-chunk flushing, so
+streamed bodies such as SSE are delivered incrementally; static assets and ISG
+snapshots are compressed once per file version and served from an in-memory
+LRU. Compressible responses carry `Vary: Accept-Encoding` (merged with existing
+`Vary` values), encoded variants use their own ETag with adapter-level dynamic
+revalidation, and `HEAD` advertises the same negotiated metadata as `GET`.
+Already-encoded responses, `Cache-Control: no-transform`, Range/`204`/`304`
+responses, binary media, and bodies under 1 KiB are never compressed.
 
 When a reverse proxy or CDN in front of the server already compresses
 responses, disable the adapter's compression and let the proxy own it:

--- a/examples/docs/src/routes/docs/adapters.md
+++ b/examples/docs/src/routes/docs/adapters.md
@@ -499,9 +499,11 @@ streaming compression. Static WebAssembly is served as `application/wasm`
 and follows that static compression path. Compressible responses carry
 `Vary: Accept-Encoding` (merged with existing `Vary` values), including on an
 application-generated `304`; encoded variants use their own collision-resistant
-weak ETag, and dynamic `If-None-Match` / `If-Modified-Since` validation runs for
-every successful response after the adapter selects the representation so
-identity and encoded validators cannot cross. Requests carrying `Range` retain
+weak ETag, and encoded dynamic requests run `If-Match` / `If-None-Match` /
+`If-Modified-Since` validation after the adapter selects the representation so
+identity and encoded validators cannot cross. `If-Match`
+uses strong comparison and preserves its precedence over
+`If-Unmodified-Since`. Requests carrying `Range` retain
 their original validators and remain identity-encoded even when the application
 returns a full `200`; `206` responses are likewise never transformed. `HEAD`
 advertises the same negotiated metadata as `GET`, including buffered compressed

--- a/examples/docs/src/routes/docs/adapters.md
+++ b/examples/docs/src/routes/docs/adapters.md
@@ -482,16 +482,17 @@ compressible text types (`text/*`, JSON, JavaScript, SVG, and other
 `+json`/`+xml` types) stream through `node:zlib` with per-chunk flushing, so
 streamed bodies such as SSE are delivered incrementally; static assets and ISG
 snapshots are compressed once per file version and served from an in-memory
-LRU. Successful ISG writes explicitly invalidate the old compressed version,
-including same-size rewrites on coarse-timestamp filesystems. Buffered cold
-work is byte- and concurrency-bounded, with excess distinct files falling back
-to streaming compression. Static WebAssembly is served as `application/wasm`
+LRU. Successful ISG writes explicitly invalidate the old compressed version
+and validator, including same-size rewrites on coarse-timestamp filesystems;
+date-only validation is bypassed when the timestamp cannot distinguish those
+generations. Buffered cold work is byte- and concurrency-bounded, with excess
+distinct files falling back to streaming compression. Static WebAssembly is served as `application/wasm`
 and follows that static compression path. Compressible
 responses carry `Vary: Accept-Encoding` (merged with existing `Vary` values),
 encoded variants use their own weak ETag, and dynamic `If-None-Match` /
 `If-Modified-Since` validation runs after the adapter selects the representation
 so identity and encoded validators cannot cross. `HEAD` advertises the same
-negotiated metadata as `GET`.
+negotiated metadata as `GET`, including buffered compressed lengths.
 Already-encoded responses, `Cache-Control: no-transform`, Range/`204`/`304`
 responses, integrity-protected responses (`Content-Digest`, `Repr-Digest`,
 legacy `Digest`/`Content-MD5`), binary media, and bodies under 1 KiB when their

--- a/examples/docs/src/routes/docs/adapters.md
+++ b/examples/docs/src/routes/docs/adapters.md
@@ -475,12 +475,13 @@ when the public origin is fixed.
 
 ### Response compression
 
-Responses are compressed by default via `Accept-Encoding` negotiation —
-brotli preferred, then gzip. Dynamic documents, route-state JSON, and other
-compressible text types (`text/*`, JSON, JavaScript, SVG, and other
-`+json`/`+xml` types) stream through `node:zlib`; static assets and ISG
-snapshots are compressed once per file version and served from an in-memory
-LRU. Compressible responses carry `Vary: Accept-Encoding` (merged with
+Responses are compressed by default via `Accept-Encoding` negotiation — the
+highest q-value wins, brotli preferred on ties. Dynamic documents, route-state
+JSON, and other compressible text types (`text/*`, JSON, JavaScript, SVG, and
+other `+json`/`+xml` types) stream through `node:zlib` with per-chunk
+flushing, so streamed bodies such as SSE are delivered incrementally; static
+assets and ISG snapshots are compressed once per file version and served from
+an in-memory LRU. Compressible responses carry `Vary: Accept-Encoding` (merged with
 existing `Vary` values) and encoded variants use their own ETag, so
 conditional revalidation never crosses encodings. Already-encoded responses,
 `Cache-Control: no-transform`, Range/`204`/`304` responses, binary media, and

--- a/examples/docs/src/routes/docs/deployment.md
+++ b/examples/docs/src/routes/docs/deployment.md
@@ -40,14 +40,16 @@ Responses are compressed by default: the adapter negotiates `Accept-Encoding`
 with brotli preferred on ties) and streams dynamic HTML, route-state JSON, and
 other compressible text types through `node:zlib`, while static assets and ISG
 snapshots are compressed once per file version and served from an in-memory
-LRU; successful ISG writes explicitly invalidate the old compressed version.
-Buffered cold work is byte- and concurrency-bounded, with overflow falling
+LRU; successful ISG writes explicitly invalidate the old compressed version
+and validator, even when coarse filesystem timestamps do not change. Buffered
+cold work is byte- and concurrency-bounded, with overflow falling
 back to streaming compression. Static WebAssembly is served as
 `application/wasm` and follows the same compression path. Compressible
 responses carry `Vary: Accept-Encoding`; encoded variants get their own weak
 ETag, with dynamic `If-None-Match` / `If-Modified-Since` validation performed
 after representation selection so identity and encoded validators cannot
-cross. `HEAD` advertises the same negotiated metadata as `GET`, and
+cross. `HEAD` advertises the same negotiated metadata as `GET`, including
+buffered compressed lengths, and
 already-encoded, `no-transform`, Range, integrity-protected (`Content-Digest`,
 `Repr-Digest`, legacy
 `Digest`/`Content-MD5`), and sub-1 KiB responses whose size is known are left

--- a/examples/docs/src/routes/docs/deployment.md
+++ b/examples/docs/src/routes/docs/deployment.md
@@ -36,7 +36,7 @@ to `createNodeRequestHandler()` only when a trusted reverse proxy overwrites
 forwarded headers.
 
 Responses are compressed by default: the adapter negotiates `Accept-Encoding`
-(brotli preferred, then gzip) and streams dynamic HTML, route-state JSON, and
+(highest q-value wins, brotli preferred on ties) and streams dynamic HTML, route-state JSON, and
 other compressible text types through `node:zlib`, while static assets and ISG
 snapshots are compressed once per file version and served from an in-memory
 LRU. Compressible responses carry `Vary: Accept-Encoding`, encoded variants

--- a/examples/docs/src/routes/docs/deployment.md
+++ b/examples/docs/src/routes/docs/deployment.md
@@ -36,13 +36,15 @@ to `createNodeRequestHandler()` only when a trusted reverse proxy overwrites
 forwarded headers.
 
 Responses are compressed by default: the adapter negotiates `Accept-Encoding`
-(highest q-value wins, brotli preferred on ties) and streams dynamic HTML, route-state JSON, and
+(highest q-value wins, including an explicitly higher `identity` preference,
+with brotli preferred on ties) and streams dynamic HTML, route-state JSON, and
 other compressible text types through `node:zlib`, while static assets and ISG
 snapshots are compressed once per file version and served from an in-memory
 LRU. Compressible responses carry `Vary: Accept-Encoding`, encoded variants
-get their own ETag, and already-encoded, `no-transform`, Range, and sub-1 KiB
-responses are left alone. If a reverse proxy or CDN in front of the server
-already compresses responses, turn it off:
+get their own ETag with dynamic conditional revalidation, `HEAD` advertises the
+same negotiated metadata as `GET`, and already-encoded, `no-transform`, Range,
+and sub-1 KiB responses are left alone. If a reverse proxy or CDN in front of
+the server already compresses responses, turn it off:
 
 ```ts [vite.config.ts]
 nodeAdapter({ compression: false });

--- a/examples/docs/src/routes/docs/deployment.md
+++ b/examples/docs/src/routes/docs/deployment.md
@@ -40,10 +40,13 @@ Responses are compressed by default: the adapter negotiates `Accept-Encoding`
 with brotli preferred on ties) and streams dynamic HTML, route-state JSON, and
 other compressible text types through `node:zlib`, while static assets and ISG
 snapshots are compressed once per file version and served from an in-memory
-LRU. Compressible responses carry `Vary: Accept-Encoding`, encoded variants
-get their own ETag with dynamic conditional revalidation, `HEAD` advertises the
-same negotiated metadata as `GET`, and already-encoded, `no-transform`, Range,
-integrity-protected (`Content-Digest`, `Repr-Digest`, legacy
+LRU. Static WebAssembly is served as `application/wasm` and follows the same
+compression path. Compressible responses carry `Vary: Accept-Encoding`;
+encoded variants get their own weak ETag, with dynamic conditional validation
+performed after representation selection so identity and encoded validators
+cannot cross. `HEAD` advertises the same negotiated metadata as `GET`, and
+already-encoded, `no-transform`, Range, integrity-protected (`Content-Digest`,
+`Repr-Digest`, legacy
 `Digest`/`Content-MD5`), and sub-1 KiB responses are left alone. If a reverse
 proxy or CDN in front of the server already compresses responses, turn it off:
 

--- a/examples/docs/src/routes/docs/deployment.md
+++ b/examples/docs/src/routes/docs/deployment.md
@@ -40,8 +40,9 @@ Responses are compressed by default: the adapter negotiates `Accept-Encoding`
 with brotli preferred on ties) and streams dynamic HTML, route-state JSON, and
 other compressible text types through `node:zlib`, while static assets and ISG
 snapshots are compressed once per file version and served from an in-memory
-LRU; buffered cold work is byte- and concurrency-bounded, with overflow
-falling back to streaming compression. Static WebAssembly is served as
+LRU; successful ISG writes explicitly invalidate the old compressed version.
+Buffered cold work is byte- and concurrency-bounded, with overflow falling
+back to streaming compression. Static WebAssembly is served as
 `application/wasm` and follows the same compression path. Compressible
 responses carry `Vary: Accept-Encoding`; encoded variants get their own weak
 ETag, with dynamic `If-None-Match` / `If-Modified-Since` validation performed
@@ -49,8 +50,9 @@ after representation selection so identity and encoded validators cannot
 cross. `HEAD` advertises the same negotiated metadata as `GET`, and
 already-encoded, `no-transform`, Range, integrity-protected (`Content-Digest`,
 `Repr-Digest`, legacy
-`Digest`/`Content-MD5`), and sub-1 KiB responses are left alone. If a reverse
-proxy or CDN in front of the server already compresses responses, turn it off:
+`Digest`/`Content-MD5`), and sub-1 KiB responses whose size is known are left
+alone. If a reverse proxy or CDN in front of the server already compresses
+responses, turn it off:
 
 ```ts [vite.config.ts]
 nodeAdapter({ compression: false });

--- a/examples/docs/src/routes/docs/deployment.md
+++ b/examples/docs/src/routes/docs/deployment.md
@@ -40,13 +40,16 @@ Responses are compressed by default: the adapter negotiates `Accept-Encoding`
 with brotli preferred on ties) and streams dynamic HTML, route-state JSON, and
 other compressible text types through `node:zlib`, while static assets and ISG
 snapshots are compressed once per file version and served from an in-memory
-LRU; successful ISG writes use an atomic file replacement and explicitly
-invalidate the old compressed version and validator, even when coarse
-filesystem timestamps do not change and a request reaches a restarted or
-sibling worker. Date-only validation is conservatively bypassed for mutable
-ISG snapshots while compression is enabled. Buffered cold work is byte- and
-concurrency-bounded, with overflow falling back to streaming compression.
-Static WebAssembly is served as
+LRU; successful ISG writes use an atomic file replacement whose durable
+identity gives sibling handlers one shared updated validator, while local cache
+generations discard old compressed bytes. Response reads stay bound to the
+same open file version that supplied their size and validator, so concurrent
+replacement cannot mix bytes with stale metadata or bypass the cold-work byte
+budget. This remains correct when coarse filesystem timestamps do not change
+and a request reaches a restarted or sibling worker. Date-only validation is
+conservatively bypassed for mutable ISG snapshots while compression is enabled.
+Buffered cold work is byte- and concurrency-bounded, with overflow falling back
+to streaming compression. Static WebAssembly is served as
 `application/wasm` and follows the same compression path. Compressible
 responses carry `Vary: Accept-Encoding`, including on application-generated
 `304` responses; encoded variants get their own collision-resistant weak ETag,

--- a/examples/docs/src/routes/docs/deployment.md
+++ b/examples/docs/src/routes/docs/deployment.md
@@ -57,11 +57,12 @@ served as `application/wasm` and follows the same compression path.
 Compressible responses carry `Vary: Accept-Encoding`, including on
 application-generated `304` responses; encoded variants get their own
 collision-resistant weak ETag,
-with dynamic `If-None-Match` / `If-Modified-Since` validation performed after
-representation selection so identity and encoded validators cannot cross.
-Range requests retain their original validators because `206` responses are
-never transformed. `HEAD` advertises the same negotiated metadata as `GET`,
-including buffered compressed lengths, and
+with dynamic `If-None-Match` / `If-Modified-Since` validation performed for
+every successful response after representation selection so identity and encoded
+validators cannot cross. Requests carrying `Range` retain their original
+validators and remain identity-encoded even when the application returns a full
+`200`; `206` responses are likewise never transformed. `HEAD` advertises the
+same negotiated metadata as `GET`, including buffered compressed lengths, and
 already-encoded, `no-transform`, Range, integrity-protected (`Content-Digest`,
 `Repr-Digest`, legacy
 `Digest`/`Content-MD5`), and sub-1 KiB responses whose size is known are left

--- a/examples/docs/src/routes/docs/deployment.md
+++ b/examples/docs/src/routes/docs/deployment.md
@@ -40,9 +40,10 @@ Responses are compressed by default: the adapter negotiates `Accept-Encoding`
 with brotli preferred on ties) and streams dynamic HTML, route-state JSON, and
 other compressible text types through `node:zlib`, while static assets and ISG
 snapshots are compressed once per file version and served from an in-memory
-LRU; successful ISG writes use an atomic file replacement whose durable
-identity gives sibling handlers one shared updated validator, while local cache
-generations discard old compressed bytes. Response reads stay bound to the
+LRU; successful ISG writes use an atomic file replacement whose filesystem
+identity stays private to local cache keys, while content-derived public
+validators remain stable across sibling handlers and deployment replicas and
+local cache generations discard old compressed bytes. Response reads stay bound to the
 same open file version that supplied their size and validator, so concurrent
 replacement cannot mix bytes with stale metadata or bypass the cold-work byte
 budget. This remains correct when coarse filesystem timestamps do not change

--- a/examples/docs/src/routes/docs/deployment.md
+++ b/examples/docs/src/routes/docs/deployment.md
@@ -49,11 +49,14 @@ replacement cannot mix bytes with stale metadata or bypass the cold-work byte
 budget. This remains correct when coarse filesystem timestamps do not change
 and a request reaches a restarted or sibling worker. Date-only validation is
 conservatively bypassed for mutable ISG snapshots while compression is enabled.
-Buffered cold work is byte- and concurrency-bounded, with overflow falling back
-to streaming compression. Static WebAssembly is served as
-`application/wasm` and follows the same compression path. Compressible
-responses carry `Vary: Accept-Encoding`, including on application-generated
-`304` responses; encoded variants get their own collision-resistant weak ETag,
+Buffered cold work is byte- and concurrency-bounded, including content-derived
+validator hashing; same-snapshot requests share one hash, and an overloaded
+response omits its ETag rather than queuing an unbounded whole-file read.
+Overflowed compression jobs fall back to streaming. Static WebAssembly is
+served as `application/wasm` and follows the same compression path.
+Compressible responses carry `Vary: Accept-Encoding`, including on
+application-generated `304` responses; encoded variants get their own
+collision-resistant weak ETag,
 with dynamic `If-None-Match` / `If-Modified-Since` validation performed after
 representation selection so identity and encoded validators cannot cross.
 Range requests retain their original validators because `206` responses are

--- a/examples/docs/src/routes/docs/deployment.md
+++ b/examples/docs/src/routes/docs/deployment.md
@@ -40,17 +40,21 @@ Responses are compressed by default: the adapter negotiates `Accept-Encoding`
 with brotli preferred on ties) and streams dynamic HTML, route-state JSON, and
 other compressible text types through `node:zlib`, while static assets and ISG
 snapshots are compressed once per file version and served from an in-memory
-LRU; successful ISG writes explicitly invalidate the old compressed version
-and validator, even when coarse filesystem timestamps do not change. Buffered
-cold work is byte- and concurrency-bounded, with overflow falling
-back to streaming compression. Static WebAssembly is served as
+LRU; successful ISG writes use an atomic file replacement and explicitly
+invalidate the old compressed version and validator, even when coarse
+filesystem timestamps do not change and a request reaches a restarted or
+sibling worker. Date-only validation is conservatively bypassed for mutable
+ISG snapshots while compression is enabled. Buffered cold work is byte- and
+concurrency-bounded, with overflow falling back to streaming compression.
+Static WebAssembly is served as
 `application/wasm` and follows the same compression path. Compressible
-responses carry `Vary: Accept-Encoding`; encoded variants get their own
-collision-resistant weak ETag, with dynamic `If-None-Match` /
-`If-Modified-Since` validation performed
-after representation selection so identity and encoded validators cannot
-cross. `HEAD` advertises the same negotiated metadata as `GET`, including
-buffered compressed lengths, and
+responses carry `Vary: Accept-Encoding`, including on application-generated
+`304` responses; encoded variants get their own collision-resistant weak ETag,
+with dynamic `If-None-Match` / `If-Modified-Since` validation performed after
+representation selection so identity and encoded validators cannot cross.
+Range requests retain their original validators because `206` responses are
+never transformed. `HEAD` advertises the same negotiated metadata as `GET`,
+including buffered compressed lengths, and
 already-encoded, `no-transform`, Range, integrity-protected (`Content-Digest`,
 `Repr-Digest`, legacy
 `Digest`/`Content-MD5`), and sub-1 KiB responses whose size is known are left

--- a/examples/docs/src/routes/docs/deployment.md
+++ b/examples/docs/src/routes/docs/deployment.md
@@ -56,10 +56,11 @@ Overflowed compression jobs fall back to streaming. Static WebAssembly is
 served as `application/wasm` and follows the same compression path.
 Compressible responses carry `Vary: Accept-Encoding`, including on
 application-generated `304` responses; encoded variants get their own
-collision-resistant weak ETag,
-with dynamic `If-None-Match` / `If-Modified-Since` validation performed for
-every successful response after representation selection so identity and encoded
-validators cannot cross. Requests carrying `Range` retain their original
+collision-resistant weak ETag, with encoded dynamic requests performing
+`If-Match` / `If-None-Match` / `If-Modified-Since` validation after
+representation selection so identity and encoded validators cannot cross.
+`If-Match` uses strong comparison and preserves its precedence over
+`If-Unmodified-Since`. Requests carrying `Range` retain their original
 validators and remain identity-encoded even when the application returns a full
 `200`; `206` responses are likewise never transformed. `HEAD` advertises the
 same negotiated metadata as `GET`, including buffered compressed lengths, and

--- a/examples/docs/src/routes/docs/deployment.md
+++ b/examples/docs/src/routes/docs/deployment.md
@@ -35,6 +35,19 @@ adapter also accepts `maxBodySize`; custom entries can pass `trustProxy: true`
 to `createNodeRequestHandler()` only when a trusted reverse proxy overwrites
 forwarded headers.
 
+Responses are compressed by default: the adapter negotiates `Accept-Encoding`
+(brotli preferred, then gzip) and streams dynamic HTML, route-state JSON, and
+other compressible text types through `node:zlib`, while static assets and ISG
+snapshots are compressed once per file version and served from an in-memory
+LRU. Compressible responses carry `Vary: Accept-Encoding`, encoded variants
+get their own ETag, and already-encoded, `no-transform`, Range, and sub-1 KiB
+responses are left alone. If a reverse proxy or CDN in front of the server
+already compresses responses, turn it off:
+
+```ts [vite.config.ts]
+nodeAdapter({ compression: false });
+```
+
 ```sh
 # Build and run
 pracht build

--- a/examples/docs/src/routes/docs/deployment.md
+++ b/examples/docs/src/routes/docs/deployment.md
@@ -43,8 +43,9 @@ snapshots are compressed once per file version and served from an in-memory
 LRU. Compressible responses carry `Vary: Accept-Encoding`, encoded variants
 get their own ETag with dynamic conditional revalidation, `HEAD` advertises the
 same negotiated metadata as `GET`, and already-encoded, `no-transform`, Range,
-and sub-1 KiB responses are left alone. If a reverse proxy or CDN in front of
-the server already compresses responses, turn it off:
+integrity-protected (`Content-Digest`, `Repr-Digest`, legacy
+`Digest`/`Content-MD5`), and sub-1 KiB responses are left alone. If a reverse
+proxy or CDN in front of the server already compresses responses, turn it off:
 
 ```ts [vite.config.ts]
 nodeAdapter({ compression: false });

--- a/examples/docs/src/routes/docs/deployment.md
+++ b/examples/docs/src/routes/docs/deployment.md
@@ -40,11 +40,13 @@ Responses are compressed by default: the adapter negotiates `Accept-Encoding`
 with brotli preferred on ties) and streams dynamic HTML, route-state JSON, and
 other compressible text types through `node:zlib`, while static assets and ISG
 snapshots are compressed once per file version and served from an in-memory
-LRU. Static WebAssembly is served as `application/wasm` and follows the same
-compression path. Compressible responses carry `Vary: Accept-Encoding`;
-encoded variants get their own weak ETag, with dynamic conditional validation
-performed after representation selection so identity and encoded validators
-cannot cross. `HEAD` advertises the same negotiated metadata as `GET`, and
+LRU; buffered cold work is byte- and concurrency-bounded, with overflow
+falling back to streaming compression. Static WebAssembly is served as
+`application/wasm` and follows the same compression path. Compressible
+responses carry `Vary: Accept-Encoding`; encoded variants get their own weak
+ETag, with dynamic `If-None-Match` / `If-Modified-Since` validation performed
+after representation selection so identity and encoded validators cannot
+cross. `HEAD` advertises the same negotiated metadata as `GET`, and
 already-encoded, `no-transform`, Range, integrity-protected (`Content-Digest`,
 `Repr-Digest`, legacy
 `Digest`/`Content-MD5`), and sub-1 KiB responses are left alone. If a reverse

--- a/examples/docs/src/routes/docs/deployment.md
+++ b/examples/docs/src/routes/docs/deployment.md
@@ -45,8 +45,9 @@ and validator, even when coarse filesystem timestamps do not change. Buffered
 cold work is byte- and concurrency-bounded, with overflow falling
 back to streaming compression. Static WebAssembly is served as
 `application/wasm` and follows the same compression path. Compressible
-responses carry `Vary: Accept-Encoding`; encoded variants get their own weak
-ETag, with dynamic `If-None-Match` / `If-Modified-Since` validation performed
+responses carry `Vary: Accept-Encoding`; encoded variants get their own
+collision-resistant weak ETag, with dynamic `If-None-Match` /
+`If-Modified-Since` validation performed
 after representation selection so identity and encoded validators cannot
 cross. `HEAD` advertises the same negotiated metadata as `GET`, including
 buffered compressed lengths, and

--- a/packages/adapter-node/README.md
+++ b/packages/adapter-node/README.md
@@ -24,6 +24,7 @@ node dist/server/server.js
 - Supports ISG time-window revalidation with background regeneration that reuses `createContext()`
 - Supports generated-entry context factories via `nodeAdapter({ createContextFrom })`
 - Supports configurable request body limits via `nodeAdapter({ maxBodySize })`
+- Compresses responses (brotli/gzip via `Accept-Encoding` negotiation) with streaming compression for dynamic bodies and an in-memory LRU for static assets; disable with `nodeAdapter({ compression: false })` behind a compressing reverse proxy
 
 ## Context factory
 

--- a/packages/adapter-node/README.md
+++ b/packages/adapter-node/README.md
@@ -24,7 +24,7 @@ node dist/server/server.js
 - Supports ISG time-window revalidation with background regeneration that reuses `createContext()`
 - Supports generated-entry context factories via `nodeAdapter({ createContextFrom })`
 - Supports configurable request body limits via `nodeAdapter({ maxBodySize })`
-- Compresses responses (brotli/gzip via `Accept-Encoding` negotiation) with streaming compression for dynamic bodies, a bounded in-memory LRU/cold-work queue for static assets, and restart-safe atomic ISG validator updates; disable with `nodeAdapter({ compression: false })` behind a compressing reverse proxy
+- Compresses responses (brotli/gzip via `Accept-Encoding` negotiation) with streaming compression for dynamic bodies, a bounded in-memory LRU/cold-work queue for static assets, version-bound file reads, and sibling-stable atomic ISG validator updates; disable with `nodeAdapter({ compression: false })` behind a compressing reverse proxy
 
 ## Context factory
 

--- a/packages/adapter-node/README.md
+++ b/packages/adapter-node/README.md
@@ -24,7 +24,7 @@ node dist/server/server.js
 - Supports ISG time-window revalidation with background regeneration that reuses `createContext()`
 - Supports generated-entry context factories via `nodeAdapter({ createContextFrom })`
 - Supports configurable request body limits via `nodeAdapter({ maxBodySize })`
-- Compresses responses (brotli/gzip via `Accept-Encoding` negotiation) with streaming compression for dynamic bodies and an in-memory LRU for static assets; disable with `nodeAdapter({ compression: false })` behind a compressing reverse proxy
+- Compresses responses (brotli/gzip via `Accept-Encoding` negotiation) with streaming compression for dynamic bodies and a bounded in-memory LRU/cold-work queue for static assets; disable with `nodeAdapter({ compression: false })` behind a compressing reverse proxy
 
 ## Context factory
 

--- a/packages/adapter-node/README.md
+++ b/packages/adapter-node/README.md
@@ -24,7 +24,7 @@ node dist/server/server.js
 - Supports ISG time-window revalidation with background regeneration that reuses `createContext()`
 - Supports generated-entry context factories via `nodeAdapter({ createContextFrom })`
 - Supports configurable request body limits via `nodeAdapter({ maxBodySize })`
-- Compresses responses (brotli/gzip via `Accept-Encoding` negotiation) with streaming compression for dynamic bodies, a bounded in-memory LRU/cold-work queue for static assets, version-bound file reads, and sibling-stable atomic ISG validator updates; disable with `nodeAdapter({ compression: false })` behind a compressing reverse proxy
+- Compresses responses (brotli/gzip via `Accept-Encoding` negotiation) with streaming compression for dynamic bodies, a bounded in-memory LRU/cold-work queue for static assets, version-bound file reads, and content-derived ISG validators stable across deployment replicas; disable with `nodeAdapter({ compression: false })` behind a compressing reverse proxy
 
 ## Context factory
 

--- a/packages/adapter-node/README.md
+++ b/packages/adapter-node/README.md
@@ -24,7 +24,7 @@ node dist/server/server.js
 - Supports ISG time-window revalidation with background regeneration that reuses `createContext()`
 - Supports generated-entry context factories via `nodeAdapter({ createContextFrom })`
 - Supports configurable request body limits via `nodeAdapter({ maxBodySize })`
-- Compresses responses (brotli/gzip via `Accept-Encoding` negotiation) with streaming compression for dynamic bodies and a bounded in-memory LRU/cold-work queue for static assets; disable with `nodeAdapter({ compression: false })` behind a compressing reverse proxy
+- Compresses responses (brotli/gzip via `Accept-Encoding` negotiation) with streaming compression for dynamic bodies, a bounded in-memory LRU/cold-work queue for static assets, and restart-safe atomic ISG validator updates; disable with `nodeAdapter({ compression: false })` behind a compressing reverse proxy
 
 ## Context factory
 

--- a/packages/adapter-node/README.md
+++ b/packages/adapter-node/README.md
@@ -24,7 +24,7 @@ node dist/server/server.js
 - Supports ISG time-window revalidation with background regeneration that reuses `createContext()`
 - Supports generated-entry context factories via `nodeAdapter({ createContextFrom })`
 - Supports configurable request body limits via `nodeAdapter({ maxBodySize })`
-- Compresses responses (brotli/gzip via `Accept-Encoding` negotiation) with streaming compression for dynamic bodies, a bounded in-memory LRU/cold-work queue for static assets, version-bound file reads, and content-derived ISG validators stable across deployment replicas; disable with `nodeAdapter({ compression: false })` behind a compressing reverse proxy
+- Compresses responses (brotli/gzip via `Accept-Encoding` negotiation) with streaming compression for dynamic bodies, a bounded in-memory LRU/cold-work queue for static assets and validator hashing, version-bound file reads, and content-derived ISG validators stable across deployment replicas; disable with `nodeAdapter({ compression: false })` behind a compressing reverse proxy
 
 ## Context factory
 

--- a/packages/adapter-node/src/node-compress.ts
+++ b/packages/adapter-node/src/node-compress.ts
@@ -1,0 +1,250 @@
+import type { ServerResponse } from "node:http";
+import type { Transform } from "node:stream";
+import { promisify } from "node:util";
+import {
+  brotliCompress,
+  constants as zlibConstants,
+  createBrotliCompress,
+  createGzip,
+  gzip,
+} from "node:zlib";
+
+/** Content encodings the Node adapter can produce, in preference order. */
+export type ContentEncoding = "br" | "gzip";
+
+/**
+ * Bodies below this many bytes are not worth compressing: the encoding
+ * overhead can exceed the savings and every compressed variant costs CPU.
+ * Applied whenever the body size is known (static files, `Content-Length`).
+ */
+export const COMPRESSION_MIN_SIZE = 1024;
+
+/**
+ * Static files up to this size are compressed once as a whole buffer (better
+ * ratio than streaming) and kept in the in-memory LRU. Larger files are
+ * streamed through zlib per request instead of being buffered.
+ */
+export const MAX_CACHEABLE_ASSET_SIZE = 1024 * 1024;
+
+const brotliCompressAsync = promisify(brotliCompress);
+const gzipAsync = promisify(gzip);
+
+const COMPRESSIBLE_MIME_TYPES = new Set([
+  "application/ecmascript",
+  "application/javascript",
+  "application/json",
+  "application/wasm",
+  "application/x-javascript",
+  "application/xml",
+]);
+
+/**
+ * Whether a `Content-Type` names a representation that compresses well.
+ * `text/*`, well-known application types, and any `+json`/`+xml` structured
+ * syntax suffix (`image/svg+xml`, `application/manifest+json`, ...). Binary
+ * media (images, fonts, video, archives) is already compressed and excluded.
+ */
+export function isCompressibleContentType(value: string | null): boolean {
+  if (!value) return false;
+  const mime = value.split(";")[0]!.trim().toLowerCase();
+  if (mime.startsWith("text/")) return true;
+  if (COMPRESSIBLE_MIME_TYPES.has(mime)) return true;
+  return mime.endsWith("+json") || mime.endsWith("+xml");
+}
+
+/**
+ * Pick the response encoding for an `Accept-Encoding` header: brotli when the
+ * client allows it, gzip otherwise, `null` (identity) when neither is
+ * acceptable. Honors q-values, `*` wildcards, and explicit `q=0` exclusions.
+ */
+export function negotiateEncoding(header: string | null): ContentEncoding | null {
+  if (!header) return null;
+
+  const qualities = new Map<string, number>();
+  for (const part of header.split(",")) {
+    const [token, ...params] = part.trim().split(";");
+    const name = token?.trim().toLowerCase();
+    if (!name) continue;
+
+    let quality = 1;
+    for (const param of params) {
+      const [key, value] = param.trim().split("=");
+      if (key?.trim().toLowerCase() !== "q") continue;
+      const parsed = Number.parseFloat(value ?? "");
+      if (!Number.isNaN(parsed)) quality = parsed;
+    }
+    qualities.set(name === "x-gzip" ? "gzip" : name, quality);
+  }
+
+  const qualityOf = (encoding: string): number =>
+    qualities.get(encoding) ?? qualities.get("*") ?? 0;
+
+  if (qualityOf("br") > 0) return "br";
+  if (qualityOf("gzip") > 0) return "gzip";
+  return null;
+}
+
+/**
+ * Whether a response may be transformed at all: informational/empty/not-
+ * modified statuses have no body to compress, Range responses would corrupt
+ * byte offsets, an existing `Content-Encoding` means someone already encoded
+ * the body, and `Cache-Control: no-transform` is an explicit opt-out.
+ */
+export function isTransformableResponse(status: number, headers: Headers): boolean {
+  if (status < 200 || status === 204 || status === 205 || status === 206 || status === 304) {
+    return false;
+  }
+  const existingEncoding = headers.get("content-encoding");
+  if (existingEncoding && existingEncoding.toLowerCase() !== "identity") return false;
+  if (headers.has("content-range")) return false;
+  const cacheControl = headers.get("cache-control");
+  if (cacheControl && /(?:^|[\s,])no-transform(?:$|[\s,;=])/i.test(cacheControl)) return false;
+  return true;
+}
+
+/** Append `Accept-Encoding` to a `Vary` header value, preserving existing members. */
+export function mergeVaryValue(existing: string | null | undefined): string {
+  if (!existing) return "Accept-Encoding";
+  const members = existing.split(",").map((member) => member.trim().toLowerCase());
+  if (members.includes("*") || members.includes("accept-encoding")) return existing;
+  return `${existing}, Accept-Encoding`;
+}
+
+/** Merge `Accept-Encoding` into the `Vary` header already written to `res`. */
+export function mergeVaryOnNodeResponse(res: ServerResponse): void {
+  const existing = res.getHeader("vary");
+  const value = Array.isArray(existing) ? existing.join(", ") : (existing?.toString() ?? null);
+  res.setHeader("vary", mergeVaryValue(value));
+}
+
+/**
+ * Derive the ETag of an encoded variant from the identity ETag. Encoded
+ * variants must not share a validator with identity — a shared tag would let
+ * a cache answer an `Accept-Encoding: identity` revalidation with a brotli
+ * body — so the encoding is folded into the opaque tag.
+ */
+export function encodeEtagForEncoding(etag: string, encoding: ContentEncoding): string {
+  if (etag.endsWith('"')) {
+    return `${etag.slice(0, -1)}-${encoding}"`;
+  }
+  return `${etag}-${encoding}`;
+}
+
+/**
+ * Create a streaming zlib transform for `encoding`. Brotli runs at quality 4
+ * for streamed (dynamic) bodies — near-gzip speed with a better ratio —
+ * because SSR latency matters more than the last few percent of savings.
+ */
+export function createCompressionTransform(
+  encoding: ContentEncoding,
+  sizeHint?: number,
+): Transform {
+  if (encoding === "br") {
+    const params: Record<number, number> = {
+      [zlibConstants.BROTLI_PARAM_QUALITY]: 4,
+    };
+    if (sizeHint !== undefined) {
+      params[zlibConstants.BROTLI_PARAM_SIZE_HINT] = sizeHint;
+    }
+    return createBrotliCompress({ params });
+  }
+  return createGzip();
+}
+
+/**
+ * Pipe `source` through a compression transform, keeping the failure
+ * semantics `pipeToResponse()` relies on: a source error destroys the
+ * transform with that error (so the caller can still answer 500), and a
+ * transform torn down mid-stream (client disconnect) releases the source so
+ * file descriptors and pooled sockets do not leak.
+ */
+export function createCompressedStream(
+  source: NodeJS.ReadableStream,
+  encoding: ContentEncoding,
+  sizeHint?: number,
+): Transform {
+  const transform = createCompressionTransform(encoding, sizeHint);
+
+  source.on("error", (error: unknown) => {
+    transform.destroy(error instanceof Error ? error : new Error(String(error)));
+  });
+  transform.on("close", () => {
+    if (!transform.writableFinished) {
+      source.unpipe?.(transform);
+      (source as { destroy?: () => void }).destroy?.();
+    }
+  });
+
+  source.pipe(transform);
+  return transform;
+}
+
+/**
+ * Compress a whole buffer at higher quality than the streaming path — used
+ * for static assets whose result lands in the LRU, where the one-time CPU
+ * cost is amortized across every later request.
+ */
+export function compressBuffer(buffer: Buffer, encoding: ContentEncoding): Promise<Buffer> {
+  if (encoding === "br") {
+    return brotliCompressAsync(buffer, {
+      params: {
+        [zlibConstants.BROTLI_PARAM_QUALITY]: 9,
+        [zlibConstants.BROTLI_PARAM_SIZE_HINT]: buffer.byteLength,
+      },
+    });
+  }
+  return gzipAsync(buffer, { level: 9 });
+}
+
+/**
+ * Byte-bounded LRU of compressed static assets, keyed by file identity
+ * (path + size + mtime) and encoding — an ISG regeneration that rewrites the
+ * HTML on disk changes the mtime and naturally invalidates its entries.
+ */
+export class CompressedAssetCache {
+  #entries = new Map<string, Buffer>();
+  #totalBytes = 0;
+  readonly #maxBytes: number;
+
+  constructor(maxBytes = 32 * 1024 * 1024) {
+    this.#maxBytes = maxBytes;
+  }
+
+  get totalBytes(): number {
+    return this.#totalBytes;
+  }
+
+  get(key: string): Buffer | undefined {
+    const entry = this.#entries.get(key);
+    if (entry === undefined) return undefined;
+    // Refresh recency.
+    this.#entries.delete(key);
+    this.#entries.set(key, entry);
+    return entry;
+  }
+
+  set(key: string, value: Buffer): void {
+    if (value.byteLength > this.#maxBytes) return;
+
+    const existing = this.#entries.get(key);
+    if (existing !== undefined) {
+      this.#entries.delete(key);
+      this.#totalBytes -= existing.byteLength;
+    }
+
+    this.#entries.set(key, value);
+    this.#totalBytes += value.byteLength;
+
+    for (const [oldestKey, oldestValue] of this.#entries) {
+      if (this.#totalBytes <= this.#maxBytes) break;
+      this.#entries.delete(oldestKey);
+      this.#totalBytes -= oldestValue.byteLength;
+    }
+  }
+}
+
+/** Per-handler compression state threaded through the static/dynamic paths. */
+export interface CompressionState {
+  request: Request;
+  cache: CompressedAssetCache;
+}

--- a/packages/adapter-node/src/node-compress.ts
+++ b/packages/adapter-node/src/node-compress.ts
@@ -297,13 +297,14 @@ export function compressBuffer(buffer: Buffer, encoding: ContentEncoding): Promi
 }
 
 /**
- * Byte-bounded LRU of compressed static assets, keyed by file identity
- * (path + size + mtime) and encoding — an ISG regeneration that rewrites the
- * HTML on disk changes the mtime and naturally invalidates its entries.
+ * Byte-bounded LRU of compressed static assets. Callers include a per-path
+ * write generation in each key so an ISG rewrite invalidates cached bytes even
+ * when the replacement has the same size and filesystem timestamp.
  * Whole-buffer work is also byte- and concurrency-bounded while pending.
  */
 export class CompressedAssetCache {
   #entries = new Map<string, Buffer>();
+  #pathGenerations = new Map<string, number>();
   #pending = new Map<string, Promise<Buffer>>();
   #pendingBytes = 0;
   #totalBytes = 0;
@@ -317,6 +318,25 @@ export class CompressedAssetCache {
 
   get totalBytes(): number {
     return this.#totalBytes;
+  }
+
+  getPathGeneration(path: string): number {
+    return this.#pathGenerations.get(path) ?? 0;
+  }
+
+  /**
+   * Advance the generation for a mutable file and discard its completed cache
+   * entries. In-flight work may still finish for the old generation, but a
+   * later request cannot select it because its key includes the new value.
+   */
+  invalidatePath(path: string): void {
+    this.#pathGenerations.set(path, this.getPathGeneration(path) + 1);
+    const prefix = `${path}\0`;
+    for (const [key, value] of this.#entries) {
+      if (!key.startsWith(prefix)) continue;
+      this.#entries.delete(key);
+      this.#totalBytes -= value.byteLength;
+    }
   }
 
   /**

--- a/packages/adapter-node/src/node-compress.ts
+++ b/packages/adapter-node/src/node-compress.ts
@@ -346,7 +346,8 @@ export function compressBuffer(buffer: Buffer, encoding: ContentEncoding): Promi
  * Byte-bounded LRU of compressed static assets. Callers include a per-path
  * write generation in each key so an ISG rewrite invalidates cached bytes even
  * when the replacement has the same size and filesystem timestamp.
- * Whole-buffer work is also byte- and concurrency-bounded while pending.
+ * Whole-buffer compression and content-derived validator work are also byte-
+ * and concurrency-bounded while pending.
  */
 export class CompressedAssetCache {
   #entries = new Map<string, Buffer>();
@@ -355,6 +356,7 @@ export class CompressedAssetCache {
   #pending = new Map<string, Promise<Buffer>>();
   #pendingFileEtags = new Map<string, Promise<string>>();
   #pendingBytes = 0;
+  #pendingFileEtagBytes = 0;
   #totalBytes = 0;
   readonly #maxBytes: number;
   readonly #maxPendingEntries: number;
@@ -394,9 +396,16 @@ export class CompressedAssetCache {
    * Cache a content-derived public validator by path + local file version.
    * The key may contain replica-local metadata because it never leaves this
    * process; `produce()` must return a validator derived only from public,
-   * replica-stable representation data.
+   * replica-stable representation data. Returns `null` when admitting a new
+   * key would exceed the pending byte or concurrency budget; callers must omit
+   * the validator for that response rather than fall back to mutable filesystem
+   * metadata.
    */
-  getOrCreateFileEtag(key: string, produce: () => Promise<string>): Promise<string> {
+  getOrCreateFileEtag(
+    key: string,
+    estimatedBytes: number,
+    produce: () => Promise<string>,
+  ): Promise<string> | null {
     const cached = this.#fileEtags.get(key);
     if (cached !== undefined) {
       this.#fileEtags.delete(key);
@@ -406,6 +415,14 @@ export class CompressedAssetCache {
 
     let pending = this.#pendingFileEtags.get(key);
     if (!pending) {
+      if (
+        this.#pendingFileEtags.size >= this.#maxPendingEntries ||
+        estimatedBytes > this.#maxBytes - this.#pendingFileEtagBytes
+      ) {
+        return null;
+      }
+
+      this.#pendingFileEtagBytes += estimatedBytes;
       pending = Promise.resolve()
         .then(produce)
         .then((etag) => {
@@ -421,6 +438,7 @@ export class CompressedAssetCache {
         })
         .finally(() => {
           this.#pendingFileEtags.delete(key);
+          this.#pendingFileEtagBytes -= estimatedBytes;
         });
       this.#pendingFileEtags.set(key, pending);
     }

--- a/packages/adapter-node/src/node-compress.ts
+++ b/packages/adapter-node/src/node-compress.ts
@@ -56,10 +56,11 @@ export function isCompressibleContentType(value: string | null): boolean {
  * Pick the response encoding for an `Accept-Encoding` header. Honors
  * q-values, `*` wildcards, and explicit `q=0` exclusions. Per RFC 9110
  * §12.5.3 the acceptable coding with the highest non-zero qvalue is
- * preferred; brotli wins ties (including the common unweighted
- * `gzip, deflate, br`). Returns `null` (identity) when neither coding is
- * acceptable — including `identity;q=0` alone, where falling back to an
- * uncompressed 200 is the robust interpretation of the SHOULD-level 406.
+ * preferred; an explicitly higher `identity` preference wins, while brotli
+ * wins ties (including the common unweighted `gzip, deflate, br`). Returns
+ * `null` (identity) when neither coding is acceptable — including
+ * `identity;q=0` alone, where falling back to an uncompressed 200 is the
+ * robust interpretation of the SHOULD-level 406.
  */
 export function negotiateEncoding(header: string | null): ContentEncoding | null {
   if (!header) return null;
@@ -85,8 +86,16 @@ export function negotiateEncoding(header: string | null): ContentEncoding | null
 
   const brQuality = qualityOf("br");
   const gzipQuality = qualityOf("gzip");
-  if (brQuality >= gzipQuality) return brQuality > 0 ? "br" : null;
-  return gzipQuality > 0 ? "gzip" : null;
+  const encoding = brQuality >= gzipQuality ? "br" : "gzip";
+  const encodingQuality = Math.max(brQuality, gzipQuality);
+  const identityQuality = qualities.get("identity");
+
+  // `identity` is special: when it is absent, keep the server's freedom to
+  // choose any acceptable coding (including the common `gzip;q=0.5` case).
+  // When the client explicitly assigns it a higher weight, however, that is a
+  // real preference for no content coding and must win the negotiation.
+  if (identityQuality !== undefined && identityQuality > encodingQuality) return null;
+  return encodingQuality > 0 ? encoding : null;
 }
 
 /**

--- a/packages/adapter-node/src/node-compress.ts
+++ b/packages/adapter-node/src/node-compress.ts
@@ -26,6 +26,14 @@ export const COMPRESSION_MIN_SIZE = 1024;
  */
 export const MAX_CACHEABLE_ASSET_SIZE = 1024 * 1024;
 
+/**
+ * Whole-file compression uses the libuv worker pool and retains both source
+ * and encoded buffers until the job completes. Keep a cold burst across many
+ * distinct paths from queuing an unbounded amount of that work; overflow uses
+ * the streaming compression path instead.
+ */
+const MAX_PENDING_ASSET_COMPRESSIONS = 8;
+
 const brotliCompressAsync = promisify(brotliCompress);
 const gzipAsync = promisify(gzip);
 
@@ -184,6 +192,27 @@ export function matchesIfNoneMatch(header: string | null, etag: string | null): 
   return candidates.some((candidate) => weakOpaqueTag(candidate) === expected);
 }
 
+/**
+ * Evaluate conditional GET/HEAD validators against the selected response
+ * representation. `If-None-Match` takes precedence over
+ * `If-Modified-Since`, as required by RFC 9110 section 13.1.3.
+ */
+export function isNotModifiedRequest(
+  request: Request,
+  etag: string | null,
+  lastModified: string | null,
+): boolean {
+  const ifNoneMatch = request.headers.get("if-none-match");
+  if (ifNoneMatch) return matchesIfNoneMatch(ifNoneMatch, etag);
+
+  const ifModifiedSince = request.headers.get("if-modified-since");
+  if (!lastModified || !ifModifiedSince) return false;
+
+  const modifiedTime = Date.parse(lastModified);
+  const sinceTime = Date.parse(ifModifiedSince);
+  return !Number.isNaN(modifiedTime) && !Number.isNaN(sinceTime) && modifiedTime <= sinceTime;
+}
+
 export interface CompressionStreamOptions {
   /** Known total body size, forwarded to brotli as a size hint. */
   sizeHint?: number;
@@ -271,15 +300,19 @@ export function compressBuffer(buffer: Buffer, encoding: ContentEncoding): Promi
  * Byte-bounded LRU of compressed static assets, keyed by file identity
  * (path + size + mtime) and encoding — an ISG regeneration that rewrites the
  * HTML on disk changes the mtime and naturally invalidates its entries.
+ * Whole-buffer work is also byte- and concurrency-bounded while pending.
  */
 export class CompressedAssetCache {
   #entries = new Map<string, Buffer>();
   #pending = new Map<string, Promise<Buffer>>();
+  #pendingBytes = 0;
   #totalBytes = 0;
   readonly #maxBytes: number;
+  readonly #maxPendingEntries: number;
 
-  constructor(maxBytes = 32 * 1024 * 1024) {
+  constructor(maxBytes = 32 * 1024 * 1024, maxPendingEntries = MAX_PENDING_ASSET_COMPRESSIONS) {
     this.#maxBytes = maxBytes;
+    this.#maxPendingEntries = maxPendingEntries;
   }
 
   get totalBytes(): number {
@@ -291,21 +324,36 @@ export class CompressedAssetCache {
    * the same file version share one `produce()` call instead of compressing
    * the same bytes N times (the post-deploy thundering herd). A failed
    * `produce()` rejects every waiter and is not cached, so the next request
-   * retries.
+   * retries. Returns `null` when admitting a new key would exceed the pending
+   * byte or concurrency budget so the caller can stream it instead.
    */
-  getOrCompress(key: string, produce: () => Promise<Buffer>): Promise<Buffer> {
+  getOrCompress(
+    key: string,
+    estimatedBytes: number,
+    produce: () => Promise<Buffer>,
+  ): Promise<Buffer> | null {
     const cached = this.get(key);
     if (cached !== undefined) return Promise.resolve(cached);
 
     let pending = this.#pending.get(key);
     if (!pending) {
-      pending = produce()
+      if (
+        this.#pending.size >= this.#maxPendingEntries ||
+        estimatedBytes > this.#maxBytes - this.#pendingBytes
+      ) {
+        return null;
+      }
+
+      this.#pendingBytes += estimatedBytes;
+      pending = Promise.resolve()
+        .then(produce)
         .then((buffer) => {
           this.set(key, buffer);
           return buffer;
         })
         .finally(() => {
           this.#pending.delete(key);
+          this.#pendingBytes -= estimatedBytes;
         });
       this.#pending.set(key, pending);
     }

--- a/packages/adapter-node/src/node-compress.ts
+++ b/packages/adapter-node/src/node-compress.ts
@@ -175,26 +175,16 @@ export interface CompressionFileStats {
 }
 
 /**
- * Build a process-independent file version for static compression metadata.
- * ISG writes replace the file atomically, so the inode changes even when a
- * same-size rewrite lands on a filesystem whose timestamps are too coarse to
- * move. `ctimeMs` is included as a fallback for filesystems that do not expose
- * useful inode numbers. This version is also used in public validators, so it
- * deliberately contains only filesystem identity shared by sibling handlers;
- * process-local cache generations belong in cache keys instead.
+ * Build a handler-local file version for compression caches. ISG writes
+ * replace the file atomically, so the inode changes even when a same-size
+ * rewrite lands on a filesystem whose timestamps are too coarse to move.
+ * `ctimeMs` is included as a fallback for filesystems that do not expose useful
+ * inode numbers. This version must never enter a public validator: device,
+ * inode, and ctime values differ across replica-local copies of identical
+ * files.
  */
 export function createCompressionFileVersion(fileStat: CompressionFileStats): string {
   return [fileStat.dev, fileStat.ino, fileStat.size, fileStat.mtimeMs, fileStat.ctimeMs].join(":");
-}
-
-/** Fold a durable file version into an identity ETag before content negotiation. */
-export function encodeEtagForFileVersion(etag: string, fileVersion: string): string {
-  const digest = createHash("sha256")
-    .update(etag)
-    .update("\0")
-    .update(fileVersion)
-    .digest("base64url");
-  return `W/"pracht-file-${digest}"`;
 }
 
 /**
@@ -360,8 +350,10 @@ export function compressBuffer(buffer: Buffer, encoding: ContentEncoding): Promi
  */
 export class CompressedAssetCache {
   #entries = new Map<string, Buffer>();
+  #fileEtags = new Map<string, string>();
   #pathGenerations = new Map<string, number>();
   #pending = new Map<string, Promise<Buffer>>();
+  #pendingFileEtags = new Map<string, Promise<string>>();
   #pendingBytes = 0;
   #totalBytes = 0;
   readonly #maxBytes: number;
@@ -393,6 +385,46 @@ export class CompressedAssetCache {
       this.#entries.delete(key);
       this.#totalBytes -= value.byteLength;
     }
+    for (const key of this.#fileEtags.keys()) {
+      if (key.startsWith(prefix)) this.#fileEtags.delete(key);
+    }
+  }
+
+  /**
+   * Cache a content-derived public validator by path + local file version.
+   * The key may contain replica-local metadata because it never leaves this
+   * process; `produce()` must return a validator derived only from public,
+   * replica-stable representation data.
+   */
+  getOrCreateFileEtag(key: string, produce: () => Promise<string>): Promise<string> {
+    const cached = this.#fileEtags.get(key);
+    if (cached !== undefined) {
+      this.#fileEtags.delete(key);
+      this.#fileEtags.set(key, cached);
+      return Promise.resolve(cached);
+    }
+
+    let pending = this.#pendingFileEtags.get(key);
+    if (!pending) {
+      pending = Promise.resolve()
+        .then(produce)
+        .then((etag) => {
+          this.#fileEtags.set(key, etag);
+          // ISG invalidation removes old path entries eagerly. Keep a final
+          // bound for externally replaced files and long-lived custom servers.
+          while (this.#fileEtags.size > 1024) {
+            const oldest = this.#fileEtags.keys().next().value;
+            if (oldest === undefined) break;
+            this.#fileEtags.delete(oldest);
+          }
+          return etag;
+        })
+        .finally(() => {
+          this.#pendingFileEtags.delete(key);
+        });
+      this.#pendingFileEtags.set(key, pending);
+    }
+    return pending;
   }
 
   /**

--- a/packages/adapter-node/src/node-compress.ts
+++ b/packages/adapter-node/src/node-compress.ts
@@ -215,6 +215,27 @@ export function containsEncodedEtag(header: string | null): boolean {
 export function matchesIfNoneMatch(header: string | null, etag: string | null): boolean {
   if (!header) return false;
 
+  const candidates = parseEntityTagList(header);
+  if (candidates.includes("*")) return true;
+  if (!etag) return false;
+
+  const weakOpaqueTag = (value: string): string =>
+    value.startsWith("W/") ? value.slice(2) : value;
+  const expected = weakOpaqueTag(etag);
+  return candidates.some((candidate) => weakOpaqueTag(candidate) === expected);
+}
+
+/** Strongly compare an `If-Match` list with the selected representation's ETag. */
+export function matchesIfMatch(header: string | null, etag: string | null): boolean {
+  if (!header) return true;
+
+  const candidates = parseEntityTagList(header);
+  if (candidates.includes("*")) return true;
+  if (!etag || etag.startsWith("W/")) return false;
+  return candidates.some((candidate) => !candidate.startsWith("W/") && candidate === etag);
+}
+
+function parseEntityTagList(header: string): string[] {
   const candidates: string[] = [];
   let start = 0;
   let quoted = false;
@@ -228,14 +249,7 @@ export function matchesIfNoneMatch(header: string | null, etag: string | null): 
     }
   }
   candidates.push(header.slice(start).trim());
-
-  if (candidates.includes("*")) return true;
-  if (!etag) return false;
-
-  const weakOpaqueTag = (value: string): string =>
-    value.startsWith("W/") ? value.slice(2) : value;
-  const expected = weakOpaqueTag(etag);
-  return candidates.some((candidate) => weakOpaqueTag(candidate) === expected);
+  return candidates;
 }
 
 /**
@@ -519,4 +533,6 @@ export class CompressedAssetCache {
 export interface CompressionState {
   request: Request;
   cache: CompressedAssetCache;
+  /** Whether the adapter removed `If-Match` to evaluate it after representation selection. */
+  ownsIfMatch?: boolean;
 }

--- a/packages/adapter-node/src/node-compress.ts
+++ b/packages/adapter-node/src/node-compress.ts
@@ -1,4 +1,5 @@
 import type { ServerResponse } from "node:http";
+import { createHash } from "node:crypto";
 import type { Transform } from "node:stream";
 import { promisify } from "node:util";
 import {
@@ -47,6 +48,7 @@ const COMPRESSIBLE_MIME_TYPES = new Set([
 ]);
 
 const INTEGRITY_HEADER_NAMES = ["content-digest", "repr-digest", "digest", "content-md5"];
+const ENCODED_ETAG_PATTERN = /^(?:W\/)?"pracht-(?:br|gzip)-[A-Za-z0-9_-]{43}"$/;
 
 /**
  * Whether a `Content-Type` names a representation that compresses well.
@@ -156,10 +158,33 @@ export function mergeVaryOnNodeResponse(res: ServerResponse): void {
  */
 export function encodeEtagForEncoding(etag: string, encoding: ContentEncoding): string {
   const opaqueTag = etag.startsWith("W/") ? etag.slice(2) : etag;
-  if (opaqueTag.endsWith('"')) {
-    return `W/${opaqueTag.slice(0, -1)}-${encoding}"`;
-  }
-  return `W/${opaqueTag}-${encoding}`;
+  const digest = createHash("sha256")
+    .update(opaqueTag)
+    .update("\0")
+    .update(encoding)
+    .digest("base64url");
+  return `W/"pracht-${encoding}-${digest}"`;
+}
+
+/**
+ * Keep an application identity tag out of the namespace used for encoded
+ * variants. Without this escape, an application that later adopts a tag equal
+ * to an older encoded validator could still make a cross-representation
+ * `If-None-Match` request look current despite collision-resistant derivation.
+ */
+export function protectIdentityEtag(etag: string): string {
+  if (!ENCODED_ETAG_PATTERN.test(etag)) return etag;
+
+  const opaqueTag = etag.startsWith("W/") ? etag.slice(2) : etag;
+  const digest = createHash("sha256").update(opaqueTag).update("\0identity").digest("base64url");
+  return `W/"pracht-identity-${digest}"`;
+}
+
+/** Whether an `If-None-Match` list contains one of this adapter's encoded tags. */
+export function containsEncodedEtag(header: string | null): boolean {
+  return (
+    header?.split(",").some((candidate) => ENCODED_ETAG_PATTERN.test(candidate.trim())) ?? false
+  );
 }
 
 /**

--- a/packages/adapter-node/src/node-compress.ts
+++ b/packages/adapter-node/src/node-compress.ts
@@ -53,9 +53,13 @@ export function isCompressibleContentType(value: string | null): boolean {
 }
 
 /**
- * Pick the response encoding for an `Accept-Encoding` header: brotli when the
- * client allows it, gzip otherwise, `null` (identity) when neither is
- * acceptable. Honors q-values, `*` wildcards, and explicit `q=0` exclusions.
+ * Pick the response encoding for an `Accept-Encoding` header. Honors
+ * q-values, `*` wildcards, and explicit `q=0` exclusions. Per RFC 9110
+ * §12.5.3 the acceptable coding with the highest non-zero qvalue is
+ * preferred; brotli wins ties (including the common unweighted
+ * `gzip, deflate, br`). Returns `null` (identity) when neither coding is
+ * acceptable — including `identity;q=0` alone, where falling back to an
+ * uncompressed 200 is the robust interpretation of the SHOULD-level 406.
  */
 export function negotiateEncoding(header: string | null): ContentEncoding | null {
   if (!header) return null;
@@ -79,9 +83,10 @@ export function negotiateEncoding(header: string | null): ContentEncoding | null
   const qualityOf = (encoding: string): number =>
     qualities.get(encoding) ?? qualities.get("*") ?? 0;
 
-  if (qualityOf("br") > 0) return "br";
-  if (qualityOf("gzip") > 0) return "gzip";
-  return null;
+  const brQuality = qualityOf("br");
+  const gzipQuality = qualityOf("gzip");
+  if (brQuality >= gzipQuality) return brQuality > 0 ? "br" : null;
+  return gzipQuality > 0 ? "gzip" : null;
 }
 
 /**
@@ -130,6 +135,20 @@ export function encodeEtagForEncoding(etag: string, encoding: ContentEncoding): 
   return `${etag}-${encoding}`;
 }
 
+export interface CompressionStreamOptions {
+  /** Known total body size, forwarded to brotli as a size hint. */
+  sizeHint?: number;
+  /**
+   * Flush the compressor after every written chunk (`Z_SYNC_FLUSH` /
+   * `BROTLI_OPERATION_FLUSH`). Required for incrementally produced bodies —
+   * SSE and other streamed responses — where zlib's default `Z_NO_FLUSH`
+   * would sit on written events until its internal buffer fills or the
+   * stream ends, breaking incremental delivery entirely (brotli emits zero
+   * bytes until end-of-stream; gzip emits only its 10-byte header).
+   */
+  incremental?: boolean;
+}
+
 /**
  * Create a streaming zlib transform for `encoding`. Brotli runs at quality 4
  * for streamed (dynamic) bodies — near-gzip speed with a better ratio —
@@ -137,18 +156,21 @@ export function encodeEtagForEncoding(etag: string, encoding: ContentEncoding): 
  */
 export function createCompressionTransform(
   encoding: ContentEncoding,
-  sizeHint?: number,
+  options: CompressionStreamOptions = {},
 ): Transform {
   if (encoding === "br") {
     const params: Record<number, number> = {
       [zlibConstants.BROTLI_PARAM_QUALITY]: 4,
     };
-    if (sizeHint !== undefined) {
-      params[zlibConstants.BROTLI_PARAM_SIZE_HINT] = sizeHint;
+    if (options.sizeHint !== undefined) {
+      params[zlibConstants.BROTLI_PARAM_SIZE_HINT] = options.sizeHint;
     }
-    return createBrotliCompress({ params });
+    return createBrotliCompress({
+      params,
+      ...(options.incremental ? { flush: zlibConstants.BROTLI_OPERATION_FLUSH } : {}),
+    });
   }
-  return createGzip();
+  return createGzip(options.incremental ? { flush: zlibConstants.Z_SYNC_FLUSH } : {});
 }
 
 /**
@@ -161,9 +183,9 @@ export function createCompressionTransform(
 export function createCompressedStream(
   source: NodeJS.ReadableStream,
   encoding: ContentEncoding,
-  sizeHint?: number,
+  options: CompressionStreamOptions = {},
 ): Transform {
-  const transform = createCompressionTransform(encoding, sizeHint);
+  const transform = createCompressionTransform(encoding, options);
 
   source.on("error", (error: unknown) => {
     transform.destroy(error instanceof Error ? error : new Error(String(error)));
@@ -203,6 +225,7 @@ export function compressBuffer(buffer: Buffer, encoding: ContentEncoding): Promi
  */
 export class CompressedAssetCache {
   #entries = new Map<string, Buffer>();
+  #pending = new Map<string, Promise<Buffer>>();
   #totalBytes = 0;
   readonly #maxBytes: number;
 
@@ -212,6 +235,32 @@ export class CompressedAssetCache {
 
   get totalBytes(): number {
     return this.#totalBytes;
+  }
+
+  /**
+   * Cached lookup with in-flight deduplication: concurrent first requests to
+   * the same file version share one `produce()` call instead of compressing
+   * the same bytes N times (the post-deploy thundering herd). A failed
+   * `produce()` rejects every waiter and is not cached, so the next request
+   * retries.
+   */
+  getOrCompress(key: string, produce: () => Promise<Buffer>): Promise<Buffer> {
+    const cached = this.get(key);
+    if (cached !== undefined) return Promise.resolve(cached);
+
+    let pending = this.#pending.get(key);
+    if (!pending) {
+      pending = produce()
+        .then((buffer) => {
+          this.set(key, buffer);
+          return buffer;
+        })
+        .finally(() => {
+          this.#pending.delete(key);
+        });
+      this.#pending.set(key, pending);
+    }
+    return pending;
   }
 
   get(key: string): Buffer | undefined {

--- a/packages/adapter-node/src/node-compress.ts
+++ b/packages/adapter-node/src/node-compress.ts
@@ -142,13 +142,46 @@ export function mergeVaryOnNodeResponse(res: ServerResponse): void {
  * Derive the ETag of an encoded variant from the identity ETag. Encoded
  * variants must not share a validator with identity — a shared tag would let
  * a cache answer an `Accept-Encoding: identity` revalidation with a brotli
- * body — so the encoding is folded into the opaque tag.
+ * body — so the encoding is folded into the opaque tag. The derived tag is
+ * always weak: streaming compression can produce different wire bytes for the
+ * same decoded content when source chunk boundaries differ.
  */
 export function encodeEtagForEncoding(etag: string, encoding: ContentEncoding): string {
-  if (etag.endsWith('"')) {
-    return `${etag.slice(0, -1)}-${encoding}"`;
+  const opaqueTag = etag.startsWith("W/") ? etag.slice(2) : etag;
+  if (opaqueTag.endsWith('"')) {
+    return `W/${opaqueTag.slice(0, -1)}-${encoding}"`;
   }
-  return `${etag}-${encoding}`;
+  return `W/${opaqueTag}-${encoding}`;
+}
+
+/**
+ * Weakly compare an `If-None-Match` list with the selected representation's
+ * ETag. Commas inside the quoted opaque tag are data, not list separators.
+ */
+export function matchesIfNoneMatch(header: string | null, etag: string | null): boolean {
+  if (!header) return false;
+
+  const candidates: string[] = [];
+  let start = 0;
+  let quoted = false;
+  for (let index = 0; index < header.length; index += 1) {
+    const character = header[index];
+    if (character === '"') {
+      quoted = !quoted;
+    } else if (character === "," && !quoted) {
+      candidates.push(header.slice(start, index).trim());
+      start = index + 1;
+    }
+  }
+  candidates.push(header.slice(start).trim());
+
+  if (candidates.includes("*")) return true;
+  if (!etag) return false;
+
+  const weakOpaqueTag = (value: string): string =>
+    value.startsWith("W/") ? value.slice(2) : value;
+  const expected = weakOpaqueTag(etag);
+  return candidates.some((candidate) => weakOpaqueTag(candidate) === expected);
 }
 
 export interface CompressionStreamOptions {

--- a/packages/adapter-node/src/node-compress.ts
+++ b/packages/adapter-node/src/node-compress.ts
@@ -179,21 +179,12 @@ export interface CompressionFileStats {
  * ISG writes replace the file atomically, so the inode changes even when a
  * same-size rewrite lands on a filesystem whose timestamps are too coarse to
  * move. `ctimeMs` is included as a fallback for filesystems that do not expose
- * useful inode numbers, and the in-process generation still distinguishes any
- * write observed by the current handler.
+ * useful inode numbers. This version is also used in public validators, so it
+ * deliberately contains only filesystem identity shared by sibling handlers;
+ * process-local cache generations belong in cache keys instead.
  */
-export function createCompressionFileVersion(
-  fileStat: CompressionFileStats,
-  generation: number,
-): string {
-  return [
-    fileStat.dev,
-    fileStat.ino,
-    fileStat.size,
-    fileStat.mtimeMs,
-    fileStat.ctimeMs,
-    generation,
-  ].join(":");
+export function createCompressionFileVersion(fileStat: CompressionFileStats): string {
+  return [fileStat.dev, fileStat.ino, fileStat.size, fileStat.mtimeMs, fileStat.ctimeMs].join(":");
 }
 
 /** Fold a durable file version into an identity ETag before content negotiation. */

--- a/packages/adapter-node/src/node-compress.ts
+++ b/packages/adapter-node/src/node-compress.ts
@@ -38,6 +38,8 @@ const COMPRESSIBLE_MIME_TYPES = new Set([
   "application/xml",
 ]);
 
+const INTEGRITY_HEADER_NAMES = ["content-digest", "repr-digest", "digest", "content-md5"];
+
 /**
  * Whether a `Content-Type` names a representation that compresses well.
  * `text/*`, well-known application types, and any `+json`/`+xml` structured
@@ -113,6 +115,11 @@ export function isTransformableResponse(status: number, headers: Headers): boole
   if (headers.has("content-range")) return false;
   const cacheControl = headers.get("cache-control");
   if (cacheControl && /(?:^|[\s,])no-transform(?:$|[\s,;=])/i.test(cacheControl)) return false;
+  // Integrity fields are calculated over the selected content/representation,
+  // which includes its Content-Encoding. Streaming compression cannot
+  // recompute them before the headers are sent, so preserve the identity body
+  // instead of forwarding a digest that no longer matches the wire bytes.
+  if (INTEGRITY_HEADER_NAMES.some((name) => headers.has(name))) return false;
   return true;
 }
 

--- a/packages/adapter-node/src/node-compress.ts
+++ b/packages/adapter-node/src/node-compress.ts
@@ -166,6 +166,46 @@ export function encodeEtagForEncoding(etag: string, encoding: ContentEncoding): 
   return `W/"pracht-${encoding}-${digest}"`;
 }
 
+export interface CompressionFileStats {
+  ctimeMs: number;
+  dev: number;
+  ino: number;
+  mtimeMs: number;
+  size: number;
+}
+
+/**
+ * Build a process-independent file version for static compression metadata.
+ * ISG writes replace the file atomically, so the inode changes even when a
+ * same-size rewrite lands on a filesystem whose timestamps are too coarse to
+ * move. `ctimeMs` is included as a fallback for filesystems that do not expose
+ * useful inode numbers, and the in-process generation still distinguishes any
+ * write observed by the current handler.
+ */
+export function createCompressionFileVersion(
+  fileStat: CompressionFileStats,
+  generation: number,
+): string {
+  return [
+    fileStat.dev,
+    fileStat.ino,
+    fileStat.size,
+    fileStat.mtimeMs,
+    fileStat.ctimeMs,
+    generation,
+  ].join(":");
+}
+
+/** Fold a durable file version into an identity ETag before content negotiation. */
+export function encodeEtagForFileVersion(etag: string, fileVersion: string): string {
+  const digest = createHash("sha256")
+    .update(etag)
+    .update("\0")
+    .update(fileVersion)
+    .digest("base64url");
+  return `W/"pracht-file-${digest}"`;
+}
+
 /**
  * Keep an application identity tag out of the namespace used for encoded
  * variants. Without this escape, an application that later adopts a tag equal

--- a/packages/adapter-node/src/node-entry.ts
+++ b/packages/adapter-node/src/node-entry.ts
@@ -18,6 +18,12 @@ export interface NodeServerEntryModuleOptions {
    * Origin check.
    */
   configureServerFrom?: string;
+  /**
+   * Compress responses with brotli or gzip based on `Accept-Encoding`
+   * (default: `true`). Set to `false` when a reverse proxy or CDN in front of
+   * the Node server already compresses responses.
+   */
+  compression?: boolean;
 }
 
 export function createNodeServerEntryModule(options: NodeServerEntryModuleOptions = {}): string {
@@ -70,6 +76,7 @@ export function createNodeServerEntryModule(options: NodeServerEntryModuleOption
     `  canonicalOrigin: ${JSON.stringify(canonicalOrigin ?? undefined)},`,
     "  createContext: createPrachtContext,",
     `  maxBodySize: ${JSON.stringify(options.maxBodySize ?? undefined)},`,
+    `  compression: ${JSON.stringify(options.compression ?? undefined)},`,
     "});",
     "",
     "const entryHref = process.argv[1] ? pathToFileURL(process.argv[1]).href : null;",

--- a/packages/adapter-node/src/node-handler.ts
+++ b/packages/adapter-node/src/node-handler.ts
@@ -757,19 +757,28 @@ function createApplicationRequest(
   request: Request,
   compression: CompressionState | undefined,
 ): Request {
+  const ifMatch = request.headers.get("if-match");
   const ifNoneMatch = request.headers.get("if-none-match");
   if (
     !compression ||
     (request.method !== "GET" && request.method !== "HEAD") ||
     request.headers.has("range") ||
-    (!ifNoneMatch && !request.headers.has("if-modified-since")) ||
+    (!ifMatch && !ifNoneMatch && !request.headers.has("if-modified-since")) ||
     (!negotiateEncoding(request.headers.get("accept-encoding")) &&
+      !containsEncodedEtag(ifMatch) &&
       !containsEncodedEtag(ifNoneMatch))
   ) {
     return request;
   }
 
   const headers = new Headers(request.headers);
+  if (ifMatch) {
+    compression.ownsIfMatch = true;
+    headers.delete("if-match");
+    // If-Match takes precedence, so the recipient must ignore
+    // If-Unmodified-Since rather than exposing it alone to the application.
+    headers.delete("if-unmodified-since");
+  }
   headers.delete("if-none-match");
   headers.delete("if-modified-since");
   return new Request(request, { headers });

--- a/packages/adapter-node/src/node-handler.ts
+++ b/packages/adapter-node/src/node-handler.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import { open, type FileHandle } from "node:fs/promises";
 import type { IncomingMessage, ServerResponse } from "node:http";
 import { join, resolve, sep } from "node:path";
@@ -35,7 +36,6 @@ import {
   createCompressionFileVersion,
   createCompressedStream,
   encodeEtagForEncoding,
-  encodeEtagForFileVersion,
   isCompressibleContentType,
   isNotModifiedRequest,
   isTransformableResponse,
@@ -363,8 +363,6 @@ async function serveStaticFile(
     if (staticResult.contentType.includes("text/html")) {
       applyHeadersManifest(headers, headersManifest, pathname);
     }
-    applyCompressionFileValidator(headers, compressionFileVersion);
-
     const encoding = negotiateFileEncoding(request, headers, fileStat.size, compression);
 
     if (isNotModified(request, headers, compressionGeneration === 0)) {
@@ -579,7 +577,14 @@ async function serveISGEntry<TContext>(
       }),
     );
     applyHeadersManifest(headers, headersManifest, pathname);
-    applyCompressionFileValidator(headers, compressionFileVersion);
+    await applyCompressionContentValidator(
+      headers,
+      htmlPath,
+      file,
+      compressionFileVersion,
+      compressionGeneration,
+      compression,
+    );
     headers.set("x-pracht-isg", isStale ? "stale" : "fresh");
 
     const encoding = negotiateFileEncoding(request, headers, fileStat.size, compression);
@@ -775,14 +780,33 @@ function createWeakEtag(fileStat: { mtimeMs: number; size: number }): string {
   return `W/"${fileStat.size.toString(16)}-${Math.floor(fileStat.mtimeMs).toString(16)}"`;
 }
 
-function applyCompressionFileValidator(
+async function applyCompressionContentValidator(
   headers: Headers,
+  filePath: string,
+  file: FileHandle,
   compressionFileVersion: string | undefined,
-): void {
-  if (!compressionFileVersion) return;
-  const etag = headers.get("etag");
-  if (!etag) return;
-  headers.set("etag", encodeEtagForFileVersion(etag, compressionFileVersion));
+  compressionGeneration: number,
+  compression: CompressionState | undefined,
+): Promise<void> {
+  if (!compressionFileVersion || !compression) return;
+  const key = `${filePath}\0${compressionFileVersion}\0${compressionGeneration}`;
+  const etag = await compression.cache.getOrCreateFileEtag(key, () => createFileContentEtag(file));
+  headers.set("etag", etag);
+}
+
+async function createFileContentEtag(file: FileHandle): Promise<string> {
+  const hash = createHash("sha256");
+  const buffer = Buffer.allocUnsafe(64 * 1024);
+  let position = 0;
+
+  while (true) {
+    const { bytesRead } = await file.read(buffer, 0, buffer.byteLength, position);
+    if (bytesRead === 0) break;
+    hash.update(buffer.subarray(0, bytesRead));
+    position += bytesRead;
+  }
+
+  return `W/"pracht-file-${hash.digest("base64url")}"`;
 }
 
 function isNotModified(request: Request, headers: Headers, allowLastModified = true): boolean {

--- a/packages/adapter-node/src/node-handler.ts
+++ b/packages/adapter-node/src/node-handler.ts
@@ -29,6 +29,7 @@ import {
 import {
   COMPRESSION_MIN_SIZE,
   CompressedAssetCache,
+  containsEncodedEtag,
   type CompressionState,
   compressBuffer,
   type ContentEncoding,
@@ -40,6 +41,7 @@ import {
   MAX_CACHEABLE_ASSET_SIZE,
   mergeVaryValue,
   negotiateEncoding,
+  protectIdentityEtag,
 } from "./node-compress.ts";
 import { regenerateISGPage } from "./node-isg.ts";
 import {
@@ -405,8 +407,11 @@ function negotiateFileEncoding(
   fileSize: number,
   compression: CompressionState | undefined,
 ): ContentEncoding | null {
+  if (!compression) return null;
+
+  const identityEtag = headers.get("etag");
+  if (identityEtag) headers.set("etag", protectIdentityEtag(identityEtag));
   if (
-    !compression ||
     !isCompressibleContentType(headers.get("content-type")) ||
     !isTransformableResponse(200, headers)
   ) {
@@ -429,8 +434,7 @@ function negotiateFileEncoding(
   // buffered path below replaces it with the exact encoded length; the
   // streaming path must use chunked transfer instead.
   headers.delete("content-length");
-  const etag = headers.get("etag");
-  if (etag) headers.set("etag", encodeEtagForEncoding(etag, encoding));
+  if (identityEtag) headers.set("etag", encodeEtagForEncoding(identityEtag, encoding));
   return encoding;
 }
 
@@ -677,18 +681,21 @@ function isRouteStateRequest(url: URL, headers: Headers): boolean {
 
 /**
  * Dynamic compression owns conditional validation after it has selected the
- * outgoing representation. Do not let an application short-circuit an encoded
- * request against identity metadata before that selection happens.
+ * outgoing representation and escaped its reserved validator namespace. Do
+ * not let an application short-circuit against the source identity metadata
+ * before either step happens.
  */
 function createApplicationRequest(
   request: Request,
   compression: CompressionState | undefined,
 ): Request {
+  const ifNoneMatch = request.headers.get("if-none-match");
   if (
     !compression ||
     (request.method !== "GET" && request.method !== "HEAD") ||
-    (!request.headers.has("if-none-match") && !request.headers.has("if-modified-since")) ||
-    !negotiateEncoding(request.headers.get("accept-encoding"))
+    (!ifNoneMatch && !request.headers.has("if-modified-since")) ||
+    (!negotiateEncoding(request.headers.get("accept-encoding")) &&
+      !containsEncodedEtag(ifNoneMatch))
   ) {
     return request;
   }

--- a/packages/adapter-node/src/node-handler.ts
+++ b/packages/adapter-node/src/node-handler.ts
@@ -167,11 +167,18 @@ export function createNodeRequestHandler<TContext = unknown>(
         routeSupportsMarkdown(options.markdownManifest, url.pathname));
 
     if (url.pathname === PRACHT_REVALIDATE_ENDPOINT) {
-      const response = await handleRevalidationEndpoint(request, options, staticDir, isgManifest, {
+      const response = await handleRevalidationEndpoint(
         request,
-        req,
-        res,
-      });
+        options,
+        staticDir,
+        isgManifest,
+        {
+          request,
+          req,
+          res,
+        },
+        compression,
+      );
       await writeWebResponse(res, response, compression);
       return;
     }
@@ -250,6 +257,7 @@ export function createNodeRequestHandler<TContext = unknown>(
       if (htmlPath) {
         await mkdir(dirname(htmlPath), { recursive: true });
         await writeFile(htmlPath, html, "utf-8");
+        compressedAssetCache.invalidatePath(htmlPath);
       }
     }
 
@@ -430,7 +438,8 @@ async function writeFileBody(
   }
 
   if (fileStat.size <= MAX_CACHEABLE_ASSET_SIZE) {
-    const key = `${filePath}\0${fileStat.size}\0${fileStat.mtimeMs}\0${encoding}`;
+    const generation = compression.cache.getPathGeneration(filePath);
+    const key = `${filePath}\0${generation}\0${fileStat.size}\0${fileStat.mtimeMs}\0${encoding}`;
     const pending = compression.cache.getOrCompress(key, fileStat.size, async () =>
       compressBuffer(await readFile(filePath), encoding),
     );
@@ -498,7 +507,13 @@ async function serveISGEntry<TContext>(
   }
 
   if (isStale) {
-    regenerateISGPage(options, pathname, htmlPath, contextArgs).catch((err) => {
+    regenerateISGPageAndInvalidateCache(
+      options,
+      pathname,
+      htmlPath,
+      contextArgs,
+      compression,
+    ).catch((err) => {
       console.error(`ISG regeneration failed for ${pathname}:`, err);
     });
   }
@@ -512,6 +527,7 @@ async function handleRevalidationEndpoint<TContext>(
   staticDir: string | undefined,
   isgManifest: Record<string, ISGManifestEntry>,
   contextArgs: NodeAdapterContextArgs,
+  compression: CompressionState | undefined,
 ): Promise<Response> {
   const parsed = await readRevalidationRequest(request, resolveRevalidationToken());
   if (!parsed.ok) return parsed.response;
@@ -545,7 +561,15 @@ async function handleRevalidationEndpoint<TContext>(
 
       // A failed regeneration keeps the existing on-disk HTML and is reported
       // in `failed` instead of aborting the whole batch with a 500.
-      if (await regenerateISGPage(options, pathname, htmlPath!, contextArgs)) {
+      if (
+        await regenerateISGPageAndInvalidateCache(
+          options,
+          pathname,
+          htmlPath!,
+          contextArgs,
+          compression,
+        )
+      ) {
         report.revalidated(pathname);
       } else {
         report.failed(pathname, "regeneration_failed");
@@ -557,6 +581,18 @@ async function handleRevalidationEndpoint<TContext>(
   }
 
   return jsonResponse(report.toJSON());
+}
+
+async function regenerateISGPageAndInvalidateCache<TContext>(
+  options: NodeAdapterOptions<TContext>,
+  pathname: string,
+  htmlPath: string,
+  contextArgs: NodeAdapterContextArgs,
+  compression: CompressionState | undefined,
+): Promise<boolean> {
+  const regenerated = await regenerateISGPage(options, pathname, htmlPath, contextArgs);
+  if (regenerated) compression?.cache.invalidatePath(htmlPath);
+  return regenerated;
 }
 
 /**

--- a/packages/adapter-node/src/node-handler.ts
+++ b/packages/adapter-node/src/node-handler.ts
@@ -1,5 +1,4 @@
-import { createReadStream } from "node:fs";
-import { readFile, stat } from "node:fs/promises";
+import { open, type FileHandle } from "node:fs/promises";
 import type { IncomingMessage, ServerResponse } from "node:http";
 import { join, resolve, sep } from "node:path";
 
@@ -348,54 +347,61 @@ async function serveStaticFile(
   pathname: string,
   compression: CompressionState | undefined,
 ): Promise<void> {
-  const fileStat = await stat(staticResult.filePath);
-  const compressionGeneration = compression?.cache.getPathGeneration(staticResult.filePath) ?? 0;
-  const compressionFileVersion = compression
-    ? createCompressionFileVersion(fileStat, compressionGeneration)
-    : undefined;
-  const headers = applyDefaultSecurityHeaders(
-    new Headers({
-      "content-type": staticResult.contentType,
-      "cache-control": staticResult.cacheControl,
-      etag: createWeakEtag(fileStat),
-      "last-modified": fileStat.mtime.toUTCString(),
-    }),
-  );
-  if (staticResult.contentType.includes("text/html")) {
-    applyHeadersManifest(headers, headersManifest, pathname);
-  }
-  applyCompressionFileValidator(headers, compressionFileVersion);
+  const file = await open(staticResult.filePath, "r");
+  try {
+    const fileStat = await file.stat();
+    const compressionGeneration = compression?.cache.getPathGeneration(staticResult.filePath) ?? 0;
+    const compressionFileVersion = compression ? createCompressionFileVersion(fileStat) : undefined;
+    const headers = applyDefaultSecurityHeaders(
+      new Headers({
+        "content-type": staticResult.contentType,
+        "cache-control": staticResult.cacheControl,
+        etag: createWeakEtag(fileStat),
+        "last-modified": fileStat.mtime.toUTCString(),
+      }),
+    );
+    if (staticResult.contentType.includes("text/html")) {
+      applyHeadersManifest(headers, headersManifest, pathname);
+    }
+    applyCompressionFileValidator(headers, compressionFileVersion);
 
-  const encoding = negotiateFileEncoding(request, headers, fileStat.size, compression);
+    const encoding = negotiateFileEncoding(request, headers, fileStat.size, compression);
 
-  if (isNotModified(request, headers, compressionGeneration === 0)) {
-    res.statusCode = 304;
+    if (isNotModified(request, headers, compressionGeneration === 0)) {
+      res.statusCode = 304;
+      writeNodeHeaders(res, headers);
+      res.end();
+      return;
+    }
+
+    res.statusCode = 200;
     writeNodeHeaders(res, headers);
-    res.end();
-    return;
-  }
-
-  res.statusCode = 200;
-  writeNodeHeaders(res, headers);
-  if (request.method === "HEAD") {
-    await writeFileHead(
+    if (request.method === "HEAD") {
+      await writeFileHead(
+        res,
+        staticResult.filePath,
+        file,
+        fileStat,
+        encoding,
+        compression,
+        compressionFileVersion,
+        compressionGeneration,
+      );
+      return;
+    }
+    await writeFileBody(
       res,
       staticResult.filePath,
+      file,
       fileStat,
       encoding,
       compression,
       compressionFileVersion,
+      compressionGeneration,
     );
-    return;
+  } finally {
+    await file.close();
   }
-  await writeFileBody(
-    res,
-    staticResult.filePath,
-    fileStat,
-    encoding,
-    compression,
-    compressionFileVersion,
-  );
 }
 
 /**
@@ -445,29 +451,35 @@ function negotiateFileEncoding(
 /**
  * Stream a file body, compressed when an encoding was negotiated. Files up to
  * `MAX_CACHEABLE_ASSET_SIZE` are compressed once at high quality and served
- * from an in-memory LRU keyed by path + write generation + size + mtime, so
- * hashed assets and (re)generated ISG documents pay the compression cost once
- * per version. Larger files stream through zlib per request.
+ * from an in-memory LRU keyed by path + durable file identity + local write
+ * generation, so hashed assets and (re)generated ISG documents pay the
+ * compression cost once per version. The open handle binds the bytes to the
+ * metadata and validator selected by the caller even if the path is replaced
+ * concurrently. Larger files stream through zlib per request.
  */
 async function writeFileBody(
   res: ServerResponse,
   filePath: string,
+  file: FileHandle,
   fileStat: { mtimeMs: number; size: number },
   encoding: ContentEncoding | null,
   compression: CompressionState | undefined,
   compressionFileVersion: string | undefined,
+  compressionGeneration: number,
 ): Promise<void> {
   if (!encoding || !compression || !compressionFileVersion) {
-    await pipeToResponse(createReadStream(filePath), res);
+    await pipeToResponse(file.createReadStream({ autoClose: false }), res);
     return;
   }
 
   const pending = getBufferedCompressedFile(
     filePath,
+    file,
     fileStat,
     encoding,
     compression,
     compressionFileVersion,
+    compressionGeneration,
   );
   if (pending) {
     const compressed = await pending;
@@ -477,37 +489,51 @@ async function writeFileBody(
   }
 
   await pipeToResponse(
-    createCompressedStream(createReadStream(filePath), encoding, { sizeHint: fileStat.size }),
+    createCompressedStream(file.createReadStream({ autoClose: false }), encoding, {
+      sizeHint: fileStat.size,
+    }),
     res,
   );
 }
 
 function getBufferedCompressedFile(
   filePath: string,
+  file: FileHandle,
   fileStat: { mtimeMs: number; size: number },
   encoding: ContentEncoding,
   compression: CompressionState,
   compressionFileVersion: string,
+  compressionGeneration: number,
 ): Promise<Buffer> | null {
   if (fileStat.size > MAX_CACHEABLE_ASSET_SIZE) return null;
 
-  const key = `${filePath}\0${compressionFileVersion}\0${encoding}`;
+  const key = `${filePath}\0${compressionFileVersion}\0${compressionGeneration}\0${encoding}`;
   return compression.cache.getOrCompress(key, fileStat.size, async () =>
-    compressBuffer(await readFile(filePath), encoding),
+    compressBuffer(await file.readFile(), encoding),
   );
 }
 
 async function writeFileHead(
   res: ServerResponse,
   filePath: string,
+  file: FileHandle,
   fileStat: { mtimeMs: number; size: number },
   encoding: ContentEncoding | null,
   compression: CompressionState | undefined,
   compressionFileVersion: string | undefined,
+  compressionGeneration: number,
 ): Promise<void> {
   const pending =
     encoding && compression && compressionFileVersion
-      ? getBufferedCompressedFile(filePath, fileStat, encoding, compression, compressionFileVersion)
+      ? getBufferedCompressedFile(
+          filePath,
+          file,
+          fileStat,
+          encoding,
+          compression,
+          compressionFileVersion,
+          compressionGeneration,
+        )
       : null;
   if (pending) {
     const compressed = await pending;
@@ -530,59 +556,82 @@ async function serveISGEntry<TContext>(
   const htmlPath = resolveContainedPath(staticDir, pathname);
   if (!htmlPath) return false;
 
-  const fileStat = await stat(htmlPath).catch(() => null);
-  if (!fileStat?.isFile()) return false;
-  const compressionGeneration = compression?.cache.getPathGeneration(htmlPath) ?? 0;
-  const compressionFileVersion = compression
-    ? createCompressionFileVersion(fileStat, compressionGeneration)
-    : undefined;
+  const file = await open(htmlPath, "r").catch(() => null);
+  if (!file) return false;
 
-  const ageMs = Date.now() - fileStat.mtimeMs;
-  const revalidateSeconds = getTimeRevalidateSeconds(entry.revalidate);
-  const isStale = revalidateSeconds !== null && ageMs > revalidateSeconds * 1000;
+  try {
+    const fileStat = await file.stat();
+    if (!fileStat.isFile()) return false;
+    const compressionGeneration = compression?.cache.getPathGeneration(htmlPath) ?? 0;
+    const compressionFileVersion = compression ? createCompressionFileVersion(fileStat) : undefined;
 
-  const headers = applyDefaultSecurityHeaders(
-    new Headers({
-      "content-type": "text/html; charset=utf-8",
-      "cache-control": "public, max-age=0, must-revalidate",
-      etag: createWeakEtag(fileStat),
-      "last-modified": fileStat.mtime.toUTCString(),
-      vary: ROUTE_STATE_REQUEST_HEADER,
-    }),
-  );
-  applyHeadersManifest(headers, headersManifest, pathname);
-  applyCompressionFileValidator(headers, compressionFileVersion);
-  headers.set("x-pracht-isg", isStale ? "stale" : "fresh");
+    const ageMs = Date.now() - fileStat.mtimeMs;
+    const revalidateSeconds = getTimeRevalidateSeconds(entry.revalidate);
+    const isStale = revalidateSeconds !== null && ageMs > revalidateSeconds * 1000;
 
-  const encoding = negotiateFileEncoding(request, headers, fileStat.size, compression);
+    const headers = applyDefaultSecurityHeaders(
+      new Headers({
+        "content-type": "text/html; charset=utf-8",
+        "cache-control": "public, max-age=0, must-revalidate",
+        etag: createWeakEtag(fileStat),
+        "last-modified": fileStat.mtime.toUTCString(),
+        vary: ROUTE_STATE_REQUEST_HEADER,
+      }),
+    );
+    applyHeadersManifest(headers, headersManifest, pathname);
+    applyCompressionFileValidator(headers, compressionFileVersion);
+    headers.set("x-pracht-isg", isStale ? "stale" : "fresh");
 
-  if (isNotModified(request, headers, compression === undefined)) {
-    res.statusCode = 304;
-    writeNodeHeaders(res, headers);
-    res.end();
-  } else {
-    res.statusCode = 200;
-    writeNodeHeaders(res, headers);
-    if (request.method === "HEAD") {
-      await writeFileHead(res, htmlPath, fileStat, encoding, compression, compressionFileVersion);
+    const encoding = negotiateFileEncoding(request, headers, fileStat.size, compression);
+
+    if (isNotModified(request, headers, compression === undefined)) {
+      res.statusCode = 304;
+      writeNodeHeaders(res, headers);
+      res.end();
     } else {
-      await writeFileBody(res, htmlPath, fileStat, encoding, compression, compressionFileVersion);
+      res.statusCode = 200;
+      writeNodeHeaders(res, headers);
+      if (request.method === "HEAD") {
+        await writeFileHead(
+          res,
+          htmlPath,
+          file,
+          fileStat,
+          encoding,
+          compression,
+          compressionFileVersion,
+          compressionGeneration,
+        );
+      } else {
+        await writeFileBody(
+          res,
+          htmlPath,
+          file,
+          fileStat,
+          encoding,
+          compression,
+          compressionFileVersion,
+          compressionGeneration,
+        );
+      }
     }
-  }
 
-  if (isStale) {
-    regenerateISGPageAndInvalidateCache(
-      options,
-      pathname,
-      htmlPath,
-      contextArgs,
-      compression,
-    ).catch((err) => {
-      console.error(`ISG regeneration failed for ${pathname}:`, err);
-    });
-  }
+    if (isStale) {
+      regenerateISGPageAndInvalidateCache(
+        options,
+        pathname,
+        htmlPath,
+        contextArgs,
+        compression,
+      ).catch((err) => {
+        console.error(`ISG regeneration failed for ${pathname}:`, err);
+      });
+    }
 
-  return true;
+    return true;
+  } finally {
+    await file.close();
+  }
 }
 
 async function handleRevalidationEndpoint<TContext>(

--- a/packages/adapter-node/src/node-handler.ts
+++ b/packages/adapter-node/src/node-handler.ts
@@ -1,5 +1,5 @@
 import { createReadStream } from "node:fs";
-import { mkdir, stat, writeFile } from "node:fs/promises";
+import { mkdir, readFile, stat, writeFile } from "node:fs/promises";
 import type { IncomingMessage, ServerResponse } from "node:http";
 import { dirname, join, resolve, sep } from "node:path";
 
@@ -26,6 +26,20 @@ import {
   routeSupportsMarkdown,
 } from "@pracht/core/server";
 
+import {
+  COMPRESSION_MIN_SIZE,
+  CompressedAssetCache,
+  type CompressionState,
+  compressBuffer,
+  type ContentEncoding,
+  createCompressedStream,
+  encodeEtagForEncoding,
+  isCompressibleContentType,
+  isTransformableResponse,
+  MAX_CACHEABLE_ASSET_SIZE,
+  mergeVaryValue,
+  negotiateEncoding,
+} from "./node-compress.ts";
 import { regenerateISGPage } from "./node-isg.ts";
 import {
   createWebRequest,
@@ -88,6 +102,14 @@ export interface NodeAdapterOptions<TContext = unknown> {
   trustProxy?: boolean;
   /** Maximum request body size in bytes. Defaults to 1 MiB. */
   maxBodySize?: number;
+  /**
+   * Compress responses with brotli or gzip based on `Accept-Encoding`
+   * (default: `true`). Applies to HTML documents, route-state JSON, and other
+   * compressible text types; static assets are compressed at runtime through
+   * an in-memory LRU of compressed variants. Set to `false` when a reverse
+   * proxy or CDN in front of the server already compresses responses.
+   */
+  compression?: boolean;
 }
 
 let warnedAboutMissingCanonicalOrigin = false;
@@ -101,6 +123,8 @@ export function createNodeRequestHandler<TContext = unknown>(
   const trustProxy = options.trustProxy ?? false;
   const canonicalOrigin = options.canonicalOrigin;
   const maxBodySize = options.maxBodySize;
+  const compressionEnabled = options.compression !== false;
+  const compressedAssetCache = new CompressedAssetCache();
 
   if (maxBodySize !== undefined && (!Number.isInteger(maxBodySize) || maxBodySize <= 0)) {
     throw new Error("nodeAdapter({ maxBodySize }) expects a positive integer number of bytes.");
@@ -126,6 +150,9 @@ export function createNodeRequestHandler<TContext = unknown>(
       throw err;
     }
     const url = new URL(request.url);
+    const compression: CompressionState | undefined = compressionEnabled
+      ? { cache: compressedAssetCache, request }
+      : undefined;
     const isTransportRouteStateRequest = isRouteStateRequest(url, request.headers);
     // Only routes that can actually answer with markdown skip the static and
     // ISG fast paths: the client has to prefer markdown over HTML (a browser's
@@ -144,7 +171,7 @@ export function createNodeRequestHandler<TContext = unknown>(
         req,
         res,
       });
-      await writeWebResponse(res, response);
+      await writeWebResponse(res, response, compression);
       return;
     }
 
@@ -156,7 +183,14 @@ export function createNodeRequestHandler<TContext = unknown>(
     ) {
       const staticResult = await resolveStaticFile(staticDir, url.pathname, isgManifest);
       if (staticResult) {
-        await serveStaticFile(request, res, staticResult, headersManifest, url.pathname);
+        await serveStaticFile(
+          request,
+          res,
+          staticResult,
+          headersManifest,
+          url.pathname,
+          compression,
+        );
         return;
       }
     }
@@ -177,6 +211,7 @@ export function createNodeRequestHandler<TContext = unknown>(
         isgManifest[url.pathname],
         headersManifest,
         { request, req, res },
+        compression,
       );
       if (served) return;
     }
@@ -229,6 +264,7 @@ export function createNodeRequestHandler<TContext = unknown>(
     await writeWebResponse(
       res,
       isIsgDocument ? response : preventHeuristicCaching(request, response),
+      compression,
     );
   };
 
@@ -283,6 +319,7 @@ async function serveStaticFile(
   staticResult: { filePath: string; contentType: string; cacheControl: string },
   headersManifest: HeadersManifest,
   pathname: string,
+  compression: CompressionState | undefined,
 ): Promise<void> {
   const fileStat = await stat(staticResult.filePath);
   const headers = applyDefaultSecurityHeaders(
@@ -297,6 +334,8 @@ async function serveStaticFile(
     applyHeadersManifest(headers, headersManifest, pathname);
   }
 
+  const encoding = negotiateFileEncoding(request, headers, fileStat.size, compression);
+
   if (isNotModified(request, headers)) {
     res.statusCode = 304;
     writeNodeHeaders(res, headers);
@@ -310,7 +349,82 @@ async function serveStaticFile(
     res.end();
     return;
   }
-  await pipeToResponse(createReadStream(staticResult.filePath), res);
+  await writeFileBody(res, staticResult.filePath, fileStat, encoding, compression);
+}
+
+/**
+ * Decide the on-the-wire encoding for a file response and stamp the
+ * compression headers. Mutates `headers` before the conditional-request check
+ * so the `ETag` the client revalidates against always names the encoded
+ * variant it was served — encoded and identity variants never share a
+ * validator.
+ */
+function negotiateFileEncoding(
+  request: Request,
+  headers: Headers,
+  fileSize: number,
+  compression: CompressionState | undefined,
+): ContentEncoding | null {
+  if (
+    !compression ||
+    !isCompressibleContentType(headers.get("content-type")) ||
+    !isTransformableResponse(200, headers)
+  ) {
+    return null;
+  }
+
+  // The representation varies by Accept-Encoding even when this response goes
+  // out as identity (small file today, larger after the next deploy).
+  headers.set("vary", mergeVaryValue(headers.get("vary")));
+
+  if (fileSize < COMPRESSION_MIN_SIZE || request.method === "HEAD") {
+    return null;
+  }
+
+  const encoding = negotiateEncoding(compression.request.headers.get("accept-encoding"));
+  if (!encoding) return null;
+
+  headers.set("content-encoding", encoding);
+  const etag = headers.get("etag");
+  if (etag) headers.set("etag", encodeEtagForEncoding(etag, encoding));
+  return encoding;
+}
+
+/**
+ * Stream a file body, compressed when an encoding was negotiated. Files up to
+ * `MAX_CACHEABLE_ASSET_SIZE` are compressed once at high quality and served
+ * from an in-memory LRU keyed by path + size + mtime, so hashed assets and
+ * (re)generated ISG documents pay the compression cost once per version.
+ * Larger files stream through zlib per request.
+ */
+async function writeFileBody(
+  res: ServerResponse,
+  filePath: string,
+  fileStat: { mtimeMs: number; size: number },
+  encoding: ContentEncoding | null,
+  compression: CompressionState | undefined,
+): Promise<void> {
+  if (!encoding || !compression) {
+    await pipeToResponse(createReadStream(filePath), res);
+    return;
+  }
+
+  if (fileStat.size <= MAX_CACHEABLE_ASSET_SIZE) {
+    const key = `${filePath}\0${fileStat.size}\0${fileStat.mtimeMs}\0${encoding}`;
+    let compressed = compression.cache.get(key);
+    if (compressed === undefined) {
+      compressed = await compressBuffer(await readFile(filePath), encoding);
+      compression.cache.set(key, compressed);
+    }
+    res.setHeader("content-length", compressed.byteLength);
+    res.end(compressed);
+    return;
+  }
+
+  await pipeToResponse(
+    createCompressedStream(createReadStream(filePath), encoding, fileStat.size),
+    res,
+  );
 }
 
 async function serveISGEntry<TContext>(
@@ -322,6 +436,7 @@ async function serveISGEntry<TContext>(
   entry: ISGManifestEntry,
   headersManifest: HeadersManifest,
   contextArgs: NodeAdapterContextArgs,
+  compression: CompressionState | undefined,
 ): Promise<boolean> {
   const htmlPath = resolveContainedPath(staticDir, pathname);
   if (!htmlPath) return false;
@@ -345,6 +460,8 @@ async function serveISGEntry<TContext>(
   applyHeadersManifest(headers, headersManifest, pathname);
   headers.set("x-pracht-isg", isStale ? "stale" : "fresh");
 
+  const encoding = negotiateFileEncoding(request, headers, fileStat.size, compression);
+
   if (isNotModified(request, headers)) {
     res.statusCode = 304;
     writeNodeHeaders(res, headers);
@@ -355,7 +472,7 @@ async function serveISGEntry<TContext>(
     if (request.method === "HEAD") {
       res.end();
     } else {
-      await pipeToResponse(createReadStream(htmlPath), res);
+      await writeFileBody(res, htmlPath, fileStat, encoding, compression);
     }
   }
 

--- a/packages/adapter-node/src/node-handler.ts
+++ b/packages/adapter-node/src/node-handler.ts
@@ -346,6 +346,7 @@ async function serveStaticFile(
   compression: CompressionState | undefined,
 ): Promise<void> {
   const fileStat = await stat(staticResult.filePath);
+  const compressionGeneration = compression?.cache.getPathGeneration(staticResult.filePath) ?? 0;
   const headers = applyDefaultSecurityHeaders(
     new Headers({
       "content-type": staticResult.contentType,
@@ -357,10 +358,11 @@ async function serveStaticFile(
   if (staticResult.contentType.includes("text/html")) {
     applyHeadersManifest(headers, headersManifest, pathname);
   }
+  applyCompressionGenerationValidator(headers, compressionGeneration);
 
   const encoding = negotiateFileEncoding(request, headers, fileStat.size, compression);
 
-  if (isNotModified(request, headers)) {
+  if (isNotModified(request, headers, compressionGeneration === 0)) {
     res.statusCode = 304;
     writeNodeHeaders(res, headers);
     res.end();
@@ -370,10 +372,24 @@ async function serveStaticFile(
   res.statusCode = 200;
   writeNodeHeaders(res, headers);
   if (request.method === "HEAD") {
-    res.end();
+    await writeFileHead(
+      res,
+      staticResult.filePath,
+      fileStat,
+      encoding,
+      compression,
+      compressionGeneration,
+    );
     return;
   }
-  await writeFileBody(res, staticResult.filePath, fileStat, encoding, compression);
+  await writeFileBody(
+    res,
+    staticResult.filePath,
+    fileStat,
+    encoding,
+    compression,
+    compressionGeneration,
+  );
 }
 
 /**
@@ -421,9 +437,9 @@ function negotiateFileEncoding(
 /**
  * Stream a file body, compressed when an encoding was negotiated. Files up to
  * `MAX_CACHEABLE_ASSET_SIZE` are compressed once at high quality and served
- * from an in-memory LRU keyed by path + size + mtime, so hashed assets and
- * (re)generated ISG documents pay the compression cost once per version.
- * Larger files stream through zlib per request.
+ * from an in-memory LRU keyed by path + write generation + size + mtime, so
+ * hashed assets and (re)generated ISG documents pay the compression cost once
+ * per version. Larger files stream through zlib per request.
  */
 async function writeFileBody(
   res: ServerResponse,
@@ -431,30 +447,65 @@ async function writeFileBody(
   fileStat: { mtimeMs: number; size: number },
   encoding: ContentEncoding | null,
   compression: CompressionState | undefined,
+  compressionGeneration: number,
 ): Promise<void> {
   if (!encoding || !compression) {
     await pipeToResponse(createReadStream(filePath), res);
     return;
   }
 
-  if (fileStat.size <= MAX_CACHEABLE_ASSET_SIZE) {
-    const generation = compression.cache.getPathGeneration(filePath);
-    const key = `${filePath}\0${generation}\0${fileStat.size}\0${fileStat.mtimeMs}\0${encoding}`;
-    const pending = compression.cache.getOrCompress(key, fileStat.size, async () =>
-      compressBuffer(await readFile(filePath), encoding),
-    );
-    if (pending) {
-      const compressed = await pending;
-      res.setHeader("content-length", compressed.byteLength);
-      res.end(compressed);
-      return;
-    }
+  const pending = getBufferedCompressedFile(
+    filePath,
+    fileStat,
+    encoding,
+    compression,
+    compressionGeneration,
+  );
+  if (pending) {
+    const compressed = await pending;
+    res.setHeader("content-length", compressed.byteLength);
+    res.end(compressed);
+    return;
   }
 
   await pipeToResponse(
     createCompressedStream(createReadStream(filePath), encoding, { sizeHint: fileStat.size }),
     res,
   );
+}
+
+function getBufferedCompressedFile(
+  filePath: string,
+  fileStat: { mtimeMs: number; size: number },
+  encoding: ContentEncoding,
+  compression: CompressionState,
+  compressionGeneration: number,
+): Promise<Buffer> | null {
+  if (fileStat.size > MAX_CACHEABLE_ASSET_SIZE) return null;
+
+  const key = `${filePath}\0${compressionGeneration}\0${fileStat.size}\0${fileStat.mtimeMs}\0${encoding}`;
+  return compression.cache.getOrCompress(key, fileStat.size, async () =>
+    compressBuffer(await readFile(filePath), encoding),
+  );
+}
+
+async function writeFileHead(
+  res: ServerResponse,
+  filePath: string,
+  fileStat: { mtimeMs: number; size: number },
+  encoding: ContentEncoding | null,
+  compression: CompressionState | undefined,
+  compressionGeneration: number,
+): Promise<void> {
+  const pending =
+    encoding && compression
+      ? getBufferedCompressedFile(filePath, fileStat, encoding, compression, compressionGeneration)
+      : null;
+  if (pending) {
+    const compressed = await pending;
+    res.setHeader("content-length", compressed.byteLength);
+  }
+  res.end();
 }
 
 async function serveISGEntry<TContext>(
@@ -473,6 +524,7 @@ async function serveISGEntry<TContext>(
 
   const fileStat = await stat(htmlPath).catch(() => null);
   if (!fileStat?.isFile()) return false;
+  const compressionGeneration = compression?.cache.getPathGeneration(htmlPath) ?? 0;
 
   const ageMs = Date.now() - fileStat.mtimeMs;
   const revalidateSeconds = getTimeRevalidateSeconds(entry.revalidate);
@@ -488,11 +540,12 @@ async function serveISGEntry<TContext>(
     }),
   );
   applyHeadersManifest(headers, headersManifest, pathname);
+  applyCompressionGenerationValidator(headers, compressionGeneration);
   headers.set("x-pracht-isg", isStale ? "stale" : "fresh");
 
   const encoding = negotiateFileEncoding(request, headers, fileStat.size, compression);
 
-  if (isNotModified(request, headers)) {
+  if (isNotModified(request, headers, compressionGeneration === 0)) {
     res.statusCode = 304;
     writeNodeHeaders(res, headers);
     res.end();
@@ -500,9 +553,9 @@ async function serveISGEntry<TContext>(
     res.statusCode = 200;
     writeNodeHeaders(res, headers);
     if (request.method === "HEAD") {
-      res.end();
+      await writeFileHead(res, htmlPath, fileStat, encoding, compression, compressionGeneration);
     } else {
-      await writeFileBody(res, htmlPath, fileStat, encoding, compression);
+      await writeFileBody(res, htmlPath, fileStat, encoding, compression, compressionGeneration);
     }
   }
 
@@ -658,6 +711,26 @@ function createWeakEtag(fileStat: { mtimeMs: number; size: number }): string {
   return `W/"${fileStat.size.toString(16)}-${Math.floor(fileStat.mtimeMs).toString(16)}"`;
 }
 
-function isNotModified(request: Request, headers: Headers): boolean {
-  return isNotModifiedRequest(request, headers.get("etag"), headers.get("last-modified"));
+function applyCompressionGenerationValidator(headers: Headers, generation: number): void {
+  if (generation <= 0) return;
+  const etag = headers.get("etag");
+  if (!etag) return;
+
+  const opaqueTag = etag.startsWith("W/") ? etag.slice(2) : etag;
+  const suffix = `-g${generation.toString(16)}`;
+  headers.set(
+    "etag",
+    opaqueTag.endsWith('"') ? `W/${opaqueTag.slice(0, -1)}${suffix}"` : `W/${opaqueTag}${suffix}`,
+  );
+}
+
+function isNotModified(request: Request, headers: Headers, allowLastModified = true): boolean {
+  // A sub-second/coarse-filesystem rewrite can retain its HTTP-date while its
+  // in-memory generation and ETag advance. In that case only the ETag can
+  // safely validate the selected representation.
+  return isNotModifiedRequest(
+    request,
+    headers.get("etag"),
+    allowLastModified ? headers.get("last-modified") : null,
+  );
 }

--- a/packages/adapter-node/src/node-handler.ts
+++ b/packages/adapter-node/src/node-handler.ts
@@ -297,8 +297,22 @@ export function createNodeRequestHandler<TContext = unknown>(
       }
 
       try {
+        // Header selection happens before a streamed body starts. If that body
+        // fails before sending bytes, discard every staged header from the
+        // abandoned response so the plain fallback is not mislabeled as
+        // brotli/gzip (or cached with the abandoned response's metadata).
+        for (const name of res.getHeaderNames()) res.removeHeader(name);
         res.statusCode = 500;
-        res.setHeader("content-type", "text/plain; charset=utf-8");
+        res.statusMessage = "Internal Server Error";
+        writeNodeResponseHeaders(
+          res,
+          applyDefaultSecurityHeaders(
+            new Headers({
+              "cache-control": "no-store",
+              "content-type": "text/plain; charset=utf-8",
+            }),
+          ),
+        );
         res.end("Internal Server Error");
       } catch {
         res.destroy();
@@ -385,6 +399,10 @@ function negotiateFileEncoding(
   if (!encoding) return null;
 
   headers.set("content-encoding", encoding);
+  // A manifest can carry the identity representation's Content-Length. The
+  // buffered path below replaces it with the exact encoded length; the
+  // streaming path must use chunked transfer instead.
+  headers.delete("content-length");
   const etag = headers.get("etag");
   if (etag) headers.set("etag", encodeEtagForEncoding(etag, encoding));
   return encoding;

--- a/packages/adapter-node/src/node-handler.ts
+++ b/packages/adapter-node/src/node-handler.ts
@@ -35,9 +35,9 @@ import {
   createCompressedStream,
   encodeEtagForEncoding,
   isCompressibleContentType,
+  isNotModifiedRequest,
   isTransformableResponse,
   MAX_CACHEABLE_ASSET_SIZE,
-  matchesIfNoneMatch,
   mergeVaryValue,
   negotiateEncoding,
 } from "./node-compress.ts";
@@ -431,12 +431,15 @@ async function writeFileBody(
 
   if (fileStat.size <= MAX_CACHEABLE_ASSET_SIZE) {
     const key = `${filePath}\0${fileStat.size}\0${fileStat.mtimeMs}\0${encoding}`;
-    const compressed = await compression.cache.getOrCompress(key, async () =>
+    const pending = compression.cache.getOrCompress(key, fileStat.size, async () =>
       compressBuffer(await readFile(filePath), encoding),
     );
-    res.setHeader("content-length", compressed.byteLength);
-    res.end(compressed);
-    return;
+    if (pending) {
+      const compressed = await pending;
+      res.setHeader("content-length", compressed.byteLength);
+      res.end(compressed);
+      return;
+    }
   }
 
   await pipeToResponse(
@@ -584,9 +587,9 @@ function isRouteStateRequest(url: URL, headers: Headers): boolean {
 }
 
 /**
- * Dynamic compression owns `If-None-Match` after it has selected the outgoing
- * representation. Do not let an application short-circuit an encoded request
- * against the identity representation's ETag before that selection happens.
+ * Dynamic compression owns conditional validation after it has selected the
+ * outgoing representation. Do not let an application short-circuit an encoded
+ * request against identity metadata before that selection happens.
  */
 function createApplicationRequest(
   request: Request,
@@ -595,7 +598,7 @@ function createApplicationRequest(
   if (
     !compression ||
     (request.method !== "GET" && request.method !== "HEAD") ||
-    !request.headers.has("if-none-match") ||
+    (!request.headers.has("if-none-match") && !request.headers.has("if-modified-since")) ||
     !negotiateEncoding(request.headers.get("accept-encoding"))
   ) {
     return request;
@@ -603,6 +606,7 @@ function createApplicationRequest(
 
   const headers = new Headers(request.headers);
   headers.delete("if-none-match");
+  headers.delete("if-modified-since");
   return new Request(request, { headers });
 }
 
@@ -619,27 +623,5 @@ function createWeakEtag(fileStat: { mtimeMs: number; size: number }): string {
 }
 
 function isNotModified(request: Request, headers: Headers): boolean {
-  const ifNoneMatch = request.headers.get("if-none-match");
-  if (ifNoneMatch) {
-    // RFC 9110 §13.1.3: when If-None-Match is present, If-Modified-Since MUST
-    // be ignored — the ETag decides alone. This matters with per-encoding
-    // ETags: a client revalidating an identity body with its identity ETag
-    // plus a Last-Modified date must get a fresh 200 when brotli is
-    // negotiated, not a 304 that relabels its identity cache entry with the
-    // brotli variant's validator.
-    const etag = headers.get("etag");
-    return matchesIfNoneMatch(ifNoneMatch, etag);
-  }
-
-  const lastModified = headers.get("last-modified");
-  const ifModifiedSince = request.headers.get("if-modified-since");
-  if (lastModified && ifModifiedSince) {
-    const modifiedTime = Date.parse(lastModified);
-    const sinceTime = Date.parse(ifModifiedSince);
-    if (!Number.isNaN(modifiedTime) && !Number.isNaN(sinceTime) && modifiedTime <= sinceTime) {
-      return true;
-    }
-  }
-
-  return false;
+  return isNotModifiedRequest(request, headers.get("etag"), headers.get("last-modified"));
 }

--- a/packages/adapter-node/src/node-handler.ts
+++ b/packages/adapter-node/src/node-handler.ts
@@ -430,6 +430,12 @@ function negotiateFileEncoding(
   // out as identity (small file today, larger after the next deploy).
   headers.set("vary", mergeVaryValue(headers.get("vary")));
 
+  // The application needs the original validators to decide whether and which
+  // byte range to serve. Keep the entire request identity-encoded even when it
+  // ignores an invalid/unsupported Range and answers with a full 200, otherwise
+  // that identity decision could be relabeled as a compressed representation.
+  if (request.headers.has("range")) return null;
+
   if (fileSize < COMPRESSION_MIN_SIZE) {
     return null;
   }

--- a/packages/adapter-node/src/node-handler.ts
+++ b/packages/adapter-node/src/node-handler.ts
@@ -581,6 +581,7 @@ async function serveISGEntry<TContext>(
       headers,
       htmlPath,
       file,
+      fileStat.size,
       compressionFileVersion,
       compressionGeneration,
       compression,
@@ -784,14 +785,24 @@ async function applyCompressionContentValidator(
   headers: Headers,
   filePath: string,
   file: FileHandle,
+  fileSize: number,
   compressionFileVersion: string | undefined,
   compressionGeneration: number,
   compression: CompressionState | undefined,
 ): Promise<void> {
   if (!compressionFileVersion || !compression) return;
   const key = `${filePath}\0${compressionFileVersion}\0${compressionGeneration}`;
-  const etag = await compression.cache.getOrCreateFileEtag(key, () => createFileContentEtag(file));
-  headers.set("etag", etag);
+  const pending = compression.cache.getOrCreateFileEtag(key, fileSize, () =>
+    createFileContentEtag(file),
+  );
+  if (!pending) {
+    // The stat-derived fallback can alias a same-size rewrite on a coarse
+    // filesystem. Omit the validator under load instead of advertising one we
+    // cannot prove names these bytes.
+    headers.delete("etag");
+    return;
+  }
+  headers.set("etag", await pending);
 }
 
 async function createFileContentEtag(file: FileHandle): Promise<string> {

--- a/packages/adapter-node/src/node-handler.ts
+++ b/packages/adapter-node/src/node-handler.ts
@@ -411,18 +411,16 @@ async function writeFileBody(
 
   if (fileStat.size <= MAX_CACHEABLE_ASSET_SIZE) {
     const key = `${filePath}\0${fileStat.size}\0${fileStat.mtimeMs}\0${encoding}`;
-    let compressed = compression.cache.get(key);
-    if (compressed === undefined) {
-      compressed = await compressBuffer(await readFile(filePath), encoding);
-      compression.cache.set(key, compressed);
-    }
+    const compressed = await compression.cache.getOrCompress(key, async () =>
+      compressBuffer(await readFile(filePath), encoding),
+    );
     res.setHeader("content-length", compressed.byteLength);
     res.end(compressed);
     return;
   }
 
   await pipeToResponse(
-    createCompressedStream(createReadStream(filePath), encoding, fileStat.size),
+    createCompressedStream(createReadStream(filePath), encoding, { sizeHint: fileStat.size }),
     res,
   );
 }
@@ -578,13 +576,18 @@ function createWeakEtag(fileStat: { mtimeMs: number; size: number }): string {
 }
 
 function isNotModified(request: Request, headers: Headers): boolean {
-  const etag = headers.get("etag");
   const ifNoneMatch = request.headers.get("if-none-match");
-  if (etag && ifNoneMatch) {
+  if (ifNoneMatch) {
+    // RFC 9110 §13.1.3: when If-None-Match is present, If-Modified-Since MUST
+    // be ignored — the ETag decides alone. This matters with per-encoding
+    // ETags: a client revalidating an identity body with its identity ETag
+    // plus a Last-Modified date must get a fresh 200 when brotli is
+    // negotiated, not a 304 that relabels its identity cache entry with the
+    // brotli variant's validator.
+    const etag = headers.get("etag");
+    if (!etag) return false;
     const candidates = ifNoneMatch.split(",").map((value) => value.trim());
-    if (candidates.includes("*") || candidates.includes(etag)) {
-      return true;
-    }
+    return candidates.includes("*") || candidates.includes(etag);
   }
 
   const lastModified = headers.get("last-modified");

--- a/packages/adapter-node/src/node-handler.ts
+++ b/packages/adapter-node/src/node-handler.ts
@@ -377,7 +377,7 @@ function negotiateFileEncoding(
   // out as identity (small file today, larger after the next deploy).
   headers.set("vary", mergeVaryValue(headers.get("vary")));
 
-  if (fileSize < COMPRESSION_MIN_SIZE || request.method === "HEAD") {
+  if (fileSize < COMPRESSION_MIN_SIZE) {
     return null;
   }
 

--- a/packages/adapter-node/src/node-handler.ts
+++ b/packages/adapter-node/src/node-handler.ts
@@ -1,7 +1,7 @@
 import { createReadStream } from "node:fs";
-import { mkdir, readFile, stat, writeFile } from "node:fs/promises";
+import { readFile, stat } from "node:fs/promises";
 import type { IncomingMessage, ServerResponse } from "node:http";
-import { dirname, join, resolve, sep } from "node:path";
+import { join, resolve, sep } from "node:path";
 
 import {
   applyDefaultSecurityHeaders,
@@ -33,8 +33,10 @@ import {
   type CompressionState,
   compressBuffer,
   type ContentEncoding,
+  createCompressionFileVersion,
   createCompressedStream,
   encodeEtagForEncoding,
+  encodeEtagForFileVersion,
   isCompressibleContentType,
   isNotModifiedRequest,
   isTransformableResponse,
@@ -43,7 +45,7 @@ import {
   negotiateEncoding,
   protectIdentityEtag,
 } from "./node-compress.ts";
-import { regenerateISGPage } from "./node-isg.ts";
+import { regenerateISGPage, writeISGFile } from "./node-isg.ts";
 import {
   createWebRequest,
   isClientDisconnectError,
@@ -257,8 +259,7 @@ export function createNodeRequestHandler<TContext = unknown>(
       const html = await response.clone().text();
       const htmlPath = resolveContainedPath(staticDir, url.pathname);
       if (htmlPath) {
-        await mkdir(dirname(htmlPath), { recursive: true });
-        await writeFile(htmlPath, html, "utf-8");
+        await writeISGFile(htmlPath, html);
         compressedAssetCache.invalidatePath(htmlPath);
       }
     }
@@ -349,6 +350,9 @@ async function serveStaticFile(
 ): Promise<void> {
   const fileStat = await stat(staticResult.filePath);
   const compressionGeneration = compression?.cache.getPathGeneration(staticResult.filePath) ?? 0;
+  const compressionFileVersion = compression
+    ? createCompressionFileVersion(fileStat, compressionGeneration)
+    : undefined;
   const headers = applyDefaultSecurityHeaders(
     new Headers({
       "content-type": staticResult.contentType,
@@ -360,7 +364,7 @@ async function serveStaticFile(
   if (staticResult.contentType.includes("text/html")) {
     applyHeadersManifest(headers, headersManifest, pathname);
   }
-  applyCompressionGenerationValidator(headers, compressionGeneration);
+  applyCompressionFileValidator(headers, compressionFileVersion);
 
   const encoding = negotiateFileEncoding(request, headers, fileStat.size, compression);
 
@@ -380,7 +384,7 @@ async function serveStaticFile(
       fileStat,
       encoding,
       compression,
-      compressionGeneration,
+      compressionFileVersion,
     );
     return;
   }
@@ -390,7 +394,7 @@ async function serveStaticFile(
     fileStat,
     encoding,
     compression,
-    compressionGeneration,
+    compressionFileVersion,
   );
 }
 
@@ -451,9 +455,9 @@ async function writeFileBody(
   fileStat: { mtimeMs: number; size: number },
   encoding: ContentEncoding | null,
   compression: CompressionState | undefined,
-  compressionGeneration: number,
+  compressionFileVersion: string | undefined,
 ): Promise<void> {
-  if (!encoding || !compression) {
+  if (!encoding || !compression || !compressionFileVersion) {
     await pipeToResponse(createReadStream(filePath), res);
     return;
   }
@@ -463,7 +467,7 @@ async function writeFileBody(
     fileStat,
     encoding,
     compression,
-    compressionGeneration,
+    compressionFileVersion,
   );
   if (pending) {
     const compressed = await pending;
@@ -483,11 +487,11 @@ function getBufferedCompressedFile(
   fileStat: { mtimeMs: number; size: number },
   encoding: ContentEncoding,
   compression: CompressionState,
-  compressionGeneration: number,
+  compressionFileVersion: string,
 ): Promise<Buffer> | null {
   if (fileStat.size > MAX_CACHEABLE_ASSET_SIZE) return null;
 
-  const key = `${filePath}\0${compressionGeneration}\0${fileStat.size}\0${fileStat.mtimeMs}\0${encoding}`;
+  const key = `${filePath}\0${compressionFileVersion}\0${encoding}`;
   return compression.cache.getOrCompress(key, fileStat.size, async () =>
     compressBuffer(await readFile(filePath), encoding),
   );
@@ -499,11 +503,11 @@ async function writeFileHead(
   fileStat: { mtimeMs: number; size: number },
   encoding: ContentEncoding | null,
   compression: CompressionState | undefined,
-  compressionGeneration: number,
+  compressionFileVersion: string | undefined,
 ): Promise<void> {
   const pending =
-    encoding && compression
-      ? getBufferedCompressedFile(filePath, fileStat, encoding, compression, compressionGeneration)
+    encoding && compression && compressionFileVersion
+      ? getBufferedCompressedFile(filePath, fileStat, encoding, compression, compressionFileVersion)
       : null;
   if (pending) {
     const compressed = await pending;
@@ -529,6 +533,9 @@ async function serveISGEntry<TContext>(
   const fileStat = await stat(htmlPath).catch(() => null);
   if (!fileStat?.isFile()) return false;
   const compressionGeneration = compression?.cache.getPathGeneration(htmlPath) ?? 0;
+  const compressionFileVersion = compression
+    ? createCompressionFileVersion(fileStat, compressionGeneration)
+    : undefined;
 
   const ageMs = Date.now() - fileStat.mtimeMs;
   const revalidateSeconds = getTimeRevalidateSeconds(entry.revalidate);
@@ -544,12 +551,12 @@ async function serveISGEntry<TContext>(
     }),
   );
   applyHeadersManifest(headers, headersManifest, pathname);
-  applyCompressionGenerationValidator(headers, compressionGeneration);
+  applyCompressionFileValidator(headers, compressionFileVersion);
   headers.set("x-pracht-isg", isStale ? "stale" : "fresh");
 
   const encoding = negotiateFileEncoding(request, headers, fileStat.size, compression);
 
-  if (isNotModified(request, headers, compressionGeneration === 0)) {
+  if (isNotModified(request, headers, compression === undefined)) {
     res.statusCode = 304;
     writeNodeHeaders(res, headers);
     res.end();
@@ -557,9 +564,9 @@ async function serveISGEntry<TContext>(
     res.statusCode = 200;
     writeNodeHeaders(res, headers);
     if (request.method === "HEAD") {
-      await writeFileHead(res, htmlPath, fileStat, encoding, compression, compressionGeneration);
+      await writeFileHead(res, htmlPath, fileStat, encoding, compression, compressionFileVersion);
     } else {
-      await writeFileBody(res, htmlPath, fileStat, encoding, compression, compressionGeneration);
+      await writeFileBody(res, htmlPath, fileStat, encoding, compression, compressionFileVersion);
     }
   }
 
@@ -693,6 +700,7 @@ function createApplicationRequest(
   if (
     !compression ||
     (request.method !== "GET" && request.method !== "HEAD") ||
+    request.headers.has("range") ||
     (!ifNoneMatch && !request.headers.has("if-modified-since")) ||
     (!negotiateEncoding(request.headers.get("accept-encoding")) &&
       !containsEncodedEtag(ifNoneMatch))
@@ -718,17 +726,14 @@ function createWeakEtag(fileStat: { mtimeMs: number; size: number }): string {
   return `W/"${fileStat.size.toString(16)}-${Math.floor(fileStat.mtimeMs).toString(16)}"`;
 }
 
-function applyCompressionGenerationValidator(headers: Headers, generation: number): void {
-  if (generation <= 0) return;
+function applyCompressionFileValidator(
+  headers: Headers,
+  compressionFileVersion: string | undefined,
+): void {
+  if (!compressionFileVersion) return;
   const etag = headers.get("etag");
   if (!etag) return;
-
-  const opaqueTag = etag.startsWith("W/") ? etag.slice(2) : etag;
-  const suffix = `-g${generation.toString(16)}`;
-  headers.set(
-    "etag",
-    opaqueTag.endsWith('"') ? `W/${opaqueTag.slice(0, -1)}${suffix}"` : `W/${opaqueTag}${suffix}`,
-  );
+  headers.set("etag", encodeEtagForFileVersion(etag, compressionFileVersion));
 }
 
 function isNotModified(request: Request, headers: Headers, allowLastModified = true): boolean {

--- a/packages/adapter-node/src/node-handler.ts
+++ b/packages/adapter-node/src/node-handler.ts
@@ -37,6 +37,7 @@ import {
   isCompressibleContentType,
   isTransformableResponse,
   MAX_CACHEABLE_ASSET_SIZE,
+  matchesIfNoneMatch,
   mergeVaryValue,
   negotiateEncoding,
 } from "./node-compress.ts";
@@ -216,15 +217,16 @@ export function createNodeRequestHandler<TContext = unknown>(
       if (served) return;
     }
 
+    const applicationRequest = createApplicationRequest(request, compression);
     const context = options.createContext
-      ? await options.createContext({ request, req, res })
+      ? await options.createContext({ request: applicationRequest, req, res })
       : undefined;
 
     const response = await handlePrachtRequest({
       app: options.app,
       context,
       registry: options.registry,
-      request,
+      request: applicationRequest,
       apiRoutes: options.apiRoutes,
       clientEntryUrl: options.clientEntryUrl,
       islandsEntryUrl: options.islandsEntryUrl,
@@ -581,6 +583,29 @@ function isRouteStateRequest(url: URL, headers: Headers): boolean {
   return headers.get(ROUTE_STATE_REQUEST_HEADER) === "1" || url.searchParams.get("_data") === "1";
 }
 
+/**
+ * Dynamic compression owns `If-None-Match` after it has selected the outgoing
+ * representation. Do not let an application short-circuit an encoded request
+ * against the identity representation's ETag before that selection happens.
+ */
+function createApplicationRequest(
+  request: Request,
+  compression: CompressionState | undefined,
+): Request {
+  if (
+    !compression ||
+    (request.method !== "GET" && request.method !== "HEAD") ||
+    !request.headers.has("if-none-match") ||
+    !negotiateEncoding(request.headers.get("accept-encoding"))
+  ) {
+    return request;
+  }
+
+  const headers = new Headers(request.headers);
+  headers.delete("if-none-match");
+  return new Request(request, { headers });
+}
+
 function isStaticAssetMethod(method: string): boolean {
   return method === "GET" || method === "HEAD";
 }
@@ -603,9 +628,7 @@ function isNotModified(request: Request, headers: Headers): boolean {
     // negotiated, not a 304 that relabels its identity cache entry with the
     // brotli variant's validator.
     const etag = headers.get("etag");
-    if (!etag) return false;
-    const candidates = ifNoneMatch.split(",").map((value) => value.trim());
-    return candidates.includes("*") || candidates.includes(etag);
+    return matchesIfNoneMatch(ifNoneMatch, etag);
   }
 
   const lastModified = headers.get("last-modified");

--- a/packages/adapter-node/src/node-isg.ts
+++ b/packages/adapter-node/src/node-isg.ts
@@ -1,5 +1,6 @@
-import { mkdir, writeFile } from "node:fs/promises";
-import { dirname } from "node:path";
+import { randomUUID } from "node:crypto";
+import { mkdir, rename, rm, stat, writeFile } from "node:fs/promises";
+import { basename, dirname, join } from "node:path";
 import {
   createISGRegenerationRequest,
   createRevalidationSingleFlight,
@@ -12,6 +13,34 @@ import type { NodeAdapterContextArgs, NodeAdapterOptions } from "./node-handler.
 // requests (or repeated webhook posts) for the same output file collapses
 // into a single regeneration instead of N parallel renders racing to write.
 const regenerationSingleFlight = createRevalidationSingleFlight();
+
+/**
+ * Publish an ISG snapshot as one filesystem replacement. Besides preventing
+ * readers from observing a partially-written document, the replacement gives
+ * the file a new durable identity so validators and compression caches in
+ * restarted or sibling Node workers cannot alias a same-size rewrite whose
+ * mtime is unchanged on a coarse-timestamp filesystem.
+ */
+export async function writeISGFile(htmlPath: string, html: string): Promise<void> {
+  const directory = dirname(htmlPath);
+  await mkdir(directory, { recursive: true });
+  const existing = await stat(htmlPath).catch(() => null);
+  const temporaryPath = join(
+    directory,
+    `.${basename(htmlPath)}.${process.pid}.${randomUUID()}.tmp`,
+  );
+
+  try {
+    await writeFile(temporaryPath, html, {
+      encoding: "utf-8",
+      flush: true,
+      ...(existing ? { mode: existing.mode & 0o777 } : {}),
+    });
+    await rename(temporaryPath, htmlPath);
+  } finally {
+    await rm(temporaryPath, { force: true }).catch(() => undefined);
+  }
+}
 
 /**
  * Regenerate an ISG page and write it to disk. Returns `true` when fresh
@@ -48,8 +77,7 @@ export async function regenerateISGPage<TContext>(
     }
 
     const html = await response.text();
-    await mkdir(dirname(htmlPath), { recursive: true });
-    await writeFile(htmlPath, html, "utf-8");
+    await writeISGFile(htmlPath, html);
     return true;
   });
 }

--- a/packages/adapter-node/src/node-request.ts
+++ b/packages/adapter-node/src/node-request.ts
@@ -8,6 +8,7 @@ import {
   encodeEtagForEncoding,
   isCompressibleContentType,
   isTransformableResponse,
+  matchesIfNoneMatch,
   mergeVaryOnNodeResponse,
   negotiateEncoding,
 } from "./node-compress.ts";
@@ -246,16 +247,18 @@ export async function writeWebResponse(
 
   const responseEtag = res.getHeader("etag");
   if (
-    encoding &&
+    compression &&
     response.status === 200 &&
-    (compression?.request.method === "GET" || compression?.request.method === "HEAD") &&
-    typeof responseEtag === "string" &&
-    matchesIfNoneMatch(compression.request.headers.get("if-none-match"), responseEtag)
+    (compression.request.method === "GET" || compression.request.method === "HEAD") &&
+    matchesIfNoneMatch(
+      compression.request.headers.get("if-none-match"),
+      typeof responseEtag === "string" ? responseEtag : null,
+    )
   ) {
-    // The application only knows its identity ETag, while the client sends
-    // back the encoding-specific validator emitted by this adapter. Evaluate
-    // that derived validator here so transparent compression does not turn a
-    // revalidation that should be 304 into a full 200 response.
+    // Evaluate the selected representation's validator here. For encoded
+    // requests the application did not receive `If-None-Match`, because it
+    // only knows the identity ETag and could otherwise short-circuit with a
+    // cross-encoding 304 before this adapter derives the variant validator.
     res.statusCode = 304;
     res.statusMessage = "Not Modified";
     res.removeHeader("content-length");
@@ -279,17 +282,6 @@ export async function writeWebResponse(
     encoding ? createCompressedStream(source, encoding, { incremental: true }) : source,
     res,
   );
-}
-
-function matchesIfNoneMatch(header: string | null, etag: string): boolean {
-  if (!header) return false;
-  const weakOpaqueTag = (value: string): string =>
-    value.startsWith("W/") ? value.slice(2) : value;
-  const expected = weakOpaqueTag(etag);
-  return header
-    .split(",")
-    .map((candidate) => candidate.trim())
-    .some((candidate) => candidate === "*" || weakOpaqueTag(candidate) === expected);
 }
 
 export function writeNodeResponseHeaders(res: ServerResponse, headers: Headers): void {

--- a/packages/adapter-node/src/node-request.ts
+++ b/packages/adapter-node/src/node-request.ts
@@ -9,9 +9,11 @@ import {
   isCompressibleContentType,
   isNotModifiedRequest,
   isTransformableResponse,
+  matchesIfMatch,
   mergeVaryOnNodeResponse,
   negotiateEncoding,
   protectIdentityEtag,
+  type CompressionState,
 } from "./node-compress.ts";
 
 const BODYLESS_METHODS = new Set(["GET", "HEAD"]);
@@ -212,7 +214,7 @@ function normalizeRequestTarget(
 export async function writeWebResponse(
   res: ServerResponse,
   response: Response,
-  compression?: { request: Request },
+  compression?: CompressionState,
 ): Promise<void> {
   res.statusCode = response.status;
   res.statusMessage = response.statusText;
@@ -256,11 +258,37 @@ export async function writeWebResponse(
   }
 
   const responseEtag = getNodeHeaderValue(res, "etag");
-  if (
+  const isSuccessfulRetrieval =
     compression &&
     response.status >= 200 &&
     response.status < 300 &&
-    (compression.request.method === "GET" || compression.request.method === "HEAD") &&
+    (compression.request.method === "GET" || compression.request.method === "HEAD");
+  if (
+    isSuccessfulRetrieval &&
+    compression.ownsIfMatch &&
+    !matchesIfMatch(compression.request.headers.get("if-match"), responseEtag)
+  ) {
+    res.statusCode = 412;
+    res.statusMessage = "Precondition Failed";
+    for (const name of [
+      "content-digest",
+      "content-encoding",
+      "content-length",
+      "content-md5",
+      "content-range",
+      "content-type",
+      "digest",
+      "repr-digest",
+    ]) {
+      res.removeHeader(name);
+    }
+    res.setHeader("cache-control", "no-store");
+    cancelResponseBody(response);
+    res.end();
+    return;
+  }
+  if (
+    isSuccessfulRetrieval &&
     isNotModifiedRequest(
       compression.request,
       responseEtag,
@@ -276,13 +304,7 @@ export async function writeWebResponse(
     res.statusMessage = "Not Modified";
     res.removeHeader("content-length");
     res.removeHeader("content-range");
-    if (response.body) {
-      // Cancellation is cleanup, not part of the conditional response. A
-      // proxied/custom stream is allowed to reject cancellation; do not let
-      // that replace an otherwise valid 304 with the outer 500 fallback (or
-      // hold the response open while asynchronous cleanup settles).
-      void response.body.cancel().catch(() => undefined);
-    }
+    cancelResponseBody(response);
     res.end();
     return;
   }
@@ -302,6 +324,15 @@ export async function writeWebResponse(
     encoding ? createCompressedStream(source, encoding, { incremental: true }) : source,
     res,
   );
+}
+
+function cancelResponseBody(response: Response): void {
+  if (!response.body) return;
+  // Cancellation is cleanup, not part of the conditional response. A
+  // proxied/custom stream is allowed to reject cancellation; do not let that
+  // replace a valid 304/412 with the outer 500 fallback (or hold the response
+  // open while asynchronous cleanup settles).
+  void response.body.cancel().catch(() => undefined);
 }
 
 function getNodeHeaderValue(res: ServerResponse, name: string): string | null {

--- a/packages/adapter-node/src/node-request.ts
+++ b/packages/adapter-node/src/node-request.ts
@@ -7,8 +7,8 @@ import {
   createCompressedStream,
   encodeEtagForEncoding,
   isCompressibleContentType,
+  isNotModifiedRequest,
   isTransformableResponse,
-  matchesIfNoneMatch,
   mergeVaryOnNodeResponse,
   negotiateEncoding,
 } from "./node-compress.ts";
@@ -245,20 +245,22 @@ export async function writeWebResponse(
     }
   }
 
-  const responseEtag = res.getHeader("etag");
+  const responseEtag = getNodeHeaderValue(res, "etag");
   if (
     compression &&
     response.status === 200 &&
     (compression.request.method === "GET" || compression.request.method === "HEAD") &&
-    matchesIfNoneMatch(
-      compression.request.headers.get("if-none-match"),
-      typeof responseEtag === "string" ? responseEtag : null,
+    isNotModifiedRequest(
+      compression.request,
+      responseEtag,
+      getNodeHeaderValue(res, "last-modified"),
     )
   ) {
-    // Evaluate the selected representation's validator here. For encoded
-    // requests the application did not receive `If-None-Match`, because it
-    // only knows the identity ETag and could otherwise short-circuit with a
-    // cross-encoding 304 before this adapter derives the variant validator.
+    // Evaluate the selected representation's validators here. For encoded
+    // requests the application did not receive `If-None-Match` or
+    // `If-Modified-Since`, because it only knows identity metadata and could
+    // otherwise short-circuit with a cross-encoding 304 before this adapter
+    // derives the variant validator.
     res.statusCode = 304;
     res.statusMessage = "Not Modified";
     res.removeHeader("content-length");
@@ -282,6 +284,11 @@ export async function writeWebResponse(
     encoding ? createCompressedStream(source, encoding, { incremental: true }) : source,
     res,
   );
+}
+
+function getNodeHeaderValue(res: ServerResponse, name: string): string | null {
+  const value = res.getHeader(name);
+  return Array.isArray(value) ? value.join(", ") : (value?.toString() ?? null);
 }
 
 export function writeNodeResponseHeaders(res: ServerResponse, headers: Headers): void {

--- a/packages/adapter-node/src/node-request.ts
+++ b/packages/adapter-node/src/node-request.ts
@@ -250,7 +250,15 @@ export async function writeWebResponse(
   }
 
   const source: NodeJS.ReadableStream = Readable.fromWeb(response.body as never);
-  await pipeToResponse(encoding ? createCompressedStream(source, encoding) : source, res);
+  // `incremental` flushes the compressor per written chunk: dynamic bodies
+  // may be produced over time (SSE, streamed API responses), and a compressor
+  // that only drains at end-of-stream would hold every event back until the
+  // response closes. For single-chunk bodies (SSR documents, route-state
+  // JSON) the extra flush costs a handful of bytes.
+  await pipeToResponse(
+    encoding ? createCompressedStream(source, encoding, { incremental: true }) : source,
+    res,
+  );
 }
 
 export function writeNodeResponseHeaders(res: ServerResponse, headers: Headers): void {

--- a/packages/adapter-node/src/node-request.ts
+++ b/packages/adapter-node/src/node-request.ts
@@ -229,15 +229,17 @@ export async function writeWebResponse(
   ) {
     res.setHeader("etag", protectIdentityEtag(sourceEtag));
   }
+  const compressibleContentType = isCompressibleContentType(response.headers.get("content-type"));
+  if (compression && (compressibleContentType || response.status === 304)) {
+    // An application-generated 304 may omit Content-Type, but it still needs
+    // the Vary field the adapter adds to the corresponding 200 response.
+    mergeVaryOnNodeResponse(res);
+  }
   if (
     compression &&
-    isCompressibleContentType(response.headers.get("content-type")) &&
+    compressibleContentType &&
     isTransformableResponse(response.status, response.headers)
   ) {
-    // Compressible whatever this client accepts, so caches must key on the
-    // encoding even when this particular response goes out as identity.
-    mergeVaryOnNodeResponse(res);
-
     const contentLength = Number.parseInt(response.headers.get("content-length") ?? "", 10);
     const belowThreshold = !Number.isNaN(contentLength) && contentLength < COMPRESSION_MIN_SIZE;
 

--- a/packages/adapter-node/src/node-request.ts
+++ b/packages/adapter-node/src/node-request.ts
@@ -1,6 +1,17 @@
 import type { IncomingMessage, ServerResponse } from "node:http";
 import { Readable } from "node:stream";
 
+import {
+  COMPRESSION_MIN_SIZE,
+  type ContentEncoding,
+  createCompressedStream,
+  encodeEtagForEncoding,
+  isCompressibleContentType,
+  isTransformableResponse,
+  mergeVaryOnNodeResponse,
+  negotiateEncoding,
+} from "./node-compress.ts";
+
 const BODYLESS_METHODS = new Set(["GET", "HEAD"]);
 export const DEFAULT_MAX_BODY_SIZE = 1024 * 1024; // 1 MiB
 
@@ -196,18 +207,50 @@ function normalizeRequestTarget(
   return target;
 }
 
-export async function writeWebResponse(res: ServerResponse, response: Response): Promise<void> {
+export async function writeWebResponse(
+  res: ServerResponse,
+  response: Response,
+  compression?: { request: Request },
+): Promise<void> {
   res.statusCode = response.status;
   res.statusMessage = response.statusText;
 
   writeNodeResponseHeaders(res, response.headers);
+
+  let encoding: ContentEncoding | null = null;
+  if (
+    compression &&
+    isCompressibleContentType(response.headers.get("content-type")) &&
+    isTransformableResponse(response.status, response.headers)
+  ) {
+    // Compressible whatever this client accepts, so caches must key on the
+    // encoding even when this particular response goes out as identity.
+    mergeVaryOnNodeResponse(res);
+
+    const contentLength = Number.parseInt(response.headers.get("content-length") ?? "", 10);
+    const belowThreshold = !Number.isNaN(contentLength) && contentLength < COMPRESSION_MIN_SIZE;
+
+    if (response.body && compression.request.method !== "HEAD" && !belowThreshold) {
+      encoding = negotiateEncoding(compression.request.headers.get("accept-encoding"));
+    }
+
+    if (encoding) {
+      res.removeHeader("content-length");
+      res.setHeader("content-encoding", encoding);
+      const etag = res.getHeader("etag");
+      if (typeof etag === "string") {
+        res.setHeader("etag", encodeEtagForEncoding(etag, encoding));
+      }
+    }
+  }
 
   if (!response.body) {
     res.end();
     return;
   }
 
-  await pipeToResponse(Readable.fromWeb(response.body as never), res);
+  const source: NodeJS.ReadableStream = Readable.fromWeb(response.body as never);
+  await pipeToResponse(encoding ? createCompressedStream(source, encoding) : source, res);
 }
 
 export function writeNodeResponseHeaders(res: ServerResponse, headers: Headers): void {

--- a/packages/adapter-node/src/node-request.ts
+++ b/packages/adapter-node/src/node-request.ts
@@ -230,7 +230,7 @@ export async function writeWebResponse(
     const contentLength = Number.parseInt(response.headers.get("content-length") ?? "", 10);
     const belowThreshold = !Number.isNaN(contentLength) && contentLength < COMPRESSION_MIN_SIZE;
 
-    if (response.body && compression.request.method !== "HEAD" && !belowThreshold) {
+    if ((response.body || compression.request.method === "HEAD") && !belowThreshold) {
       encoding = negotiateEncoding(compression.request.headers.get("accept-encoding"));
     }
 
@@ -242,6 +242,26 @@ export async function writeWebResponse(
         res.setHeader("etag", encodeEtagForEncoding(etag, encoding));
       }
     }
+  }
+
+  const responseEtag = res.getHeader("etag");
+  if (
+    encoding &&
+    response.status === 200 &&
+    (compression?.request.method === "GET" || compression?.request.method === "HEAD") &&
+    typeof responseEtag === "string" &&
+    matchesIfNoneMatch(compression.request.headers.get("if-none-match"), responseEtag)
+  ) {
+    // The application only knows its identity ETag, while the client sends
+    // back the encoding-specific validator emitted by this adapter. Evaluate
+    // that derived validator here so transparent compression does not turn a
+    // revalidation that should be 304 into a full 200 response.
+    res.statusCode = 304;
+    res.statusMessage = "Not Modified";
+    res.removeHeader("content-length");
+    if (response.body) await response.body.cancel();
+    res.end();
+    return;
   }
 
   if (!response.body) {
@@ -259,6 +279,17 @@ export async function writeWebResponse(
     encoding ? createCompressedStream(source, encoding, { incremental: true }) : source,
     res,
   );
+}
+
+function matchesIfNoneMatch(header: string | null, etag: string): boolean {
+  if (!header) return false;
+  const weakOpaqueTag = (value: string): string =>
+    value.startsWith("W/") ? value.slice(2) : value;
+  const expected = weakOpaqueTag(etag);
+  return header
+    .split(",")
+    .map((candidate) => candidate.trim())
+    .some((candidate) => candidate === "*" || weakOpaqueTag(candidate) === expected);
 }
 
 export function writeNodeResponseHeaders(res: ServerResponse, headers: Headers): void {

--- a/packages/adapter-node/src/node-request.ts
+++ b/packages/adapter-node/src/node-request.ts
@@ -237,6 +237,7 @@ export async function writeWebResponse(
   }
   if (
     compression &&
+    !compression.request.headers.has("range") &&
     compressibleContentType &&
     isTransformableResponse(response.status, response.headers)
   ) {
@@ -257,7 +258,8 @@ export async function writeWebResponse(
   const responseEtag = getNodeHeaderValue(res, "etag");
   if (
     compression &&
-    response.status === 200 &&
+    response.status >= 200 &&
+    response.status < 300 &&
     (compression.request.method === "GET" || compression.request.method === "HEAD") &&
     isNotModifiedRequest(
       compression.request,
@@ -273,6 +275,7 @@ export async function writeWebResponse(
     res.statusCode = 304;
     res.statusMessage = "Not Modified";
     res.removeHeader("content-length");
+    res.removeHeader("content-range");
     if (response.body) {
       // Cancellation is cleanup, not part of the conditional response. A
       // proxied/custom stream is allowed to reject cancellation; do not let

--- a/packages/adapter-node/src/node-request.ts
+++ b/packages/adapter-node/src/node-request.ts
@@ -11,6 +11,7 @@ import {
   isTransformableResponse,
   mergeVaryOnNodeResponse,
   negotiateEncoding,
+  protectIdentityEtag,
 } from "./node-compress.ts";
 
 const BODYLESS_METHODS = new Set(["GET", "HEAD"]);
@@ -219,6 +220,15 @@ export async function writeWebResponse(
   writeNodeResponseHeaders(res, response.headers);
 
   let encoding: ContentEncoding | null = null;
+  const sourceEtag = getNodeHeaderValue(res, "etag");
+  const sourceEncoding = response.headers.get("content-encoding");
+  if (
+    compression &&
+    sourceEtag &&
+    (!sourceEncoding || sourceEncoding.toLowerCase() === "identity")
+  ) {
+    res.setHeader("etag", protectIdentityEtag(sourceEtag));
+  }
   if (
     compression &&
     isCompressibleContentType(response.headers.get("content-type")) &&
@@ -238,10 +248,7 @@ export async function writeWebResponse(
     if (encoding) {
       res.removeHeader("content-length");
       res.setHeader("content-encoding", encoding);
-      const etag = res.getHeader("etag");
-      if (typeof etag === "string") {
-        res.setHeader("etag", encodeEtagForEncoding(etag, encoding));
-      }
+      if (sourceEtag) res.setHeader("etag", encodeEtagForEncoding(sourceEtag, encoding));
     }
   }
 
@@ -264,7 +271,13 @@ export async function writeWebResponse(
     res.statusCode = 304;
     res.statusMessage = "Not Modified";
     res.removeHeader("content-length");
-    if (response.body) await response.body.cancel();
+    if (response.body) {
+      // Cancellation is cleanup, not part of the conditional response. A
+      // proxied/custom stream is allowed to reject cancellation; do not let
+      // that replace an otherwise valid 304 with the outer 500 fallback (or
+      // hold the response open while asynchronous cleanup settles).
+      void response.body.cancel().catch(() => undefined);
+    }
     res.end();
     return;
   }

--- a/packages/adapter-node/src/node-static.ts
+++ b/packages/adapter-node/src/node-static.ts
@@ -25,6 +25,7 @@ const MIME_TYPES: Record<string, string> = {
   ".markdown": "text/markdown; charset=utf-8",
   ".xml": "application/xml",
   ".webmanifest": "application/manifest+json",
+  ".wasm": "application/wasm",
 };
 
 /**

--- a/packages/adapter-node/test/compression.test.ts
+++ b/packages/adapter-node/test/compression.test.ts
@@ -124,6 +124,8 @@ describe("negotiateEncoding", () => {
     expect(negotiateEncoding("br;q=0.5, gzip;q=0.5")).toBe("br"); // ties go to brotli
     expect(negotiateEncoding("gzip;q=0.5, *;q=1")).toBe("br"); // wildcard covers br at q=1
     expect(negotiateEncoding("identity;q=0, gzip")).toBe("gzip");
+    expect(negotiateEncoding("gzip;q=0.5, identity;q=1, *;q=0")).toBeNull();
+    expect(negotiateEncoding("gzip;q=1, identity;q=1, *;q=0")).toBe("gzip");
   });
 });
 
@@ -422,6 +424,70 @@ describe("dynamic response compression", () => {
     expect(response.headers.vary).toContain("Accept-Encoding");
   });
 
+  it("revalidates an encoding-specific dynamic ETag", async () => {
+    const identityEtag = 'W/"dynamic-v1"';
+    const base = await listen(
+      createNodeRequestHandler({
+        apiRoutes: resolveApiRoutes(["/src/api/etag.ts"]),
+        app: defineApp({ routes: [] }),
+        registry: {
+          apiModules: {
+            "/src/api/etag.ts": async () => ({
+              GET: async ({ request }) =>
+                request.headers.get("if-none-match") === identityEtag
+                  ? new Response(null, {
+                      status: 304,
+                      headers: { etag: identityEtag },
+                    })
+                  : new Response("etag payload ".repeat(300), {
+                      headers: { etag: identityEtag, "content-type": "text/plain" },
+                    }),
+            }),
+          },
+        },
+      }),
+    );
+
+    const first = await rawRequest(`${base}/api/etag`, { "accept-encoding": "gzip" });
+    const revalidated = await rawRequest(`${base}/api/etag`, {
+      "accept-encoding": "gzip",
+      "if-none-match": first.headers.etag!,
+    });
+
+    expect(first.status).toBe(200);
+    expect(first.headers.etag).toBe('W/"dynamic-v1-gzip"');
+    expect(revalidated.status).toBe(304);
+    expect(revalidated.headers.etag).toBe(first.headers.etag);
+    expect(revalidated.headers.vary).toContain("Accept-Encoding");
+    expect(revalidated.body.byteLength).toBe(0);
+  });
+
+  it("uses the GET representation metadata for dynamic HEAD responses", async () => {
+    const headers = { etag: 'W/"head-v1"', "content-type": "text/plain" };
+    const base = await listen(
+      createNodeRequestHandler({
+        apiRoutes: resolveApiRoutes(["/src/api/head.ts"]),
+        app: defineApp({ routes: [] }),
+        registry: {
+          apiModules: {
+            "/src/api/head.ts": async () => ({
+              GET: async () => new Response("head payload ".repeat(300), { headers }),
+              HEAD: async () => new Response(null, { headers }),
+            }),
+          },
+        },
+      }),
+    );
+
+    const get = await rawRequest(`${base}/api/head`, { "accept-encoding": "br" });
+    const head = await rawRequest(`${base}/api/head`, { "accept-encoding": "br" }, "HEAD");
+
+    expect(head.status).toBe(200);
+    expect(head.headers["content-encoding"]).toBe(get.headers["content-encoding"]);
+    expect(head.headers.etag).toBe(get.headers.etag);
+    expect(head.body.byteLength).toBe(0);
+  });
+
   it("keeps a streamed multi-chunk body intact through the compressor", async () => {
     const chunks = Array.from({ length: 32 }, (_, i) => `chunk-${i}-${"z".repeat(256)}\n`);
     const base = await listen(
@@ -716,19 +782,21 @@ describe("static asset compression", () => {
     expect(response.body.toString("utf-8")).toContain("payload");
   });
 
-  it("omits the body but keeps negotiation headers identity-shaped for HEAD", async () => {
+  it("omits the body but keeps GET negotiation metadata for HEAD", async () => {
     const { handler } = createStaticHandler();
     const base = await listen(handler);
 
-    const response = await rawRequest(
+    const get = await rawRequest(`${base}/assets/app.js`, { "accept-encoding": "br, gzip" });
+    const head = await rawRequest(
       `${base}/assets/app.js`,
       { "accept-encoding": "br, gzip" },
       "HEAD",
     );
 
-    expect(response.status).toBe(200);
-    expect(response.headers["content-encoding"]).toBeUndefined();
-    expect(response.headers.vary).toContain("Accept-Encoding");
-    expect(response.body.byteLength).toBe(0);
+    expect(head.status).toBe(200);
+    expect(head.headers["content-encoding"]).toBe(get.headers["content-encoding"]);
+    expect(head.headers.etag).toBe(get.headers.etag);
+    expect(head.headers.vary).toContain("Accept-Encoding");
+    expect(head.body.byteLength).toBe(0);
   });
 });

--- a/packages/adapter-node/test/compression.test.ts
+++ b/packages/adapter-node/test/compression.test.ts
@@ -20,6 +20,7 @@ import {
   isCompressibleContentType,
   mergeVaryValue,
   negotiateEncoding,
+  protectIdentityEtag,
 } from "../src/node-compress.ts";
 
 const tempDirs: string[] = [];
@@ -130,8 +131,15 @@ describe("negotiateEncoding", () => {
   });
 
   it("weakens derived ETags for encoded variants", () => {
-    expect(encodeEtagForEncoding('"strong-v1"', "gzip")).toBe('W/"strong-v1-gzip"');
-    expect(encodeEtagForEncoding('W/"weak-v1"', "br")).toBe('W/"weak-v1-br"');
+    const gzip = encodeEtagForEncoding('"strong-v1"', "gzip");
+    const brotli = encodeEtagForEncoding('W/"weak-v1"', "br");
+
+    expect(gzip).toMatch(/^W\/"pracht-gzip-[A-Za-z0-9_-]{43}"$/);
+    expect(brotli).toMatch(/^W\/"pracht-br-[A-Za-z0-9_-]{43}"$/);
+    expect(encodeEtagForEncoding('W/"strong-v1"', "gzip")).toBe(gzip);
+    expect(encodeEtagForEncoding('"release"', "br")).not.toBe('W/"release-br"');
+    expect(protectIdentityEtag(gzip)).toMatch(/^W\/"pracht-identity-[A-Za-z0-9_-]{43}"$/);
+    expect(protectIdentityEtag('"ordinary"')).toBe('"ordinary"');
   });
 });
 
@@ -550,9 +558,9 @@ describe("dynamic response compression", () => {
     expect(identity.headers.etag).toBe(identityEtag);
     expect(crossEncoding.status).toBe(200);
     expect(crossEncoding.headers["content-encoding"]).toBe("gzip");
-    expect(crossEncoding.headers.etag).toBe('W/"dynamic-v1-gzip"');
+    expect(crossEncoding.headers.etag).toBe(encodeEtagForEncoding(identityEtag, "gzip"));
     expect(first.status).toBe(200);
-    expect(first.headers.etag).toBe('W/"dynamic-v1-gzip"');
+    expect(first.headers.etag).toBe(encodeEtagForEncoding(identityEtag, "gzip"));
     expect(revalidated.status).toBe(304);
     expect(revalidated.headers.etag).toBe(first.headers.etag);
     expect(revalidated.headers.vary).toContain("Accept-Encoding");
@@ -602,7 +610,7 @@ describe("dynamic response compression", () => {
       "if-modified-since": lastModified,
     });
 
-    expect(first.headers.etag).toBe('W/"modified-v1-gzip"');
+    expect(first.headers.etag).toBe(encodeEtagForEncoding(identityEtag, "gzip"));
     expect(revalidated.status).toBe(304);
     expect(revalidated.headers.etag).toBe(first.headers.etag);
     expect(revalidated.headers.vary).toContain("Accept-Encoding");
@@ -637,7 +645,7 @@ describe("dynamic response compression", () => {
       "if-none-match": first.headers.etag!,
     });
 
-    expect(first.headers.etag).toBe('W/"release,1-gzip"');
+    expect(first.headers.etag).toBe(encodeEtagForEncoding('"release,1"', "gzip"));
     expect(revalidated.status).toBe(304);
     expect(revalidated.headers.etag).toBe(first.headers.etag);
   });
@@ -667,6 +675,78 @@ describe("dynamic response compression", () => {
     expect(head.headers["content-length"]).toBe(get.headers["content-length"]);
     expect(head.headers.etag).toBe(get.headers.etag);
     expect(head.body.byteLength).toBe(0);
+  });
+
+  it("does not alias an encoded validator with a later identity ETag", async () => {
+    let identityEtag = '"release"';
+    let body = "first ".repeat(800);
+    const base = await listen(
+      createNodeRequestHandler({
+        apiRoutes: resolveApiRoutes(["/src/api/collision.ts"]),
+        app: defineApp({ routes: [] }),
+        registry: {
+          apiModules: {
+            "/src/api/collision.ts": async () => ({
+              GET: async ({ request }) =>
+                request.headers.get("if-none-match") === identityEtag
+                  ? new Response(null, { status: 304, headers: { etag: identityEtag } })
+                  : new Response(body, {
+                      headers: { etag: identityEtag, "content-type": "text/plain" },
+                    }),
+            }),
+          },
+        },
+      }),
+    );
+
+    const encoded = await rawRequest(`${base}/api/collision`, { "accept-encoding": "br" });
+    identityEtag = encoded.headers.etag!;
+    body = "second ".repeat(800);
+    const identity = await rawRequest(`${base}/api/collision`, {
+      "accept-encoding": "identity",
+      "if-none-match": encoded.headers.etag!,
+    });
+
+    expect(identity.status).toBe(200);
+    expect(identity.headers.etag).toBe(protectIdentityEtag(identityEtag));
+    expect(identity.headers.etag).not.toBe(encoded.headers.etag);
+    expect(identity.body.toString("utf-8")).toBe(body);
+  });
+
+  it("keeps a matching 304 when response-body cancellation rejects", async () => {
+    const identityEtag = '"cancel-v1"';
+    const base = await listen(
+      createNodeRequestHandler({
+        apiRoutes: resolveApiRoutes(["/src/api/cancel.ts"]),
+        app: defineApp({ routes: [] }),
+        registry: {
+          apiModules: {
+            "/src/api/cancel.ts": async () => ({
+              GET: async () =>
+                new Response(
+                  new ReadableStream({
+                    cancel() {
+                      throw new Error("cancel failed");
+                    },
+                    start(controller) {
+                      controller.enqueue(new TextEncoder().encode("payload ".repeat(400)));
+                    },
+                  }),
+                  { headers: { etag: identityEtag, "content-type": "text/plain" } },
+                ),
+            }),
+          },
+        },
+      }),
+    );
+
+    const response = await rawRequest(`${base}/api/cancel`, {
+      "accept-encoding": "gzip",
+      "if-none-match": encodeEtagForEncoding(identityEtag, "gzip"),
+    });
+
+    expect(response.status).toBe(304);
+    expect(response.body.byteLength).toBe(0);
   });
 
   it("keeps a streamed multi-chunk body intact through the compressor", async () => {
@@ -844,7 +924,7 @@ describe("static asset compression", () => {
 
     // Encoded variants must not share a validator with identity.
     expect(identity.headers.etag).toBeDefined();
-    expect(compressed.headers.etag).toBe(`${identity.headers.etag!.slice(0, -1)}-br"`);
+    expect(compressed.headers.etag).toBe(encodeEtagForEncoding(identity.headers.etag!, "br"));
   });
 
   it("answers 304 against the encoded variant's ETag", async () => {

--- a/packages/adapter-node/test/compression.test.ts
+++ b/packages/adapter-node/test/compression.test.ts
@@ -374,6 +374,38 @@ describe("dynamic response compression", () => {
     expect(response.body.byteLength).toBe(4096);
   });
 
+  it.each(["content-digest", "repr-digest", "digest", "content-md5"])(
+    "preserves identity encoding when a response carries %s",
+    async (integrityHeader) => {
+      const body = "integrity-protected payload ".repeat(200);
+      const base = await listen(
+        createNodeRequestHandler({
+          apiRoutes: resolveApiRoutes(["/src/api/integrity.ts"]),
+          app: defineApp({ routes: [] }),
+          registry: {
+            apiModules: {
+              "/src/api/integrity.ts": async () => ({
+                GET: async () =>
+                  new Response(body, {
+                    headers: {
+                      "content-type": "text/plain",
+                      [integrityHeader]: "identity-digest",
+                    },
+                  }),
+              }),
+            },
+          },
+        }),
+      );
+
+      const response = await rawRequest(`${base}/api/integrity`, { "accept-encoding": "br" });
+
+      expect(response.headers["content-encoding"]).toBeUndefined();
+      expect(response.headers[integrityHeader]).toBe("identity-digest");
+      expect(response.body.toString("utf-8")).toBe(body);
+    },
+  );
+
   it("skips tiny bodies when the Content-Length is known", async () => {
     const base = await listen(
       createNodeRequestHandler({
@@ -744,6 +776,30 @@ describe("static asset compression", () => {
     expect(response.status).toBe(200);
     expect(response.headers["content-encoding"]).toBe("gzip");
     expect(gunzipSync(response.body).toString("utf-8")).toContain("<p>prerendered</p>");
+  });
+
+  it("drops an identity Content-Length when streaming a large compressed page", async () => {
+    const staticDir = makeTempDir();
+    const html = `<html><body>${"large prerendered page ".repeat(60_000)}</body></html>`;
+    writeFileSync(join(staticDir, "index.html"), html, "utf-8");
+
+    const base = await listen(
+      createNodeRequestHandler({
+        app: defineApp({ routes: [] }),
+        canonicalOrigin: "http://localhost",
+        headersManifest: {
+          "/": { "content-length": String(Buffer.byteLength(html)) },
+        },
+        staticDir,
+      }),
+    );
+
+    const response = await rawRequest(`${base}/`, { "accept-encoding": "br" });
+
+    expect(Buffer.byteLength(html)).toBeGreaterThan(1024 * 1024);
+    expect(response.headers["content-encoding"]).toBe("br");
+    expect(response.headers["content-length"]).toBeUndefined();
+    expect(brotliDecompressSync(response.body).toString("utf-8")).toBe(html);
   });
 
   it("leaves tiny and binary files identity-encoded", async () => {

--- a/packages/adapter-node/test/compression.test.ts
+++ b/packages/adapter-node/test/compression.test.ts
@@ -1,4 +1,5 @@
 import { mkdtempSync, mkdirSync, rmSync, utimesSync, writeFileSync } from "node:fs";
+import { open } from "node:fs/promises";
 import {
   createServer,
   request as httpRequest,
@@ -9,7 +10,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { once } from "node:events";
 import { brotliDecompressSync, createBrotliDecompress, createGunzip, gunzipSync } from "node:zlib";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { defineApp, resolveApiRoutes, route, timeRevalidate } from "@pracht/core";
 
@@ -1066,6 +1067,91 @@ describe("static asset compression", () => {
     expect(gunzipSync(etagRevalidation.body).toString("utf-8")).toBe(freshHtml);
     expect(dateRevalidation.status).toBe(200);
     expect(gunzipSync(dateRevalidation.body).toString("utf-8")).toBe(freshHtml);
+  });
+
+  it("keeps regenerated ISG validators stable across sibling handlers", async () => {
+    const staticDir = makeTempDir();
+    const app = defineApp({
+      routes: [
+        route("/page", "./routes/page.tsx", {
+          render: "isg",
+          revalidate: timeRevalidate(3600),
+        }),
+      ],
+    });
+    const options = {
+      app,
+      headersManifest: { "/page": { etag: '"page-document"' } },
+      isgManifest: { "/page": { revalidate: timeRevalidate(3600) } },
+      registry: {
+        routeModules: {
+          "./routes/page.tsx": async () => ({
+            Component: () => `<main>${"sibling-safe".repeat(400)}</main>`,
+          }),
+        },
+      },
+      staticDir,
+    };
+    const primaryBase = await listen(createNodeRequestHandler(options));
+    const siblingBase = await listen(createNodeRequestHandler(options));
+
+    // The cold render writes the snapshot and advances only the primary
+    // handler's process-local cache generation.
+    const cold = await rawRequest(`${primaryBase}/page`);
+    expect(cold.status).toBe(200);
+
+    const primary = await rawRequest(`${primaryBase}/page`, { "accept-encoding": "gzip" });
+    const sibling = await rawRequest(`${siblingBase}/page`, { "accept-encoding": "gzip" });
+
+    expect(primary.headers.etag).toBe(sibling.headers.etag);
+    expect(gunzipSync(primary.body)).toEqual(gunzipSync(sibling.body));
+  });
+
+  it("reads the same file version that supplied compression metadata", async () => {
+    const staticDir = makeTempDir();
+    const assetDir = join(staticDir, "assets");
+    const assetPath = join(assetDir, "app.js");
+    mkdirSync(assetDir, { recursive: true });
+    const oldSource = `// old\n${"oldPayload();\n".repeat(400)}`;
+    const newSource = `// new\n${"newPayload();\n".repeat(80_000)}`;
+    writeFileSync(assetPath, oldSource, "utf-8");
+
+    const replacementHandler = createNodeRequestHandler({
+      app: defineApp({ routes: [] }),
+      staticDir,
+    });
+    const probe = await open(assetPath, "r");
+    const fileHandlePrototype = Object.getPrototypeOf(probe) as {
+      readFile(): Promise<Buffer>;
+    };
+    await probe.close();
+    const originalReadFile = fileHandlePrototype.readFile;
+    let replaced = false;
+    const readFileSpy = vi
+      .spyOn(fileHandlePrototype, "readFile")
+      .mockImplementation(async function (this: { readFile(): Promise<Buffer> }) {
+        if (!replaced) {
+          replaced = true;
+          await writeISGFile(assetPath, newSource);
+        }
+        return originalReadFile.call(this);
+      });
+    const base = await listen(replacementHandler);
+    let raced: RawResponse;
+
+    try {
+      raced = await rawRequest(`${base}/assets/app.js`, { "accept-encoding": "gzip" });
+      expect(replaced).toBe(true);
+      expect(gunzipSync(raced.body).toString("utf-8")).toBe(oldSource);
+    } finally {
+      readFileSpy.mockRestore();
+    }
+
+    const replacement = await rawRequest(`${base}/assets/app.js`, {
+      "accept-encoding": "gzip",
+    });
+    expect(gunzipSync(replacement.body).toString("utf-8")).toBe(newSource);
+    expect(replacement.headers.etag).not.toBe(raced.headers.etag);
   });
 
   it("ignores If-Modified-Since when If-None-Match is present (RFC 9110 §13.1.3)", async () => {

--- a/packages/adapter-node/test/compression.test.ts
+++ b/packages/adapter-node/test/compression.test.ts
@@ -664,6 +664,7 @@ describe("dynamic response compression", () => {
 
     expect(head.status).toBe(200);
     expect(head.headers["content-encoding"]).toBe(get.headers["content-encoding"]);
+    expect(head.headers["content-length"]).toBe(get.headers["content-length"]);
     expect(head.headers.etag).toBe(get.headers.etag);
     expect(head.body.byteLength).toBe(0);
   });
@@ -1013,6 +1014,7 @@ describe("static asset compression", () => {
 
     expect(head.status).toBe(200);
     expect(head.headers["content-encoding"]).toBe(get.headers["content-encoding"]);
+    expect(head.headers["content-length"]).toBe(get.headers["content-length"]);
     expect(head.headers.etag).toBe(get.headers.etag);
     expect(head.headers.vary).toContain("Accept-Encoding");
     expect(head.body.byteLength).toBe(0);

--- a/packages/adapter-node/test/compression.test.ts
+++ b/packages/adapter-node/test/compression.test.ts
@@ -1,0 +1,566 @@
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import {
+  createServer,
+  request as httpRequest,
+  type IncomingMessage,
+  type ServerResponse,
+} from "node:http";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { once } from "node:events";
+import { brotliDecompressSync, gunzipSync } from "node:zlib";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { defineApp, resolveApiRoutes, route } from "@pracht/core";
+
+import { createNodeRequestHandler } from "../src/index.ts";
+import {
+  CompressedAssetCache,
+  isCompressibleContentType,
+  mergeVaryValue,
+  negotiateEncoding,
+} from "../src/node-compress.ts";
+
+const tempDirs: string[] = [];
+const servers = new Set<ReturnType<typeof createServer>>();
+
+function makeTempDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), "pracht-adapter-node-compress-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+interface RawResponse {
+  status: number;
+  headers: IncomingMessage["headers"];
+  body: Buffer;
+}
+
+/**
+ * A raw HTTP request that never advertises `Accept-Encoding` on its own and
+ * never decompresses — unlike `fetch`, which does both — so the tests can
+ * assert on the exact bytes and headers on the wire.
+ */
+function rawRequest(
+  url: string,
+  headers: Record<string, string> = {},
+  method = "GET",
+): Promise<RawResponse> {
+  return new Promise((resolveRequest, reject) => {
+    const req = httpRequest(url, { headers, method }, (res) => {
+      const chunks: Buffer[] = [];
+      res.on("data", (chunk: Buffer) => chunks.push(chunk));
+      res.on("end", () =>
+        resolveRequest({
+          body: Buffer.concat(chunks),
+          headers: res.headers,
+          status: res.statusCode ?? 0,
+        }),
+      );
+    });
+    req.on("error", reject);
+    req.end();
+  });
+}
+
+async function listen(
+  handler: (req: IncomingMessage, res: ServerResponse) => Promise<void>,
+): Promise<string> {
+  const server = createServer((req: IncomingMessage, res: ServerResponse) => {
+    void handler(req, res);
+  });
+  servers.add(server);
+  server.listen(0, "127.0.0.1");
+  await once(server, "listening");
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    throw new Error("Expected TCP server address");
+  }
+  return `http://127.0.0.1:${address.port}`;
+}
+
+afterEach(async () => {
+  for (const server of servers) {
+    server.close();
+    await once(server, "close");
+  }
+  servers.clear();
+
+  while (tempDirs.length > 0) {
+    const dir = tempDirs.pop();
+    if (dir) rmSync(dir, { force: true, recursive: true });
+  }
+});
+
+describe("negotiateEncoding", () => {
+  it("prefers brotli over gzip", () => {
+    expect(negotiateEncoding("gzip, deflate, br")).toBe("br");
+    expect(negotiateEncoding("br")).toBe("br");
+  });
+
+  it("falls back to gzip when brotli is not acceptable", () => {
+    expect(negotiateEncoding("gzip, deflate")).toBe("gzip");
+    expect(negotiateEncoding("gzip, br;q=0")).toBe("gzip");
+    expect(negotiateEncoding("x-gzip")).toBe("gzip");
+  });
+
+  it("returns identity when nothing usable is acceptable", () => {
+    expect(negotiateEncoding(null)).toBeNull();
+    expect(negotiateEncoding("")).toBeNull();
+    expect(negotiateEncoding("identity")).toBeNull();
+    expect(negotiateEncoding("deflate, zstd")).toBeNull();
+    expect(negotiateEncoding("gzip;q=0, br;q=0")).toBeNull();
+  });
+
+  it("honors wildcards and q-values", () => {
+    expect(negotiateEncoding("*")).toBe("br");
+    expect(negotiateEncoding("*;q=0.5, br;q=0")).toBe("gzip");
+    expect(negotiateEncoding("gzip;q=1.0, br;q=0.1")).toBe("br");
+    expect(negotiateEncoding("*;q=0")).toBeNull();
+  });
+});
+
+describe("isCompressibleContentType", () => {
+  it("allows text, structured syntax, and well-known application types", () => {
+    expect(isCompressibleContentType("text/html; charset=utf-8")).toBe(true);
+    expect(isCompressibleContentType("text/css")).toBe(true);
+    expect(isCompressibleContentType("application/json")).toBe(true);
+    expect(isCompressibleContentType("application/javascript")).toBe(true);
+    expect(isCompressibleContentType("image/svg+xml")).toBe(true);
+    expect(isCompressibleContentType("application/manifest+json")).toBe(true);
+  });
+
+  it("rejects binary media and missing types", () => {
+    expect(isCompressibleContentType(null)).toBe(false);
+    expect(isCompressibleContentType("image/png")).toBe(false);
+    expect(isCompressibleContentType("font/woff2")).toBe(false);
+    expect(isCompressibleContentType("application/octet-stream")).toBe(false);
+    expect(isCompressibleContentType("video/mp4")).toBe(false);
+  });
+});
+
+describe("mergeVaryValue", () => {
+  it("merges without duplicating and respects wildcards", () => {
+    expect(mergeVaryValue(null)).toBe("Accept-Encoding");
+    expect(mergeVaryValue("x-pracht-route-state-request")).toBe(
+      "x-pracht-route-state-request, Accept-Encoding",
+    );
+    expect(mergeVaryValue("accept-encoding")).toBe("accept-encoding");
+    expect(mergeVaryValue("*")).toBe("*");
+  });
+});
+
+describe("CompressedAssetCache", () => {
+  it("evicts the least recently used entries once over budget", () => {
+    const cache = new CompressedAssetCache(10);
+    cache.set("a", Buffer.alloc(4));
+    cache.set("b", Buffer.alloc(4));
+    // Touch "a" so "b" is the eviction candidate.
+    expect(cache.get("a")).toBeDefined();
+    cache.set("c", Buffer.alloc(4));
+
+    expect(cache.get("b")).toBeUndefined();
+    expect(cache.get("a")).toBeDefined();
+    expect(cache.get("c")).toBeDefined();
+    expect(cache.totalBytes).toBeLessThanOrEqual(10);
+  });
+
+  it("never stores an entry larger than its budget", () => {
+    const cache = new CompressedAssetCache(10);
+    cache.set("huge", Buffer.alloc(64));
+    expect(cache.get("huge")).toBeUndefined();
+    expect(cache.totalBytes).toBe(0);
+  });
+});
+
+describe("dynamic response compression", () => {
+  const longText = "Pracht compresses dynamic documents. ".repeat(100);
+
+  function createSsrHandler(options?: { compression?: boolean }) {
+    return createNodeRequestHandler({
+      app: defineApp({ routes: [route("/page", "./routes/page.tsx", { render: "ssr" })] }),
+      compression: options?.compression,
+      registry: {
+        routeModules: {
+          "./routes/page.tsx": async () => ({
+            Component: () => longText,
+          }),
+        },
+      },
+    });
+  }
+
+  it("streams brotli-compressed HTML when the client accepts it", async () => {
+    const base = await listen(createSsrHandler());
+
+    const response = await rawRequest(`${base}/page`, { "accept-encoding": "gzip, br" });
+
+    expect(response.status).toBe(200);
+    expect(response.headers["content-encoding"]).toBe("br");
+    expect(response.headers["content-length"]).toBeUndefined();
+    expect(response.headers.vary).toContain("Accept-Encoding");
+    expect(brotliDecompressSync(response.body).toString("utf-8")).toContain(
+      "Pracht compresses dynamic documents.",
+    );
+  });
+
+  it("falls back to gzip when brotli is not accepted", async () => {
+    const base = await listen(createSsrHandler());
+
+    const response = await rawRequest(`${base}/page`, { "accept-encoding": "gzip" });
+
+    expect(response.headers["content-encoding"]).toBe("gzip");
+    expect(gunzipSync(response.body).toString("utf-8")).toContain(
+      "Pracht compresses dynamic documents.",
+    );
+  });
+
+  it("serves identity with Vary when the client sends no Accept-Encoding", async () => {
+    const base = await listen(createSsrHandler());
+
+    const response = await rawRequest(`${base}/page`);
+
+    expect(response.headers["content-encoding"]).toBeUndefined();
+    expect(response.headers.vary).toContain("Accept-Encoding");
+    expect(response.body.toString("utf-8")).toContain("Pracht compresses dynamic documents.");
+  });
+
+  it("compresses route-state JSON for client navigations", async () => {
+    const base = await listen(
+      createNodeRequestHandler({
+        app: defineApp({ routes: [route("/data", "./routes/data.tsx", { render: "ssr" })] }),
+        registry: {
+          routeModules: {
+            "./routes/data.tsx": async () => ({
+              Component: () => "ok",
+              loader: async () => ({ rows: Array.from({ length: 200 }, (_, i) => `row-${i}`) }),
+            }),
+          },
+        },
+      }),
+    );
+
+    const response = await rawRequest(`${base}/data`, {
+      "accept-encoding": "br",
+      "x-pracht-route-state-request": "1",
+    });
+
+    expect(response.headers["content-type"]).toContain("application/json");
+    expect(response.headers["content-encoding"]).toBe("br");
+    expect(response.headers.vary).toContain("Accept-Encoding");
+    const payload = JSON.parse(brotliDecompressSync(response.body).toString("utf-8"));
+    expect(payload.data.rows).toHaveLength(200);
+  });
+
+  it("does not compress non-compressible content types", async () => {
+    const base = await listen(
+      createNodeRequestHandler({
+        apiRoutes: resolveApiRoutes(["/src/api/binary.ts"]),
+        app: defineApp({ routes: [] }),
+        registry: {
+          apiModules: {
+            "/src/api/binary.ts": async () => ({
+              GET: async () =>
+                new Response(Buffer.alloc(4096, 7), {
+                  headers: { "content-type": "application/octet-stream" },
+                }),
+            }),
+          },
+        },
+      }),
+    );
+
+    const response = await rawRequest(`${base}/api/binary`, { "accept-encoding": "br, gzip" });
+
+    expect(response.headers["content-encoding"]).toBeUndefined();
+    expect(response.headers.vary ?? "").not.toContain("Accept-Encoding");
+    expect(response.body.byteLength).toBe(4096);
+  });
+
+  it("never double-compresses an already-encoded response", async () => {
+    const base = await listen(
+      createNodeRequestHandler({
+        apiRoutes: resolveApiRoutes(["/src/api/pre.ts"]),
+        app: defineApp({ routes: [] }),
+        registry: {
+          apiModules: {
+            "/src/api/pre.ts": async () => ({
+              GET: async () =>
+                new Response("pretend-gzipped-bytes", {
+                  headers: {
+                    "content-encoding": "gzip",
+                    "content-type": "text/plain",
+                  },
+                }),
+            }),
+          },
+        },
+      }),
+    );
+
+    const response = await rawRequest(`${base}/api/pre`, { "accept-encoding": "br" });
+
+    expect(response.headers["content-encoding"]).toBe("gzip");
+    expect(response.body.toString("utf-8")).toBe("pretend-gzipped-bytes");
+  });
+
+  it("respects Cache-Control: no-transform", async () => {
+    const base = await listen(
+      createNodeRequestHandler({
+        apiRoutes: resolveApiRoutes(["/src/api/raw.ts"]),
+        app: defineApp({ routes: [] }),
+        registry: {
+          apiModules: {
+            "/src/api/raw.ts": async () => ({
+              GET: async () =>
+                new Response("x".repeat(4096), {
+                  headers: {
+                    "cache-control": "public, no-transform",
+                    "content-type": "text/plain",
+                  },
+                }),
+            }),
+          },
+        },
+      }),
+    );
+
+    const response = await rawRequest(`${base}/api/raw`, { "accept-encoding": "br, gzip" });
+
+    expect(response.headers["content-encoding"]).toBeUndefined();
+    expect(response.body.byteLength).toBe(4096);
+  });
+
+  it("skips tiny bodies when the Content-Length is known", async () => {
+    const base = await listen(
+      createNodeRequestHandler({
+        apiRoutes: resolveApiRoutes(["/src/api/tiny.ts"]),
+        app: defineApp({ routes: [] }),
+        registry: {
+          apiModules: {
+            "/src/api/tiny.ts": async () => ({
+              GET: async () =>
+                new Response("ok", {
+                  headers: { "content-length": "2", "content-type": "text/plain" },
+                }),
+            }),
+          },
+        },
+      }),
+    );
+
+    const response = await rawRequest(`${base}/api/tiny`, { "accept-encoding": "br, gzip" });
+
+    expect(response.headers["content-encoding"]).toBeUndefined();
+    expect(response.headers.vary).toContain("Accept-Encoding");
+    expect(response.body.toString("utf-8")).toBe("ok");
+  });
+
+  it("merges Accept-Encoding into an existing Vary header", async () => {
+    const base = await listen(
+      createNodeRequestHandler({
+        apiRoutes: resolveApiRoutes(["/src/api/vary.ts"]),
+        app: defineApp({ routes: [] }),
+        registry: {
+          apiModules: {
+            "/src/api/vary.ts": async () => ({
+              GET: async () =>
+                new Response("y".repeat(4096), {
+                  headers: { "content-type": "text/plain", vary: "Accept" },
+                }),
+            }),
+          },
+        },
+      }),
+    );
+
+    const response = await rawRequest(`${base}/api/vary`, { "accept-encoding": "gzip" });
+
+    expect(response.headers["content-encoding"]).toBe("gzip");
+    expect(response.headers.vary).toContain("Accept");
+    expect(response.headers.vary).toContain("Accept-Encoding");
+  });
+
+  it("keeps a streamed multi-chunk body intact through the compressor", async () => {
+    const chunks = Array.from({ length: 32 }, (_, i) => `chunk-${i}-${"z".repeat(256)}\n`);
+    const base = await listen(
+      createNodeRequestHandler({
+        apiRoutes: resolveApiRoutes(["/src/api/stream.ts"]),
+        app: defineApp({ routes: [] }),
+        registry: {
+          apiModules: {
+            "/src/api/stream.ts": async () => ({
+              GET: async () =>
+                new Response(
+                  new ReadableStream({
+                    async start(controller) {
+                      for (const chunk of chunks) {
+                        controller.enqueue(new TextEncoder().encode(chunk));
+                        await new Promise((resolveTick) => setTimeout(resolveTick, 1));
+                      }
+                      controller.close();
+                    },
+                  }),
+                  { headers: { "content-type": "text/plain" } },
+                ),
+            }),
+          },
+        },
+      }),
+    );
+
+    const response = await rawRequest(`${base}/api/stream`, { "accept-encoding": "gzip" });
+
+    expect(response.headers["content-encoding"]).toBe("gzip");
+    expect(gunzipSync(response.body).toString("utf-8")).toBe(chunks.join(""));
+  });
+
+  it("can be disabled entirely with compression: false", async () => {
+    const base = await listen(createSsrHandler({ compression: false }));
+
+    const response = await rawRequest(`${base}/page`, { "accept-encoding": "br, gzip" });
+
+    expect(response.headers["content-encoding"]).toBeUndefined();
+    expect(response.headers.vary ?? "").not.toContain("Accept-Encoding");
+    expect(response.body.toString("utf-8")).toContain("Pracht compresses dynamic documents.");
+  });
+});
+
+describe("static asset compression", () => {
+  function createStaticHandler(options?: { compression?: boolean }): {
+    handler: ReturnType<typeof createNodeRequestHandler>;
+  } {
+    const staticDir = makeTempDir();
+    mkdirSync(join(staticDir, "assets"), { recursive: true });
+    writeFileSync(
+      join(staticDir, "assets", "app.js"),
+      `// pracht\n${'console.log("payload");\n'.repeat(300)}`,
+      "utf-8",
+    );
+    writeFileSync(join(staticDir, "assets", "tiny.css"), "a{color:red}", "utf-8");
+    writeFileSync(join(staticDir, "assets", "pixel.png"), Buffer.alloc(4096, 3));
+    writeFileSync(
+      join(staticDir, "index.html"),
+      `<html><body>${"<p>prerendered</p>".repeat(200)}</body></html>`,
+      "utf-8",
+    );
+
+    const handler = createNodeRequestHandler({
+      app: defineApp({ routes: [] }),
+      compression: options?.compression,
+      staticDir,
+    });
+    return { handler };
+  }
+
+  it("serves brotli-compressed assets with a distinct weak ETag", async () => {
+    const { handler } = createStaticHandler();
+    const base = await listen(handler);
+
+    const identity = await rawRequest(`${base}/assets/app.js`);
+    const compressed = await rawRequest(`${base}/assets/app.js`, {
+      "accept-encoding": "gzip, br",
+    });
+
+    expect(compressed.status).toBe(200);
+    expect(compressed.headers["content-encoding"]).toBe("br");
+    expect(compressed.headers["content-type"]).toBe("application/javascript");
+    expect(compressed.headers.vary).toContain("Accept-Encoding");
+    expect(compressed.headers["content-length"]).toBe(String(compressed.body.byteLength));
+    expect(compressed.body.byteLength).toBeLessThan(identity.body.byteLength);
+    expect(brotliDecompressSync(compressed.body).toString("utf-8")).toBe(
+      identity.body.toString("utf-8"),
+    );
+
+    // Encoded variants must not share a validator with identity.
+    expect(identity.headers.etag).toBeDefined();
+    expect(compressed.headers.etag).toBe(`${identity.headers.etag!.slice(0, -1)}-br"`);
+  });
+
+  it("answers 304 against the encoded variant's ETag", async () => {
+    const { handler } = createStaticHandler();
+    const base = await listen(handler);
+
+    const compressed = await rawRequest(`${base}/assets/app.js`, { "accept-encoding": "br" });
+    const revalidated = await rawRequest(`${base}/assets/app.js`, {
+      "accept-encoding": "br",
+      "if-none-match": compressed.headers.etag!,
+    });
+
+    expect(revalidated.status).toBe(304);
+    expect(revalidated.body.byteLength).toBe(0);
+
+    // The identity ETag does not validate the encoded variant.
+    const identity = await rawRequest(`${base}/assets/app.js`);
+    const crossEncoding = await rawRequest(`${base}/assets/app.js`, {
+      "accept-encoding": "br",
+      "if-modified-since": "Thu, 01 Jan 1970 00:00:00 GMT",
+      "if-none-match": identity.headers.etag!,
+    });
+    expect(crossEncoding.status).toBe(200);
+    expect(crossEncoding.headers["content-encoding"]).toBe("br");
+  });
+
+  it("serves compressed prerendered HTML", async () => {
+    const { handler } = createStaticHandler();
+    const base = await listen(handler);
+
+    const response = await rawRequest(`${base}/`, { "accept-encoding": "gzip" });
+
+    expect(response.status).toBe(200);
+    expect(response.headers["content-encoding"]).toBe("gzip");
+    expect(gunzipSync(response.body).toString("utf-8")).toContain("<p>prerendered</p>");
+  });
+
+  it("leaves tiny and binary files identity-encoded", async () => {
+    const { handler } = createStaticHandler();
+    const base = await listen(handler);
+
+    const tiny = await rawRequest(`${base}/assets/tiny.css`, { "accept-encoding": "br, gzip" });
+    expect(tiny.headers["content-encoding"]).toBeUndefined();
+    expect(tiny.body.toString("utf-8")).toBe("a{color:red}");
+
+    const binary = await rawRequest(`${base}/assets/pixel.png`, { "accept-encoding": "br, gzip" });
+    expect(binary.headers["content-encoding"]).toBeUndefined();
+    expect(binary.headers.vary ?? "").not.toContain("Accept-Encoding");
+    expect(binary.body.byteLength).toBe(4096);
+  });
+
+  it("serves identical compressed bytes from the in-memory LRU on repeat requests", async () => {
+    const { handler } = createStaticHandler();
+    const base = await listen(handler);
+
+    const first = await rawRequest(`${base}/assets/app.js`, { "accept-encoding": "br" });
+    const second = await rawRequest(`${base}/assets/app.js`, { "accept-encoding": "br" });
+
+    expect(second.headers.etag).toBe(first.headers.etag);
+    expect(second.body.equals(first.body)).toBe(true);
+  });
+
+  it("keeps static files identity-encoded when compression is disabled", async () => {
+    const { handler } = createStaticHandler({ compression: false });
+    const base = await listen(handler);
+
+    const response = await rawRequest(`${base}/assets/app.js`, { "accept-encoding": "br, gzip" });
+
+    expect(response.headers["content-encoding"]).toBeUndefined();
+    expect(response.headers.vary ?? "").not.toContain("Accept-Encoding");
+    expect(response.body.toString("utf-8")).toContain("payload");
+  });
+
+  it("omits the body but keeps negotiation headers identity-shaped for HEAD", async () => {
+    const { handler } = createStaticHandler();
+    const base = await listen(handler);
+
+    const response = await rawRequest(
+      `${base}/assets/app.js`,
+      { "accept-encoding": "br, gzip" },
+      "HEAD",
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers["content-encoding"]).toBeUndefined();
+    expect(response.headers.vary).toContain("Accept-Encoding");
+    expect(response.body.byteLength).toBe(0);
+  });
+});

--- a/packages/adapter-node/test/compression.test.ts
+++ b/packages/adapter-node/test/compression.test.ts
@@ -710,6 +710,86 @@ describe("dynamic response compression", () => {
     expect(revalidated.body.byteLength).toBe(0);
   });
 
+  it("evaluates If-Match against the selected dynamic representation", async () => {
+    const identityEtag = '"match-v1"';
+    const receivedPreconditions: Array<{ match: string | null; unmodified: string | null }> = [];
+    const base = await listen(
+      createNodeRequestHandler({
+        apiRoutes: resolveApiRoutes(["/src/api/match.ts"]),
+        app: defineApp({ routes: [] }),
+        registry: {
+          apiModules: {
+            "/src/api/match.ts": async () => ({
+              GET: async ({ request }) => {
+                const match = request.headers.get("if-match");
+                receivedPreconditions.push({
+                  match,
+                  unmodified: request.headers.get("if-unmodified-since"),
+                });
+                if (match && match !== identityEtag && match !== "*") {
+                  return new Response("precondition failed", { status: 412 });
+                }
+                return new Response("match payload ".repeat(300), {
+                  headers: {
+                    ...(new URL(request.url).searchParams.has("identity")
+                      ? { "cache-control": "no-transform" }
+                      : {}),
+                    etag: identityEtag,
+                    "last-modified": "Fri, 15 Aug 2025 00:00:00 GMT",
+                    "content-type": "text/plain",
+                  },
+                });
+              },
+            }),
+          },
+        },
+      }),
+    );
+
+    const crossEncoding = await rawRequest(`${base}/api/match`, {
+      "accept-encoding": "gzip",
+      "if-match": identityEtag,
+    });
+    const wildcard = await rawRequest(`${base}/api/match`, {
+      "accept-encoding": "gzip",
+      "if-match": "*",
+      "if-unmodified-since": "Thu, 01 Jan 1970 00:00:00 GMT",
+    });
+    const selectedIdentity = await rawRequest(`${base}/api/match?identity=1`, {
+      "accept-encoding": "gzip",
+      "if-match": identityEtag,
+    });
+    const weakIdentityMatch = await rawRequest(`${base}/api/match?identity=1`, {
+      "accept-encoding": "gzip",
+      "if-match": `W/${identityEtag}`,
+    });
+
+    expect(crossEncoding.status).toBe(412);
+    expect(crossEncoding.headers.etag).toBe(encodeEtagForEncoding(identityEtag, "gzip"));
+    expect(crossEncoding.headers["content-encoding"]).toBeUndefined();
+    expect(crossEncoding.headers["cache-control"]).toBe("no-store");
+    expect(crossEncoding.body.byteLength).toBe(0);
+
+    expect(wildcard.status).toBe(200);
+    expect(wildcard.headers["content-encoding"]).toBe("gzip");
+    expect(gunzipSync(wildcard.body).toString("utf-8")).toContain("match payload");
+
+    expect(selectedIdentity.status).toBe(200);
+    expect(selectedIdentity.headers["content-encoding"]).toBeUndefined();
+    expect(selectedIdentity.headers.etag).toBe(identityEtag);
+    expect(selectedIdentity.body.toString("utf-8")).toContain("match payload");
+
+    expect(weakIdentityMatch.status).toBe(412);
+    expect(weakIdentityMatch.headers["content-encoding"]).toBeUndefined();
+    expect(weakIdentityMatch.body.byteLength).toBe(0);
+    expect(receivedPreconditions).toEqual([
+      { match: null, unmodified: null },
+      { match: null, unmodified: null },
+      { match: null, unmodified: null },
+      { match: null, unmodified: null },
+    ]);
+  });
+
   it("revalidates encoded ETags for successful non-200 responses", async () => {
     const identityEtag = '"non-authoritative-v1"';
     const base = await listen(

--- a/packages/adapter-node/test/compression.test.ts
+++ b/packages/adapter-node/test/compression.test.ts
@@ -8,7 +8,7 @@ import {
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { once } from "node:events";
-import { brotliDecompressSync, gunzipSync } from "node:zlib";
+import { brotliDecompressSync, createBrotliDecompress, createGunzip, gunzipSync } from "node:zlib";
 import { afterEach, describe, expect, it } from "vitest";
 
 import { defineApp, resolveApiRoutes, route } from "@pracht/core";
@@ -115,8 +115,15 @@ describe("negotiateEncoding", () => {
   it("honors wildcards and q-values", () => {
     expect(negotiateEncoding("*")).toBe("br");
     expect(negotiateEncoding("*;q=0.5, br;q=0")).toBe("gzip");
-    expect(negotiateEncoding("gzip;q=1.0, br;q=0.1")).toBe("br");
     expect(negotiateEncoding("*;q=0")).toBeNull();
+  });
+
+  it("prefers the acceptable coding with the highest qvalue (RFC 9110 §12.5.3)", () => {
+    expect(negotiateEncoding("gzip;q=1.0, br;q=0.1")).toBe("gzip");
+    expect(negotiateEncoding("gzip;q=0.8, br;q=0.9")).toBe("br");
+    expect(negotiateEncoding("br;q=0.5, gzip;q=0.5")).toBe("br"); // ties go to brotli
+    expect(negotiateEncoding("gzip;q=0.5, *;q=1")).toBe("br"); // wildcard covers br at q=1
+    expect(negotiateEncoding("identity;q=0, gzip")).toBe("gzip");
   });
 });
 
@@ -170,6 +177,40 @@ describe("CompressedAssetCache", () => {
     cache.set("huge", Buffer.alloc(64));
     expect(cache.get("huge")).toBeUndefined();
     expect(cache.totalBytes).toBe(0);
+  });
+
+  it("deduplicates concurrent compressions of the same key", async () => {
+    const cache = new CompressedAssetCache(1024);
+    let produced = 0;
+    const produce = async (): Promise<Buffer> => {
+      produced += 1;
+      await new Promise((resolveTick) => setTimeout(resolveTick, 10));
+      return Buffer.from("compressed");
+    };
+
+    const results = await Promise.all(
+      Array.from({ length: 8 }, () => cache.getOrCompress("asset", produce)),
+    );
+
+    expect(produced).toBe(1);
+    for (const result of results) expect(result.toString()).toBe("compressed");
+    // Later requests hit the stored entry, not `produce`.
+    await cache.getOrCompress("asset", produce);
+    expect(produced).toBe(1);
+  });
+
+  it("does not cache a failed compression and lets the next request retry", async () => {
+    const cache = new CompressedAssetCache(1024);
+    let calls = 0;
+    const failThenSucceed = async (): Promise<Buffer> => {
+      calls += 1;
+      if (calls === 1) throw new Error("EIO");
+      return Buffer.from("ok");
+    };
+
+    await expect(cache.getOrCompress("asset", failThenSucceed)).rejects.toThrow("EIO");
+    await expect(cache.getOrCompress("asset", failThenSucceed)).resolves.toBeDefined();
+    expect(calls).toBe(2);
   });
 });
 
@@ -415,6 +456,87 @@ describe("dynamic response compression", () => {
     expect(gunzipSync(response.body).toString("utf-8")).toBe(chunks.join(""));
   });
 
+  for (const [encoding, createDecompressor] of [
+    ["gzip", createGunzip],
+    ["br", createBrotliDecompress],
+  ] as const) {
+    it(`delivers ${encoding}-compressed SSE events incrementally, not at stream end`, async () => {
+      // The producer holds the stream open until the test observes the first
+      // event on the wire. Without per-chunk flushing the compressor sits on
+      // the event (brotli emits zero bytes, gzip only its header) and this
+      // deadlocks: the event would only surface when the stream closes.
+      let releaseGate!: () => void;
+      const gate = new Promise<void>((resolveGate) => {
+        releaseGate = resolveGate;
+      });
+
+      const base = await listen(
+        createNodeRequestHandler({
+          apiRoutes: resolveApiRoutes(["/src/api/events.ts"]),
+          app: defineApp({ routes: [] }),
+          registry: {
+            apiModules: {
+              "/src/api/events.ts": async () => ({
+                GET: async () =>
+                  new Response(
+                    new ReadableStream({
+                      async start(controller) {
+                        controller.enqueue(new TextEncoder().encode("data: first\n\n"));
+                        await gate;
+                        controller.enqueue(new TextEncoder().encode("data: second\n\n"));
+                        controller.close();
+                      },
+                    }),
+                    { headers: { "content-type": "text/event-stream" } },
+                  ),
+              }),
+            },
+          },
+        }),
+      );
+
+      let openRequest: ReturnType<typeof httpRequest> | undefined;
+      const firstEventWhileOpen = await new Promise<string>((resolveProbe, reject) => {
+        const timeout = setTimeout(() => {
+          releaseGate();
+          reject(new Error("first SSE event was not delivered while the stream was open"));
+        }, 3000);
+        const req = httpRequest(
+          `${base}/api/events`,
+          { headers: { "accept-encoding": encoding } },
+          (res) => {
+            expect(res.headers["content-encoding"]).toBe(encoding);
+            const decompressor = createDecompressor();
+            let decompressed = "";
+            let observed = false;
+            decompressor.on("data", (chunk: Buffer) => {
+              decompressed += chunk.toString("utf-8");
+              if (!observed && decompressed.includes("data: first\n\n")) {
+                observed = true;
+                clearTimeout(timeout);
+                resolveProbe(decompressed);
+                releaseGate();
+              }
+            });
+            decompressor.on("error", reject);
+            res.pipe(decompressor);
+          },
+        );
+        req.on("error", reject);
+        req.end();
+        openRequest = req;
+      });
+
+      // Tear the client connection down so server close in `afterEach` does
+      // not wait out the keep-alive window of a socket the test is done with.
+      openRequest?.destroy();
+      releaseGate();
+
+      expect(firstEventWhileOpen).toContain("data: first");
+      expect(firstEventWhileOpen).not.toContain("data: second");
+    });
+  }
+
   it("can be disabled entirely with compression: false", async () => {
     const base = await listen(createSsrHandler({ compression: false }));
 
@@ -499,6 +621,52 @@ describe("static asset compression", () => {
     });
     expect(crossEncoding.status).toBe(200);
     expect(crossEncoding.headers["content-encoding"]).toBe("br");
+  });
+
+  it("ignores If-Modified-Since when If-None-Match is present (RFC 9110 §13.1.3)", async () => {
+    const { handler } = createStaticHandler();
+    const base = await listen(handler);
+
+    const identity = await rawRequest(`${base}/assets/app.js`);
+
+    // A client revalidating its identity-encoded cache entry sends both
+    // validators. The brotli variant carries a different ETag, so this must
+    // be a fresh 200: the still-fresh Last-Modified date must not shadow the
+    // ETag mismatch, or the client's identity body would be relabeled with
+    // the brotli variant's validator by a spurious 304.
+    const crossEncoding = await rawRequest(`${base}/assets/app.js`, {
+      "accept-encoding": "br",
+      "if-modified-since": identity.headers["last-modified"]!,
+      "if-none-match": identity.headers.etag!,
+    });
+    expect(crossEncoding.status).toBe(200);
+    expect(crossEncoding.headers["content-encoding"]).toBe("br");
+
+    // A matching ETag still answers 304 even alongside a stale IMS date.
+    const conditional = await rawRequest(`${base}/assets/app.js`, {
+      "accept-encoding": "br",
+      "if-modified-since": "Thu, 01 Jan 1970 00:00:00 GMT",
+      "if-none-match": crossEncoding.headers.etag!,
+    });
+    expect(conditional.status).toBe(304);
+  });
+
+  it("serves identical bytes to concurrent first requests for the same asset", async () => {
+    const { handler } = createStaticHandler();
+    const base = await listen(handler);
+
+    const responses = await Promise.all(
+      Array.from({ length: 8 }, () =>
+        rawRequest(`${base}/assets/app.js`, { "accept-encoding": "br" }),
+      ),
+    );
+
+    const [first, ...rest] = responses;
+    expect(first!.headers["content-encoding"]).toBe("br");
+    for (const response of rest) {
+      expect(response.headers.etag).toBe(first!.headers.etag);
+      expect(response.body.equals(first!.body)).toBe(true);
+    }
   });
 
   it("serves compressed prerendered HTML", async () => {

--- a/packages/adapter-node/test/compression.test.ts
+++ b/packages/adapter-node/test/compression.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { mkdtempSync, mkdirSync, rmSync, utimesSync, writeFileSync } from "node:fs";
 import {
   createServer,
   request as httpRequest,
@@ -11,9 +11,10 @@ import { once } from "node:events";
 import { brotliDecompressSync, createBrotliDecompress, createGunzip, gunzipSync } from "node:zlib";
 import { afterEach, describe, expect, it } from "vitest";
 
-import { defineApp, resolveApiRoutes, route } from "@pracht/core";
+import { defineApp, resolveApiRoutes, route, timeRevalidate } from "@pracht/core";
 
 import { createNodeRequestHandler } from "../src/index.ts";
+import { writeISGFile } from "../src/node-isg.ts";
 import {
   CompressedAssetCache,
   encodeEtagForEncoding,
@@ -438,6 +439,47 @@ describe("dynamic response compression", () => {
     expect(response.body.byteLength).toBe(4096);
   });
 
+  it("preserves conditional headers for Range responses that are never compressed", async () => {
+    let receivedIfNoneMatch: string | null = null;
+    const identityEtag = '"range-v1"';
+    const base = await listen(
+      createNodeRequestHandler({
+        apiRoutes: resolveApiRoutes(["/src/api/range.ts"]),
+        app: defineApp({ routes: [] }),
+        registry: {
+          apiModules: {
+            "/src/api/range.ts": async () => ({
+              GET: async ({ request }) => {
+                receivedIfNoneMatch = request.headers.get("if-none-match");
+                if (receivedIfNoneMatch === identityEtag) {
+                  return new Response(null, { status: 304, headers: { etag: identityEtag } });
+                }
+                return new Response("part", {
+                  status: 206,
+                  headers: {
+                    "content-range": "bytes 0-3/10",
+                    "content-type": "text/plain",
+                    etag: identityEtag,
+                  },
+                });
+              },
+            }),
+          },
+        },
+      }),
+    );
+
+    const response = await rawRequest(`${base}/api/range`, {
+      "accept-encoding": "gzip",
+      "if-none-match": identityEtag,
+      range: "bytes=0-3",
+    });
+
+    expect(receivedIfNoneMatch).toBe(identityEtag);
+    expect(response.status).toBe(304);
+    expect(response.headers["content-range"]).toBeUndefined();
+  });
+
   it.each(["content-digest", "repr-digest", "digest", "content-md5"])(
     "preserves identity encoding when a response carries %s",
     async (integrityHeader) => {
@@ -565,6 +607,37 @@ describe("dynamic response compression", () => {
     expect(revalidated.headers.etag).toBe(first.headers.etag);
     expect(revalidated.headers.vary).toContain("Accept-Encoding");
     expect(revalidated.body.byteLength).toBe(0);
+  });
+
+  it("keeps Accept-Encoding in Vary on an application-generated identity 304", async () => {
+    const identityEtag = '"identity-v1"';
+    const base = await listen(
+      createNodeRequestHandler({
+        apiRoutes: resolveApiRoutes(["/src/api/identity-304.ts"]),
+        app: defineApp({ routes: [] }),
+        registry: {
+          apiModules: {
+            "/src/api/identity-304.ts": async () => ({
+              GET: async ({ request }) =>
+                request.headers.get("if-none-match") === identityEtag
+                  ? new Response(null, { status: 304, headers: { etag: identityEtag } })
+                  : new Response("identity payload ".repeat(300), {
+                      headers: { etag: identityEtag, "content-type": "text/plain" },
+                    }),
+            }),
+          },
+        },
+      }),
+    );
+
+    const first = await rawRequest(`${base}/api/identity-304`);
+    const revalidated = await rawRequest(`${base}/api/identity-304`, {
+      "if-none-match": identityEtag,
+    });
+
+    expect(first.headers.vary).toContain("Accept-Encoding");
+    expect(revalidated.status).toBe(304);
+    expect(revalidated.headers.vary).toContain("Accept-Encoding");
   });
 
   it("evaluates If-Modified-Since after selecting the dynamic encoding", async () => {
@@ -949,6 +1022,50 @@ describe("static asset compression", () => {
     });
     expect(crossEncoding.status).toBe(200);
     expect(crossEncoding.headers["content-encoding"]).toBe("br");
+  });
+
+  it("does not reuse same-metadata ISG validators after a handler restart", async () => {
+    const staticDir = makeTempDir();
+    const htmlDir = join(staticDir, "page");
+    const htmlPath = join(htmlDir, "index.html");
+    mkdirSync(htmlDir, { recursive: true });
+    const staleHtml = `<main>${"a".repeat(4096)}</main>`;
+    const freshHtml = `<main>${"b".repeat(4096)}</main>`;
+    const fixedTimestamp = new Date(1_700_000_000_000);
+    writeFileSync(htmlPath, staleHtml, "utf-8");
+    utimesSync(htmlPath, fixedTimestamp, fixedTimestamp);
+
+    const createHandler = () =>
+      createNodeRequestHandler({
+        app: defineApp({ routes: [] }),
+        headersManifest: { "/page": { etag: '"page-document"' } },
+        isgManifest: { "/page": { revalidate: timeRevalidate(3600) } },
+        staticDir,
+      });
+
+    const firstBase = await listen(createHandler());
+    const stale = await rawRequest(`${firstBase}/page`, { "accept-encoding": "gzip" });
+    expect(gunzipSync(stale.body).toString("utf-8")).toBe(staleHtml);
+
+    await writeISGFile(htmlPath, freshHtml);
+    // Model a coarse filesystem whose externally visible mtime does not move.
+    utimesSync(htmlPath, fixedTimestamp, fixedTimestamp);
+
+    const restartedBase = await listen(createHandler());
+    const etagRevalidation = await rawRequest(`${restartedBase}/page`, {
+      "accept-encoding": "gzip",
+      "if-none-match": stale.headers.etag!,
+    });
+    const dateRevalidation = await rawRequest(`${restartedBase}/page`, {
+      "accept-encoding": "gzip",
+      "if-modified-since": stale.headers["last-modified"]!,
+    });
+
+    expect(etagRevalidation.status).toBe(200);
+    expect(etagRevalidation.headers.etag).not.toBe(stale.headers.etag);
+    expect(gunzipSync(etagRevalidation.body).toString("utf-8")).toBe(freshHtml);
+    expect(dateRevalidation.status).toBe(200);
+    expect(gunzipSync(dateRevalidation.body).toString("utf-8")).toBe(freshHtml);
   });
 
   it("ignores If-Modified-Since when If-None-Match is present (RFC 9110 §13.1.3)", async () => {

--- a/packages/adapter-node/test/compression.test.ts
+++ b/packages/adapter-node/test/compression.test.ts
@@ -16,6 +16,7 @@ import { defineApp, resolveApiRoutes, route } from "@pracht/core";
 import { createNodeRequestHandler } from "../src/index.ts";
 import {
   CompressedAssetCache,
+  encodeEtagForEncoding,
   isCompressibleContentType,
   mergeVaryValue,
   negotiateEncoding,
@@ -126,6 +127,11 @@ describe("negotiateEncoding", () => {
     expect(negotiateEncoding("identity;q=0, gzip")).toBe("gzip");
     expect(negotiateEncoding("gzip;q=0.5, identity;q=1, *;q=0")).toBeNull();
     expect(negotiateEncoding("gzip;q=1, identity;q=1, *;q=0")).toBe("gzip");
+  });
+
+  it("weakens derived ETags for encoded variants", () => {
+    expect(encodeEtagForEncoding('"strong-v1"', "gzip")).toBe('W/"strong-v1-gzip"');
+    expect(encodeEtagForEncoding('W/"weak-v1"', "br")).toBe('W/"weak-v1-br"');
   });
 });
 
@@ -457,7 +463,7 @@ describe("dynamic response compression", () => {
   });
 
   it("revalidates an encoding-specific dynamic ETag", async () => {
-    const identityEtag = 'W/"dynamic-v1"';
+    const identityEtag = '"dynamic-v1"';
     const base = await listen(
       createNodeRequestHandler({
         apiRoutes: resolveApiRoutes(["/src/api/etag.ts"]),
@@ -480,18 +486,56 @@ describe("dynamic response compression", () => {
       }),
     );
 
+    const identity = await rawRequest(`${base}/api/etag`);
+    const crossEncoding = await rawRequest(`${base}/api/etag`, {
+      "accept-encoding": "gzip",
+      "if-none-match": identity.headers.etag!,
+    });
     const first = await rawRequest(`${base}/api/etag`, { "accept-encoding": "gzip" });
     const revalidated = await rawRequest(`${base}/api/etag`, {
       "accept-encoding": "gzip",
       "if-none-match": first.headers.etag!,
     });
 
+    expect(identity.headers.etag).toBe(identityEtag);
+    expect(crossEncoding.status).toBe(200);
+    expect(crossEncoding.headers["content-encoding"]).toBe("gzip");
+    expect(crossEncoding.headers.etag).toBe('W/"dynamic-v1-gzip"');
     expect(first.status).toBe(200);
     expect(first.headers.etag).toBe('W/"dynamic-v1-gzip"');
     expect(revalidated.status).toBe(304);
     expect(revalidated.headers.etag).toBe(first.headers.etag);
     expect(revalidated.headers.vary).toContain("Accept-Encoding");
     expect(revalidated.body.byteLength).toBe(0);
+  });
+
+  it("revalidates encoded ETags whose opaque tag contains a comma", async () => {
+    const base = await listen(
+      createNodeRequestHandler({
+        apiRoutes: resolveApiRoutes(["/src/api/comma-etag.ts"]),
+        app: defineApp({ routes: [] }),
+        registry: {
+          apiModules: {
+            "/src/api/comma-etag.ts": async () => ({
+              GET: async () =>
+                new Response("comma etag payload ".repeat(300), {
+                  headers: { etag: '"release,1"', "content-type": "text/plain" },
+                }),
+            }),
+          },
+        },
+      }),
+    );
+
+    const first = await rawRequest(`${base}/api/comma-etag`, { "accept-encoding": "gzip" });
+    const revalidated = await rawRequest(`${base}/api/comma-etag`, {
+      "accept-encoding": "gzip",
+      "if-none-match": first.headers.etag!,
+    });
+
+    expect(first.headers.etag).toBe('W/"release,1-gzip"');
+    expect(revalidated.status).toBe(304);
+    expect(revalidated.headers.etag).toBe(first.headers.etag);
   });
 
   it("uses the GET representation metadata for dynamic HEAD responses", async () => {
@@ -659,6 +703,7 @@ describe("static asset compression", () => {
     );
     writeFileSync(join(staticDir, "assets", "tiny.css"), "a{color:red}", "utf-8");
     writeFileSync(join(staticDir, "assets", "pixel.png"), Buffer.alloc(4096, 3));
+    writeFileSync(join(staticDir, "assets", "module.wasm"), Buffer.alloc(4096, 5));
     writeFileSync(
       join(staticDir, "index.html"),
       `<html><body>${"<p>prerendered</p>".repeat(200)}</body></html>`,
@@ -776,6 +821,19 @@ describe("static asset compression", () => {
     expect(response.status).toBe(200);
     expect(response.headers["content-encoding"]).toBe("gzip");
     expect(gunzipSync(response.body).toString("utf-8")).toContain("<p>prerendered</p>");
+  });
+
+  it("serves static WebAssembly with its compressible MIME type", async () => {
+    const { handler } = createStaticHandler();
+    const base = await listen(handler);
+
+    const response = await rawRequest(`${base}/assets/module.wasm`, {
+      "accept-encoding": "gzip",
+    });
+
+    expect(response.headers["content-type"]).toBe("application/wasm");
+    expect(response.headers["content-encoding"]).toBe("gzip");
+    expect(gunzipSync(response.body)).toEqual(Buffer.alloc(4096, 5));
   });
 
   it("drops an identity Content-Length when streaming a large compressed page", async () => {

--- a/packages/adapter-node/test/compression.test.ts
+++ b/packages/adapter-node/test/compression.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, mkdirSync, rmSync, utimesSync, writeFileSync } from "node:fs";
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, utimesSync, writeFileSync } from "node:fs";
 import { open } from "node:fs/promises";
 import {
   createServer,
@@ -1025,6 +1025,34 @@ describe("static asset compression", () => {
     expect(crossEncoding.headers["content-encoding"]).toBe("br");
   });
 
+  it("keeps static validators stable across replica-local file copies", async () => {
+    const source = `// replica\n${'console.log("stable");\n'.repeat(300)}`;
+    const fixedTimestamp = new Date(Math.floor(Date.now() / 1000) * 1000);
+    const createReplica = (): string => {
+      const staticDir = makeTempDir();
+      const assetDir = join(staticDir, "assets");
+      const assetPath = join(assetDir, "app.js");
+      mkdirSync(assetDir, { recursive: true });
+      writeFileSync(assetPath, source, "utf-8");
+      utimesSync(assetPath, fixedTimestamp, fixedTimestamp);
+      return staticDir;
+    };
+
+    const firstBase = await listen(
+      createNodeRequestHandler({ app: defineApp({ routes: [] }), staticDir: createReplica() }),
+    );
+    const secondBase = await listen(
+      createNodeRequestHandler({ app: defineApp({ routes: [] }), staticDir: createReplica() }),
+    );
+    const first = await rawRequest(`${firstBase}/assets/app.js`, { "accept-encoding": "gzip" });
+    const second = await rawRequest(`${secondBase}/assets/app.js`, {
+      "accept-encoding": "gzip",
+    });
+
+    expect(first.headers.etag).toBe(second.headers.etag);
+    expect(gunzipSync(first.body)).toEqual(gunzipSync(second.body));
+  });
+
   it("does not reuse same-metadata ISG validators after a handler restart", async () => {
     const staticDir = makeTempDir();
     const htmlDir = join(staticDir, "page");
@@ -1069,8 +1097,9 @@ describe("static asset compression", () => {
     expect(gunzipSync(dateRevalidation.body).toString("utf-8")).toBe(freshHtml);
   });
 
-  it("keeps regenerated ISG validators stable across sibling handlers", async () => {
-    const staticDir = makeTempDir();
+  it("keeps regenerated ISG validators stable across deployment replicas", async () => {
+    const primaryStaticDir = makeTempDir();
+    const siblingStaticDir = makeTempDir();
     const app = defineApp({
       routes: [
         route("/page", "./routes/page.tsx", {
@@ -1090,15 +1119,28 @@ describe("static asset compression", () => {
           }),
         },
       },
-      staticDir,
     };
-    const primaryBase = await listen(createNodeRequestHandler(options));
-    const siblingBase = await listen(createNodeRequestHandler(options));
+    const primaryBase = await listen(
+      createNodeRequestHandler({ ...options, staticDir: primaryStaticDir }),
+    );
 
     // The cold render writes the snapshot and advances only the primary
     // handler's process-local cache generation.
     const cold = await rawRequest(`${primaryBase}/page`);
     expect(cold.status).toBe(200);
+
+    // Model another deployment replica: the bytes and build metadata match,
+    // but its local device/inode/ctime identity necessarily differs.
+    const primaryHtmlPath = join(primaryStaticDir, "page", "index.html");
+    const siblingHtmlPath = join(siblingStaticDir, "page", "index.html");
+    const fixedTimestamp = new Date(Math.floor(Date.now() / 1000) * 1000);
+    mkdirSync(join(siblingStaticDir, "page"), { recursive: true });
+    writeFileSync(siblingHtmlPath, readFileSync(primaryHtmlPath));
+    utimesSync(primaryHtmlPath, fixedTimestamp, fixedTimestamp);
+    utimesSync(siblingHtmlPath, fixedTimestamp, fixedTimestamp);
+    const siblingBase = await listen(
+      createNodeRequestHandler({ ...options, staticDir: siblingStaticDir }),
+    );
 
     const primary = await rawRequest(`${primaryBase}/page`, { "accept-encoding": "gzip" });
     const sibling = await rawRequest(`${siblingBase}/page`, { "accept-encoding": "gzip" });

--- a/packages/adapter-node/test/compression.test.ts
+++ b/packages/adapter-node/test/compression.test.ts
@@ -196,15 +196,65 @@ describe("CompressedAssetCache", () => {
       return Buffer.from("compressed");
     };
 
-    const results = await Promise.all(
-      Array.from({ length: 8 }, () => cache.getOrCompress("asset", produce)),
-    );
+    const requests = Array.from({ length: 8 }, () => cache.getOrCompress("asset", 10, produce));
+    expect(requests.every(Boolean)).toBe(true);
+    const results = await Promise.all(requests as Promise<Buffer>[]);
 
     expect(produced).toBe(1);
     for (const result of results) expect(result.toString()).toBe("compressed");
     // Later requests hit the stored entry, not `produce`.
-    await cache.getOrCompress("asset", produce);
+    await cache.getOrCompress("asset", 10, produce);
     expect(produced).toBe(1);
+  });
+
+  it("bounds the source bytes retained by distinct in-flight compressions", async () => {
+    const cache = new CompressedAssetCache(10, 8);
+    let releaseGate!: () => void;
+    const gate = new Promise<void>((resolveGate) => {
+      releaseGate = resolveGate;
+    });
+    const produce = async (value: string): Promise<Buffer> => {
+      await gate;
+      return Buffer.from(value);
+    };
+
+    const first = cache.getOrCompress("a", 6, () => produce("a"));
+    expect(first).not.toBeNull();
+
+    const second = cache.getOrCompress("b", 4, () => produce("b"));
+    expect(second).not.toBeNull();
+    // The pending byte budget is full even though concurrency remains.
+    expect(cache.getOrCompress("c", 1, () => produce("c"))).toBeNull();
+
+    releaseGate();
+    await Promise.all([first!, second!]);
+
+    // Once pending work drains, a new cold key can use the buffered path.
+    await expect(cache.getOrCompress("c", 1, async () => Buffer.from("c"))).resolves.toEqual(
+      Buffer.from("c"),
+    );
+  });
+
+  it("caps distinct in-flight jobs without blocking same-key waiters", async () => {
+    const cache = new CompressedAssetCache(100, 2);
+    let releaseGate!: () => void;
+    const gate = new Promise<void>((resolveGate) => {
+      releaseGate = resolveGate;
+    });
+    const produce = async (value: string): Promise<Buffer> => {
+      await gate;
+      return Buffer.from(value);
+    };
+
+    const first = cache.getOrCompress("a", 1, () => produce("a"));
+    const second = cache.getOrCompress("b", 1, () => produce("b"));
+    expect(first).not.toBeNull();
+    expect(second).not.toBeNull();
+    expect(cache.getOrCompress("a", 1, () => produce("duplicate"))).toBe(first);
+    expect(cache.getOrCompress("c", 1, () => produce("c"))).toBeNull();
+
+    releaseGate();
+    await Promise.all([first!, second!]);
   });
 
   it("does not cache a failed compression and lets the next request retry", async () => {
@@ -216,8 +266,8 @@ describe("CompressedAssetCache", () => {
       return Buffer.from("ok");
     };
 
-    await expect(cache.getOrCompress("asset", failThenSucceed)).rejects.toThrow("EIO");
-    await expect(cache.getOrCompress("asset", failThenSucceed)).resolves.toBeDefined();
+    await expect(cache.getOrCompress("asset", 2, failThenSucceed)).rejects.toThrow("EIO");
+    await expect(cache.getOrCompress("asset", 2, failThenSucceed)).resolves.toBeDefined();
     expect(calls).toBe(2);
   });
 });
@@ -507,6 +557,60 @@ describe("dynamic response compression", () => {
     expect(revalidated.headers.etag).toBe(first.headers.etag);
     expect(revalidated.headers.vary).toContain("Accept-Encoding");
     expect(revalidated.body.byteLength).toBe(0);
+  });
+
+  it("evaluates If-Modified-Since after selecting the dynamic encoding", async () => {
+    const identityEtag = '"modified-v1"';
+    const lastModified = "Fri, 15 Aug 2025 00:00:00 GMT";
+    const receivedConditionalHeaders: Array<{ etag: boolean; modified: boolean }> = [];
+    const base = await listen(
+      createNodeRequestHandler({
+        apiRoutes: resolveApiRoutes(["/src/api/modified.ts"]),
+        app: defineApp({ routes: [] }),
+        registry: {
+          apiModules: {
+            "/src/api/modified.ts": async () => ({
+              GET: async ({ request }) => {
+                const conditional = {
+                  etag: request.headers.has("if-none-match"),
+                  modified: request.headers.has("if-modified-since"),
+                };
+                receivedConditionalHeaders.push(conditional);
+                if (conditional.modified) {
+                  return new Response(null, {
+                    status: 304,
+                    headers: { etag: identityEtag, "last-modified": lastModified },
+                  });
+                }
+                return new Response("modified payload ".repeat(300), {
+                  headers: {
+                    etag: identityEtag,
+                    "last-modified": lastModified,
+                    "content-type": "text/plain",
+                  },
+                });
+              },
+            }),
+          },
+        },
+      }),
+    );
+
+    const first = await rawRequest(`${base}/api/modified`, { "accept-encoding": "gzip" });
+    const revalidated = await rawRequest(`${base}/api/modified`, {
+      "accept-encoding": "gzip",
+      "if-modified-since": lastModified,
+    });
+
+    expect(first.headers.etag).toBe('W/"modified-v1-gzip"');
+    expect(revalidated.status).toBe(304);
+    expect(revalidated.headers.etag).toBe(first.headers.etag);
+    expect(revalidated.headers.vary).toContain("Accept-Encoding");
+    expect(revalidated.body.byteLength).toBe(0);
+    expect(receivedConditionalHeaders).toEqual([
+      { etag: false, modified: false },
+      { etag: false, modified: false },
+    ]);
   });
 
   it("revalidates encoded ETags whose opaque tag contains a comma", async () => {

--- a/packages/adapter-node/test/compression.test.ts
+++ b/packages/adapter-node/test/compression.test.ts
@@ -280,6 +280,51 @@ describe("CompressedAssetCache", () => {
     await expect(cache.getOrCompress("asset", 2, failThenSucceed)).resolves.toBeDefined();
     expect(calls).toBe(2);
   });
+
+  it("bounds source bytes read by distinct in-flight validator hashes", async () => {
+    const cache = new CompressedAssetCache(10, 8);
+    let releaseGate!: () => void;
+    const gate = new Promise<void>((resolveGate) => {
+      releaseGate = resolveGate;
+    });
+    const produce = async (value: string): Promise<string> => {
+      await gate;
+      return value;
+    };
+
+    const first = cache.getOrCreateFileEtag("a", 6, () => produce('W/"a"'));
+    const second = cache.getOrCreateFileEtag("b", 4, () => produce('W/"b"'));
+    expect(first).not.toBeNull();
+    expect(second).not.toBeNull();
+    expect(cache.getOrCreateFileEtag("c", 1, () => produce('W/"c"'))).toBeNull();
+
+    releaseGate();
+    await Promise.all([first!, second!]);
+
+    await expect(cache.getOrCreateFileEtag("c", 1, async () => 'W/"c"')).resolves.toBe('W/"c"');
+  });
+
+  it("caps distinct validator hashes without blocking same-key waiters", async () => {
+    const cache = new CompressedAssetCache(100, 2);
+    let releaseGate!: () => void;
+    const gate = new Promise<void>((resolveGate) => {
+      releaseGate = resolveGate;
+    });
+    const produce = async (value: string): Promise<string> => {
+      await gate;
+      return value;
+    };
+
+    const first = cache.getOrCreateFileEtag("a", 1, () => produce('W/"a"'));
+    const second = cache.getOrCreateFileEtag("b", 1, () => produce('W/"b"'));
+    expect(first).not.toBeNull();
+    expect(second).not.toBeNull();
+    expect(cache.getOrCreateFileEtag("a", 1, () => produce('W/"duplicate"'))).toBe(first);
+    expect(cache.getOrCreateFileEtag("c", 1, () => produce('W/"c"'))).toBeNull();
+
+    releaseGate();
+    await Promise.all([first!, second!]);
+  });
 });
 
 describe("dynamic response compression", () => {
@@ -1147,6 +1192,36 @@ describe("static asset compression", () => {
 
     expect(primary.headers.etag).toBe(sibling.headers.etag);
     expect(gunzipSync(primary.body)).toEqual(gunzipSync(sibling.body));
+  });
+
+  it("omits the ISG ETag when content-validator work cannot be admitted", async () => {
+    const staticDir = makeTempDir();
+    const htmlDir = join(staticDir, "page");
+    const html = `<main>${"bounded validator work ".repeat(300)}</main>`;
+    mkdirSync(htmlDir, { recursive: true });
+    writeFileSync(join(htmlDir, "index.html"), html, "utf-8");
+    const etagSpy = vi
+      .spyOn(CompressedAssetCache.prototype, "getOrCreateFileEtag")
+      .mockReturnValue(null);
+
+    try {
+      const base = await listen(
+        createNodeRequestHandler({
+          app: defineApp({ routes: [] }),
+          canonicalOrigin: "http://localhost",
+          isgManifest: { "/page": { revalidate: timeRevalidate(3600) } },
+          staticDir,
+        }),
+      );
+      const response = await rawRequest(`${base}/page`, { "accept-encoding": "gzip" });
+
+      expect(response.status).toBe(200);
+      expect(response.headers.etag).toBeUndefined();
+      expect(response.headers["content-encoding"]).toBe("gzip");
+      expect(gunzipSync(response.body).toString("utf-8")).toBe(html);
+    } finally {
+      etagSpy.mockRestore();
+    }
   });
 
   it("reads the same file version that supplied compression metadata", async () => {

--- a/packages/adapter-node/test/compression.test.ts
+++ b/packages/adapter-node/test/compression.test.ts
@@ -526,6 +526,61 @@ describe("dynamic response compression", () => {
     expect(response.headers["content-range"]).toBeUndefined();
   });
 
+  it("keeps ignored Range requests identity-encoded before application validation", async () => {
+    const identityEtag = '"ignored-range-v1"';
+    const received: Array<{ etag: string | null; range: string | null }> = [];
+    const base = await listen(
+      createNodeRequestHandler({
+        apiRoutes: resolveApiRoutes(["/src/api/ignored-range.ts"]),
+        app: defineApp({ routes: [] }),
+        registry: {
+          apiModules: {
+            "/src/api/ignored-range.ts": async () => ({
+              GET: async ({ request }) => {
+                received.push({
+                  etag: request.headers.get("if-none-match"),
+                  range: request.headers.get("range"),
+                });
+                if (request.headers.get("if-none-match") === identityEtag) {
+                  return new Response(null, { status: 304, headers: { etag: identityEtag } });
+                }
+                return new Response("ignored range payload ".repeat(300), {
+                  headers: { etag: identityEtag, "content-type": "text/plain" },
+                });
+              },
+            }),
+          },
+        },
+      }),
+    );
+
+    const ranged = await rawRequest(`${base}/api/ignored-range`, {
+      "accept-encoding": "gzip",
+      range: "not-a-valid-range",
+    });
+    const revalidated = await rawRequest(`${base}/api/ignored-range`, {
+      "accept-encoding": "gzip",
+      "if-none-match": identityEtag,
+      range: "not-a-valid-range",
+    });
+    const ordinary = await rawRequest(`${base}/api/ignored-range`, {
+      "accept-encoding": "gzip",
+    });
+
+    expect(ranged.status).toBe(200);
+    expect(ranged.headers["content-encoding"]).toBeUndefined();
+    expect(ranged.headers.etag).toBe(identityEtag);
+    expect(revalidated.status).toBe(304);
+    expect(revalidated.headers.etag).toBe(identityEtag);
+    expect(ordinary.headers["content-encoding"]).toBe("gzip");
+    expect(ordinary.headers.etag).toBe(encodeEtagForEncoding(identityEtag, "gzip"));
+    expect(received).toEqual([
+      { etag: null, range: "not-a-valid-range" },
+      { etag: identityEtag, range: "not-a-valid-range" },
+      { etag: null, range: null },
+    ]);
+  });
+
   it.each(["content-digest", "repr-digest", "digest", "content-md5"])(
     "preserves identity encoding when a response carries %s",
     async (integrityHeader) => {
@@ -652,6 +707,81 @@ describe("dynamic response compression", () => {
     expect(revalidated.status).toBe(304);
     expect(revalidated.headers.etag).toBe(first.headers.etag);
     expect(revalidated.headers.vary).toContain("Accept-Encoding");
+    expect(revalidated.body.byteLength).toBe(0);
+  });
+
+  it("revalidates encoded ETags for successful non-200 responses", async () => {
+    const identityEtag = '"non-authoritative-v1"';
+    const base = await listen(
+      createNodeRequestHandler({
+        apiRoutes: resolveApiRoutes(["/src/api/non-authoritative.ts"]),
+        app: defineApp({ routes: [] }),
+        registry: {
+          apiModules: {
+            "/src/api/non-authoritative.ts": async () => ({
+              GET: async () =>
+                new Response("non-authoritative payload ".repeat(300), {
+                  status: 203,
+                  headers: { etag: identityEtag, "content-type": "text/plain" },
+                }),
+            }),
+          },
+        },
+      }),
+    );
+
+    const first = await rawRequest(`${base}/api/non-authoritative`, {
+      "accept-encoding": "gzip",
+    });
+    const revalidated = await rawRequest(`${base}/api/non-authoritative`, {
+      "accept-encoding": "gzip",
+      "if-none-match": first.headers.etag!,
+    });
+
+    expect(first.status).toBe(203);
+    expect(first.headers["content-encoding"]).toBe("gzip");
+    expect(first.headers.etag).toBe(encodeEtagForEncoding(identityEtag, "gzip"));
+    expect(revalidated.status).toBe(304);
+    expect(revalidated.headers.etag).toBe(first.headers.etag);
+    expect(revalidated.body.byteLength).toBe(0);
+  });
+
+  it("drops partial-response metadata when revalidating a successful 206", async () => {
+    const identityEtag = '"partial-v1"';
+    const base = await listen(
+      createNodeRequestHandler({
+        apiRoutes: resolveApiRoutes(["/src/api/partial.ts"]),
+        app: defineApp({ routes: [] }),
+        registry: {
+          apiModules: {
+            "/src/api/partial.ts": async () => ({
+              GET: async () =>
+                new Response("part", {
+                  status: 206,
+                  headers: {
+                    "content-range": "bytes 0-3/10",
+                    "content-type": "text/plain",
+                    etag: identityEtag,
+                  },
+                }),
+            }),
+          },
+        },
+      }),
+    );
+
+    const first = await rawRequest(`${base}/api/partial`, {
+      "accept-encoding": "gzip",
+    });
+    const revalidated = await rawRequest(`${base}/api/partial`, {
+      "accept-encoding": "gzip",
+      "if-none-match": first.headers.etag!,
+    });
+
+    expect(first.status).toBe(206);
+    expect(first.headers["content-range"]).toBe("bytes 0-3/10");
+    expect(revalidated.status).toBe(304);
+    expect(revalidated.headers["content-range"]).toBeUndefined();
     expect(revalidated.body.byteLength).toBe(0);
   });
 
@@ -1297,6 +1427,20 @@ describe("static asset compression", () => {
       "if-none-match": crossEncoding.headers.etag!,
     });
     expect(conditional.status).toBe(304);
+  });
+
+  it("keeps static Range requests identity-encoded when returning a full response", async () => {
+    const { handler } = createStaticHandler();
+    const base = await listen(handler);
+
+    const response = await rawRequest(`${base}/assets/app.js`, {
+      "accept-encoding": "br",
+      range: "bytes=0-3",
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.headers["content-encoding"]).toBeUndefined();
+    expect(response.body.toString("utf-8")).toContain("payload");
   });
 
   it("serves identical bytes to concurrent first requests for the same asset", async () => {

--- a/packages/adapter-node/test/index.test.ts
+++ b/packages/adapter-node/test/index.test.ts
@@ -335,6 +335,9 @@ describe("createNodeRequestHandler", () => {
           revalidate: [timeRevalidate(3600), webhookRevalidate()],
         },
       },
+      headersManifest: {
+        "/pricing": { etag: '"pricing-document"' },
+      },
       registry: {
         routeModules: {
           "./routes/pricing.tsx": async () => ({
@@ -414,6 +417,8 @@ describe("createNodeRequestHandler", () => {
         headers: { "accept-encoding": "gzip" },
       });
       expect(staleCompressed.headers.get("content-encoding")).toBe("gzip");
+      const staleEtag = staleCompressed.headers.get("etag");
+      const staleLastModified = staleCompressed.headers.get("last-modified");
       await expect(staleCompressed.text()).resolves.toContain("expired");
 
       const refreshed = await fetch(endpoint, {
@@ -431,7 +436,24 @@ describe("createNodeRequestHandler", () => {
         headers: { "accept-encoding": "gzip" },
       });
       expect(freshCompressed.headers.get("content-encoding")).toBe("gzip");
+      expect(freshCompressed.headers.get("etag")).not.toBe(staleEtag);
+      expect(freshCompressed.headers.get("last-modified")).toBe(staleLastModified);
       await expect(freshCompressed.text()).resolves.toContain("missing");
+
+      const staleEtagRevalidation = await fetch(`http://127.0.0.1:${address.port}/pricing`, {
+        headers: { "accept-encoding": "gzip", "if-none-match": staleEtag! },
+      });
+      expect(staleEtagRevalidation.status).toBe(200);
+      await expect(staleEtagRevalidation.text()).resolves.toContain("missing");
+
+      const staleDateRevalidation = await fetch(`http://127.0.0.1:${address.port}/pricing`, {
+        headers: {
+          "accept-encoding": "gzip",
+          "if-modified-since": staleLastModified!,
+        },
+      });
+      expect(staleDateRevalidation.status).toBe(200);
+      await expect(staleDateRevalidation.text()).resolves.toContain("missing");
       expect(await refreshed.json()).toMatchObject({ revalidated: ["/pricing"] });
     } finally {
       if (previousToken === undefined) {

--- a/packages/adapter-node/test/index.test.ts
+++ b/packages/adapter-node/test/index.test.ts
@@ -338,7 +338,8 @@ describe("createNodeRequestHandler", () => {
       registry: {
         routeModules: {
           "./routes/pricing.tsx": async () => ({
-            Component: ({ data }) => `<main>${(data as { cookie: string }).cookie}</main>`,
+            Component: ({ data }) =>
+              `<main>${(data as { cookie: string }).cookie}${" cacheable".repeat(300)}</main>`,
             loader: async ({ context }) => ({
               cookie: (context as { cookie?: string }).cookie ?? "missing",
             }),
@@ -396,6 +397,42 @@ describe("createNodeRequestHandler", () => {
       });
       expect(readFileSync(htmlPath, "utf-8")).toContain("missing");
       expect(readFileSync(htmlPath, "utf-8")).not.toContain("should-not-leak");
+
+      // Prime the compressed-file LRU with a stale page, then regenerate a
+      // same-size replacement while preserving its timestamp. Filesystem
+      // metadata alone cannot distinguish these versions, so the successful
+      // regeneration must explicitly invalidate the cached bytes.
+      const freshHtml = readFileSync(htmlPath, "utf-8");
+      const staleHtml = freshHtml.replace("missing", "expired");
+      expect(staleHtml).not.toBe(freshHtml);
+      expect(Buffer.byteLength(staleHtml)).toBe(Buffer.byteLength(freshHtml));
+      const fixedTimestamp = new Date();
+      writeFileSync(htmlPath, staleHtml, "utf-8");
+      utimesSync(htmlPath, fixedTimestamp, fixedTimestamp);
+
+      const staleCompressed = await fetch(`http://127.0.0.1:${address.port}/pricing`, {
+        headers: { "accept-encoding": "gzip" },
+      });
+      expect(staleCompressed.headers.get("content-encoding")).toBe("gzip");
+      await expect(staleCompressed.text()).resolves.toContain("expired");
+
+      const refreshed = await fetch(endpoint, {
+        body,
+        headers: { authorization: "Bearer secret", "content-type": "application/json" },
+        method: "POST",
+      });
+      expect(refreshed.status).toBe(200);
+      const regeneratedHtml = readFileSync(htmlPath, "utf-8");
+      expect(Buffer.byteLength(regeneratedHtml)).toBe(Buffer.byteLength(staleHtml));
+      expect(regeneratedHtml).toContain("missing");
+      utimesSync(htmlPath, fixedTimestamp, fixedTimestamp);
+
+      const freshCompressed = await fetch(`http://127.0.0.1:${address.port}/pricing`, {
+        headers: { "accept-encoding": "gzip" },
+      });
+      expect(freshCompressed.headers.get("content-encoding")).toBe("gzip");
+      await expect(freshCompressed.text()).resolves.toContain("missing");
+      expect(await refreshed.json()).toMatchObject({ revalidated: ["/pricing"] });
     } finally {
       if (previousToken === undefined) {
         delete process.env.PRACHT_REVALIDATE_TOKEN;

--- a/packages/adapter-node/test/index.test.ts
+++ b/packages/adapter-node/test/index.test.ts
@@ -110,6 +110,11 @@ describe("createNodeServerEntryModule", () => {
     const source = createNodeServerEntryModule();
     expect(source).toContain("const configurePrachtServer = undefined;");
   });
+
+  it("passes the compression toggle through to the generated handler", () => {
+    expect(createNodeServerEntryModule()).toContain("compression: undefined");
+    expect(createNodeServerEntryModule({ compression: false })).toContain("compression: false");
+  });
 });
 
 describe("createNodeRequestHandler", () => {

--- a/packages/adapter-node/test/index.test.ts
+++ b/packages/adapter-node/test/index.test.ts
@@ -807,6 +807,7 @@ describe("createNodeRequestHandler", () => {
                       controller.error(failure);
                     },
                   }),
+                  { headers: { "content-type": "text/plain" } },
                 ),
             }),
           },
@@ -826,9 +827,14 @@ describe("createNodeRequestHandler", () => {
 
       // Nothing was written yet, so a real status is still possible — the
       // client must not just see the connection drop.
-      const response = await fetch(`http://127.0.0.1:${address.port}/api/stream`);
+      const response = await fetch(`http://127.0.0.1:${address.port}/api/stream`, {
+        headers: { "accept-encoding": "br" },
+      });
       expect(response.status).toBe(500);
-      await response.text();
+      expect(response.statusText).toBe("Internal Server Error");
+      expect(response.headers.get("content-encoding")).toBeNull();
+      expect(response.headers.get("cache-control")).toBe("no-store");
+      await expect(response.text()).resolves.toBe("Internal Server Error");
 
       await waitFor(() => errors.some((entry) => String(entry).includes("Unhandled error")));
     });

--- a/packages/adapter-node/test/static-mime.test.ts
+++ b/packages/adapter-node/test/static-mime.test.ts
@@ -30,6 +30,7 @@ describe("static content types", () => {
     ["skill.md", "text/markdown; charset=utf-8"],
     ["skill.markdown", "text/markdown; charset=utf-8"],
     ["llms.txt", "text/plain; charset=utf-8"],
+    ["module.wasm", "application/wasm"],
   ])("serves %s as %s", async (file, contentType) => {
     const staticDir = makeStaticDir({ [file]: "# hello" });
 

--- a/skills/pracht-deploy/SKILL.md
+++ b/skills/pracht-deploy/SKILL.md
@@ -63,6 +63,12 @@ incoming `Host` header. `maxBodySize` is also available on `nodeAdapter()`.
 Only custom entries behind a trusted proxy that overwrites forwarded headers
 should use `createNodeRequestHandler({ trustProxy: true })`.
 
+The Node adapter compresses responses by default (brotli/gzip negotiated via
+`Accept-Encoding`, streaming for dynamic bodies, an in-memory LRU for static
+assets). When the deployment sits behind a reverse proxy or CDN that already
+compresses responses, set `nodeAdapter({ compression: false })` so bodies are
+not compressed twice.
+
 ### Build
 
 ```bash


### PR DESCRIPTION
## Summary

- Adds brotli/gzip response compression to `@pracht/adapter-node`, negotiated per request from `Accept-Encoding` (brotli preferred, then gzip; q-values, `*` wildcards, and explicit `q=0` exclusions honored) using `node:zlib`.
- **Dynamic responses** (SSR/ISG documents, route-state JSON, API responses with compressible types) stream through a zlib transform inserted into the existing `pipeToResponse` plumbing — no buffering added, and the source/destination failure semantics (client-disconnect vs. server-error classification) are preserved.
- **Static assets and ISG snapshots** are compressed at runtime: files up to 1 MiB are compressed once per file version at higher quality and served from a byte-bounded (32 MiB) in-memory LRU keyed by path + size + mtime — so hashed assets pay the cost once, and ISG regenerations that rewrite HTML on disk naturally invalidate their cached variants. Larger files stream through zlib per request.
- **MIME allowlist**: `text/*`, JSON, JavaScript, XML, wasm, and `+json`/`+xml` structured-syntax types (`image/svg+xml`, `application/manifest+json`, ...). Binary media is never re-compressed.
- **Never touched**: responses that already carry `Content-Encoding`, `Cache-Control: no-transform`, 1xx/204/205/206/304 statuses, Range responses, and bodies under 1 KiB when the size is known.
- **Cache correctness**: compressible responses always carry `Vary: Accept-Encoding` (merged with existing `Vary` members such as `x-pracht-route-state-request`), even when served identity-encoded. Encoded variants get their own weak ETag (the encoding is folded into the tag, e.g. `W/"1a2f-18c-br"`), so `If-None-Match` revalidation never crosses encodings and the 304 path stays correct per variant.
- **Opt-out**: `nodeAdapter({ compression: false })` / `createNodeRequestHandler({ compression: false })` for apps behind a reverse proxy or CDN that already compresses; documented as the recommended setup in that topology.

### Scope note: runtime static compression instead of build-time precompression

Build-time `.br`/`.gz` sibling emission was considered and deliberately not taken: SSG/ISG HTML is written by the CLI's prerender pass *after* the Vite client build completes, so a precompress option would have to span vite-plugin, the CLI build command, and the adapter — and ISG regeneration rewrites HTML at runtime, which would leave precompressed siblings stale. The runtime LRU covers all of that (including regenerated ISG documents) with a one-time per-file-version compression cost, keeping the diff contained to `@pracht/adapter-node`.

## Testing

- [x] `pnpm run verify` (build, format, lint, typecheck, test, e2e) — all steps pass
- 27 new unit tests in `packages/adapter-node/test/compression.test.ts` covering negotiation (q-values, wildcards, `x-gzip`, exclusions), MIME filtering, `Vary` merging, ETag variant separation and per-encoding 304s, the 1 KiB threshold, `no-transform`, already-encoded passthrough, streamed multi-chunk bodies, LRU caching/eviction, HEAD behavior, and the `compression: false` opt-out
- `e2e/node-build.test.ts` extended with compressed-response assertions for a prerendered document (brotli + `Vary` + variant ETag), a hashed asset (gzip), and route-state JSON (brotli)

## Checklist

- [x] Docs updated if needed — `docs/ADAPTERS.md` (Node options table + new "Response compression" section with the reverse-proxy recommendation), `examples/docs/src/routes/docs/adapters.md`, `examples/docs/src/routes/docs/deployment.md`, `packages/adapter-node/README.md`
- [x] Skills updated if needed — `skills/pracht-deploy/SKILL.md` notes the default and the reverse-proxy opt-out
- [x] Changeset added if published packages changed — minor for `@pracht/adapter-node`

🤖 Generated with [Claude Code](https://claude.com/claude-code)