### PR TITLE
Support additional route extensions

### DIFF
--- a/.changeset/custom-route-extensions.md
+++ b/.changeset/custom-route-extensions.md
@@ -3,4 +3,4 @@
 "@pracht/cli": patch
 ---
 
-Replace built-in TSRX route handling with the format-agnostic `additionalExtensions` plugin option. Configured dot-prefixed extensions now participate in route and shell discovery, pages routing, dependency optimization, loader hints, client export stripping, verification, and generated-type watching; custom formats remain responsible for supplying their own Vite transform and TypeScript declaration.
+Add the format-agnostic `additionalExtensions` plugin option while preserving built-in TSRX discovery and its ambient declaration for compatibility. Configured dot-prefixed extensions now participate in route and shell discovery, pages routing, loader hints, client export stripping, verification, and generated-type watching. Vite-scannable formats join initial dependency scanning; other custom formats remain responsible for their optimizer integration, source transform, and TypeScript declaration.

--- a/.changeset/custom-route-extensions.md
+++ b/.changeset/custom-route-extensions.md
@@ -1,0 +1,6 @@
+---
+"@pracht/vite-plugin": minor
+"@pracht/cli": patch
+---
+
+Replace built-in TSRX route handling with the format-agnostic `additionalExtensions` plugin option. Configured dot-prefixed extensions now participate in route and shell discovery, pages routing, dependency optimization, loader hints, client export stripping, verification, and generated-type watching; custom formats remain responsible for supplying their own Vite transform and TypeScript declaration.

--- a/docs/ROUTING.md
+++ b/docs/ROUTING.md
@@ -727,6 +727,24 @@ export function headers() {
 }
 ```
 
+### Additional Route Extensions
+
+Route and shell formats beyond Pracht's built-in TypeScript, JavaScript, and
+Markdown extensions can opt into discovery through `additionalExtensions`:
+
+```typescript
+pracht({
+  pagesDir: "/src/pages",
+  additionalExtensions: [".vue"],
+});
+```
+
+Values must be dot-prefixed. The option works in both pages and manifest mode;
+Pracht discovers the modules and applies route-specific client/server handling,
+while a separately registered Vite plugin must compile the custom format. Add
+an ambient TypeScript module declaration when the format's tooling does not
+provide one.
+
 ### Per-Route Render Mode
 
 Page files can export a `RENDER_MODE` constant to set the rendering strategy:

--- a/docs/ROUTING.md
+++ b/docs/ROUTING.md
@@ -743,7 +743,16 @@ Values must be dot-prefixed. The option works in both pages and manifest mode;
 Pracht discovers the modules and applies route-specific client/server handling,
 while a separately registered Vite plugin must compile the custom format. Add
 an ambient TypeScript module declaration when the format's tooling does not
-provide one.
+provide one. Keep the array inline or in a directly referenced `const` when
+possible so `pracht verify` and the development type watcher can classify the
+files statically; dynamic expressions still work at build time but produce a
+verification warning. Vite-scannable component formats participate in initial
+dependency scanning automatically. Other format plugins must opt their extension
+into Vite's dependency optimizer themselves.
+
+`.tsrx` remains discovered without this option for backward compatibility and
+keeps its bundled ambient module declaration. It may also be listed explicitly
+when adopting the format-agnostic configuration.
 
 ### Per-Route Render Mode
 

--- a/docs/WORKSPACE.md
+++ b/docs/WORKSPACE.md
@@ -124,11 +124,13 @@ described in `VISION_MVP.md`.
   client and SSR builds.
 - **Additional route extensions** — `pracht({ additionalExtensions: [".ext"] })`
   adds dot-prefixed route and shell module extensions to manifest- and
-  pages-router discovery, dependency optimization, loader hints, HMR/typegen
-  watching, and client-only export stripping. Users still register the Vite
-  plugin that compiles the format and provide its TypeScript declaration.
-  Additional-format globs keep bare module ids so extension-matching transforms
-  can run. See `examples/tsrx/` for a working custom-format app.
+  pages-router discovery, loader hints, HMR/typegen watching, and client-only
+  export stripping. Vite-scannable formats join initial dependency scanning;
+  other format plugins remain responsible for their optimizer integration,
+  source transform, and TypeScript declaration. Additional-format globs keep
+  bare module ids so extension-matching transforms can run. `.tsrx` discovery
+  and its ambient declaration remain enabled without configuration for backward
+  compatibility. See `examples/tsrx/` for a working custom-format app.
 
 - **Claude Code skills** — Repo-local skills in `skills/` (see
   [skills/README.md](../skills/README.md) for the full index). Two audiences:

--- a/docs/WORKSPACE.md
+++ b/docs/WORKSPACE.md
@@ -122,14 +122,13 @@ described in `VISION_MVP.md`.
   image tools, PWA, etc.) alongside `pracht()` in `vite.config.ts`. No special
   integration required — plugins participate in the full Vite pipeline for both
   client and SSR builds.
-- **TSRX support** — `.tsrx` route and shell modules work without a pracht
-  option: users add
-  [`@tsrx/vite-plugin-preact`](https://github.com/Ripple-TS/ripple) to their
-  Vite `plugins` array alongside `pracht()`. The pracht plugin globs `.tsrx`
-  files in its route/shell discovery and the client-only export-stripping pass
-  recognises the extension via the directory check, so no `?pracht-client`
-  query suffix is attached (the upstream `tsrxPreact` plugin matches by bare
-  extension). See `examples/tsrx/` for a working app.
+- **Additional route extensions** — `pracht({ additionalExtensions: [".ext"] })`
+  adds dot-prefixed route and shell module extensions to manifest- and
+  pages-router discovery, dependency optimization, loader hints, HMR/typegen
+  watching, and client-only export stripping. Users still register the Vite
+  plugin that compiles the format and provide its TypeScript declaration.
+  Additional-format globs keep bare module ids so extension-matching transforms
+  can run. See `examples/tsrx/` for a working custom-format app.
 
 - **Claude Code skills** — Repo-local skills in `skills/` (see
   [skills/README.md](../skills/README.md) for the full index). Two audiences:

--- a/e2e/tsrx-build.test.ts
+++ b/e2e/tsrx-build.test.ts
@@ -16,8 +16,9 @@ import { expect, test } from "@playwright/test";
 import { fixtureCopyFilter } from "./fixture-copy.ts";
 import { acquireE2EWorkerPort, type E2EWorkerPortLease } from "./ports.ts";
 
-// End-to-end coverage for `.tsrx` route modules compiled by
-// `@tsrx/vite-plugin-preact`. Builds `examples/tsrx/` in a temp dir, asserts
+// End-to-end coverage for a custom route extension configured through
+// `additionalExtensions` and compiled by `@tsrx/vite-plugin-preact`. Builds
+// `examples/tsrx/` in a temp dir and asserts
 // that: the `.tsrx` route is prerendered with its scoped CSS, that a `.tsx`
 // route and a `.tsrx` route coexist, that server-only exports from the `.tsrx`
 // source are stripped from the client bundle, and that the built Node server

--- a/e2e/tsrx-build.test.ts
+++ b/e2e/tsrx-build.test.ts
@@ -7,6 +7,7 @@ import {
   readFileSync,
   readdirSync,
   rmSync,
+  writeFileSync,
 } from "node:fs";
 import { resolve } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -93,7 +94,7 @@ test("pracht build prerenders a .tsrx route with scoped CSS and strips its loade
   }
 });
 
-test("built Node server serves .tsrx and .tsx routes", async () => {
+test("built Node server preserves implicit .tsrx compatibility", async () => {
   test.setTimeout(120_000);
 
   const { exampleDir, tempDir } = createTempExampleDir("pracht-tsrx-serve-");
@@ -105,6 +106,7 @@ test("built Node server serves .tsrx and .tsx routes", async () => {
   try {
     rmSync(distDir, { force: true, recursive: true });
 
+    useImplicitTsrxCompatibility(exampleDir);
     buildExample(exampleDir);
     expect(existsSync(serverEntryPath)).toBe(true);
 
@@ -178,6 +180,16 @@ function buildExample(exampleDir: string): void {
     },
     stdio: "pipe",
   });
+}
+
+function useImplicitTsrxCompatibility(exampleDir: string): void {
+  const configPath = resolve(exampleDir, "vite.config.ts");
+  const config = readFileSync(configPath, "utf-8");
+  const withoutExplicitExtension = config.replace(', additionalExtensions: [".tsrx"]', "");
+  if (withoutExplicitExtension === config) {
+    throw new Error("TSRX fixture no longer contains the explicit additionalExtensions option.");
+  }
+  writeFileSync(configPath, withoutExplicitExtension);
 }
 
 function collectJsSource(dir: string): string {

--- a/examples/docs/src/routes/docs/routing.md
+++ b/examples/docs/src/routes/docs/routing.md
@@ -322,7 +322,15 @@ pracht({
 This works in both pages and manifest mode. Pracht discovers the files and
 applies its route client/server handling; register the format's Vite transform
 plugin separately and add an ambient TypeScript module declaration if its
-tooling does not provide one.
+tooling does not provide one. Keep the array inline or in a directly referenced
+`const` so `pracht verify` and the development type watcher can classify custom
+files statically. Dynamic expressions still build through Vite but produce a
+verification warning. Vite-scannable component formats participate in initial
+dependency scanning automatically; other format plugins must configure Vite's
+dependency optimizer themselves.
+
+Existing `.tsrx` routes remain discovered without this option for backward
+compatibility and retain Pracht's ambient module declaration.
 
 ### Per-Route Render Mode
 

--- a/examples/docs/src/routes/docs/routing.md
+++ b/examples/docs/src/routes/docs/routing.md
@@ -307,6 +307,23 @@ export function headers() {
 }
 ```
 
+### Additional Route Extensions
+
+Custom route and shell formats can opt into discovery with dot-prefixed
+`additionalExtensions` values:
+
+```ts [vite.config.ts]
+pracht({
+  pagesDir: "/src/pages",
+  additionalExtensions: [".vue"],
+});
+```
+
+This works in both pages and manifest mode. Pracht discovers the files and
+applies its route client/server handling; register the format's Vite transform
+plugin separately and add an ambient TypeScript module declaration if its
+tooling does not provide one.
+
 ### Per-Route Render Mode
 
 Page files can export a `RENDER_MODE` constant to override the rendering strategy:

--- a/examples/tsrx/README.md
+++ b/examples/tsrx/README.md
@@ -3,10 +3,9 @@
 Demonstrates `.tsrx` route modules — TSRX/Ripple-flavoured Preact components —
 running side by side with regular `.tsx` routes inside a Pracht app.
 
-There is no special pracht option to enable this: install
-[`@tsrx/vite-plugin-preact`](https://github.com/Ripple-TS/ripple) and add it to
-your Vite `plugins` array alongside `pracht()`. Pracht's route/shell globs and
-server-only export stripping both recognise `.tsrx` automatically.
+Install [`@tsrx/vite-plugin-preact`](https://github.com/Ripple-TS/ripple), add it
+to your Vite `plugins` array, and tell Pracht to discover `.tsrx` route and shell
+modules through its format-agnostic `additionalExtensions` option.
 
 ```ts
 // vite.config.ts
@@ -15,9 +14,14 @@ import { pracht } from "@pracht/vite-plugin";
 import { tsrxPreact } from "@tsrx/vite-plugin-preact";
 
 export default defineConfig({
-  plugins: [tsrxPreact(), pracht()],
+  plugins: [tsrxPreact(), pracht({ additionalExtensions: [".tsrx"] })],
 });
 ```
+
+The format plugin remains responsible for compiling `.tsrx`; Pracht discovers
+the modules and applies its usual route client/server handling. The local
+`src/vite-env.d.ts` declaration teaches TypeScript about imports of this custom
+extension.
 
 ## Layout
 

--- a/examples/tsrx/README.md
+++ b/examples/tsrx/README.md
@@ -4,8 +4,9 @@ Demonstrates `.tsrx` route modules â€” TSRX/Ripple-flavoured Preact components â
 running side by side with regular `.tsx` routes inside a Pracht app.
 
 Install [`@tsrx/vite-plugin-preact`](https://github.com/Ripple-TS/ripple), add it
-to your Vite `plugins` array, and tell Pracht to discover `.tsrx` route and shell
-modules through its format-agnostic `additionalExtensions` option.
+to your Vite `plugins` array, and optionally list `.tsrx` through Pracht's
+format-agnostic `additionalExtensions` option. This example uses the explicit
+form; implicit `.tsrx` discovery remains available for backward compatibility.
 
 ```ts
 // vite.config.ts
@@ -19,9 +20,8 @@ export default defineConfig({
 ```
 
 The format plugin remains responsible for compiling `.tsrx`; Pracht discovers
-the modules and applies its usual route client/server handling. The local
-`src/vite-env.d.ts` declaration teaches TypeScript about imports of this custom
-extension.
+the modules, applies its usual route client/server handling, and retains the
+ambient `.tsrx` module declaration shipped for compatibility.
 
 ## Layout
 

--- a/examples/tsrx/src/vite-env.d.ts
+++ b/examples/tsrx/src/vite-env.d.ts
@@ -1,0 +1,4 @@
+declare module "*.tsrx" {
+  const mod: Record<string, unknown>;
+  export = mod;
+}

--- a/examples/tsrx/src/vite-env.d.ts
+++ b/examples/tsrx/src/vite-env.d.ts
@@ -1,4 +1,0 @@
-declare module "*.tsrx" {
-  const mod: Record<string, unknown>;
-  export = mod;
-}

--- a/examples/tsrx/vite.config.ts
+++ b/examples/tsrx/vite.config.ts
@@ -6,9 +6,8 @@ export default defineConfig(async () => {
   const { nodeAdapter } = await import("@pracht/adapter-node");
 
   return {
-    // `tsrxPreact()` is `enforce: "pre"`, so it compiles `.tsrx` modules before
-    // the pracht pipeline sees them. Pracht's route/shell globs and server-only
-    // export stripping both recognise `.tsrx` automatically.
-    plugins: [tsrxPreact(), pracht({ adapter: nodeAdapter() })],
+    // `tsrxPreact()` transforms the custom format; `additionalExtensions`
+    // tells Pracht to discover it as a route or shell module.
+    plugins: [tsrxPreact(), pracht({ adapter: nodeAdapter(), additionalExtensions: [".tsrx"] })],
   };
 });

--- a/examples/tsrx/vite.config.ts
+++ b/examples/tsrx/vite.config.ts
@@ -6,8 +6,9 @@ export default defineConfig(async () => {
   const { nodeAdapter } = await import("@pracht/adapter-node");
 
   return {
-    // `tsrxPreact()` transforms the custom format; `additionalExtensions`
-    // tells Pracht to discover it as a route or shell module.
+    // `tsrxPreact()` transforms the custom format. Pracht still discovers
+    // `.tsrx` implicitly for compatibility; the explicit option demonstrates
+    // the generic configuration recommended for new custom formats.
     plugins: [tsrxPreact(), pracht({ adapter: nodeAdapter(), additionalExtensions: [".tsrx"] })],
   };
 });

--- a/packages/cli/src/commands/dev.ts
+++ b/packages/cli/src/commands/dev.ts
@@ -8,6 +8,7 @@ import { collectAppGraph } from "../app-graph.js";
 import { loadDotEnvIntoProcess } from "../dotenv.js";
 import { formatDevBanner, supportsColor } from "../dev-banner.js";
 import { readProjectConfig, resolveProjectPath } from "../project.js";
+import { isRouteSource } from "../verification-helpers.js";
 import { requirePositiveInteger } from "../utils.js";
 import {
   DEFAULT_CAPABILITIES_OUT,
@@ -88,10 +89,6 @@ export default defineCommand({
   },
 });
 
-// Extensions that can introduce or remove a route (see the typegen module
-// resolution and markdown route support).
-const ROUTE_MODULE_PATTERN = /\.(?:ts|tsx|tsrx|js|jsx|md|mdx)$/;
-
 /**
  * Keep generated route types in sync while the dev server runs. Opt-in by
  * having run `pracht typegen` once: when the generated declaration exists at
@@ -114,7 +111,8 @@ function watchGeneratedRouteTypes(server: ViteDevServer, root: string): boolean 
     resolve(root, DEFAULT_RUNTIME_OUT),
     resolve(root, DEFAULT_CAPABILITIES_OUT),
   ]);
-  const appFilePath = resolveProjectPath(root, readProjectConfig(root).appFile);
+  const project = readProjectConfig(root);
+  const appFilePath = resolveProjectPath(root, project.appFile);
   let queued: ReturnType<typeof setTimeout> | null = null;
   let running = false;
   let rerunQueued = false;
@@ -149,7 +147,7 @@ function watchGeneratedRouteTypes(server: ViteDevServer, root: string): boolean 
   const queueRegenerate = (file: string, requireRouteExtension = true) => {
     if (
       !file.startsWith(root) ||
-      (requireRouteExtension && !ROUTE_MODULE_PATTERN.test(file)) ||
+      (requireRouteExtension && !isRouteSource(file, project.additionalExtensions)) ||
       generatedPaths.has(file)
     ) {
       return;

--- a/packages/cli/src/commands/dev.ts
+++ b/packages/cli/src/commands/dev.ts
@@ -8,7 +8,7 @@ import { collectAppGraph } from "../app-graph.js";
 import { loadDotEnvIntoProcess } from "../dotenv.js";
 import { formatDevBanner, supportsColor } from "../dev-banner.js";
 import { readProjectConfig, resolveProjectPath } from "../project.js";
-import { isRouteSource } from "../verification-helpers.js";
+import { isRouteSource, isWithinDirectory } from "../verification-helpers.js";
 import { requirePositiveInteger } from "../utils.js";
 import {
   DEFAULT_CAPABILITIES_OUT,
@@ -113,6 +113,9 @@ function watchGeneratedRouteTypes(server: ViteDevServer, root: string): boolean 
   ]);
   const project = readProjectConfig(root);
   const appFilePath = resolveProjectPath(root, project.appFile);
+  const routeSourceDirs = (
+    project.mode === "pages" ? [project.pagesDir] : [project.routesDir, project.shellsDir]
+  ).map((directory) => resolveProjectPath(root, directory));
   let queued: ReturnType<typeof setTimeout> | null = null;
   let running = false;
   let rerunQueued = false;
@@ -145,9 +148,14 @@ function watchGeneratedRouteTypes(server: ViteDevServer, root: string): boolean 
   };
 
   const queueRegenerate = (file: string, requireRouteExtension = true) => {
+    const couldUseUnresolvedExtension =
+      !project.additionalExtensionsIsStatic &&
+      routeSourceDirs.some((directory) => isWithinDirectory(file, directory));
     if (
       !file.startsWith(root) ||
-      (requireRouteExtension && !isRouteSource(file, project.additionalExtensions)) ||
+      (requireRouteExtension &&
+        !isRouteSource(file, project.additionalExtensions) &&
+        !couldUseUnresolvedExtension) ||
       generatedPaths.has(file)
     ) {
       return;

--- a/packages/cli/src/commands/typegen.ts
+++ b/packages/cli/src/commands/typegen.ts
@@ -558,7 +558,8 @@ function inferRouteParams(path: string): string[] {
 }
 
 // Only modules TypeScript can resolve type-only imports for. Route files in
-// other formats (`.md`, `.mdx`, `.tsrx`) fall back to `unknown` data.
+// other formats (Markdown and configured additional extensions) fall back to
+// `unknown` data.
 const IMPORTABLE_MODULE_PATTERN = /\.(ts|tsx|js|jsx)$/;
 
 function formatRouteDataType(route: RouteEntry, context: DeclarationContext): string {

--- a/packages/cli/src/constants.ts
+++ b/packages/cli/src/constants.ts
@@ -17,6 +17,7 @@ function readPackageVersion(): string {
 }
 
 export const PROJECT_DEFAULTS = {
+  additionalExtensions: [] as string[],
   apiDir: "/src/api",
   appFile: "/src/routes.ts",
   capabilitiesDir: "/src/capabilities",

--- a/packages/cli/src/project.ts
+++ b/packages/cli/src/project.ts
@@ -6,6 +6,7 @@ import { ensureTrailingNewline } from "./utils.js";
 import { PROJECT_DEFAULTS } from "./constants.js";
 
 export interface ProjectConfig {
+  additionalExtensions: string[];
   apiDir: string;
   appFile: string;
   capabilitiesDir: string;
@@ -39,11 +40,15 @@ export function readProjectConfig(root: string): ProjectConfig {
   };
 
   for (const key of Object.keys(PROJECT_DEFAULTS)) {
+    if (key === "additionalExtensions") continue;
     const value = readQuotedConfigValue(rawConfig, key);
     if (typeof value === "string") {
       config[key] = key === "pagesDefaultRender" ? value : normalizeConfigPath(value);
     }
   }
+  config.additionalExtensions = (
+    readQuotedConfigArray(rawConfig, "additionalExtensions") ?? []
+  ).map((extension) => extension.toLowerCase());
 
   config.mode = config.pagesDir ? "pages" : "manifest";
   return config as unknown as ProjectConfig;
@@ -133,8 +138,12 @@ export function listFilesRecursively(dir: string): string[] {
   return files;
 }
 
-export function hasPagesAppShell(filePath: string): boolean {
-  return /^_app\.(ts|tsx|tsrx|js|jsx)$/.test(basename(filePath));
+export function hasPagesAppShell(filePath: string, additionalExtensions: string[] = []): boolean {
+  const extension = basename(filePath).slice("_app".length);
+  return (
+    basename(filePath).startsWith("_app.") &&
+    new Set([".ts", ".tsx", ".js", ".jsx", ...additionalExtensions]).has(extension)
+  );
 }
 
 function findConfigFile(root: string): string | null {
@@ -169,6 +178,41 @@ function readQuotedConfigValue(source: string, key: string): string | null {
   if (declarations.length !== 1) return null;
   const declaration = declarations[0];
   return readQuotedValueAt(source, (declaration.index ?? 0) + declaration[0].length);
+}
+
+function readQuotedConfigArray(source: string, key: string): string[] | null {
+  if (!source) return null;
+  const masked = maskCommentsAndStrings(source);
+  const properties = [...masked.matchAll(new RegExp(`\\b${key}\\s*:`, "g"))];
+  if (properties.length !== 1) return null;
+  const property = properties[0];
+  const valueStart = (property.index ?? 0) + property[0].length;
+
+  const direct = readStringArrayAt(source, valueStart);
+  if (direct !== null) return direct;
+
+  const identifier = /^\s*([A-Za-z_$][\w$]*)\b/.exec(source.slice(valueStart))?.[1];
+  if (!identifier) return null;
+  const declarations = [...masked.matchAll(new RegExp(`\\bconst\\s+${identifier}\\s*=`, "g"))];
+  if (declarations.length !== 1) return null;
+  const declaration = declarations[0];
+  return readStringArrayAt(source, (declaration.index ?? 0) + declaration[0].length);
+}
+
+function readStringArrayAt(source: string, start: number): string[] | null {
+  const arraySource = /^\s*\[([^\]]*)\]/.exec(source.slice(start))?.[1];
+  if (arraySource === undefined) return null;
+  if (!arraySource.trim()) return [];
+
+  const values: string[] = [];
+  let offset = 0;
+  while (offset < arraySource.length) {
+    const match = /^\s*(["'`])([^"'`]+)\1\s*(?:,|$)/.exec(arraySource.slice(offset));
+    if (!match) return null;
+    values.push(match[2]);
+    offset += match[0].length;
+  }
+  return values;
 }
 
 function hasConfigProperty(source: string, key: string): boolean {

--- a/packages/cli/src/project.ts
+++ b/packages/cli/src/project.ts
@@ -7,6 +7,7 @@ import { PROJECT_DEFAULTS } from "./constants.js";
 
 export interface ProjectConfig {
   additionalExtensions: string[];
+  additionalExtensionsIsStatic: boolean;
   apiDir: string;
   appFile: string;
   capabilitiesDir: string;
@@ -29,6 +30,8 @@ export function readProjectConfig(root: string): ProjectConfig {
   const rawConfig = configFile ? readFileSync(configFile, "utf-8") : "";
   const hasPagesDefaultRender = hasConfigProperty(rawConfig, "pagesDefaultRender");
   const resolvedPagesDefaultRender = readQuotedConfigValue(rawConfig, "pagesDefaultRender");
+  const hasAdditionalExtensions = hasConfigValue(rawConfig, "additionalExtensions");
+  const resolvedAdditionalExtensions = readQuotedConfigArray(rawConfig, "additionalExtensions");
   const config: Record<string, unknown> = {
     ...PROJECT_DEFAULTS,
     configFile,
@@ -36,6 +39,7 @@ export function readProjectConfig(root: string): ProjectConfig {
     mode: "manifest" as const,
     rawConfig,
     root,
+    additionalExtensionsIsStatic: !hasAdditionalExtensions || resolvedAdditionalExtensions !== null,
     pagesDefaultRenderIsStatic: !hasPagesDefaultRender || resolvedPagesDefaultRender !== null,
   };
 
@@ -46,9 +50,9 @@ export function readProjectConfig(root: string): ProjectConfig {
       config[key] = key === "pagesDefaultRender" ? value : normalizeConfigPath(value);
     }
   }
-  config.additionalExtensions = (
-    readQuotedConfigArray(rawConfig, "additionalExtensions") ?? []
-  ).map((extension) => extension.toLowerCase());
+  config.additionalExtensions = (resolvedAdditionalExtensions ?? []).map((extension) =>
+    extension.toLowerCase(),
+  );
 
   config.mode = config.pagesDir ? "pages" : "manifest";
   return config as unknown as ProjectConfig;
@@ -184,14 +188,21 @@ function readQuotedConfigArray(source: string, key: string): string[] | null {
   if (!source) return null;
   const masked = maskCommentsAndStrings(source);
   const properties = [...masked.matchAll(new RegExp(`\\b${key}\\s*:`, "g"))];
-  if (properties.length !== 1) return null;
-  const property = properties[0];
-  const valueStart = (property.index ?? 0) + property[0].length;
+  if (properties.length > 1) return null;
 
-  const direct = readStringArrayAt(source, valueStart);
-  if (direct !== null) return direct;
+  let identifier: string | undefined;
+  if (properties.length === 1) {
+    const property = properties[0];
+    const valueStart = (property.index ?? 0) + property[0].length;
+    const direct = readStringArrayAt(source, valueStart);
+    if (direct !== null) return direct;
+    identifier = /^\s*([A-Za-z_$][\w$]*)\b/.exec(source.slice(valueStart))?.[1];
+  } else {
+    const shorthandProperties = [...masked.matchAll(new RegExp(`\\b${key}\\b(?=\\s*[,}])`, "g"))];
+    if (shorthandProperties.length !== 1) return null;
+    identifier = key;
+  }
 
-  const identifier = /^\s*([A-Za-z_$][\w$]*)\b/.exec(source.slice(valueStart))?.[1];
   if (!identifier) return null;
   const declarations = [...masked.matchAll(new RegExp(`\\bconst\\s+${identifier}\\s*=`, "g"))];
   if (declarations.length !== 1) return null;
@@ -256,6 +267,13 @@ function skipConfigTrivia(source: string, start: number): number {
 
 function hasConfigProperty(source: string, key: string): boolean {
   return new RegExp(`\\b${key}\\s*:`).test(maskCommentsAndStrings(source));
+}
+
+function hasConfigValue(source: string, key: string): boolean {
+  const masked = maskCommentsAndStrings(source);
+  return (
+    new RegExp(`\\b${key}\\s*:`).test(masked) || new RegExp(`\\b${key}\\b(?=\\s*[,}])`).test(masked)
+  );
 }
 
 function readQuotedValueAt(source: string, start: number): string | null {

--- a/packages/cli/src/project.ts
+++ b/packages/cli/src/project.ts
@@ -146,7 +146,7 @@ export function hasPagesAppShell(filePath: string, additionalExtensions: string[
   const extension = basename(filePath).slice("_app".length);
   return (
     basename(filePath).startsWith("_app.") &&
-    new Set([".ts", ".tsx", ".js", ".jsx", ...additionalExtensions]).has(extension)
+    new Set([".ts", ".tsx", ".tsrx", ".js", ".jsx", ...additionalExtensions]).has(extension)
   );
 }
 

--- a/packages/cli/src/project.ts
+++ b/packages/cli/src/project.ts
@@ -200,19 +200,58 @@ function readQuotedConfigArray(source: string, key: string): string[] | null {
 }
 
 function readStringArrayAt(source: string, start: number): string[] | null {
-  const arraySource = /^\s*\[([^\]]*)\]/.exec(source.slice(start))?.[1];
-  if (arraySource === undefined) return null;
-  if (!arraySource.trim()) return [];
-
   const values: string[] = [];
-  let offset = 0;
-  while (offset < arraySource.length) {
-    const match = /^\s*(["'`])([^"'`]+)\1\s*(?:,|$)/.exec(arraySource.slice(offset));
-    if (!match) return null;
-    values.push(match[2]);
-    offset += match[0].length;
+  let offset = skipConfigTrivia(source, start);
+  if (source[offset] !== "[") return null;
+  offset += 1;
+
+  while (offset < source.length) {
+    offset = skipConfigTrivia(source, offset);
+    if (source[offset] === "]") return values;
+
+    const quote = source[offset];
+    if (quote !== '"' && quote !== "'" && quote !== "`") return null;
+    const valueStart = offset + 1;
+    offset = valueStart;
+    while (offset < source.length && source[offset] !== quote) {
+      // Escapes and template interpolation require JavaScript evaluation;
+      // this reader deliberately resolves static literal values only.
+      if (source[offset] === "\\" || (quote === "`" && source.startsWith("${", offset))) {
+        return null;
+      }
+      offset += 1;
+    }
+    if (offset === source.length || offset === valueStart) return null;
+    values.push(source.slice(valueStart, offset));
+
+    offset = skipConfigTrivia(source, offset + 1);
+    if (source[offset] === "]") return values;
+    if (source[offset] !== ",") return null;
+    offset += 1;
   }
-  return values;
+  return null;
+}
+
+function skipConfigTrivia(source: string, start: number): number {
+  let offset = start;
+  while (offset < source.length) {
+    if (/\s/.test(source[offset])) {
+      offset += 1;
+      continue;
+    }
+    if (source.startsWith("//", offset)) {
+      const newline = source.indexOf("\n", offset + 2);
+      offset = newline === -1 ? source.length : newline + 1;
+      continue;
+    }
+    if (source.startsWith("/*", offset)) {
+      const end = source.indexOf("*/", offset + 2);
+      offset = end === -1 ? source.length : end + 2;
+      continue;
+    }
+    break;
+  }
+  return offset;
 }
 
 function hasConfigProperty(source: string, key: string): boolean {

--- a/packages/cli/src/project.ts
+++ b/packages/cli/src/project.ts
@@ -5,6 +5,8 @@ import { maskCommentsAndStrings } from "@pracht/capabilities/static";
 import { ensureTrailingNewline } from "./utils.js";
 import { PROJECT_DEFAULTS } from "./constants.js";
 
+const BUILT_IN_ROUTE_EXTENSIONS = new Set([".ts", ".tsx", ".js", ".jsx", ".md", ".mdx"]);
+
 export interface ProjectConfig {
   additionalExtensions: string[];
   additionalExtensionsIsStatic: boolean;
@@ -50,9 +52,9 @@ export function readProjectConfig(root: string): ProjectConfig {
       config[key] = key === "pagesDefaultRender" ? value : normalizeConfigPath(value);
     }
   }
-  config.additionalExtensions = (resolvedAdditionalExtensions ?? []).map((extension) =>
-    extension.toLowerCase(),
-  );
+  config.additionalExtensions = [
+    ...new Set((resolvedAdditionalExtensions ?? []).map((extension) => extension.toLowerCase())),
+  ].filter((extension) => !BUILT_IN_ROUTE_EXTENSIONS.has(extension));
 
   config.mode = config.pagesDir ? "pages" : "manifest";
   return config as unknown as ProjectConfig;

--- a/packages/cli/src/verification-checks.ts
+++ b/packages/cli/src/verification-checks.ts
@@ -53,6 +53,17 @@ export function collectConfigChecks(
   } else {
     checks.push(createCheck("ok", "Vite config registers the pracht plugin."));
   }
+
+  if (!project.additionalExtensionsIsStatic) {
+    checks.push(
+      createCheck(
+        "warning",
+        "additionalExtensions could not be resolved statically. The live Vite configuration " +
+          "still controls builds, but static route verification cannot classify custom-format " +
+          "files reliably. Use an inline string array or a const string array when possible.",
+      ),
+    );
+  }
 }
 
 export function collectManifestVerification(

--- a/packages/cli/src/verification-checks.ts
+++ b/packages/cli/src/verification-checks.ts
@@ -14,8 +14,9 @@ import {
 import {
   createCheck,
   isWithinDirectory,
+  isPageSource,
+  isRouteSource,
   MODULE_SOURCE_RE,
-  PAGE_SOURCE_RE,
   normalizePath,
   resolveApiRoutePath,
   toModuleSpecifier,
@@ -340,16 +341,37 @@ function collectChangedManifestModuleChecks(
   const manifestDir = dirname(manifestPath);
   const referencedModules = new Set(relativeModules.map(normalizePath));
   const moduleDirectories = [
-    { dir: resolveProjectPath(project.root, project.routesDir), label: "route module" },
-    { dir: resolveProjectPath(project.root, project.shellsDir), label: "shell module" },
-    { dir: resolveProjectPath(project.root, project.middlewareDir), label: "middleware module" },
-    { dir: resolveProjectPath(project.root, project.serverDir), label: "server module" },
+    {
+      additionalExtensions: true,
+      dir: resolveProjectPath(project.root, project.routesDir),
+      label: "route module",
+    },
+    {
+      additionalExtensions: true,
+      dir: resolveProjectPath(project.root, project.shellsDir),
+      label: "shell module",
+    },
+    {
+      additionalExtensions: false,
+      dir: resolveProjectPath(project.root, project.middlewareDir),
+      label: "middleware module",
+    },
+    {
+      additionalExtensions: false,
+      dir: resolveProjectPath(project.root, project.serverDir),
+      label: "server module",
+    },
   ];
 
   for (const file of changedFiles) {
     const directory = moduleDirectories.find((entry) => isWithinDirectory(file, entry.dir));
     if (!directory) continue;
-    if (!MODULE_SOURCE_RE.test(file)) continue;
+    if (
+      !(directory.additionalExtensions
+        ? isRouteSource(file, project.additionalExtensions)
+        : MODULE_SOURCE_RE.test(file))
+    )
+      continue;
 
     const display = displayPath(project.root, file);
     const modulePath = normalizePath(toModuleSpecifier(manifestDir, file));
@@ -396,7 +418,7 @@ export function collectPagesVerification(
     return;
   }
 
-  const pages = scanPagesDirectory(pagesDir);
+  const pages = scanPagesDirectory(pagesDir, project.additionalExtensions);
   const routes = pages.filter((page) => page.kind === "route");
   const notFoundPages = pages.filter((page) => page.kind === "not-found");
   const appShells = pages.filter((page) => page.kind === "shell");
@@ -613,7 +635,7 @@ function collectChangedPagesChecks(
 ): void {
   for (const file of changedFiles) {
     if (!isWithinDirectory(file, pagesDir)) continue;
-    if (!PAGE_SOURCE_RE.test(file)) continue;
+    if (!isPageSource(file, project.additionalExtensions)) continue;
 
     const display = displayPath(project.root, file);
     if (!existsSync(file)) {
@@ -626,7 +648,7 @@ function collectChangedPagesChecks(
       continue;
     }
 
-    const page = describePagesFile(pagesDir, file);
+    const page = describePagesFile(pagesDir, file, project.additionalExtensions);
     if (page.kind === "shell") {
       checks.push(
         createCheck(
@@ -964,7 +986,11 @@ function appHasPrerenderedRoutes(project: ProjectConfig, root: string): boolean 
   if (!existsSync(sourceDir)) return false;
 
   const files = statSync(sourceDir).isDirectory()
-    ? listFilesRecursively(sourceDir).filter((file) => MODULE_SOURCE_RE.test(file))
+    ? listFilesRecursively(sourceDir).filter((file) =>
+        project.mode === "pages"
+          ? isPageSource(file, project.additionalExtensions)
+          : isRouteSource(file, project.additionalExtensions),
+      )
     : [sourceDir];
 
   return files.some((file) => {

--- a/packages/cli/src/verification-helpers.ts
+++ b/packages/cli/src/verification-helpers.ts
@@ -10,8 +10,20 @@ export const CONFIG_FILE_NAMES = new Set([
 ]);
 
 // Declaration files are TypeScript inputs, never executable framework modules.
-export const MODULE_SOURCE_RE = /(?<!\.d)\.(ts|tsx|tsrx|js|jsx)$/;
-export const PAGE_SOURCE_RE = /\.(ts|tsx|tsrx|js|jsx|md|mdx)$/;
+export const MODULE_SOURCE_RE = /(?<!\.d)\.(ts|tsx|js|jsx)$/;
+export const PAGE_SOURCE_RE = /\.(ts|tsx|js|jsx|md|mdx)$/;
+
+export function isPageSource(file: string, additionalExtensions: string[] = []): boolean {
+  return PAGE_SOURCE_RE.test(file) || hasAdditionalExtension(file, additionalExtensions);
+}
+
+export function isRouteSource(file: string, additionalExtensions: string[] = []): boolean {
+  return PAGE_SOURCE_RE.test(file) || hasAdditionalExtension(file, additionalExtensions);
+}
+
+function hasAdditionalExtension(file: string, additionalExtensions: string[]): boolean {
+  return additionalExtensions.some((extension) => file.endsWith(extension));
+}
 
 export interface Check {
   message: string;

--- a/packages/cli/src/verification-helpers.ts
+++ b/packages/cli/src/verification-helpers.ts
@@ -12,12 +12,15 @@ export const CONFIG_FILE_NAMES = new Set([
 // Declaration files are TypeScript inputs, never executable framework modules.
 export const MODULE_SOURCE_RE = /(?<!\.d)\.(ts|tsx|js|jsx)$/;
 export const PAGE_SOURCE_RE = /\.(ts|tsx|js|jsx|md|mdx)$/;
+const DECLARATION_SOURCE_RE = /\.d\.ts$/;
 
 export function isPageSource(file: string, additionalExtensions: string[] = []): boolean {
+  if (DECLARATION_SOURCE_RE.test(file)) return false;
   return PAGE_SOURCE_RE.test(file) || hasAdditionalExtension(file, additionalExtensions);
 }
 
 export function isRouteSource(file: string, additionalExtensions: string[] = []): boolean {
+  if (DECLARATION_SOURCE_RE.test(file)) return false;
   return PAGE_SOURCE_RE.test(file) || hasAdditionalExtension(file, additionalExtensions);
 }
 

--- a/packages/cli/src/verification-helpers.ts
+++ b/packages/cli/src/verification-helpers.ts
@@ -11,7 +11,7 @@ export const CONFIG_FILE_NAMES = new Set([
 
 // Declaration files are TypeScript inputs, never executable framework modules.
 export const MODULE_SOURCE_RE = /(?<!\.d)\.(ts|tsx|js|jsx)$/;
-export const PAGE_SOURCE_RE = /\.(ts|tsx|js|jsx|md|mdx)$/;
+export const PAGE_SOURCE_RE = /\.(ts|tsx|tsrx|js|jsx|md|mdx)$/;
 const DECLARATION_SOURCE_RE = /\.d\.ts$/;
 
 export function isPageSource(file: string, additionalExtensions: string[] = []): boolean {

--- a/packages/cli/src/verification-pages.ts
+++ b/packages/cli/src/verification-pages.ts
@@ -3,7 +3,7 @@ import { readFileSync } from "node:fs";
 import { basename, relative } from "node:path";
 
 import { hasPagesAppShell, listFilesRecursively } from "./project.js";
-import { normalizeRoutePath, PAGE_SOURCE_RE } from "./verification-helpers.js";
+import { isPageSource, normalizeRoutePath } from "./verification-helpers.js";
 
 export type PagesFile =
   | { file: string; kind: "shell"; hasRevalidateExport: boolean }
@@ -22,20 +22,28 @@ export interface PagesRoute {
     | { kind: "time"; seconds: number };
 }
 
-export function scanPagesDirectory(pagesDir: string): PagesFile[] {
+export function scanPagesDirectory(
+  pagesDir: string,
+  additionalExtensions: string[] = [],
+): PagesFile[] {
   return listFilesRecursively(pagesDir)
-    .filter((file) => PAGE_SOURCE_RE.test(file))
-    .map((file) => describePagesFile(pagesDir, file));
+    .filter((file) => isPageSource(file, additionalExtensions))
+    .map((file) => describePagesFile(pagesDir, file, additionalExtensions));
 }
 
-export function describePagesFile(pagesDir: string, file: string): PagesFile {
+export function describePagesFile(
+  pagesDir: string,
+  file: string,
+  additionalExtensions: string[] = [],
+): PagesFile {
   const relativePath = relative(pagesDir, file).replace(/\\/g, "/");
-  const routePath = relativePath.replace(/\.(tsx?|tsrx|jsx?|mdx?)$/, "");
+  const extensionIndex = relativePath.lastIndexOf(".");
+  const routePath = extensionIndex === -1 ? relativePath : relativePath.slice(0, extensionIndex);
   const name = basename(routePath);
   const source = readFileSync(file, "utf-8");
   const analysisSource = maskMarkdownFences(source, relativePath);
 
-  if (hasPagesAppShell(file)) {
+  if (hasPagesAppShell(file, additionalExtensions)) {
     return {
       file,
       kind: "shell",

--- a/packages/cli/src/verification-scope.ts
+++ b/packages/cli/src/verification-scope.ts
@@ -95,9 +95,15 @@ export function filterFrameworkFiles(
     if (CONFIG_FILE_NAMES.has(basename(file))) return true;
     if (normalizePath(file) === normalizePath(packageJsonPath)) return true;
     if (project.mode === "manifest" && normalizePath(file) === normalizePath(appFile)) return true;
-    if (isWithinDirectory(file, routesDir) && isRouteSource(file, project.additionalExtensions))
+    if (
+      isWithinDirectory(file, routesDir) &&
+      (!project.additionalExtensionsIsStatic || isRouteSource(file, project.additionalExtensions))
+    )
       return true;
-    if (isWithinDirectory(file, shellsDir) && isRouteSource(file, project.additionalExtensions))
+    if (
+      isWithinDirectory(file, shellsDir) &&
+      (!project.additionalExtensionsIsStatic || isRouteSource(file, project.additionalExtensions))
+    )
       return true;
     if (isWithinDirectory(file, middlewareDir) && MODULE_SOURCE_RE.test(file)) return true;
     if (isWithinDirectory(file, serverDir) && MODULE_SOURCE_RE.test(file)) return true;
@@ -105,7 +111,7 @@ export function filterFrameworkFiles(
     if (
       pagesDir &&
       isWithinDirectory(file, pagesDir) &&
-      isPageSource(file, project.additionalExtensions)
+      (!project.additionalExtensionsIsStatic || isPageSource(file, project.additionalExtensions))
     )
       return true;
     return false;

--- a/packages/cli/src/verification-scope.ts
+++ b/packages/cli/src/verification-scope.ts
@@ -5,8 +5,9 @@ import { resolveProjectPath, type ProjectConfig } from "./project.js";
 import {
   CONFIG_FILE_NAMES,
   MODULE_SOURCE_RE,
-  PAGE_SOURCE_RE,
   isWithinDirectory,
+  isPageSource,
+  isRouteSource,
   normalizePath,
 } from "./verification-helpers.js";
 
@@ -94,12 +95,19 @@ export function filterFrameworkFiles(
     if (CONFIG_FILE_NAMES.has(basename(file))) return true;
     if (normalizePath(file) === normalizePath(packageJsonPath)) return true;
     if (project.mode === "manifest" && normalizePath(file) === normalizePath(appFile)) return true;
-    if (isWithinDirectory(file, routesDir) && MODULE_SOURCE_RE.test(file)) return true;
-    if (isWithinDirectory(file, shellsDir) && MODULE_SOURCE_RE.test(file)) return true;
+    if (isWithinDirectory(file, routesDir) && isRouteSource(file, project.additionalExtensions))
+      return true;
+    if (isWithinDirectory(file, shellsDir) && isRouteSource(file, project.additionalExtensions))
+      return true;
     if (isWithinDirectory(file, middlewareDir) && MODULE_SOURCE_RE.test(file)) return true;
     if (isWithinDirectory(file, serverDir) && MODULE_SOURCE_RE.test(file)) return true;
     if (isWithinDirectory(file, apiDir) && MODULE_SOURCE_RE.test(file)) return true;
-    if (pagesDir && isWithinDirectory(file, pagesDir) && PAGE_SOURCE_RE.test(file)) return true;
+    if (
+      pagesDir &&
+      isWithinDirectory(file, pagesDir) &&
+      isPageSource(file, project.additionalExtensions)
+    )
+      return true;
     return false;
   });
 }

--- a/packages/cli/test/project.test.ts
+++ b/packages/cli/test/project.test.ts
@@ -82,6 +82,19 @@ describe("readProjectConfig additionalExtensions", () => {
 
     expect(project.additionalExtensions).toEqual([".tsrx", ".vue"]);
   });
+
+  it("matches plugin normalization for built-in and duplicate extensions", () => {
+    const project = readProjectConfig(
+      makeProject(
+        'export default { plugins: [pracht({ additionalExtensions: [".TSX", ".md", ".MDX", ".tsrx", ".Vue", ".vue"] })] };',
+      ),
+    );
+
+    expect(project.additionalExtensions).toEqual([".tsrx", ".vue"]);
+    expect(hasPagesAppShell("/app/src/pages/_app.md", project.additionalExtensions)).toBe(false);
+    expect(hasPagesAppShell("/app/src/pages/_app.tsrx", project.additionalExtensions)).toBe(true);
+    expect(hasPagesAppShell("/app/src/pages/_app.vue", project.additionalExtensions)).toBe(true);
+  });
 });
 
 describe("hasPagesAppShell", () => {

--- a/packages/cli/test/project.test.ts
+++ b/packages/cli/test/project.test.ts
@@ -3,7 +3,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 
-import { readProjectConfig } from "../src/project.ts";
+import { hasPagesAppShell, readProjectConfig } from "../src/project.ts";
 
 const tempDirs: string[] = [];
 
@@ -81,5 +81,11 @@ describe("readProjectConfig additionalExtensions", () => {
     );
 
     expect(project.additionalExtensions).toEqual([".tsrx", ".vue"]);
+  });
+});
+
+describe("hasPagesAppShell", () => {
+  it("preserves implicit TSRX shell compatibility", () => {
+    expect(hasPagesAppShell("/app/src/pages/_app.tsrx")).toBe(true);
   });
 });

--- a/packages/cli/test/project.test.ts
+++ b/packages/cli/test/project.test.ts
@@ -29,6 +29,7 @@ describe("readProjectConfig additionalExtensions", () => {
     );
 
     expect(project.additionalExtensions).toEqual([".tsrx", ".vue"]);
+    expect(project.additionalExtensionsIsStatic).toBe(true);
   });
 
   it("reads a quoted array through a const and defaults to an empty list", () => {
@@ -41,6 +42,26 @@ describe("readProjectConfig additionalExtensions", () => {
 
     expect(configured.additionalExtensions).toEqual([".custom"]);
     expect(defaults.additionalExtensions).toEqual([]);
+    expect(configured.additionalExtensionsIsStatic).toBe(true);
+    expect(defaults.additionalExtensionsIsStatic).toBe(true);
+  });
+
+  it("reads an object-shorthand const and reports dynamic expressions", () => {
+    const shorthand = readProjectConfig(
+      makeProject(
+        'const additionalExtensions = [".vue"] as const;\nexport default { plugins: [pracht({ additionalExtensions })] };',
+      ),
+    );
+    const dynamic = readProjectConfig(
+      makeProject(
+        "const additionalExtensions = getRouteExtensions();\nexport default { plugins: [pracht({ additionalExtensions })] };",
+      ),
+    );
+
+    expect(shorthand.additionalExtensions).toEqual([".vue"]);
+    expect(shorthand.additionalExtensionsIsStatic).toBe(true);
+    expect(dynamic.additionalExtensions).toEqual([]);
+    expect(dynamic.additionalExtensionsIsStatic).toBe(false);
   });
 
   it("reads arrays with comments and a trailing comma", () => {

--- a/packages/cli/test/project.test.ts
+++ b/packages/cli/test/project.test.ts
@@ -42,4 +42,23 @@ describe("readProjectConfig additionalExtensions", () => {
     expect(configured.additionalExtensions).toEqual([".custom"]);
     expect(defaults.additionalExtensions).toEqual([]);
   });
+
+  it("reads arrays with comments and a trailing comma", () => {
+    const project = readProjectConfig(
+      makeProject(`
+        export default {
+          plugins: [
+            pracht({
+              additionalExtensions: [
+                ".tsrx", // Ripple routes
+                /* Vue routes */ ".vue",
+              ],
+            }),
+          ],
+        };
+      `),
+    );
+
+    expect(project.additionalExtensions).toEqual([".tsrx", ".vue"]);
+  });
 });

--- a/packages/cli/test/project.test.ts
+++ b/packages/cli/test/project.test.ts
@@ -1,0 +1,45 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { readProjectConfig } from "../src/project.ts";
+
+const tempDirs: string[] = [];
+
+function makeProject(config: string): string {
+  const root = mkdtempSync(join(tmpdir(), "pracht-project-config-"));
+  tempDirs.push(root);
+  writeFileSync(join(root, "vite.config.ts"), config);
+  return root;
+}
+
+afterEach(() => {
+  while (tempDirs.length > 0) {
+    rmSync(tempDirs.pop()!, { force: true, recursive: true });
+  }
+});
+
+describe("readProjectConfig additionalExtensions", () => {
+  it("reads an inline quoted array", () => {
+    const project = readProjectConfig(
+      makeProject(
+        'export default { plugins: [pracht({ additionalExtensions: [".tsrx", ".vue"] })] };',
+      ),
+    );
+
+    expect(project.additionalExtensions).toEqual([".tsrx", ".vue"]);
+  });
+
+  it("reads a quoted array through a const and defaults to an empty list", () => {
+    const configured = readProjectConfig(
+      makeProject(
+        'const routeExtensions = [".custom"] as const;\nexport default { plugins: [pracht({ additionalExtensions: routeExtensions })] };',
+      ),
+    );
+    const defaults = readProjectConfig(makeProject("export default { plugins: [pracht()] };"));
+
+    expect(configured.additionalExtensions).toEqual([".custom"]);
+    expect(defaults.additionalExtensions).toEqual([]);
+  });
+});

--- a/packages/cli/test/verification-helpers.test.ts
+++ b/packages/cli/test/verification-helpers.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+
+import { isPageSource, isRouteSource } from "../src/verification-helpers.ts";
+
+describe("route source detection", () => {
+  it("excludes declaration files from built-in and configured route extensions", () => {
+    expect(isRouteSource("src/routes/route.d.ts")).toBe(false);
+    expect(isRouteSource("src/routes/route.d.ts", [".ts"])).toBe(false);
+    expect(isPageSource("src/pages/route.d.ts", [".ts"])).toBe(false);
+  });
+
+  it("includes built-in and configured route extensions", () => {
+    expect(isRouteSource("src/routes/route.tsx")).toBe(true);
+    expect(isRouteSource("src/routes/route.md")).toBe(true);
+    expect(isRouteSource("src/routes/route.custom", [".custom"])).toBe(true);
+  });
+});

--- a/packages/cli/test/verification-helpers.test.ts
+++ b/packages/cli/test/verification-helpers.test.ts
@@ -11,6 +11,7 @@ describe("route source detection", () => {
 
   it("includes built-in and configured route extensions", () => {
     expect(isRouteSource("src/routes/route.tsx")).toBe(true);
+    expect(isRouteSource("src/routes/route.tsrx")).toBe(true);
     expect(isRouteSource("src/routes/route.md")).toBe(true);
     expect(isRouteSource("src/routes/route.custom", [".custom"])).toBe(true);
   });

--- a/packages/vite-plugin/README.md
+++ b/packages/vite-plugin/README.md
@@ -59,7 +59,8 @@ DOM subtrees and should be benchmarked against your app before enabling broadly.
 ## Additional Route Extensions
 
 Use `additionalExtensions` when a Vite plugin compiles route or shell modules
-with another file extension. For example, TSRX modules can be enabled with:
+with another file extension. For example, TSRX can use the explicit generic
+configuration (while remaining implicitly supported for compatibility):
 
 ```ts
 // vite.config.ts
@@ -73,11 +74,18 @@ export default defineConfig({
 ```
 
 Extensions must be dot-prefixed. Pracht discovers configured extensions in
-route and shell directories for both manifest and pages-router modes, includes
-them in dependency optimization, and strips server-only route exports from
-client bundles. The companion Vite plugin is still responsible for compiling
-the file format, and the app should provide any ambient TypeScript module
-declaration that format requires.
+route and shell directories for both manifest and pages-router modes and strips
+server-only route exports from client bundles. Vite-scannable component formats
+join initial dependency scanning automatically; other format plugins must opt
+their extension into Vite's dependency optimizer. The companion plugin remains
+responsible for compiling the file format, and the app should provide any
+ambient TypeScript module declaration that format requires. Keep the array
+inline or in a directly referenced `const` for complete CLI verification;
+dynamic expressions still build but produce a verification warning.
+
+Existing `.tsrx` routes and shells remain discovered without
+`additionalExtensions`, and Pracht keeps its ambient `.tsrx` declaration so a
+compatible CLI patch cannot strand applications on the previous plugin minor.
 
 ## Peer Dependencies
 

--- a/packages/vite-plugin/README.md
+++ b/packages/vite-plugin/README.md
@@ -56,12 +56,10 @@ pracht({
 Keep it opt-in for now: it is best suited to SSR-heavy pages with large static
 DOM subtrees and should be benchmarked against your app before enabling broadly.
 
-## TSRX (`.tsrx`) Support
+## Additional Route Extensions
 
-`.tsrx` modules — TSRX/Ripple-flavoured Preact components — are supported out
-of the box. Bring your own
-[`@tsrx/vite-plugin-preact`](https://github.com/Ripple-TS/ripple) and add it to
-your `plugins` array alongside `pracht()`:
+Use `additionalExtensions` when a Vite plugin compiles route or shell modules
+with another file extension. For example, TSRX modules can be enabled with:
 
 ```ts
 // vite.config.ts
@@ -70,13 +68,16 @@ import { pracht } from "@pracht/vite-plugin";
 import { tsrxPreact } from "@tsrx/vite-plugin-preact";
 
 export default defineConfig({
-  plugins: [tsrxPreact(), pracht()],
+  plugins: [tsrxPreact(), pracht({ additionalExtensions: [".tsrx"] })],
 });
 ```
 
-The pracht plugin globs `.tsrx` files alongside `.tsx` for routes and shells
-(both manifest- and pages-router modes), and its server-only export stripping
-pass treats them the same way — no separate pracht option is required.
+Extensions must be dot-prefixed. Pracht discovers configured extensions in
+route and shell directories for both manifest and pages-router modes, includes
+them in dependency optimization, and strips server-only route exports from
+client bundles. The companion Vite plugin is still responsible for compiling
+the file format, and the app should provide any ambient TypeScript module
+declaration that format requires.
 
 ## Peer Dependencies
 

--- a/packages/vite-plugin/src/client-module-query.ts
+++ b/packages/vite-plugin/src/client-module-query.ts
@@ -30,13 +30,12 @@ export function stripPrachtClientModuleQuery(id: string): string {
 export function getRolldownLang(id: string): RolldownLang {
   const path = stripPrachtClientModuleQuery(id).split("?")[0];
   if (/\.(c|m)?tsx$/i.test(path)) return "tsx";
-  // `.tsrx` files are pre-compiled by `@tsrx/vite-plugin-preact` to plain JS
-  // (with JSX runtime calls) before pracht's post transform runs. Parse as
-  // `tsx` since the parser is permissive enough to accept plain JS.
-  if (/\.tsrx$/i.test(path)) return "tsx";
   if (/\.(c|m)?ts$/i.test(path)) return "ts";
   if (/\.(c|m)?jsx$/i.test(path)) return "jsx";
   if (/\.mdx?$/i.test(path)) return "jsx";
   if (/\.(c|m)?js$/i.test(path)) return "js";
+  // Additional route formats are transformed by their own Vite plugin before
+  // Pracht's post transform. TSX is permissive enough for the resulting JS and
+  // JSX-runtime calls.
   return "tsx";
 }

--- a/packages/vite-plugin/src/index.ts
+++ b/packages/vite-plugin/src/index.ts
@@ -448,7 +448,7 @@ export function pracht(options: PrachtPluginOptions = {}): Plugin[] {
     config(config) {
       return withPrachtOptimizeDepsEntries(
         config,
-        createPrachtOptimizeDepsEntries(resolved),
+        resolved,
         createPrachtOptimizeDepsInclude(config.root ?? process.cwd()),
       );
     },
@@ -634,15 +634,22 @@ function createPrachtOptimizeDepsInclude(root: string): string[] {
 
 function withPrachtOptimizeDepsEntries(
   config: UserConfig,
-  prachtEntries: string[],
+  resolved: ResolvedPrachtPluginOptions,
   prachtInclude: string[],
 ): UserConfig {
+  const prachtEntries = createPrachtOptimizeDepsEntries(resolved, config.optimizeDeps?.extensions);
   const environments = Object.fromEntries(
     Object.entries(config.environments ?? {}).map(([name, environment]) => [
       name,
       {
         optimizeDeps: {
-          entries: mergeOptimizeDepsEntries(environment.optimizeDeps?.entries, prachtEntries),
+          entries: mergeOptimizeDepsEntries(
+            environment.optimizeDeps?.entries,
+            createPrachtOptimizeDepsEntries(
+              resolved,
+              environment.optimizeDeps?.extensions ?? config.optimizeDeps?.extensions,
+            ),
+          ),
         },
       },
     ]),
@@ -659,12 +666,34 @@ function withPrachtOptimizeDepsEntries(
   };
 }
 
-function createPrachtOptimizeDepsEntries(resolved: ResolvedPrachtPluginOptions): string[] {
+const VITE_SCANNABLE_ROUTE_EXTENSIONS = new Set([
+  ".ts",
+  ".tsx",
+  ".js",
+  ".jsx",
+  ".mts",
+  ".mjs",
+  ".cts",
+  ".cjs",
+  // Vite's dependency scanner extracts module scripts from these formats.
+  ".vue",
+  ".svelte",
+  ".astro",
+  ".imba",
+]);
+
+function createPrachtOptimizeDepsEntries(
+  resolved: ResolvedPrachtPluginOptions,
+  optimizerExtensions: string[] | undefined,
+): string[] {
   const scriptExtensions = "{ts,tsx,js,jsx}";
-  const routeExtensions = extensionGlob([
-    ...DEFAULT_ROUTE_EXTENSIONS,
-    ...resolved.additionalExtensions,
-  ]);
+  const explicitlyScannable = new Set(optimizerExtensions ?? []);
+  const routeExtensions = extensionGlob(
+    [...new Set([...DEFAULT_ROUTE_EXTENSIONS, ...resolved.additionalExtensions])].filter(
+      (extension) =>
+        VITE_SCANNABLE_ROUTE_EXTENSIONS.has(extension) || explicitlyScannable.has(extension),
+    ),
+  );
   const apiDir = toOptimizeDepsEntry(resolved.apiDir);
   const apiEntries = [`${apiDir}/**/*.{ts,js,tsx,jsx}`, `!${apiDir}/**/*.d.ts`];
   const entries = resolved.pagesDir

--- a/packages/vite-plugin/src/index.ts
+++ b/packages/vite-plugin/src/index.ts
@@ -51,6 +51,11 @@ import {
   type PrachtPluginOptions,
   type ResolvedPrachtPluginOptions,
 } from "./plugin-options.ts";
+import {
+  DEFAULT_ROUTE_EXTENSIONS,
+  extensionGlob,
+  withAdditionalExtensions,
+} from "./route-extensions.ts";
 
 export type { RenderMode };
 export type { PrachtAdapter } from "./plugin-adapter.ts";
@@ -92,6 +97,10 @@ export function pracht(options: PrachtPluginOptions = {}): Plugin[] {
   const isPagesMode = !!resolved.pagesDir;
   let root = process.cwd();
   let routeFileDirs: string[] = [];
+  const routeFileExtensions = withAdditionalExtensions(
+    DEFAULT_ROUTE_EXTENSIONS,
+    resolved.additionalExtensions,
+  );
   let capabilityModulePaths = new Set<string>();
 
   if (isPagesMode && options.appFile) {
@@ -419,7 +428,7 @@ export function pracht(options: PrachtPluginOptions = {}): Plugin[] {
 
       const shouldStrip =
         isPrachtClientModuleId(id) ||
-        (!transformOptions?.ssr && isRouteOrShellFile(id, routeFileDirs));
+        (!transformOptions?.ssr && isRouteOrShellFile(id, routeFileDirs, routeFileExtensions));
       if (!shouldStrip) return null;
 
       const transformed = stripServerOnlyExportsForClient(code, id);
@@ -652,7 +661,10 @@ function withPrachtOptimizeDepsEntries(
 
 function createPrachtOptimizeDepsEntries(resolved: ResolvedPrachtPluginOptions): string[] {
   const scriptExtensions = "{ts,tsx,js,jsx}";
-  const routeExtensions = "{ts,tsx,js,jsx,md,mdx,tsrx}";
+  const routeExtensions = extensionGlob([
+    ...DEFAULT_ROUTE_EXTENSIONS,
+    ...resolved.additionalExtensions,
+  ]);
   const apiDir = toOptimizeDepsEntry(resolved.apiDir);
   const apiEntries = [`${apiDir}/**/*.{ts,js,tsx,jsx}`, `!${apiDir}/**/*.d.ts`];
   const entries = resolved.pagesDir
@@ -722,8 +734,6 @@ function invalidateVirtualModules(server: import("vite").ViteDevServer): void {
   if (devMod) server.moduleGraph.invalidateModule(devMod);
 }
 
-const ROUTE_FILE_EXTENSIONS = new Set([".ts", ".tsx", ".js", ".jsx", ".md", ".mdx", ".tsrx"]);
-
 function computeRouteFileDirs(root: string, resolved: ResolvedPrachtPluginOptions): string[] {
   const dirs = resolved.pagesDir ? [resolved.pagesDir] : [resolved.routesDir, resolved.shellsDir];
   return dirs.map((dir) => canonicalFilePath(resolveConfigPath(root, dir))).map(withTrailingSep);
@@ -758,7 +768,7 @@ function canonicalFilePath(path: string): string {
   }
 }
 
-function isRouteOrShellFile(id: string, dirs: string[]): boolean {
+function isRouteOrShellFile(id: string, dirs: string[], extensions: Set<string>): boolean {
   if (dirs.length === 0) return false;
   const queryStart = id.indexOf("?");
   const path = queryStart === -1 ? id : id.slice(0, queryStart);
@@ -767,7 +777,7 @@ function isRouteOrShellFile(id: string, dirs: string[]): boolean {
   const extIndex = path.lastIndexOf(".");
   if (extIndex === -1) return false;
   const ext = path.slice(extIndex);
-  if (!ROUTE_FILE_EXTENSIONS.has(ext)) return false;
+  if (!extensions.has(ext)) return false;
   const normalized = toPosixPath(path);
   return dirs.some((dir) => normalized.startsWith(dir));
 }

--- a/packages/vite-plugin/src/pages-router.ts
+++ b/packages/vite-plugin/src/pages-router.ts
@@ -2,6 +2,12 @@ import { readdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
 import { basename, extname, join, relative } from "node:path";
 import { maskCommentsAndStrings } from "@pracht/capabilities/static";
 import { detectLoaderExport } from "./route-loader-hints.ts";
+import {
+  DEFAULT_ROUTE_EXTENSIONS,
+  DEFAULT_SHELL_EXTENSIONS,
+  normalizeAdditionalExtensions,
+  withAdditionalExtensions,
+} from "./route-extensions.ts";
 
 export interface ScannedPage {
   absolutePath: string;
@@ -20,14 +26,18 @@ export interface ScannedPage {
 export interface PagesRouterOptions {
   pagesDir: string;
   pagesDefaultRender?: string;
+  additionalExtensions?: readonly string[];
 }
 
-const PAGE_EXTENSIONS = new Set([".tsx", ".tsrx", ".ts", ".jsx", ".js", ".md", ".mdx"]);
-const SHELL_EXTENSIONS = new Set([".tsx", ".tsrx", ".ts", ".jsx", ".js"]);
-
-export function scanPagesDirectory(pagesDir: string): ScannedPage[] {
+export function scanPagesDirectory(
+  pagesDir: string,
+  additionalExtensions: readonly string[] = [],
+): ScannedPage[] {
+  const normalizedExtensions = normalizeAdditionalExtensions(additionalExtensions);
+  const pageExtensions = withAdditionalExtensions(DEFAULT_ROUTE_EXTENSIONS, normalizedExtensions);
+  const shellExtensions = withAdditionalExtensions(DEFAULT_SHELL_EXTENSIONS, normalizedExtensions);
   const pages: ScannedPage[] = [];
-  scan(pagesDir, pagesDir, pages);
+  scan(pagesDir, pagesDir, pages, pageExtensions, shellExtensions);
   const appShell = pages.find((page) => page.routePath === "__shell__");
   if (appShell?.hasRevalidateExport) {
     throw new Error(
@@ -38,7 +48,13 @@ export function scanPagesDirectory(pagesDir: string): ScannedPage[] {
   return sortRoutes(pages);
 }
 
-function scan(dir: string, root: string, pages: ScannedPage[]): void {
+function scan(
+  dir: string,
+  root: string,
+  pages: ScannedPage[],
+  pageExtensions: Set<string>,
+  shellExtensions: Set<string>,
+): void {
   let entries: string[];
   try {
     entries = readdirSync(dir);
@@ -51,14 +67,15 @@ function scan(dir: string, root: string, pages: ScannedPage[]): void {
     const stat = statSync(abs);
 
     if (stat.isDirectory()) {
-      scan(abs, root, pages);
+      scan(abs, root, pages, pageExtensions, shellExtensions);
       continue;
     }
 
     const ext = extname(entry);
-    if (!PAGE_EXTENSIONS.has(ext)) continue;
+    if (!pageExtensions.has(ext)) continue;
 
     const name = basename(entry, ext);
+    if (name === "_app" && !shellExtensions.has(ext)) continue;
 
     // Skip _-prefixed files except _app
     if (name.startsWith("_") && name !== "_app") continue;
@@ -89,7 +106,8 @@ function scan(dir: string, root: string, pages: ScannedPage[]): void {
 }
 
 export function filePathToRoutePath(relativePath: string): string {
-  let route = relativePath.replace(/\.(tsx?|tsrx|jsx?|mdx?)$/, "");
+  const extension = extname(relativePath);
+  let route = extension ? relativePath.slice(0, -extension.length) : relativePath;
   route = route.replace(/\\/g, "/");
 
   // _app is not a route
@@ -282,10 +300,14 @@ export function generatePagesManifestSource(
   // useImportSyntax: when true, emit `() => import("path")` for IDE navigation.
   // Only used for ejected files; virtual modules must use plain strings.
   const useImport = options.useImportSyntax ?? false;
+  const shellExtensions = withAdditionalExtensions(
+    DEFAULT_SHELL_EXTENSIONS,
+    normalizeAdditionalExtensions(options.additionalExtensions),
+  );
 
   const allFiles = scanAllFiles(pagesDir);
   const appFile = allFiles.find(
-    (f) => basename(f, extname(f)) === "_app" && SHELL_EXTENSIONS.has(extname(f)),
+    (f) => basename(f, extname(f)) === "_app" && shellExtensions.has(extname(f)),
   );
 
   const coreImports = pages.some((page) => page.revalidateSeconds !== undefined)
@@ -422,7 +444,7 @@ export function generateRoutesFile(
   outputPath: string,
   options: PagesRouterOptions,
 ): void {
-  const pages = scanPagesDirectory(pagesDir);
+  const pages = scanPagesDirectory(pagesDir, options.additionalExtensions);
   // For standalone files, replace `const app` with `export const app`
   const manifestSource = generatePagesManifestSource(pages, {
     ...options,

--- a/packages/vite-plugin/src/plugin-codegen.ts
+++ b/packages/vite-plugin/src/plugin-codegen.ts
@@ -14,8 +14,12 @@ import {
 } from "./plugin-options.ts";
 import { createRouteLoaderHints } from "./route-loader-hints.ts";
 import { createWebmcpBootstrapSource, hasWebmcpCapabilities } from "./plugin-capabilities.ts";
+import {
+  DEFAULT_ROUTE_EXTENSIONS,
+  extensionGlob,
+  withAdditionalExtensions,
+} from "./route-extensions.ts";
 
-const ROUTE_MODULE_EXTENSIONS = new Set([".ts", ".tsx", ".js", ".jsx", ".md", ".mdx", ".tsrx"]);
 const NON_FULL_HYDRATION_RE = /hydration\s*:\s*["'](?:islands|none)["']/;
 const FULL_HYDRATION_RE = /hydration\s*:\s*["']full["']/;
 const PAGES_NON_FULL_HYDRATION_RE = /export\s+const\s+HYDRATION\s*=\s*["'](?:islands|none)["']/;
@@ -37,7 +41,7 @@ function findMatching(source: string, start: number, open: string, close: string
   return -1;
 }
 
-function scanFiles(dir: string, files: string[]): void {
+function scanFiles(dir: string, files: string[], extensions: Set<string>): void {
   let entries: string[];
   try {
     entries = readdirSync(dir);
@@ -54,8 +58,8 @@ function scanFiles(dir: string, files: string[]): void {
       continue;
     }
     if (stat.isDirectory()) {
-      scanFiles(abs, files);
-    } else if (ROUTE_MODULE_EXTENSIONS.has(extname(entry))) {
+      scanFiles(abs, files, extensions);
+    } else if (extensions.has(extname(entry))) {
       files.push(abs);
     }
   }
@@ -69,7 +73,11 @@ function createNonFullHydrationExcludes(
 
   if (resolved.pagesDir) {
     const files: string[] = [];
-    scanFiles(resolve(root, resolved.pagesDir.replace(/^\//, "")), files);
+    scanFiles(
+      resolve(root, resolved.pagesDir.replace(/^\//, "")),
+      files,
+      withAdditionalExtensions(DEFAULT_ROUTE_EXTENSIONS, resolved.additionalExtensions),
+    );
     for (const file of files) {
       try {
         if (PAGES_NON_FULL_HYDRATION_RE.test(readFileSync(file, "utf-8"))) {
@@ -141,25 +149,31 @@ export function createPrachtClientModuleSource(
     ? generatePagesAppInlineSource(resolved, buildOptions.root)
     : `import { app } from ${JSON.stringify(resolved.appFile)};`;
 
-  // Main route/shell globs. `.tsrx` is globbed separately *without* the
-  // `?pracht-client` query suffix — the upstream `@tsrx/vite-plugin-preact`
-  // plugin only matches ids by bare `.tsrx` extension, and the server-only
-  // export stripping pass already catches these files via the route/shell
-  // directory check during client builds.
+  // Additional formats are globbed separately without the `?pracht-client`
+  // query suffix so their Vite transform plugins can match the bare extension.
+  // Pracht's directory-aware post transform still strips server-only exports.
   const dirPrefix = isPagesMode ? resolved.pagesDir : resolved.routesDir;
   const routeGlob = `${dirPrefix}/**/*.{ts,tsx,js,jsx,md,mdx}`;
-  const routeTsrxGlob = `${dirPrefix}/**/*.tsrx`;
+  const additionalRouteGlob =
+    resolved.additionalExtensions.length > 0
+      ? `${dirPrefix}/**/*.${extensionGlob(resolved.additionalExtensions)}`
+      : null;
   const routeExcludes = createNonFullHydrationExcludes(resolved, buildOptions.root);
   const routeGlobPattern = routeExcludes.length > 0 ? [routeGlob, ...routeExcludes] : routeGlob;
-  const routeTsrxGlobPattern =
-    routeExcludes.length > 0 ? [routeTsrxGlob, ...routeExcludes] : routeTsrxGlob;
+  const additionalRouteGlobPattern =
+    additionalRouteGlob && routeExcludes.length > 0
+      ? [additionalRouteGlob, ...routeExcludes]
+      : additionalRouteGlob;
 
   const shellGlob = isPagesMode
     ? `${resolved.pagesDir}/**/_app.{ts,tsx,js,jsx}`
     : `${resolved.shellsDir}/**/*.{ts,tsx,js,jsx,md,mdx}`;
-  const shellTsrxGlob = isPagesMode
-    ? `${resolved.pagesDir}/**/_app.tsrx`
-    : `${resolved.shellsDir}/**/*.tsrx`;
+  const additionalShellGlob =
+    resolved.additionalExtensions.length === 0
+      ? null
+      : isPagesMode
+        ? `${resolved.pagesDir}/**/_app.${extensionGlob(resolved.additionalExtensions)}`
+        : `${resolved.shellsDir}/**/*.${extensionGlob(resolved.additionalExtensions)}`;
   // Base directory for relative manifest refs: the app manifest file's
   // directory (refs like "./routes/home.tsx" are written relative to it).
   const appFilePosix = resolved.appFile.replace(/\\/g, "/").replace(/^\.\//, "");
@@ -173,11 +187,15 @@ export function createPrachtClientModuleSource(
     `const routeLoaderHints = ${JSON.stringify(routeLoaderHints)};`,
     `const routeModules = {`,
     `  ...import.meta.glob(${JSON.stringify(routeGlobPattern)}, { query: ${JSON.stringify(PRACHT_CLIENT_MODULE_QUERY)} }),`,
-    `  ...import.meta.glob(${JSON.stringify(routeTsrxGlobPattern)}),`,
+    ...(additionalRouteGlobPattern
+      ? [`  ...import.meta.glob(${JSON.stringify(additionalRouteGlobPattern)}),`]
+      : []),
     `};`,
     `const shellModules = {`,
     `  ...import.meta.glob(${JSON.stringify(shellGlob)}, { query: ${JSON.stringify(PRACHT_CLIENT_MODULE_QUERY)} }),`,
-    `  ...import.meta.glob(${JSON.stringify(shellTsrxGlob)}),`,
+    ...(additionalShellGlob
+      ? [`  ...import.meta.glob(${JSON.stringify(additionalShellGlob)}),`]
+      : []),
     `};`,
     "",
     "const resolvedApp = resolveApp(app);",
@@ -456,7 +474,10 @@ function createRouteLoaderHintsForVirtualModules(
   root = process.cwd(),
 ): Record<string, boolean> {
   if (options.pagesDir) {
-    const pages = scanPagesDirectory(resolve(root, options.pagesDir.slice(1)));
+    const pages = scanPagesDirectory(
+      resolve(root, options.pagesDir.slice(1)),
+      options.additionalExtensions,
+    );
     const hints: Record<string, boolean> = {};
     for (const page of pages) {
       const key = `${options.pagesDir}/${page.relativePath.replace(/\\/g, "/")}`;
@@ -469,6 +490,7 @@ function createRouteLoaderHintsForVirtualModules(
   const appFileDir = dirname(appFileAbs);
   const routesDirAbs = resolve(root, options.routesDir.slice(1));
   return createRouteLoaderHints(routesDirAbs, {
+    additionalExtensions: options.additionalExtensions,
     appFileDir,
     rootRelativePrefix: options.routesDir,
   });
@@ -482,25 +504,33 @@ export function createPrachtRegistryModuleSource(options: PrachtPluginOptions = 
   const routeGlob = isPagesMode
     ? `${resolved.pagesDir}/**/*.{ts,tsx,js,jsx,md,mdx}`
     : `${resolved.routesDir}/**/*.{ts,tsx,js,jsx,md,mdx}`;
-  const routeTsrxGlob = isPagesMode
-    ? `${resolved.pagesDir}/**/*.tsrx`
-    : `${resolved.routesDir}/**/*.tsrx`;
+  const additionalRouteGlob =
+    resolved.additionalExtensions.length === 0
+      ? null
+      : `${isPagesMode ? resolved.pagesDir : resolved.routesDir}/**/*.${extensionGlob(resolved.additionalExtensions)}`;
 
   const shellGlob = isPagesMode
     ? `${resolved.pagesDir}/**/_app.{ts,tsx,js,jsx}`
     : `${resolved.shellsDir}/**/*.{ts,tsx,js,jsx,md,mdx}`;
-  const shellTsrxGlob = isPagesMode
-    ? `${resolved.pagesDir}/**/_app.tsrx`
-    : `${resolved.shellsDir}/**/*.tsrx`;
+  const additionalShellGlob =
+    resolved.additionalExtensions.length === 0
+      ? null
+      : isPagesMode
+        ? `${resolved.pagesDir}/**/_app.${extensionGlob(resolved.additionalExtensions)}`
+        : `${resolved.shellsDir}/**/*.${extensionGlob(resolved.additionalExtensions)}`;
 
   return [
     `export const routeModules = {`,
     `  ...import.meta.glob(${JSON.stringify(routeGlob)}),`,
-    `  ...import.meta.glob(${JSON.stringify(routeTsrxGlob)}),`,
+    ...(additionalRouteGlob
+      ? [`  ...import.meta.glob(${JSON.stringify(additionalRouteGlob)}),`]
+      : []),
     `};`,
     `export const shellModules = {`,
     `  ...import.meta.glob(${JSON.stringify(shellGlob)}),`,
-    `  ...import.meta.glob(${JSON.stringify(shellTsrxGlob)}),`,
+    ...(additionalShellGlob
+      ? [`  ...import.meta.glob(${JSON.stringify(additionalShellGlob)}),`]
+      : []),
     `};`,
     `export const middlewareModules = import.meta.glob(${JSON.stringify(`${resolved.middlewareDir}/**/*.{ts,tsx,js,jsx}`)});`,
     `export const apiModules = import.meta.glob(${JSON.stringify(apiGlobs)});`,
@@ -530,6 +560,7 @@ function generatePagesAppInlineSource(
 ): string {
   const absPagesDir = resolve(root, options.pagesDir.slice(1));
   const cacheKey = JSON.stringify({
+    additionalExtensions: options.additionalExtensions,
     absPagesDir,
     pagesDefaultRender: options.pagesDefaultRender,
     pagesDirPrefix: options.pagesDir,
@@ -537,8 +568,9 @@ function generatePagesAppInlineSource(
   const cached = pagesAppSourceCache.get(cacheKey);
   if (cached) return cached;
 
-  const pages = scanPagesDirectory(absPagesDir);
+  const pages = scanPagesDirectory(absPagesDir, options.additionalExtensions);
   const source = generatePagesManifestSource(pages, {
+    additionalExtensions: options.additionalExtensions,
     pagesDir: absPagesDir,
     pagesDefaultRender: options.pagesDefaultRender,
     pagesDirPrefix: options.pagesDir,

--- a/packages/vite-plugin/src/plugin-codegen.ts
+++ b/packages/vite-plugin/src/plugin-codegen.ts
@@ -16,6 +16,7 @@ import { createRouteLoaderHints } from "./route-loader-hints.ts";
 import { createWebmcpBootstrapSource, hasWebmcpCapabilities } from "./plugin-capabilities.ts";
 import {
   DEFAULT_ROUTE_EXTENSIONS,
+  LEGACY_BARE_ROUTE_EXTENSIONS,
   extensionGlob,
   withAdditionalExtensions,
 } from "./route-extensions.ts";
@@ -152,12 +153,12 @@ export function createPrachtClientModuleSource(
   // Additional formats are globbed separately without the `?pracht-client`
   // query suffix so their Vite transform plugins can match the bare extension.
   // Pracht's directory-aware post transform still strips server-only exports.
+  const bareRouteExtensions = [
+    ...withAdditionalExtensions(LEGACY_BARE_ROUTE_EXTENSIONS, resolved.additionalExtensions),
+  ];
   const dirPrefix = isPagesMode ? resolved.pagesDir : resolved.routesDir;
   const routeGlob = `${dirPrefix}/**/*.{ts,tsx,js,jsx,md,mdx}`;
-  const additionalRouteGlob =
-    resolved.additionalExtensions.length > 0
-      ? `${dirPrefix}/**/*.${extensionGlob(resolved.additionalExtensions)}`
-      : null;
+  const additionalRouteGlob = `${dirPrefix}/**/*.${extensionGlob(bareRouteExtensions)}`;
   const routeExcludes = createNonFullHydrationExcludes(resolved, buildOptions.root);
   const routeGlobPattern = routeExcludes.length > 0 ? [routeGlob, ...routeExcludes] : routeGlob;
   const additionalRouteGlobPattern =
@@ -168,12 +169,9 @@ export function createPrachtClientModuleSource(
   const shellGlob = isPagesMode
     ? `${resolved.pagesDir}/**/_app.{ts,tsx,js,jsx}`
     : `${resolved.shellsDir}/**/*.{ts,tsx,js,jsx,md,mdx}`;
-  const additionalShellGlob =
-    resolved.additionalExtensions.length === 0
-      ? null
-      : isPagesMode
-        ? `${resolved.pagesDir}/**/_app.${extensionGlob(resolved.additionalExtensions)}`
-        : `${resolved.shellsDir}/**/*.${extensionGlob(resolved.additionalExtensions)}`;
+  const additionalShellGlob = isPagesMode
+    ? `${resolved.pagesDir}/**/_app.${extensionGlob(bareRouteExtensions)}`
+    : `${resolved.shellsDir}/**/*.${extensionGlob(bareRouteExtensions)}`;
   // Base directory for relative manifest refs: the app manifest file's
   // directory (refs like "./routes/home.tsx" are written relative to it).
   const appFilePosix = resolved.appFile.replace(/\\/g, "/").replace(/^\.\//, "");
@@ -187,15 +185,11 @@ export function createPrachtClientModuleSource(
     `const routeLoaderHints = ${JSON.stringify(routeLoaderHints)};`,
     `const routeModules = {`,
     `  ...import.meta.glob(${JSON.stringify(routeGlobPattern)}, { query: ${JSON.stringify(PRACHT_CLIENT_MODULE_QUERY)} }),`,
-    ...(additionalRouteGlobPattern
-      ? [`  ...import.meta.glob(${JSON.stringify(additionalRouteGlobPattern)}),`]
-      : []),
+    `  ...import.meta.glob(${JSON.stringify(additionalRouteGlobPattern)}),`,
     `};`,
     `const shellModules = {`,
     `  ...import.meta.glob(${JSON.stringify(shellGlob)}, { query: ${JSON.stringify(PRACHT_CLIENT_MODULE_QUERY)} }),`,
-    ...(additionalShellGlob
-      ? [`  ...import.meta.glob(${JSON.stringify(additionalShellGlob)}),`]
-      : []),
+    `  ...import.meta.glob(${JSON.stringify(additionalShellGlob)}),`,
     `};`,
     "",
     "const resolvedApp = resolveApp(app);",
@@ -500,37 +494,30 @@ export function createPrachtRegistryModuleSource(options: PrachtPluginOptions = 
   const resolved = resolveOptions(options);
   const apiGlobs = [`${resolved.apiDir}/**/*.{ts,js,tsx,jsx}`, `!${resolved.apiDir}/**/*.d.ts`];
   const isPagesMode = !!resolved.pagesDir;
+  const bareRouteExtensions = [
+    ...withAdditionalExtensions(LEGACY_BARE_ROUTE_EXTENSIONS, resolved.additionalExtensions),
+  ];
 
   const routeGlob = isPagesMode
     ? `${resolved.pagesDir}/**/*.{ts,tsx,js,jsx,md,mdx}`
     : `${resolved.routesDir}/**/*.{ts,tsx,js,jsx,md,mdx}`;
-  const additionalRouteGlob =
-    resolved.additionalExtensions.length === 0
-      ? null
-      : `${isPagesMode ? resolved.pagesDir : resolved.routesDir}/**/*.${extensionGlob(resolved.additionalExtensions)}`;
+  const additionalRouteGlob = `${isPagesMode ? resolved.pagesDir : resolved.routesDir}/**/*.${extensionGlob(bareRouteExtensions)}`;
 
   const shellGlob = isPagesMode
     ? `${resolved.pagesDir}/**/_app.{ts,tsx,js,jsx}`
     : `${resolved.shellsDir}/**/*.{ts,tsx,js,jsx,md,mdx}`;
-  const additionalShellGlob =
-    resolved.additionalExtensions.length === 0
-      ? null
-      : isPagesMode
-        ? `${resolved.pagesDir}/**/_app.${extensionGlob(resolved.additionalExtensions)}`
-        : `${resolved.shellsDir}/**/*.${extensionGlob(resolved.additionalExtensions)}`;
+  const additionalShellGlob = isPagesMode
+    ? `${resolved.pagesDir}/**/_app.${extensionGlob(bareRouteExtensions)}`
+    : `${resolved.shellsDir}/**/*.${extensionGlob(bareRouteExtensions)}`;
 
   return [
     `export const routeModules = {`,
     `  ...import.meta.glob(${JSON.stringify(routeGlob)}),`,
-    ...(additionalRouteGlob
-      ? [`  ...import.meta.glob(${JSON.stringify(additionalRouteGlob)}),`]
-      : []),
+    `  ...import.meta.glob(${JSON.stringify(additionalRouteGlob)}),`,
     `};`,
     `export const shellModules = {`,
     `  ...import.meta.glob(${JSON.stringify(shellGlob)}),`,
-    ...(additionalShellGlob
-      ? [`  ...import.meta.glob(${JSON.stringify(additionalShellGlob)}),`]
-      : []),
+    `  ...import.meta.glob(${JSON.stringify(additionalShellGlob)}),`,
     `};`,
     `export const middlewareModules = import.meta.glob(${JSON.stringify(`${resolved.middlewareDir}/**/*.{ts,tsx,js,jsx}`)});`,
     `export const apiModules = import.meta.glob(${JSON.stringify(apiGlobs)});`,

--- a/packages/vite-plugin/src/plugin-options.ts
+++ b/packages/vite-plugin/src/plugin-options.ts
@@ -47,7 +47,8 @@ export interface PrachtPluginOptions {
    * Additional dot-prefixed route and shell module extensions to discover,
    * such as `[".vue"]`. Register the Vite plugin that transforms the format
    * separately; Pracht only discovers the modules and applies its route
-   * client/server handling. Defaults to no additional extensions.
+   * client/server handling. Defaults to no additional extensions. `.tsrx`
+   * remains discovered without configuration for backward compatibility.
    */
   additionalExtensions?: readonly string[];
   /**

--- a/packages/vite-plugin/src/plugin-options.ts
+++ b/packages/vite-plugin/src/plugin-options.ts
@@ -2,6 +2,7 @@ import type { RenderMode } from "@pracht/core";
 import type { PreactSsrPrecompileOptions } from "@pracht/preact-ssr-precompile";
 import type { EnvSafetyOptions } from "./env-safety.ts";
 import { createDefaultNodeAdapter, type PrachtAdapter } from "./plugin-adapter.ts";
+import { normalizeAdditionalExtensions } from "./route-extensions.ts";
 
 export type LlmsTxtSection = "pages" | "api" | "capabilities";
 
@@ -42,6 +43,13 @@ export interface PrachtPluginOptions {
   middlewareDir?: string;
   apiDir?: string;
   serverDir?: string;
+  /**
+   * Additional dot-prefixed route and shell module extensions to discover,
+   * such as `[".vue"]`. Register the Vite plugin that transforms the format
+   * separately; Pracht only discovers the modules and applies its route
+   * client/server handling. Defaults to no additional extensions.
+   */
+  additionalExtensions?: readonly string[];
   /**
    * Directory containing island components hydrated on
    * `hydration: "islands"` routes. Defaults to "/src/islands".
@@ -98,6 +106,7 @@ const DEFAULTS: ResolvedPrachtPluginOptions = {
   shellsDir: "/src/shells",
   apiDir: "/src/api",
   serverDir: "/src/server",
+  additionalExtensions: [],
   islandsDir: "/src/islands",
   capabilitiesDir: "/src/capabilities",
   adapter: createDefaultNodeAdapter(),
@@ -121,6 +130,7 @@ export function resolveOptions(options: PrachtPluginOptions): ResolvedPrachtPlug
   if (resolved.llmsTxt === undefined) {
     resolved.llmsTxt = false;
   }
+  resolved.additionalExtensions = normalizeAdditionalExtensions(resolved.additionalExtensions);
   if (!new Set(["spa", "ssr", "ssg", "isg"]).has(resolved.pagesDefaultRender)) {
     throw new Error('pracht({ pagesDefaultRender }) expects "spa", "ssr", "ssg", or "isg".');
   }

--- a/packages/vite-plugin/src/route-extensions.ts
+++ b/packages/vite-plugin/src/route-extensions.ts
@@ -1,5 +1,16 @@
-export const DEFAULT_ROUTE_EXTENSIONS = [".ts", ".tsx", ".js", ".jsx", ".md", ".mdx"];
-export const DEFAULT_SHELL_EXTENSIONS = [".ts", ".tsx", ".js", ".jsx"];
+export const BUILT_IN_ROUTE_EXTENSIONS = [".ts", ".tsx", ".js", ".jsx", ".md", ".mdx"];
+export const LEGACY_BARE_ROUTE_EXTENSIONS = [".tsrx"];
+export const DEFAULT_ROUTE_EXTENSIONS = [
+  ...BUILT_IN_ROUTE_EXTENSIONS,
+  ...LEGACY_BARE_ROUTE_EXTENSIONS,
+];
+export const DEFAULT_SHELL_EXTENSIONS = [
+  ".ts",
+  ".tsx",
+  ".js",
+  ".jsx",
+  ...LEGACY_BARE_ROUTE_EXTENSIONS,
+];
 
 const EXTENSION_RE = /^\.[a-z0-9][a-z0-9_-]*$/i;
 
@@ -20,7 +31,10 @@ export function normalizeAdditionalExtensions(extensions: readonly string[] | un
     return extension.toLowerCase();
   });
 
-  const defaults = new Set(DEFAULT_ROUTE_EXTENSIONS);
+  // Keep `.tsrx` when it is explicitly configured even though it remains a
+  // compatibility default. That lets the TSRX example exercise the same bare
+  // custom-format glob path as every newly configured extension.
+  const defaults = new Set(BUILT_IN_ROUTE_EXTENSIONS);
   return [...new Set(normalized)].filter((extension) => !defaults.has(extension));
 }
 

--- a/packages/vite-plugin/src/route-extensions.ts
+++ b/packages/vite-plugin/src/route-extensions.ts
@@ -1,0 +1,37 @@
+export const DEFAULT_ROUTE_EXTENSIONS = [".ts", ".tsx", ".js", ".jsx", ".md", ".mdx"];
+export const DEFAULT_SHELL_EXTENSIONS = [".ts", ".tsx", ".js", ".jsx"];
+
+const EXTENSION_RE = /^\.[a-z0-9][a-z0-9_-]*$/i;
+
+export function normalizeAdditionalExtensions(extensions: readonly string[] | undefined): string[] {
+  if (extensions === undefined) return [];
+  if (!Array.isArray(extensions)) {
+    throw new Error(
+      "pracht({ additionalExtensions }) expects an array of dot-prefixed extensions.",
+    );
+  }
+
+  const normalized = extensions.map((extension) => {
+    if (typeof extension !== "string" || !EXTENSION_RE.test(extension)) {
+      throw new Error(
+        `pracht({ additionalExtensions }) expects dot-prefixed extensions such as ".vue", got ${JSON.stringify(extension)}.`,
+      );
+    }
+    return extension.toLowerCase();
+  });
+
+  const defaults = new Set(DEFAULT_ROUTE_EXTENSIONS);
+  return [...new Set(normalized)].filter((extension) => !defaults.has(extension));
+}
+
+export function extensionGlob(extensions: readonly string[]): string {
+  const names = extensions.map((extension) => extension.slice(1));
+  return names.length === 1 ? names[0] : `{${names.join(",")}}`;
+}
+
+export function withAdditionalExtensions(
+  defaults: readonly string[],
+  additionalExtensions: readonly string[],
+): Set<string> {
+  return new Set([...defaults, ...additionalExtensions]);
+}

--- a/packages/vite-plugin/src/route-loader-hints.ts
+++ b/packages/vite-plugin/src/route-loader-hints.ts
@@ -1,7 +1,11 @@
 import { readdirSync, readFileSync, statSync } from "node:fs";
 import { extname, join, relative } from "node:path";
+import {
+  DEFAULT_ROUTE_EXTENSIONS,
+  normalizeAdditionalExtensions,
+  withAdditionalExtensions,
+} from "./route-extensions.ts";
 
-const ROUTE_EXTENSIONS = new Set([".tsx", ".ts", ".jsx", ".js", ".md", ".mdx"]);
 const LOADER_DECLARATION_RE = /export\s+(?:async\s+)?(?:function|const|let|var)\s+loader\b/;
 const EXPORT_BLOCK_RE = /export\s*\{([^}]*)\}\s*(?:from\s*["'][^"']+["'])?/g;
 const EXPORT_ALL_RE = /export\s+\*\s+from\s*["'][^"']+["']/;
@@ -35,7 +39,7 @@ export function detectLoaderExport(source: string): boolean {
   return EXPORT_ALL_RE.test(source);
 }
 
-function scanRouteFiles(dir: string, files: string[]): void {
+function scanRouteFiles(dir: string, files: string[], extensions: Set<string>): void {
   let entries: string[];
   try {
     entries = readdirSync(dir);
@@ -47,11 +51,11 @@ function scanRouteFiles(dir: string, files: string[]): void {
     const abs = join(dir, entry);
     const stat = statSync(abs);
     if (stat.isDirectory()) {
-      scanRouteFiles(abs, files);
+      scanRouteFiles(abs, files, extensions);
       continue;
     }
 
-    if (ROUTE_EXTENSIONS.has(extname(entry))) {
+    if (extensions.has(extname(entry))) {
       files.push(abs);
     }
   }
@@ -63,11 +67,19 @@ function toPosixPath(path: string): string {
 
 export function createRouteLoaderHints(
   routesDir: string,
-  options: { appFileDir?: string; rootRelativePrefix?: string } = {},
+  options: {
+    additionalExtensions?: readonly string[];
+    appFileDir?: string;
+    rootRelativePrefix?: string;
+  } = {},
 ): Record<string, boolean> {
   const files: string[] = [];
   const hints: Record<string, boolean> = {};
-  scanRouteFiles(routesDir, files);
+  const extensions = withAdditionalExtensions(
+    DEFAULT_ROUTE_EXTENSIONS,
+    normalizeAdditionalExtensions(options.additionalExtensions),
+  );
+  scanRouteFiles(routesDir, files, extensions);
 
   for (const file of files) {
     const hasLoader = detectLoaderExport(readFileSync(file, "utf-8"));

--- a/packages/vite-plugin/test/pages-router.test.ts
+++ b/packages/vite-plugin/test/pages-router.test.ts
@@ -30,6 +30,17 @@ afterEach(() => {
 });
 
 describe("scanPagesDirectory", () => {
+  it("preserves built-in TSRX route and shell discovery", () => {
+    const pagesDir = makeTempPagesDir();
+    writeFileSync(join(pagesDir, "index.tsrx"), "export function Component() { return null; }\n");
+    writeFileSync(join(pagesDir, "_app.tsrx"), "export function Shell() { return null; }\n");
+
+    expect(scanPagesDirectory(pagesDir).map((page) => page.relativePath)).toEqual(["index.tsrx"]);
+    expect(generatePagesManifestSource(scanPagesDirectory(pagesDir), { pagesDir })).toContain(
+      "_app.tsrx",
+    );
+  });
+
   it("discovers configured additional route and shell extensions only when enabled", () => {
     const pagesDir = makeTempPagesDir();
     writeFileSync(join(pagesDir, "index.custom"), "export function Component() { return null; }\n");
@@ -434,8 +445,8 @@ describe("pracht plugin config", () => {
 
     const expectedPrachtEntries = [
       "src/routes.ts",
-      "src/routes/**/*.{ts,tsx,js,jsx,md,mdx}",
-      "src/shells/**/*.{ts,tsx,js,jsx,md,mdx}",
+      "src/routes/**/*.{ts,tsx,js,jsx}",
+      "src/shells/**/*.{ts,tsx,js,jsx}",
       "src/middleware/**/*.{ts,tsx,js,jsx}",
       "src/api/**/*.{ts,js,tsx,jsx}",
       "!src/api/**/*.d.ts",
@@ -451,7 +462,7 @@ describe("pracht plugin config", () => {
     ]);
   });
 
-  it("adds configured route extensions to optimize-deps entries", async () => {
+  it("adds only Vite-scannable configured extensions to optimize-deps entries", async () => {
     const plugins = await pracht({ additionalExtensions: [".tsrx", ".vue"] });
     const plugin = plugins.find((candidate) => candidate.name === "pracht:optimize-deps-entries");
     const config = plugin?.config;
@@ -462,11 +473,15 @@ describe("pracht plugin config", () => {
       { command: "serve", isSsrBuild: false, mode: "development" },
     );
 
-    expect(result.optimizeDeps?.entries).toContain(
-      "src/routes/**/*.{ts,tsx,js,jsx,md,mdx,tsrx,vue}",
+    expect(result.optimizeDeps?.entries).toContain("src/routes/**/*.{ts,tsx,js,jsx,vue}");
+    expect(result.optimizeDeps?.entries).toContain("src/shells/**/*.{ts,tsx,js,jsx,vue}");
+
+    const withFormatOptimizer = (config as (config: UserConfig, env: ConfigEnv) => UserConfig)(
+      { optimizeDeps: { extensions: [".tsrx"] } },
+      { command: "serve", isSsrBuild: false, mode: "development" },
     );
-    expect(result.optimizeDeps?.entries).toContain(
-      "src/shells/**/*.{ts,tsx,js,jsx,md,mdx,tsrx,vue}",
+    expect(withFormatOptimizer.optimizeDeps?.entries).toContain(
+      "src/routes/**/*.{ts,tsx,js,jsx,tsrx,vue}",
     );
   });
 });
@@ -478,7 +493,8 @@ describe("createPrachtRegistryModuleSource", () => {
     });
 
     expect(source).toContain("/src/pages/**/*.{ts,tsx,js,jsx,md,mdx}");
-    expect(source).not.toContain("tsrx");
+    expect(source).toContain("/src/pages/**/*.tsrx");
+    expect(source).toContain("/src/pages/**/_app.tsrx");
     expect(source).toContain(
       'import.meta.glob(["/src/api/**/*.{ts,js,tsx,jsx}","!/src/api/**/*.d.ts"])',
     );
@@ -496,12 +512,20 @@ describe("createPrachtRegistryModuleSource", () => {
     expect(source).toContain("/src/pages/**/_app.{tsrx,vue}");
   });
 
+  it("keeps compatibility TSRX client module ids bare without configuration", () => {
+    const source = createPrachtClientModuleSource();
+
+    expect(source).toContain('import.meta.glob("/src/routes/**/*.tsrx")');
+    expect(source).toContain('import.meta.glob("/src/shells/**/*.tsrx")');
+    expect(source).not.toContain('/src/routes/**/*.tsrx", { query:');
+  });
+
   it("keeps additional client module ids bare for their format plugins", () => {
     const source = createPrachtClientModuleSource({ additionalExtensions: [".custom"] });
 
-    expect(source).toContain('import.meta.glob("/src/routes/**/*.custom")');
-    expect(source).toContain('import.meta.glob("/src/shells/**/*.custom")');
-    expect(source).not.toContain('/src/routes/**/*.custom", { query:');
+    expect(source).toContain('import.meta.glob("/src/routes/**/*.{tsrx,custom}")');
+    expect(source).toContain('import.meta.glob("/src/shells/**/*.{tsrx,custom}")');
+    expect(source).not.toContain('/src/routes/**/*.{tsrx,custom}", { query:');
   });
 
   it("creates adapter-neutral development metadata", () => {

--- a/packages/vite-plugin/test/pages-router.test.ts
+++ b/packages/vite-plugin/test/pages-router.test.ts
@@ -4,7 +4,11 @@ import { join } from "node:path";
 import type { ConfigEnv, UserConfig } from "vite";
 import { afterEach, describe, expect, it } from "vitest";
 
-import { createPrachtRegistryModuleSource, pracht } from "../src/index.ts";
+import {
+  createPrachtClientModuleSource,
+  createPrachtRegistryModuleSource,
+  pracht,
+} from "../src/index.ts";
 import { createPrachtDevModuleSource } from "../src/plugin-codegen.ts";
 import { generatePagesManifestSource, scanPagesDirectory } from "../src/pages-router.ts";
 
@@ -26,6 +30,24 @@ afterEach(() => {
 });
 
 describe("scanPagesDirectory", () => {
+  it("discovers configured additional route and shell extensions only when enabled", () => {
+    const pagesDir = makeTempPagesDir();
+    writeFileSync(join(pagesDir, "index.custom"), "export function Component() { return null; }\n");
+    writeFileSync(join(pagesDir, "_app.custom"), "export function Shell() { return null; }\n");
+
+    expect(scanPagesDirectory(pagesDir)).toEqual([]);
+    expect(
+      scanPagesDirectory(pagesDir, [".custom"]).map((page) => [page.routePath, page.relativePath]),
+    ).toEqual([["/", "index.custom"]]);
+
+    const source = generatePagesManifestSource(scanPagesDirectory(pagesDir, [".custom"]), {
+      additionalExtensions: [".custom"],
+      pagesDir,
+    });
+    expect(source).toContain("shells: {");
+    expect(source).toContain("_app.custom");
+  });
+
   it("includes markdown and mdx pages in the generated route list", () => {
     const pagesDir = makeTempPagesDir();
     mkdirSync(join(pagesDir, "docs"), { recursive: true });
@@ -412,8 +434,8 @@ describe("pracht plugin config", () => {
 
     const expectedPrachtEntries = [
       "src/routes.ts",
-      "src/routes/**/*.{ts,tsx,js,jsx,md,mdx,tsrx}",
-      "src/shells/**/*.{ts,tsx,js,jsx,md,mdx,tsrx}",
+      "src/routes/**/*.{ts,tsx,js,jsx,md,mdx}",
+      "src/shells/**/*.{ts,tsx,js,jsx,md,mdx}",
       "src/middleware/**/*.{ts,tsx,js,jsx}",
       "src/api/**/*.{ts,js,tsx,jsx}",
       "!src/api/**/*.d.ts",
@@ -428,6 +450,25 @@ describe("pracht plugin config", () => {
       ...expectedPrachtEntries,
     ]);
   });
+
+  it("adds configured route extensions to optimize-deps entries", async () => {
+    const plugins = await pracht({ additionalExtensions: [".tsrx", ".vue"] });
+    const plugin = plugins.find((candidate) => candidate.name === "pracht:optimize-deps-entries");
+    const config = plugin?.config;
+    expect(typeof config).toBe("function");
+
+    const result = (config as (config: UserConfig, env: ConfigEnv) => UserConfig)(
+      {},
+      { command: "serve", isSsrBuild: false, mode: "development" },
+    );
+
+    expect(result.optimizeDeps?.entries).toContain(
+      "src/routes/**/*.{ts,tsx,js,jsx,md,mdx,tsrx,vue}",
+    );
+    expect(result.optimizeDeps?.entries).toContain(
+      "src/shells/**/*.{ts,tsx,js,jsx,md,mdx,tsrx,vue}",
+    );
+  });
 });
 
 describe("createPrachtRegistryModuleSource", () => {
@@ -437,12 +478,30 @@ describe("createPrachtRegistryModuleSource", () => {
     });
 
     expect(source).toContain("/src/pages/**/*.{ts,tsx,js,jsx,md,mdx}");
-    expect(source).toContain("/src/pages/**/*.tsrx");
+    expect(source).not.toContain("tsrx");
     expect(source).toContain(
       'import.meta.glob(["/src/api/**/*.{ts,js,tsx,jsx}","!/src/api/**/*.d.ts"])',
     );
     expect(source).toContain("/src/server/**/*.{ts,js,tsx,jsx}");
     expect(source).toContain("/src/middleware/**/*.{ts,tsx,js,jsx}");
+  });
+
+  it("adds configured route and shell extension globs", () => {
+    const source = createPrachtRegistryModuleSource({
+      additionalExtensions: [".tsrx", ".vue"],
+      pagesDir: "/src/pages",
+    });
+
+    expect(source).toContain("/src/pages/**/*.{tsrx,vue}");
+    expect(source).toContain("/src/pages/**/_app.{tsrx,vue}");
+  });
+
+  it("keeps additional client module ids bare for their format plugins", () => {
+    const source = createPrachtClientModuleSource({ additionalExtensions: [".custom"] });
+
+    expect(source).toContain('import.meta.glob("/src/routes/**/*.custom")');
+    expect(source).toContain('import.meta.glob("/src/shells/**/*.custom")');
+    expect(source).not.toContain('/src/routes/**/*.custom", { query:');
   });
 
   it("creates adapter-neutral development metadata", () => {

--- a/packages/vite-plugin/test/plugin-options.test.ts
+++ b/packages/vite-plugin/test/plugin-options.test.ts
@@ -7,6 +7,28 @@ import {
 } from "../src/plugin-codegen.ts";
 import { resolveOptions } from "../src/plugin-options.ts";
 
+describe("resolveOptions additionalExtensions", () => {
+  it("defaults to no additional route extensions", () => {
+    expect(resolveOptions({}).additionalExtensions).toEqual([]);
+  });
+
+  it("normalizes, deduplicates, and excludes built-in extensions", () => {
+    const additionalExtensions = [".TSRX", ".tsrx", ".vue", ".tsx"] as const;
+    expect(resolveOptions({ additionalExtensions }).additionalExtensions).toEqual([
+      ".tsrx",
+      ".vue",
+    ]);
+  });
+
+  it("rejects values that are not dot-prefixed extensions", () => {
+    expect(() => resolveOptions({ additionalExtensions: ["vue"] })).toThrow(
+      /dot-prefixed extensions/,
+    );
+    // @ts-expect-error — extension values must be strings.
+    expect(() => resolveOptions({ additionalExtensions: [42] })).toThrow(/dot-prefixed extensions/);
+  });
+});
+
 describe("resolveOptions budgets", () => {
   it("defaults to no budgets", () => {
     expect(resolveOptions({}).budgets).toEqual({});

--- a/packages/vite-plugin/virtual.d.ts
+++ b/packages/vite-plugin/virtual.d.ts
@@ -246,11 +246,3 @@ declare module "virtual:pracht/webmcp" {
   /** Registers WebMCP page tools; returns false when the API is unavailable. */
   export function registerPrachtWebmcpTools(): boolean;
 }
-
-// `.tsrx` modules are compiled by `@tsrx/vite-plugin-preact`. Declare an
-// ambient module so apps can `import` them without a typed source — TypeScript
-// has no built-in support for the `.tsrx` extension.
-declare module "*.tsrx" {
-  const mod: Record<string, unknown>;
-  export = mod;
-}

--- a/packages/vite-plugin/virtual.d.ts
+++ b/packages/vite-plugin/virtual.d.ts
@@ -246,3 +246,10 @@ declare module "virtual:pracht/webmcp" {
   /** Registers WebMCP page tools; returns false when the API is unavailable. */
   export function registerPrachtWebmcpTools(): boolean;
 }
+
+// Preserve the ambient declaration shipped with Pracht's compatibility-level
+// `.tsrx` discovery. Other custom formats provide their own declaration.
+declare module "*.tsrx" {
+  const mod: Record<string, unknown>;
+  export = mod;
+}


### PR DESCRIPTION
## Summary

- Replace built-in TSRX handling with a validated, format-agnostic `additionalExtensions` option across route and shell discovery, pages routing, dependency optimization, client export stripping, verification, and typegen watching.
- Keep TSRX as an opt-in integration example with its declaration scoped locally, and update framework/package docs plus the published-package changeset.
- Relevant issue: N/A.

## Testing

- [x] `pnpm run verify` (build, format, lint, typecheck, test, e2e)

## Checklist

- [x] Docs updated if needed
- [x] Skills updated if needed (N/A — no skill behavior changed)
- [x] Changeset added if published packages changed
