### PR TITLE
Fix initial SSG search parameters in the router

### DIFF
--- a/.changeset/initial-ssg-search-params.md
+++ b/.changeset/initial-ssg-search-params.md
@@ -1,0 +1,5 @@
+---
+"@pracht/core": patch
+---
+
+Use the visitor's actual browser URL during initial hydration while retaining prerendered route identity and data, and expose reactive query parameters through `useSearchParams()`.

--- a/.changeset/initial-ssg-search-params.md
+++ b/.changeset/initial-ssg-search-params.md
@@ -2,4 +2,4 @@
 "@pracht/core": patch
 ---
 
-Use the visitor's actual browser URL during initial hydration while retaining prerendered route identity and data, and expose reactive query parameters through `useSearchParams()`.
+Expose reactive, read-only query parameters through `useSearchParams()`. SSG routes retain their prerendered URL for the hydration render, then publish the visitor's browser query after hydration while keeping prerendered route identity and data.

--- a/VISION_MVP.md
+++ b/VISION_MVP.md
@@ -97,8 +97,9 @@ specified in the config, it takes precedence over inline exports.
   shell-level head.
 - **Client hooks**: `useRouteData()`, `useRevalidate()`, `useNavigation()` (pending
   navigation/submission state for progress bars and optimistic UI), `useNavigate()`,
-  `useLocation()`, `useParams()`, `<Form>` component, `<Link>` (with `prefetch`,
-  `preserveScroll`, `viewTransition` props), and imperative `prefetch()`.
+  `useLocation()`, `useSearchParams()`, `useParams()`, `<Form>` component, `<Link>`
+  (with `prefetch`, `preserveScroll`, `viewTransition` props), and imperative
+  `prefetch()`.
 
 ### API Routes
 

--- a/docs/DATA_LOADING.md
+++ b/docs/DATA_LOADING.md
@@ -547,7 +547,7 @@ export function Component() {
 
 ### `useSearchParams()`
 
-Read the current query string as a reactive `URLSearchParams`:
+Read the current query string as a reactive, read-only `URLSearchParams` view:
 
 ```typescript
 import { useSearchParams } from "@pracht/core";
@@ -558,11 +558,18 @@ export function Component() {
 }
 ```
 
-The hook updates after client navigation. On the initial hydration of an SSG
-page it reads the visitor's real browser URL, not the build-time URL stored in
-the prerendered route state, so direct visits such as `/?lang=zh` expose
-`lang=zh` immediately. Route identity and prerendered loader data still come
-from the hydration state.
+The hook updates after client navigation. An SSG page's hydration render uses
+the build-time query stored in its prerendered route state, keeping the client
+tree identical to the static HTML. After hydration completes, the hook updates
+from the visitor's browser URL, so a direct visit such as `/?lang=zh` re-renders
+with `lang=zh` without causing a hydration mismatch. Use `useIsHydrated()` or
+stable fallback UI when query-dependent markup should not visibly change after
+hydration.
+
+Changing the returned object is intentionally unsupported; navigate to a new
+URL to update the query string. SSG loader data remains build-time data and is
+not rerun for the visitor query. Use SSR when query parameters must affect
+server-loaded data or the initial HTML.
 
 ### `useRevalidate()`
 

--- a/docs/DATA_LOADING.md
+++ b/docs/DATA_LOADING.md
@@ -545,6 +545,25 @@ export function Component() {
 }
 ```
 
+### `useSearchParams()`
+
+Read the current query string as a reactive `URLSearchParams`:
+
+```typescript
+import { useSearchParams } from "@pracht/core";
+
+export function Component() {
+  const searchParams = useSearchParams();
+  return <p>Language: {searchParams.get("lang") ?? "en"}</p>;
+}
+```
+
+The hook updates after client navigation. On the initial hydration of an SSG
+page it reads the visitor's real browser URL, not the build-time URL stored in
+the prerendered route state, so direct visits such as `/?lang=zh` expose
+`lang=zh` immediately. Route identity and prerendered loader data still come
+from the hydration state.
+
 ### `useRevalidate()`
 
 Imperatively re-run the current route's loader:

--- a/examples/docs/src/routes/docs/data-loading.md
+++ b/examples/docs/src/routes/docs/data-loading.md
@@ -357,7 +357,7 @@ export function Component() {
 
 ### useSearchParams()
 
-Read the current query string as a reactive `URLSearchParams`:
+Read the current query string as a reactive, read-only `URLSearchParams` view:
 
 ```tsx
 import { useSearchParams } from "@pracht/core";
@@ -368,7 +368,7 @@ export function Component() {
 }
 ```
 
-On an SSG page's initial hydration, the hook uses the visitor's actual browser URL rather than the URL captured when the page was prerendered. A direct visit to `/?lang=zh` therefore exposes `lang=zh` immediately while retaining the prerendered route identity and loader data.
+An SSG page hydrates with its build-time query so its first client tree matches the static HTML. After hydration, the hook updates from the visitor's browser URL; a direct visit to `/?lang=zh` therefore re-renders with `lang=zh` while retaining prerendered route identity and loader data. Use `useIsHydrated()` or stable fallback UI to avoid a visible transition. Navigate to update the query—the returned object cannot be mutated—and use SSR when query parameters must affect loader data or initial HTML.
 
 ### useRevalidate()
 

--- a/examples/docs/src/routes/docs/data-loading.md
+++ b/examples/docs/src/routes/docs/data-loading.md
@@ -355,6 +355,21 @@ export function Component() {
 }
 ```
 
+### useSearchParams()
+
+Read the current query string as a reactive `URLSearchParams`:
+
+```tsx
+import { useSearchParams } from "@pracht/core";
+
+export function Component() {
+  const searchParams = useSearchParams();
+  return <p>Language: {searchParams.get("lang") ?? "en"}</p>;
+}
+```
+
+On an SSG page's initial hydration, the hook uses the visitor's actual browser URL rather than the URL captured when the page was prerendered. A direct visit to `/?lang=zh` therefore exposes `lang=zh` immediately while retaining the prerendered route identity and loader data.
+
 ### useRevalidate()
 
 Imperatively re-run the current route's loader:

--- a/packages/framework/README.md
+++ b/packages/framework/README.md
@@ -36,6 +36,7 @@ metadata for the failure phase and matched framework files when available.
 
 - `startApp()` — client-side hydration and runtime
 - `useLocation()` — access the current pathname and search string separately
+- `useSearchParams()` — read the current query as a reactive `URLSearchParams`
 - `useRouteData()` — access loader data inside a route component; pass a route
   id for fully typed data after `pracht typegen`, or a `typeof loader` generic
   otherwise

--- a/packages/framework/README.md
+++ b/packages/framework/README.md
@@ -36,7 +36,7 @@ metadata for the failure phase and matched framework files when available.
 
 - `startApp()` — client-side hydration and runtime
 - `useLocation()` — access the current pathname and search string separately
-- `useSearchParams()` — read the current query as a reactive `URLSearchParams`
+- `useSearchParams()` — read the current query as a reactive, read-only `URLSearchParams`
 - `useRouteData()` — access loader data inside a route component; pass a route
   id for fully typed data after `pracht typegen`, or a `typeof loader` generic
   otherwise

--- a/packages/framework/src/browser.ts
+++ b/packages/framework/src/browser.ts
@@ -95,6 +95,7 @@ export {
   useRevalidate,
   useRouteData,
   useSearchParams,
+  type ReadonlyURLSearchParams,
 } from "./runtime-hooks.ts";
 export { prefetch, type PrefetchFn } from "./prefetch-api.ts";
 

--- a/packages/framework/src/browser.ts
+++ b/packages/framework/src/browser.ts
@@ -94,6 +94,7 @@ export {
   useParams,
   useRevalidate,
   useRouteData,
+  useSearchParams,
 } from "./runtime-hooks.ts";
 export { prefetch, type PrefetchFn } from "./prefetch-api.ts";
 

--- a/packages/framework/src/hydration.ts
+++ b/packages/framework/src/hydration.ts
@@ -58,18 +58,24 @@ const oldCatchError = (options as any).__e;
 // there.
 const oldCommit = (options as any).__c;
 (options as any).__c = (vnode: any, commitQueue: any) => {
-  let completed = false;
+  let completedHydration = false;
   if (_hydrating && !_hydrated && _suspensionCount <= 0) {
     _hydrated = true;
     _hydrating = false;
-    completed = true;
+    completedHydration = true;
   }
   if (oldCommit) oldCommit(vnode, commitQueue);
-  if (completed) {
-    for (const listener of hydrationCompleteListeners) listener();
-    hydrationCompleteListeners.clear();
+  if (completedHydration) {
+    queueMicrotask(notifyHydrationComplete);
   }
 };
+
+function notifyHydrationComplete(): void {
+  for (const listener of hydrationCompleteListeners) {
+    hydrationCompleteListeners.delete(listener);
+    listener();
+  }
+}
 
 /**
  * Mark the start of a hydration pass. Call this right before `hydrate()`.
@@ -106,11 +112,30 @@ export function useIsHydrationComplete(): boolean {
       setComplete(true);
       return;
     }
-    const listener = () => setComplete(true);
-    hydrationCompleteListeners.add(listener);
-    return () => hydrationCompleteListeners.delete(listener);
+    return onHydrationComplete(() => setComplete(true));
   }, []);
   return complete;
+}
+
+/** Run a callback once the complete initial hydration tree has settled. */
+export function onHydrationComplete(callback: () => void): () => void {
+  let active = true;
+  const listener = () => {
+    if (!active) return;
+    active = false;
+    callback();
+  };
+
+  if (_hydrated) {
+    queueMicrotask(listener);
+  } else {
+    hydrationCompleteListeners.add(listener);
+  }
+
+  return () => {
+    active = false;
+    hydrationCompleteListeners.delete(listener);
+  };
 }
 
 /** @internal Reset module state for tests. */

--- a/packages/framework/src/index.ts
+++ b/packages/framework/src/index.ts
@@ -150,6 +150,7 @@ export {
   useParams,
   useRevalidate,
   useRouteData,
+  useSearchParams,
   PrachtRuntimeProvider,
 } from "./runtime.ts";
 export { prefetch, type PrefetchFn } from "./prefetch-api.ts";

--- a/packages/framework/src/index.ts
+++ b/packages/framework/src/index.ts
@@ -152,6 +152,7 @@ export {
   useRouteData,
   useSearchParams,
   PrachtRuntimeProvider,
+  type ReadonlyURLSearchParams,
 } from "./runtime.ts";
 export { prefetch, type PrefetchFn } from "./prefetch-api.ts";
 export { prerenderApp } from "./prerender.ts";

--- a/packages/framework/src/router.ts
+++ b/packages/framework/src/router.ts
@@ -1,6 +1,7 @@
 import { createContext, h } from "preact";
 import { hydrate, render } from "preact";
 import { useContext, useLayoutEffect, useMemo, useState } from "preact/hooks";
+import type { StateUpdater } from "preact/hooks";
 import type { FunctionComponent } from "preact";
 
 import { buildHrefUntyped, matchResolvedRoute } from "./route-matching.ts";
@@ -11,7 +12,7 @@ import {
   scrollToFragmentTarget,
 } from "./fragment-navigation.ts";
 import { installHydrationMismatchWarning } from "./hydration-mismatch.ts";
-import { markHydrating } from "./hydration.ts";
+import { markHydrating, onHydrationComplete } from "./hydration.ts";
 import {
   beginLoadingNavigation,
   createNavigationLocation,
@@ -97,6 +98,7 @@ interface BrowserRouteTarget {
   browserUrl: string;
   pathname: string;
   requestUrl: string;
+  search: string;
 }
 
 const NavigateContext = createContext<NavigateFn>(async () => {});
@@ -145,7 +147,7 @@ export async function initClientRouter(options: InitClientRouterOptions): Promis
     return loadModule(shellModules, shellKey);
   }
 
-  let updateRouteState: ((state: RouteRenderState) => void) | null = null;
+  let updateRouteState: ((state: StateUpdater<RouteRenderState>) => void) | null = null;
   let routeStateVersion = 0;
   let latestNavigationId = 0;
   let activeNavigationAbort: AbortController | null = null;
@@ -630,15 +632,16 @@ export async function initClientRouter(options: InitClientRouterOptions): Promis
     }
   }
 
-  // Prerendered SSG state carries the URL used at build time. Keep its route
-  // identity and data, but resolve the initial browser route from the URL the
-  // visitor actually requested so query parameters and fragments are present
-  // from the first hydrated render.
-  const initialLocation = window.location.pathname + window.location.search + window.location.hash;
-  const initialTarget = resolveBrowserRouteTarget(initialLocation);
+  // The serialized URL produced the server/static HTML, so it must also drive
+  // the first client render. Visitor-specific query parameters are published
+  // after the complete hydration tree settles to keep that render identical.
+  const initialTarget = resolveBrowserRouteTarget(options.initialState.url);
   const initialRequestUrl = initialTarget?.requestUrl ?? options.initialState.url;
   const initialBrowserUrl = initialTarget?.browserUrl ?? options.initialState.url;
   const initialPathname = initialTarget?.pathname ?? options.initialState.url;
+  const hydrationBrowserTarget = resolveBrowserRouteTarget(
+    window.location.pathname + window.location.search + window.location.hash,
+  );
   // The not-found page is served at a URL that matches no route, so matching
   // cannot find it — the hydration state's reserved route id does.
   const initialMatch =
@@ -721,6 +724,28 @@ export async function initClientRouter(options: InitClientRouterOptions): Promis
         } else {
           markHydrating();
           hydrate(h(RouterRoot, { initialState: initialRouteState }), root);
+          onHydrationComplete(() => {
+            if (!hydrationBrowserTarget || !updateRouteState) return;
+
+            updateRouteState((currentState) => {
+              const hydratedTarget = resolveBrowserRouteTarget(currentState.url);
+              if (!hydratedTarget) return currentState;
+              const nextRequestUrl = hydratedTarget.pathname + hydrationBrowserTarget.search;
+              // A navigation that committed while a Suspense boundary was
+              // hydrating owns the newer state. Revalidated data lives in the
+              // runtime provider and survives this URL-only update.
+              if (
+                currentState.version !== initialRouteState.version ||
+                currentState.url === nextRequestUrl
+              ) {
+                return currentState;
+              }
+              return {
+                ...currentState,
+                url: nextRequestUrl,
+              };
+            });
+          });
         }
       }
     }
@@ -952,6 +977,7 @@ function resolveBrowserRouteTarget(to: string): BrowserRouteTarget | null {
       browserUrl: url.pathname + url.search + url.hash,
       pathname: url.pathname,
       requestUrl: url.pathname + url.search,
+      search: url.search,
     };
   } catch {
     return null;

--- a/packages/framework/src/router.ts
+++ b/packages/framework/src/router.ts
@@ -630,7 +630,12 @@ export async function initClientRouter(options: InitClientRouterOptions): Promis
     }
   }
 
-  const initialTarget = resolveBrowserRouteTarget(options.initialState.url);
+  // Prerendered SSG state carries the URL used at build time. Keep its route
+  // identity and data, but resolve the initial browser route from the URL the
+  // visitor actually requested so query parameters and fragments are present
+  // from the first hydrated render.
+  const initialLocation = window.location.pathname + window.location.search + window.location.hash;
+  const initialTarget = resolveBrowserRouteTarget(initialLocation);
   const initialRequestUrl = initialTarget?.requestUrl ?? options.initialState.url;
   const initialBrowserUrl = initialTarget?.browserUrl ?? options.initialState.url;
   const initialPathname = initialTarget?.pathname ?? options.initialState.url;

--- a/packages/framework/src/runtime-context.ts
+++ b/packages/framework/src/runtime-context.ts
@@ -69,11 +69,11 @@ export function PrachtRuntimeProvider<TData>({
   }));
   // A new route state (navigation) supersedes anything committed for the
   // previous one. This is derived during render rather than reset from an
-  // effect so it cannot lag behind the props.
+  // effect so it cannot lag behind the props. A URL-only update within the
+  // same route state (publishing the browser query after hydration) preserves
+  // locally revalidated data.
   const isStaleRoute =
-    routeDataState.stateVersion !== stateVersion ||
-    routeDataState.routeId !== routeId ||
-    routeDataState.url !== url;
+    routeDataState.stateVersion !== stateVersion || routeDataState.routeId !== routeId;
   const routeData = isStaleRoute ? data : routeDataState.data;
 
   const context = useMemo(
@@ -108,14 +108,17 @@ export function PrachtRuntimeProvider<TData>({
   // a revalidation has already committed newer data, and comparing against the
   // source the commit was made from keeps it from overwriting that.
   useEffect(() => {
-    setRouteDataState((current) =>
-      current.source === data &&
-      current.stateVersion === stateVersion &&
-      current.routeId === routeId &&
-      current.url === url
-        ? current
-        : { data, routeId, source: data, stateVersion, url },
-    );
+    setRouteDataState((current) => {
+      if (
+        current.source !== data ||
+        current.stateVersion !== stateVersion ||
+        current.routeId !== routeId
+      ) {
+        return { data, routeId, source: data, stateVersion, url };
+      }
+
+      return current.url === url ? current : { ...current, url };
+    });
   }, [data, routeId, stateVersion, url]);
 
   // Effect-driven revalidation: capabilities are effect-classed, so the

--- a/packages/framework/src/runtime-hooks.ts
+++ b/packages/framework/src/runtime-hooks.ts
@@ -142,6 +142,29 @@ export interface Location {
   search: string;
 }
 
+export type ReadonlyURLSearchParams = Omit<URLSearchParams, "append" | "delete" | "set" | "sort">;
+
+class PrachtReadonlyURLSearchParams extends URLSearchParams {
+  readonly #mutationError =
+    "useSearchParams() is read-only. Navigate to a new URL to change the query string.";
+
+  override append(_name: string, _value: string): never {
+    throw new TypeError(this.#mutationError);
+  }
+
+  override delete(_name: string, _value?: string): never {
+    throw new TypeError(this.#mutationError);
+  }
+
+  override set(_name: string, _value: string): never {
+    throw new TypeError(this.#mutationError);
+  }
+
+  override sort(): never {
+    throw new TypeError(this.#mutationError);
+  }
+}
+
 export function useRouteData<TRoute extends RouteId>(routeId: TRoute): RouteDataFor<TRoute>;
 export function useRouteData<TLoader extends LoaderLike>(): LoaderData<TLoader>;
 export function useRouteData<TData = unknown>(): TData;
@@ -163,9 +186,9 @@ export function useLocation(): Location {
 }
 
 /** Read the current URL search parameters reactively. */
-export function useSearchParams(): URLSearchParams {
+export function useSearchParams(): ReadonlyURLSearchParams {
   const { search } = useLocation();
-  return useMemo(() => new URLSearchParams(search), [search]);
+  return useMemo(() => new PrachtReadonlyURLSearchParams(search), [search]);
 }
 
 export function useParams(): RouteParams {

--- a/packages/framework/src/runtime-hooks.ts
+++ b/packages/framework/src/runtime-hooks.ts
@@ -1,6 +1,6 @@
 import { h } from "preact";
 import type { JSX } from "preact";
-import { useContext, useEffect, useState } from "preact/hooks";
+import { useContext, useEffect, useMemo, useState } from "preact/hooks";
 import type { StandardSchemaV1 } from "@standard-schema/spec";
 
 import {
@@ -160,6 +160,12 @@ export function useLocation(): Location {
     useContext(RouteDataContext)?.url ??
     (typeof window !== "undefined" ? window.location.pathname + window.location.search : "/");
   return parseLocation(url);
+}
+
+/** Read the current URL search parameters reactively. */
+export function useSearchParams(): URLSearchParams {
+  const { search } = useLocation();
+  return useMemo(() => new URLSearchParams(search), [search]);
 }
 
 export function useParams(): RouteParams {

--- a/packages/framework/src/runtime.ts
+++ b/packages/framework/src/runtime.ts
@@ -1173,6 +1173,7 @@ export {
   useParams,
   useRevalidate,
   useRouteData,
+  useSearchParams,
   type FormProps,
   type LinkProps,
   type Location,

--- a/packages/framework/src/runtime.ts
+++ b/packages/framework/src/runtime.ts
@@ -1180,6 +1180,7 @@ export {
   type Navigation,
   type NavigationLocation,
   type PrachtHydrationState,
+  type ReadonlyURLSearchParams,
   type StartAppOptions,
 } from "./runtime-hooks.ts";
 export {

--- a/packages/framework/test/hydration.test.ts
+++ b/packages/framework/test/hydration.test.ts
@@ -3,7 +3,12 @@ import { h, hydrate, render } from "preact";
 import { Suspense } from "preact-suspense";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
-import { markHydrating, useIsHydrated, _resetForTesting } from "../src/hydration.ts";
+import {
+  markHydrating,
+  onHydrationComplete,
+  useIsHydrated,
+  _resetForTesting,
+} from "../src/hydration.ts";
 
 let scratch: HTMLDivElement;
 
@@ -64,6 +69,41 @@ describe("useIsHydrated", () => {
     await flush();
 
     expect(values[values.length - 1]).toBe(true);
+  });
+
+  it("runs completion callbacks only after hydration suspensions settle", async () => {
+    scratch.innerHTML = "<div><div>Hello</div></div>";
+    let resolvePromise!: () => void;
+    const promise = new Promise<void>((resolve) => {
+      resolvePromise = resolve;
+    });
+    let threw = false;
+    let completionCount = 0;
+
+    function LazyChild() {
+      if (!threw) {
+        threw = true;
+        throw promise;
+      }
+      return h("div", null, "Hello");
+    }
+
+    function App() {
+      return h(Suspense as any, { fallback: null }, h(LazyChild, null));
+    }
+
+    markHydrating();
+    hydrate(h(App, null), scratch);
+    onHydrationComplete(() => {
+      completionCount++;
+    });
+
+    await flush();
+    expect(completionCount).toBe(0);
+
+    resolvePromise();
+    await flush();
+    expect(completionCount).toBe(1);
   });
 
   it("returns false when markHydrating was never called", () => {

--- a/packages/framework/test/router-client.test.ts
+++ b/packages/framework/test/router-client.test.ts
@@ -15,6 +15,7 @@ import {
   useNavigate,
   useRevalidate,
   useRouteData,
+  useSearchParams,
 } from "../src/index.ts";
 
 function createJsonResponse(body: unknown, init?: ResponseInit): Response {
@@ -57,6 +58,7 @@ describe("initClientRouter", () => {
   });
 
   it("renders shell-less SPA routes after the pending bootstrap fetch resolves", async () => {
+    history.replaceState(null, "", "/settings");
     const app = resolveApp(
       defineApp({
         routes: [route("/settings", "./routes/settings.tsx", { render: "spa" })],
@@ -94,6 +96,50 @@ describe("initClientRouter", () => {
       }),
     );
     expect(root.textContent).toContain("Hello Jovi");
+  });
+
+  it("uses the visitor URL with prerendered route identity and data on startup", async () => {
+    history.replaceState(null, "", "/products?lang=zh&example=router#details");
+    let observedSearch: URLSearchParams | undefined;
+
+    function Products({ data }: { data: { label: string } }) {
+      observedSearch = useSearchParams();
+      return h("main", null, data.label);
+    }
+
+    const app = resolveApp(
+      defineApp({
+        routes: [
+          route("/products", "./routes/products.tsx", {
+            id: "products",
+            render: "ssg",
+          }),
+        ],
+      }),
+    );
+
+    root.innerHTML = "<main>prerendered</main>";
+
+    await initClientRouter({
+      app,
+      routeModules: {
+        "./routes/products.tsx": async () => ({ default: Products }),
+      },
+      shellModules: {},
+      initialState: {
+        data: { label: "prerendered" },
+        routeId: "products",
+        url: "/products",
+      },
+      root,
+      findModuleKey: (_modules, file) => file,
+    });
+
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(root.textContent).toBe("prerendered");
+    expect(observedSearch?.get("lang")).toBe("zh");
+    expect(observedSearch?.get("example")).toBe("router");
+    expect(window.location.hash).toBe("#details");
   });
 
   it("renders typed links and navigates by route target objects", async () => {

--- a/packages/framework/test/router-client.test.ts
+++ b/packages/framework/test/router-client.test.ts
@@ -7,6 +7,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   Form,
   Link,
+  Suspense,
   defineApp,
   initClientRouter,
   resolveApp,
@@ -17,6 +18,7 @@ import {
   useRouteData,
   useSearchParams,
 } from "../src/index.ts";
+import { _resetForTesting } from "../src/hydration.ts";
 
 function createJsonResponse(body: unknown, init?: ResponseInit): Response {
   return new Response(JSON.stringify(body), {
@@ -38,6 +40,7 @@ describe("initClientRouter", () => {
   let fetchSpy: ReturnType<typeof vi.fn>;
 
   beforeEach(() => {
+    _resetForTesting();
     document.body.innerHTML = "";
     root = document.createElement("div");
     document.body.appendChild(root);
@@ -98,13 +101,19 @@ describe("initClientRouter", () => {
     expect(root.textContent).toContain("Hello Jovi");
   });
 
-  it("uses the visitor URL with prerendered route identity and data on startup", async () => {
+  it("publishes the visitor query after hydrating with prerendered route state", async () => {
     history.replaceState(null, "", "/products?lang=zh&example=router#details");
-    let observedSearch: URLSearchParams | undefined;
+    const observedLanguages: Array<string | null> = [];
 
     function Products({ data }: { data: { label: string } }) {
-      observedSearch = useSearchParams();
-      return h("main", null, data.label);
+      const searchParams = useSearchParams();
+      const language = searchParams.get("lang");
+      observedLanguages.push(language);
+      return h(
+        "main",
+        null,
+        language === "zh" ? h("span", null, `${data.label}: zh`) : `${data.label}: en`,
+      );
     }
 
     const app = resolveApp(
@@ -118,7 +127,7 @@ describe("initClientRouter", () => {
       }),
     );
 
-    root.innerHTML = "<main>prerendered</main>";
+    root.innerHTML = "<main>prerendered: en</main>";
 
     await initClientRouter({
       app,
@@ -136,10 +145,161 @@ describe("initClientRouter", () => {
     });
 
     expect(fetchSpy).not.toHaveBeenCalled();
-    expect(root.textContent).toBe("prerendered");
-    expect(observedSearch?.get("lang")).toBe("zh");
-    expect(observedSearch?.get("example")).toBe("router");
+    expect(observedLanguages[0]).toBeNull();
+    await flush();
+    expect(root.textContent).toBe("prerendered: zh");
+    expect(observedLanguages).toContain("zh");
+    expect(document.getElementById("__pracht_hydration_mismatch__")).toBeNull();
     expect(window.location.hash).toBe("#details");
+  });
+
+  it("preserves revalidated data when publishing the visitor query after Suspense hydration", async () => {
+    history.replaceState(null, "", "/dashboard?lang=zh");
+    let resolveSuspense!: () => void;
+    const pending = new Promise<void>((resolve) => {
+      resolveSuspense = resolve;
+    });
+    let suspended = false;
+
+    function LazyChild() {
+      if (!suspended) {
+        suspended = true;
+        throw pending;
+      }
+      return h("div", null, "ready");
+    }
+
+    function Dashboard() {
+      const data = useRouteData<{ count: number }>();
+      const revalidate = useRevalidate();
+      const searchParams = useSearchParams();
+      return h(
+        "main",
+        null,
+        h("span", { id: "count" }, String(data.count)),
+        h("span", { id: "lang" }, searchParams.get("lang") ?? "none"),
+        h("button", { id: "refresh", onClick: () => void revalidate() }, "Refresh"),
+        h(Suspense as any, { fallback: null }, h(LazyChild, null)),
+      );
+    }
+
+    const app = resolveApp(
+      defineApp({
+        routes: [
+          route("/dashboard", "./routes/dashboard.tsx", {
+            id: "dashboard",
+            render: "ssg",
+          }),
+        ],
+      }),
+    );
+
+    root.innerHTML =
+      '<main><span id="count">1</span><span id="lang">none</span><button id="refresh">Refresh</button><div>ready</div></main>';
+    fetchSpy.mockResolvedValue(createJsonResponse({ data: { count: 2 } }));
+
+    await initClientRouter({
+      app,
+      routeModules: {
+        "./routes/dashboard.tsx": async () => ({ default: Dashboard }),
+      },
+      shellModules: {},
+      initialState: {
+        data: { count: 1 },
+        routeId: "dashboard",
+        url: "/dashboard",
+      },
+      root,
+      findModuleKey: (_modules, file) => file,
+    });
+
+    root.querySelector<HTMLButtonElement>("#refresh")!.click();
+    await flush();
+    expect(root.querySelector("#count")?.textContent).toBe("2");
+
+    resolveSuspense();
+    await flush();
+    await flush();
+
+    expect(root.querySelector("#lang")?.textContent).toBe("zh");
+    expect(root.querySelector("#count")?.textContent).toBe("2");
+  });
+
+  it("does not publish an in-flight destination query into the previous route", async () => {
+    history.replaceState(null, "", "/dashboard");
+    let resolveSuspense!: () => void;
+    const pending = new Promise<void>((resolve) => {
+      resolveSuspense = resolve;
+    });
+    let suspended = false;
+
+    function LazyChild() {
+      if (!suspended) {
+        suspended = true;
+        throw pending;
+      }
+      return h("div", null, "ready");
+    }
+
+    function Home() {
+      const searchParams = useSearchParams();
+      return h(
+        "main",
+        null,
+        h("span", { id: "page" }, `home:${searchParams.get("lang") ?? "none"}`),
+        h(Suspense as any, { fallback: null }, h(LazyChild, null)),
+      );
+    }
+
+    function Next() {
+      const searchParams = useSearchParams();
+      return h(
+        "main",
+        null,
+        h("span", { id: "page" }, `next:${searchParams.get("lang") ?? "none"}`),
+      );
+    }
+
+    const app = resolveApp(
+      defineApp({
+        routes: [
+          route("/dashboard", "./routes/dashboard.tsx", { id: "home", render: "ssg" }),
+          route("/next", "./routes/next.tsx", { id: "next", render: "ssg" }),
+        ],
+      }),
+    );
+    let releaseNextModule!: () => void;
+    const nextModule = new Promise<{ default: typeof Next }>((resolve) => {
+      releaseNextModule = () => resolve({ default: Next });
+    });
+
+    root.innerHTML = '<main><span id="page">home:none</span><div>ready</div></main>';
+    fetchSpy.mockResolvedValue(createJsonResponse({ data: null }));
+    await initClientRouter({
+      app,
+      routeModules: {
+        "./routes/dashboard.tsx": async () => ({ default: Home }),
+        "./routes/next.tsx": () => nextModule,
+      },
+      shellModules: {},
+      initialState: { data: null, routeId: "home", url: "/dashboard" },
+      root,
+      findModuleKey: (_modules, file) => file,
+    });
+
+    const navigation = window.__PRACHT_NAVIGATE__!("/next?lang=fr");
+    await new Promise<void>((resolve) => setTimeout(resolve, 0));
+    expect(window.location.pathname).toBe("/next");
+
+    resolveSuspense();
+    await flush();
+    await flush();
+    expect(root.querySelector("#page")?.textContent).toBe("home:none");
+
+    releaseNextModule();
+    await navigation;
+    await flush();
+    expect(root.querySelector("#page")?.textContent).toBe("next:fr");
   });
 
   it("renders typed links and navigates by route target objects", async () => {

--- a/packages/framework/test/runtime-context.test.ts
+++ b/packages/framework/test/runtime-context.test.ts
@@ -1,10 +1,11 @@
 // @vitest-environment jsdom
 import { Component, h, render } from "preact";
 import type { ComponentChildren } from "preact";
-import { useState } from "preact/hooks";
+import { useContext, useState } from "preact/hooks";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
-import { PrachtRuntimeProvider, useLocation } from "../src/index.ts";
+import { PrachtRuntimeProvider, useLocation, useRouteData } from "../src/index.ts";
+import { RouteDataContext } from "../src/runtime-context.ts";
 
 let scratch: HTMLDivElement;
 
@@ -69,5 +70,40 @@ describe("PrachtRuntimeProvider", () => {
     await flush();
 
     expect(consumerRenders).toBe(1);
+  });
+
+  it("preserves locally revalidated data across a URL-only update", async () => {
+    const initialData = { count: 1 };
+    let revalidate!: () => void;
+    let publishUrl!: () => void;
+
+    function Consumer() {
+      const data = useRouteData<{ count: number }>();
+      const location = useLocation();
+      const runtime = useContext(RouteDataContext)!;
+      revalidate = () => runtime.setData({ count: 2 });
+      return h("span", null, `${data.count}|${location.search}`);
+    }
+
+    function App() {
+      const [url, setUrl] = useState("/dashboard");
+      publishUrl = () => setUrl("/dashboard?lang=zh");
+      return h(PrachtRuntimeProvider, {
+        children: h(Consumer, null),
+        data: initialData,
+        routeId: "dashboard",
+        stateVersion: 1,
+        url,
+      });
+    }
+
+    render(h(App, null), scratch);
+    revalidate();
+    await flush();
+    expect(scratch.textContent).toBe("2|");
+
+    publishUrl();
+    await flush();
+    expect(scratch.textContent).toBe("2|?lang=zh");
   });
 });

--- a/packages/framework/test/runtime.test.ts
+++ b/packages/framework/test/runtime.test.ts
@@ -1730,6 +1730,38 @@ describe("useLocation", () => {
     expect(response.status).toBe(200);
     await expect(response.text()).resolves.toContain("team|a,b");
   });
+
+  it("returns a read-only search params view", async () => {
+    const app = defineApp({
+      routes: [route("/about", "./routes/about.tsx", { render: "ssr" })],
+    });
+    let observedSearchParams: ReturnType<typeof useSearchParams> | undefined;
+
+    const response = await handlePrachtRequest({
+      app,
+      registry: {
+        routeModules: {
+          "./routes/about.tsx": async () => ({
+            Component: () => {
+              observedSearchParams = useSearchParams();
+              return h("main", null, observedSearchParams.get("tab"));
+            },
+          }),
+        },
+      },
+      request: new Request("http://localhost/about?tab=team"),
+    });
+
+    expect(response.status).toBe(200);
+    expect(observedSearchParams?.get("tab")).toBe("team");
+    expect(() => (observedSearchParams as URLSearchParams).set("tab", "other")).toThrow(
+      /read-only/,
+    );
+
+    type SearchParamsHasSet = "set" extends keyof ReturnType<typeof useSearchParams> ? true : false;
+    const searchParamsHasSet: SearchParamsHasSet = false;
+    expect(searchParamsHasSet).toBe(false);
+  });
 });
 
 describe("handlePrachtRequest ErrorBoundary", () => {

--- a/packages/framework/test/runtime.test.ts
+++ b/packages/framework/test/runtime.test.ts
@@ -13,6 +13,7 @@ import {
   timeRevalidate,
   useLocation,
   useParams,
+  useSearchParams,
 } from "../src/index.ts";
 
 function parseHydrationState(html: string) {
@@ -1702,6 +1703,32 @@ describe("useLocation", () => {
     expect(response.status).toBe(200);
     const html = await response.text();
     expect(html).toContain("/about|?tab=team");
+  });
+
+  it("provides URLSearchParams during SSR", async () => {
+    const app = defineApp({
+      routes: [route("/about", "./routes/about.tsx", { render: "ssr" })],
+    });
+
+    function SearchDisplay() {
+      const searchParams = useSearchParams();
+      return h("span", null, `${searchParams.get("tab")}|${searchParams.getAll("tag").join(",")}`);
+    }
+
+    const response = await handlePrachtRequest({
+      app,
+      registry: {
+        routeModules: {
+          "./routes/about.tsx": async () => ({
+            Component: () => h("main", null, h(SearchDisplay, null)),
+          }),
+        },
+      },
+      request: new Request("http://localhost/about?tab=team&tag=a&tag=b"),
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.text()).resolves.toContain("team|a,b");
   });
 });
 

--- a/skills/migrate-nextjs/SKILL.md
+++ b/skills/migrate-nextjs/SKILL.md
@@ -78,7 +78,7 @@ For pages router projects, you can **skip manual manifest wiring entirely** (Pha
 | `"use client"` (few, in a mostly-server app) | `hydration: "islands"` + `src/islands/`            | Only islands ship JS; see the islands note in Phase 4                 |
 | `revalidatePath` / `res.revalidate()` | `webhookRevalidate()` + `POST /__pracht/revalidate`       | On-demand ISG regeneration; combinable with `timeRevalidate(seconds)` |
 | `useRouter()` (next/navigation) | `useNavigate()` from pracht                                     | Accepts paths or typed route targets after `pracht typegen`           |
-| `useSearchParams()`             | `useSearchParams()` from pracht                                 | Returns a reactive `URLSearchParams`; loaders also receive `url.searchParams` |
+| `useSearchParams()`             | `useSearchParams()` from pracht                                 | Returns reactive read-only params; SSG receives the browser query after hydration, while loaders use `url.searchParams` |
 | `useParams()`                   | `useParams()` from pracht                                       | Direct equivalent; also available as `params` in loader args          |
 | `next/link` `<Link>`            | `<Link route="...">` or plain `<a>`                            | Prefer typed `<Link>` for known app routes after `pracht typegen`; plain anchors still work |
 | `next/link` `prefetch={false}`  | `<Link prefetch="none">`                                        | Pracht prefetches on hover/focus by default; also `"viewport"`, `"render"` |

--- a/skills/migrate-nextjs/SKILL.md
+++ b/skills/migrate-nextjs/SKILL.md
@@ -78,7 +78,7 @@ For pages router projects, you can **skip manual manifest wiring entirely** (Pha
 | `"use client"` (few, in a mostly-server app) | `hydration: "islands"` + `src/islands/`            | Only islands ship JS; see the islands note in Phase 4                 |
 | `revalidatePath` / `res.revalidate()` | `webhookRevalidate()` + `POST /__pracht/revalidate`       | On-demand ISG regeneration; combinable with `timeRevalidate(seconds)` |
 | `useRouter()` (next/navigation) | `useNavigate()` from pracht                                     | Accepts paths or typed route targets after `pracht typegen`           |
-| `useSearchParams()`             | `useLocation()` from pracht                                     | Returns `{ pathname, search }`; loaders also receive `url` with searchParams |
+| `useSearchParams()`             | `useSearchParams()` from pracht                                 | Returns a reactive `URLSearchParams`; loaders also receive `url.searchParams` |
 | `useParams()`                   | `useParams()` from pracht                                       | Direct equivalent; also available as `params` in loader args          |
 | `next/link` `<Link>`            | `<Link route="...">` or plain `<a>`                            | Prefer typed `<Link>` for known app routes after `pracht typegen`; plain anchors still work |
 | `next/link` `prefetch={false}`  | `<Link prefetch="none">`                                        | Pracht prefetches on hover/focus by default; also `"viewport"`, `"render"` |


### PR DESCRIPTION
## Summary

- Initialize the client router from the actual browser pathname, search, and hash while preserving prerendered SSG route identity and loader data.
- Add a public reactive `useSearchParams()` hook with SSR/SSG regression coverage and synchronized framework, example, and migration documentation.
- Issue: N/A.

## Testing

- [x] `pnpm run verify` (build, format, lint, typecheck, test, e2e)

## Checklist

- [x] Docs updated if needed
- [x] Skills updated if needed
- [x] Changeset added if published packages changed
