### PR TITLE
Add Netlify deployment adapter

### DIFF
--- a/.changeset/fresh-caches-bloom.md
+++ b/.changeset/fresh-caches-bloom.md
@@ -10,7 +10,8 @@ Add a first-party Netlify Functions v2 deployment adapter.
 The adapter emits a catch-all function that preserves Markdown negotiation and
 route-state requests, serves bundled SSG output, maps ISG to Netlify durable CDN
 caching, preserves explicit cache policies, collapses unrelated page query
-parameters, and purges webhook-revalidated paths through cache tags.
+parameters, purges webhook-revalidated paths through cache tags, and strips
+visitor-specific request and Netlify context data before shared ISG rendering.
 `create-pracht` can scaffold the adapter with `netlify.toml`, local preview,
 and deployment scripts, while `pracht preview` detects Netlify projects and
 points to `pracht build && netlify dev` instead of trying to run their function

--- a/.changeset/fresh-caches-bloom.md
+++ b/.changeset/fresh-caches-bloom.md
@@ -1,6 +1,7 @@
 ---
 "@pracht/adapter-netlify": minor
 "@pracht/cli": patch
+"@pracht/core": patch
 "create-pracht": minor
 ---
 
@@ -8,8 +9,10 @@ Add a first-party Netlify Functions v2 deployment adapter.
 
 The adapter emits a catch-all function that preserves Markdown negotiation and
 route-state requests, serves bundled SSG output, maps ISG to Netlify durable CDN
-caching, and purges webhook-revalidated paths through cache tags. `create-pracht`
-can scaffold the adapter with `netlify.toml`, local preview, and deployment
-scripts, while `pracht preview` detects Netlify projects and points to
-`pracht build && netlify dev` instead of trying to run their function as a Node
-server.
+caching, preserves explicit cache policies, collapses unrelated page query
+parameters, and purges webhook-revalidated paths through cache tags.
+`create-pracht` can scaffold the adapter with `netlify.toml`, local preview,
+and deployment scripts, while `pracht preview` detects Netlify projects and
+points to `pracht build && netlify dev` instead of trying to run their function
+as a Node server. The shared cache-safety guard now also recognizes Netlify's
+targeted cache-control header as an explicit application policy.

--- a/.changeset/fresh-caches-bloom.md
+++ b/.changeset/fresh-caches-bloom.md
@@ -1,0 +1,15 @@
+---
+"@pracht/adapter-netlify": minor
+"@pracht/cli": patch
+"create-pracht": minor
+---
+
+Add a first-party Netlify Functions v2 deployment adapter.
+
+The adapter emits a catch-all function that preserves Markdown negotiation and
+route-state requests, serves bundled SSG output, maps ISG to Netlify durable CDN
+caching, and purges webhook-revalidated paths through cache tags. `create-pracht`
+can scaffold the adapter with `netlify.toml`, local preview, and deployment
+scripts, while `pracht preview` detects Netlify projects and points to
+`pracht build && netlify dev` instead of trying to run their function as a Node
+server.

--- a/.oxfmtrc.json
+++ b/.oxfmtrc.json
@@ -1,5 +1,6 @@
 {
   "$schema": "./node_modules/oxfmt/configuration_schema.json",
+  "useTabs": false,
   "ignorePatterns": [
     ".context/**",
     "**/*.md",

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 **Full-stack Preact, per route.** _(pracht /praxt/ — Dutch & German for splendor. Also: how you've always mispronounced Preact.)_
 
-Pick SPA, SSR, SSG, or ISG on a route-by-route basis. Ship less JavaScript by default. Deploy the same codebase to Node, Cloudflare, or Vercel.
+Pick SPA, SSR, SSG, or ISG on a route-by-route basis. Ship less JavaScript by default. Deploy the same codebase to Node, Cloudflare, Netlify, or Vercel.
 
 ```bash
 npm create pracht@latest my-app
@@ -28,7 +28,7 @@ npm create pracht@latest my-app
 - **Explicit over magic** — a typed `defineApp()` manifest wires routes, shells, and middleware. What runs where is never a mystery. Prefer file-based routing? Opt in to the pages router and skip the manifest entirely.
 - **Vite-native** — instant HMR, fast builds, multi-environment output out of the box.
 - **Performance budgets built in** — `pracht build --analyze` reports per-route client JS (gzip + raw), and per-route `budgets` fail the build when a route ships too much.
-- **Deploy anywhere** — one codebase, one build, three production-ready adapters (Node, Cloudflare Workers, Vercel).
+- **Deploy anywhere** — one codebase, one build, four production-ready adapters (Node, Cloudflare Workers, Netlify, Vercel).
 - **Env safety built in** — typed `serverEnv`/`publicEnv` helpers with a `PRACHT_PUBLIC_` prefix rule, and builds fail when client bundles reference non-public env vars.
 
 ## At a glance
@@ -149,7 +149,7 @@ The skills are distributed three ways (see the [catalog](skills/README.md)):
 - [docs/CAPABILITY_GRAPH.md](docs/CAPABILITY_GRAPH.md) — the capability graph product bet: proposal, decision log, staged plan
 - [docs/LLMS_TXT.md](docs/LLMS_TXT.md) — generated llms.txt: pages, API endpoints, capabilities
 - [docs/STYLING.md](docs/STYLING.md) — CSS Modules, Tailwind, CSS-in-JS limitations
-- [docs/ADAPTERS.md](docs/ADAPTERS.md) — Node, Cloudflare, Vercel deployment paths
+- [docs/ADAPTERS.md](docs/ADAPTERS.md) — Node, Cloudflare, Netlify, Vercel deployment paths
 - [docs/IMAGES.md](docs/IMAGES.md) — responsive `<Image>` component, loaders, optimization endpoint
 - [docs/MCP.md](docs/MCP.md) — built-in MCP server for coding agents (development time)
 - [docs/AGENT_WORKFLOW.md](docs/AGENT_WORKFLOW.md) — constraints, app-graph snapshots, `pracht plan`/`report`

--- a/VISION_MVP.md
+++ b/VISION_MVP.md
@@ -169,11 +169,12 @@ from `@pracht/capabilities`:
 
 Platform adapters export a request handler shaped for their runtime:
 
-| Adapter              | Runtime           | Notes                                |
-| -------------------- | ----------------- | ------------------------------------ |
-| `adapter-node`       | Node.js `http`    | Static file serving, ISG mtime check |
+| Adapter              | Runtime           | Notes                                                     |
+| -------------------- | ----------------- | --------------------------------------------------------- |
+| `adapter-node`       | Node.js `http`    | Static file serving, ISG mtime check                      |
 | `adapter-cloudflare` | Workers `fetch`   | `env.ASSETS`, Cache API-backed ISG, opt-in Workers Caching |
-| `adapter-vercel`     | Serverless / Edge | Build Output API v3 + native ISR     |
+| `adapter-netlify`    | Functions v2      | Durable CDN caching and tag-based ISG purges              |
+| `adapter-vercel`     | Serverless / Edge | Build Output API v3 + native ISR                          |
 
 Each adapter:
 
@@ -249,7 +250,7 @@ SSR and SSG, deployed to Node. Thoroughly tested with Playwright E2E tests.
 4. **`packages/cli`** — developer tooling (instant local DX)
    - `pracht dev` — one command, instant Vite dev server with HMR
    - `pracht build` — production build with clear output
-   - Node targets run the production build with `node dist/server/server.js`; Cloudflare and Vercel use their platform CLIs
+   - Node targets run the production build with `node dist/server/server.js`; Cloudflare, Netlify, and Vercel use their platform CLIs
    - Zero config to start — sensible defaults, override when needed
    - Fast feedback loop: save a file → see the change instantly
 
@@ -272,6 +273,7 @@ pracht/
     vite-plugin/      # Vite integration, virtual modules, build
     adapter-node/     # Node.js server adapter
     adapter-cloudflare/  # Cloudflare Workers adapter
+    adapter-netlify/     # Netlify Functions v2 adapter
     adapter-vercel/      # Vercel Edge adapter
     cli/              # Dev/build/generate/inspect/verify/plan/report/doctor commands
     image/            # Responsive <Image> component + optimization loaders

--- a/docs/ADAPTERS.md
+++ b/docs/ADAPTERS.md
@@ -9,7 +9,7 @@ handling and pracht's Web Request/Response interface.
 ## Architecture
 
 ```
-Platform Request (e.g. Node IncomingMessage, CF Worker fetch)
+Platform Request (e.g. Node IncomingMessage, Worker/Function fetch)
   → Adapter converts to Web Request
   → Adapter checks: is this a static asset?
     → Yes: serve from dist/client/
@@ -711,6 +711,70 @@ export default {
 
 ---
 
+## Netlify Adapter
+
+`@pracht/adapter-netlify` emits a fetch-style Netlify Functions v2 handler and
+a generated catch-all wrapper under `netlify/functions/`. Set the site's
+publish directory to `dist/client` and its functions directory to
+`netlify/functions`:
+
+```typescript
+import { netlifyAdapter } from "@pracht/adapter-netlify";
+
+pracht({ adapter: netlifyAdapter() });
+```
+
+```toml
+[build]
+  command = "pnpm build"
+  publish = "dist/client"
+
+[functions]
+  directory = "netlify/functions"
+```
+
+The generated function claims page URLs, while `/assets/*` and `/_pracht/*`
+bypass it. This keeps `Accept: text/markdown` negotiation and route-state
+requests inside Pracht without charging a function invocation for hashed
+assets. Add application-specific static prefixes with
+`netlifyAdapter({ excludedPath: ["/images/*"] })`; do not exclude page URLs.
+
+### SSG and ISG
+
+- SSG documents are read from the bundled `dist/client` output and use
+  `Netlify-CDN-Cache-Control` with durable caching. Route and shell headers from
+  `headers-manifest.json` are applied before the response enters the cache.
+- ISG renders use a sanitized, pathname-only request. Their Pracht time policy
+  becomes the durable CDN `max-age`; stale-while-revalidate is configurable
+  with `staleWhileRevalidate`.
+- Webhook-capable ISG responses carry per-path `Netlify-Cache-Tag` values.
+  Authenticated `POST /__pracht/revalidate` requests purge those tags through
+  `@netlify/functions`.
+- SSR and API responses without an explicit policy get Pracht's fail-closed
+  `private, no-cache` default. Explicit public policies are also copied to
+  Netlify's durable cache header.
+
+Generated entries can import a context factory, and custom handlers can be
+created directly:
+
+```typescript
+import { createNetlifyHandler } from "@pracht/adapter-netlify";
+
+netlifyAdapter({
+  createContextFrom: "/src/server/context.ts",
+  functionName: "pracht",
+  staleWhileRevalidate: 86_400,
+  staticMaxAge: 604_800,
+});
+```
+
+The context factory receives `{ request, context }`, where `context` is
+Netlify's Functions v2 context. Build first, then use `netlify dev` for local
+platform testing; `pracht preview` does not emulate Netlify's Functions or CDN
+cache.
+
+---
+
 ## Vercel Adapter (Phase 2)
 
 ### `createVercelEdgeHandler(options)`
@@ -852,20 +916,21 @@ nginx reverse proxy — may apply RFC 9111 heuristic freshness to a `200` with n
 `Cache-Control`, and `Cookie` is not part of its cache key. Without the default,
 an authenticated SSR page or an API `GET` can be stored and replayed to a
 different user. That hazard belongs to "shared cache in front of an origin", not
-to any one platform, so Node, Cloudflare, and Vercel apply the identical default
+to any one platform, so Node, Cloudflare, Netlify, and Vercel apply the identical default
 through one shared implementation: an app hardened on one adapter keeps the
 protection when it moves to another.
 
 Untouched: anything that already declares a policy — route-state JSON, static
 assets, and your own `headers()` exports or middleware — including a
 CDN-targeted one (`CDN-Cache-Control`, `Cloudflare-CDN-Cache-Control`,
-`Vercel-CDN-Cache-Control`, `Surrogate-Control`). Also untouched:
+`Netlify-CDN-Cache-Control`, `Vercel-CDN-Cache-Control`, `Surrogate-Control`). Also untouched:
 non-`GET`/`HEAD` responses, protocol-switch (`101`) responses, and ISG
 documents.
 
 ISG is exempt deliberately. Those responses are stored and replayed by the
 platform — Vercel's prerender cache, the Node on-disk snapshot, Cloudflare's
-Cache API — so stamping `private, no-cache` would both defeat that cache and
+Cache API, or Netlify's durable cache — so stamping `private, no-cache` would
+both defeat that cache and
 make a route's headers depend on whether its snapshot exists yet. ISG responses
 carry `public, max-age=0, must-revalidate` instead.
 
@@ -883,10 +948,11 @@ export function headers() {
 
 Routes that export `markdown` answer `Accept: text/markdown` with their raw
 source instead of HTML (see [DATA_LOADING.md](DATA_LOADING.md)). Prerendered
-documents are served by the adapter before the framework runs, so the Node and
-Cloudflare adapters have to decide up front whether a cached document can answer
-a given request. Both require **two** conditions before skipping the static file
-(Node), the assets binding, or the edge cache (Cloudflare):
+documents are served by the adapter before the framework runs, so the Node,
+Cloudflare, and Netlify adapters have to decide up front whether a cached
+document can answer a given request. All three require **two** conditions before
+skipping the static file (Node and Netlify), the assets binding, or the edge
+cache (Cloudflare):
 
 1. the request prefers markdown over HTML — the same `prefersMarkdown()`
    negotiation the runtime uses, so `*/*`, `text/html,*/*`, and a q-weighted
@@ -903,8 +969,9 @@ the same guarantee even when the app has no prerendered documents.
 
 A `.md` file in `public/` is a different thing entirely: it is a plain static
 asset, copied to `dist/client/` by the build and served by content type, not by
-negotiation. Those files answer every request the same way: the Node adapter
-sends `Content-Type: text/markdown; charset=utf-8`, and on Cloudflare and Vercel
+negotiation. Those files answer every request the same way: the Node and
+Netlify adapters send `Content-Type: text/markdown; charset=utf-8`, and on
+Cloudflare and Vercel
 the platform's own asset layer types the file (the `ASSETS` binding and the
 static rewrite respectively, neither of which the adapter intercepts). This is
 the route to take for a corpus that is markdown all the way down (a skills

--- a/docs/ADAPTERS.md
+++ b/docs/ADAPTERS.md
@@ -746,9 +746,12 @@ assets. Add application-specific static prefixes with
   `headers-manifest.json` are applied before the response enters the cache. An
   explicit cache policy remains authoritative instead of being combined with
   Pracht's durable-cache default.
-- ISG renders use a sanitized, pathname-only request. Their Pracht time policy
-  becomes the durable CDN `max-age`; stale-while-revalidate is configurable
-  with `staleWhileRevalidate`. A cacheable custom policy remains authoritative.
+- ISG renders use a sanitized, pathname-only request and an allowlisted
+  Netlify context. Visitor cookies, IP/geolocation, request IDs, and arbitrary
+  request-local context are unavailable, while deployment-wide site/server
+  metadata and `waitUntil()` remain available. Their Pracht time policy becomes
+  the durable CDN `max-age`; stale-while-revalidate is configurable with
+  `staleWhileRevalidate`. A cacheable custom policy remains authoritative.
 - Cached SSG and ISG HTML sets `Netlify-Vary: query=_data`, so route-state
   transport stays distinct while unrelated query parameters collapse onto the
   pathname cache entry. A custom `Netlify-Vary` header takes precedence.

--- a/docs/ADAPTERS.md
+++ b/docs/ADAPTERS.md
@@ -743,11 +743,17 @@ assets. Add application-specific static prefixes with
 
 - SSG documents are read from the bundled `dist/client` output and use
   `Netlify-CDN-Cache-Control` with durable caching. Route and shell headers from
-  `headers-manifest.json` are applied before the response enters the cache.
+  `headers-manifest.json` are applied before the response enters the cache. An
+  explicit cache policy remains authoritative instead of being combined with
+  Pracht's durable-cache default.
 - ISG renders use a sanitized, pathname-only request. Their Pracht time policy
   becomes the durable CDN `max-age`; stale-while-revalidate is configurable
-  with `staleWhileRevalidate`.
-- Webhook-capable ISG responses carry per-path `Netlify-Cache-Tag` values.
+  with `staleWhileRevalidate`. A cacheable custom policy remains authoritative.
+- Cached SSG and ISG HTML sets `Netlify-Vary: query=_data`, so route-state
+  transport stays distinct while unrelated query parameters collapse onto the
+  pathname cache entry. A custom `Netlify-Vary` header takes precedence.
+- Cacheable webhook-capable ISG responses carry per-path
+  `Netlify-Cache-Tag` values, including responses with custom cache policies.
   Authenticated `POST /__pracht/revalidate` requests purge those tags through
   `@netlify/functions`.
 - SSR and API responses without an explicit policy get Pracht's fail-closed

--- a/docs/AGENT_TRUST.md
+++ b/docs/AGENT_TRUST.md
@@ -73,7 +73,7 @@ export const app = defineApp({
 ```
 
 The runtime (`handlePrachtRequest`) verifies once per request — all adapters
-(Node, Cloudflare, Vercel) share the implementation because it only uses Web
+(Node, Cloudflare, Netlify, Vercel) share the implementation because it only uses Web
 platform APIs (`Headers`, `fetch`, `crypto.subtle`; Ed25519 works on Node ≥
 20, Workers, and Vercel Edge). The result surfaces on the request context for
 middleware, loaders, API routes, and capability `run()`:

--- a/docs/CAPABILITIES.md
+++ b/docs/CAPABILITIES.md
@@ -220,7 +220,7 @@ With `expose.http` set, the capability is dispatched at
 `POST /api/capabilities/<name-with-dots-as-slashes>` (e.g. `notes.search` →
 `/api/capabilities/notes/search`), or at a custom `expose.http.path`. Dispatch
 happens in the framework's request handler, so every adapter (Node,
-Cloudflare, Vercel) gets it without adapter changes. Explicit files in
+Cloudflare, Netlify, Vercel) gets it without adapter changes. Explicit files in
 `src/api/` take precedence on path collisions.
 
 The app-level API middleware configured with

--- a/docs/ENV.md
+++ b/docs/ENV.md
@@ -92,6 +92,8 @@ to `Record<string, string | undefined>`.
 
 - **Node** (`@pracht/adapter-node`): resolves to `process.env`. Available at
   module top level.
+- **Netlify** (`@pracht/adapter-netlify`): resolves to `process.env`, populated
+  by the Netlify Functions runtime. Available at module top level.
 - **Vercel** (`@pracht/adapter-vercel`): resolves to `process.env`, which the
   Vercel runtime populates in both Node and edge functions. Available at module
   top level.

--- a/docs/LLMS_TXT.md
+++ b/docs/LLMS_TXT.md
@@ -46,7 +46,7 @@ when neither is set).
 
 ## What it does
 
-- **Build** — `pracht build` writes `dist/client/llms.txt`. All three adapters
+- **Build** — `pracht build` writes `dist/client/llms.txt`. All four adapters
   serve it as a regular static file: the Node handler and the Vercel Build
   Output `handle: filesystem` route pick it up directly, and the Cloudflare
   worker serves it through the `ASSETS` binding.

--- a/docs/OPENAPI.md
+++ b/docs/OPENAPI.md
@@ -37,7 +37,7 @@ This reserves two paths while enabled:
 
 Both paths are live in the normal Vite development server. `pracht build`
 writes the equivalent static files to `dist/client/openapi.json` and, when the
-UI is enabled, `dist/client/docs/index.html`. Node, Cloudflare, and Vercel then
+UI is enabled, `dist/client/docs/index.html`. Node, Cloudflare, Netlify, and Vercel then
 serve them through their existing static-asset paths.
 
 Paths are configurable:

--- a/docs/REMOTE_MCP.md
+++ b/docs/REMOTE_MCP.md
@@ -88,7 +88,7 @@ POST /mcp
 ```
 
 Stateless: no session id, no server→client stream, no resumability. That is
-what the Node, Cloudflare, and Vercel adapters already serve.
+what the Node, Cloudflare, Netlify, and Vercel adapters already serve.
 
 ## Tool names
 

--- a/docs/WORKSPACE.md
+++ b/docs/WORKSPACE.md
@@ -13,6 +13,7 @@ described in `VISION_MVP.md`.
 | `packages/preact-ssr-precompile` | `@pracht/preact-ssr-precompile` | Experimental Rolldown/Vite plugin that precompiles safe Preact JSX DOM subtrees into server-only `jsxTemplate()` calls |
 | `packages/adapter-node`       | `@pracht/adapter-node`       | Node `IncomingMessage`/`ServerResponse` bridge, ISG stale-while-revalidate, and webhook revalidation         |
 | `packages/adapter-cloudflare` | `@pracht/adapter-cloudflare` | Cloudflare Workers fetch handler, generated worker entry source, static asset handoff, and Cache API ISG     |
+| `packages/adapter-netlify`    | `@pracht/adapter-netlify`    | Netlify Functions v2 handler, bundled static output, durable CDN caching, and tag-based ISG revalidation     |
 | `packages/adapter-vercel`     | `@pracht/adapter-vercel`     | Vercel Edge handler, Build Output API entry source, and native ISR artifacts                                 |
 | `packages/preact-worker-facets` | `@pracht/preact-worker-facets` | Experimental Cloudflare Dynamic Worker + Durable Object facets runtime for inert, stateful Preact components |
 | `packages/image`              | `@pracht/image`              | Responsive, CLS-safe `<Image>` component, pluggable optimization loaders, sharp-backed Node endpoint (see `docs/IMAGES.md`) |
@@ -73,10 +74,10 @@ described in `VISION_MVP.md`.
 - **CLI** — `pracht dev` starts a Vite dev server with SSR, `pracht build` runs
   client + server builds (with Vite manifest generation, SSG/ISG prerendering,
   ISG manifest output, executable Node server output in `dist/server/server.js`,
-  and Vercel `.vercel/output/` generation when the app targets those adapters),
+  Netlify function generation, and Vercel `.vercel/output/` generation when the app targets those adapters),
   `pracht preview` builds and serves the production output locally (Node runs
-  `dist/server/server.js`, Cloudflare delegates to `wrangler dev`, and Vercel
-  points at `vercel build`/`vercel dev`),
+  `dist/server/server.js`, Cloudflare delegates to `wrangler dev`, Netlify
+  points at `netlify dev`, and Vercel points at `vercel build`/`vercel dev`),
   `pracht verify` runs fast framework-aware checks with optional `--changed`
   and `--json` output, `pracht inspect [routes|api|build] --json` emits the
   resolved route graph, API handlers, and build metadata for agents/tools,
@@ -86,7 +87,8 @@ described in `VISION_MVP.md`.
   files, and `pracht doctor` validates app wiring across the whole project.
 - **Package builds** — `tsdown` compiles `pracht`, `@pracht/openapi`, `@pracht/vite-plugin`,
   `@pracht/preact-ssr-precompile`, `@pracht/adapter-node`,
-  `@pracht/adapter-cloudflare`, `@pracht/adapter-vercel`, and `@pracht/image`
+  `@pracht/adapter-cloudflare`, `@pracht/adapter-netlify`,
+  `@pracht/adapter-vercel`, and `@pracht/image`
   from TypeScript to
   ESM (`dist/index.mjs` + `.d.mts`). `@pracht/core` preserves its source-module
   boundaries in the published ESM so downstream builds can tree-shake named
@@ -103,6 +105,10 @@ described in `VISION_MVP.md`.
   `handlePrachtRequest()`, gives loaders/API routes/middleware access to `env`
   and `executionContext`, and stores regenerated ISG HTML in the Workers Cache
   API.
+- **Netlify adapter** — Emits a Functions v2 catch-all, serves bundled SSG
+  documents while preserving Markdown and route-state negotiation, and maps
+  ISG freshness and webhook revalidation to Netlify durable cache headers and
+  cache tags.
 - **Vercel adapter** — Emits an Edge-compatible handler, copies the build into
   `.vercel/output/static` and `.vercel/output/functions/render.func`, rewrites
   clean SSG URLs to static HTML, and emits native prerender functions for ISG.

--- a/e2e/fixture-copy.ts
+++ b/e2e/fixture-copy.ts
@@ -1,6 +1,13 @@
 import { relative } from "node:path";
 
-const excludedFixtureEntries = new Set([".vercel", ".wrangler", "dist", "test-results"]);
+const excludedFixtureEntries = new Set([
+  ".netlify",
+  ".vercel",
+  ".wrangler",
+  "dist",
+  "netlify",
+  "test-results",
+]);
 
 /** Keep generated output and local runtime state out of disposable fixture copies. */
 export function shouldCopyFixtureRelativePath(path: string): boolean {

--- a/e2e/netlify-build.test.ts
+++ b/e2e/netlify-build.test.ts
@@ -1,0 +1,85 @@
+import { execFileSync } from "node:child_process";
+import { cpSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { resolve } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+import { expect, test } from "@playwright/test";
+
+import { fixtureCopyFilter } from "./fixture-copy.ts";
+
+const repoRoot = resolve(fileURLToPath(new URL("..", import.meta.url)));
+const fixtureDir = resolve(repoRoot, "examples/basic");
+const cliEntry = resolve(repoRoot, "packages/cli/bin/pracht.js");
+
+test("pracht build emits a working Netlify Functions v2 entry", async () => {
+  test.setTimeout(120_000);
+
+  const tempRoot = resolve(repoRoot, ".tmp");
+  mkdirSync(tempRoot, { recursive: true });
+  const tempDir = mkdtempSync(resolve(tempRoot, "pracht-netlify-build-"));
+  const exampleDir = resolve(tempDir, "project");
+
+  try {
+    cpSync(fixtureDir, exampleDir, { filter: fixtureCopyFilter(fixtureDir), recursive: true });
+    execFileSync(process.execPath, [cliEntry, "build"], {
+      cwd: exampleDir,
+      env: {
+        ...process.env,
+        NODE_OPTIONS: "--experimental-strip-types",
+        PRACHT_ADAPTER: "netlify",
+      },
+      stdio: "pipe",
+    });
+
+    const wrapperPath = resolve(exampleDir, "netlify/functions/pracht.mjs");
+    const serverEntryPath = resolve(exampleDir, "dist/server/server.js");
+    expect(existsSync(wrapperPath)).toBe(true);
+    expect(existsSync(serverEntryPath)).toBe(true);
+    expect(existsSync(resolve(exampleDir, "dist/server/isg-manifest.json"))).toBe(true);
+    expect(existsSync(resolve(exampleDir, "dist/client/_pracht/isg.json"))).toBe(false);
+
+    const source = readFileSync(wrapperPath, "utf-8");
+    expect(source).toContain('import handler from "../../dist/server/server.js"');
+    expect(source).toContain('"path": "/*"');
+    expect(source).toContain('"excludedPath"');
+    expect(source).toContain('"/assets/*"');
+    expect(source).toContain('"includedFiles"');
+    expect(source).toContain('"dist/client/**"');
+    expect(source).toContain('"nodeBundler": "esbuild"');
+    expect(readFileSync(serverEntryPath, "utf-8")).toContain('buildTarget = "netlify"');
+
+    const previousStaticDir = process.env.PRACHT_STATIC_DIR;
+    try {
+      process.env.PRACHT_STATIC_DIR = resolve(exampleDir, "dist/client");
+      const { default: handler } = await import(pathToFileURL(wrapperPath).href);
+      const context = { waitUntil() {} };
+
+      const html = await handler(new Request("https://example.com/"), context);
+      expect(html.status).toBe(200);
+      expect(html.headers.get("x-pracht-shell")).toBe("public");
+      expect(html.headers.get("netlify-cdn-cache-control")).toContain("durable");
+      expect(await html.text()).toContain("Pracht starts with an explicit app manifest.");
+
+      const markdown = await handler(
+        new Request("https://example.com/", { headers: { accept: "text/markdown" } }),
+        context,
+      );
+      expect(markdown.headers.get("content-type")).toContain("text/markdown");
+      expect(await markdown.text()).toContain("# Pracht Example");
+
+      const api = await handler(new Request("https://example.com/api/health"), context);
+      expect(api.headers.get("cache-control")).toBe("private, no-cache");
+      await expect(api.json()).resolves.toEqual({ status: "ok" });
+
+      const isg = await handler(new Request("https://example.com/pricing?visitor=1"), context);
+      expect(isg.status).toBe(200);
+      expect(isg.headers.get("netlify-cdn-cache-control")).toContain("max-age=3600");
+      expect(isg.headers.get("netlify-cache-tag")).toContain("pracht:path:%2Fpricing");
+    } finally {
+      if (previousStaticDir === undefined) delete process.env.PRACHT_STATIC_DIR;
+      else process.env.PRACHT_STATIC_DIR = previousStaticDir;
+    }
+  } finally {
+    rmSync(tempDir, { force: true, recursive: true });
+  }
+});

--- a/e2e/netlify-build.test.ts
+++ b/e2e/netlify-build.test.ts
@@ -58,6 +58,7 @@ test("pracht build emits a working Netlify Functions v2 entry", async () => {
       expect(html.status).toBe(200);
       expect(html.headers.get("x-pracht-shell")).toBe("public");
       expect(html.headers.get("netlify-cdn-cache-control")).toContain("durable");
+      expect(html.headers.get("netlify-vary")).toBe("query=_data");
       expect(await html.text()).toContain("Pracht starts with an explicit app manifest.");
 
       const markdown = await handler(
@@ -75,6 +76,7 @@ test("pracht build emits a working Netlify Functions v2 entry", async () => {
       expect(isg.status).toBe(200);
       expect(isg.headers.get("netlify-cdn-cache-control")).toContain("max-age=3600");
       expect(isg.headers.get("netlify-cache-tag")).toContain("pracht:path:%2Fpricing");
+      expect(isg.headers.get("netlify-vary")).toBe("query=_data");
     } finally {
       if (previousStaticDir === undefined) delete process.env.PRACHT_STATIC_DIR;
       else process.env.PRACHT_STATIC_DIR = previousStaticDir;

--- a/examples/basic/package.json
+++ b/examples/basic/package.json
@@ -5,17 +5,20 @@
   "type": "module",
   "scripts": {
     "build:cloudflare": "node ../../scripts/run-pracht.mjs PRACHT_ADAPTER=cloudflare -- build",
+    "build:netlify": "node ../../scripts/run-pracht.mjs PRACHT_ADAPTER=netlify -- build",
     "deploy:cloudflare": "pnpm build:cloudflare && wrangler deploy",
     "typecheck": "tsc --noEmit -p tsconfig.json",
     "typegen": "node ../../scripts/run-pracht.mjs PRACHT_ADAPTER=node -- typegen",
-    "typegen:check": "pnpm typegen:check:node && pnpm typegen:check:cloudflare && pnpm typegen:check:vercel",
+    "typegen:check": "pnpm typegen:check:node && pnpm typegen:check:cloudflare && pnpm typegen:check:netlify && pnpm typegen:check:vercel",
     "typegen:check:node": "node ../../scripts/run-pracht.mjs PRACHT_ADAPTER=node -- typegen --check",
     "typegen:check:cloudflare": "node ../../scripts/run-pracht.mjs PRACHT_ADAPTER=cloudflare -- typegen --check",
+    "typegen:check:netlify": "node ../../scripts/run-pracht.mjs PRACHT_ADAPTER=netlify -- typegen --check",
     "typegen:check:vercel": "node ../../scripts/run-pracht.mjs PRACHT_ADAPTER=vercel -- typegen --check",
     "verify": "pnpm typegen:check && pnpm typecheck && node ../../scripts/run-pracht.mjs PRACHT_ADAPTER=node PRACHT_CONFIRMATION_SECRET?=basic-dev-confirmation-secret -- verify"
   },
   "dependencies": {
     "@pracht/adapter-cloudflare": "workspace:*",
+    "@pracht/adapter-netlify": "workspace:*",
     "@pracht/adapter-node": "workspace:*",
     "@pracht/adapter-vercel": "workspace:*",
     "@pracht/capabilities": "workspace:*",

--- a/examples/basic/vite.config.ts
+++ b/examples/basic/vite.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from "vite";
 import { prachtOpenApi } from "@pracht/openapi/vite";
 import { pracht } from "@pracht/vite-plugin";
 
-type DeployTarget = "cloudflare" | "node" | "vercel";
+type DeployTarget = "cloudflare" | "netlify" | "node" | "vercel";
 
 async function resolveAdapter(target: DeployTarget) {
   if (target === "vercel") {
@@ -13,6 +13,11 @@ async function resolveAdapter(target: DeployTarget) {
   if (target === "cloudflare") {
     const { cloudflareAdapter } = await import("@pracht/adapter-cloudflare");
     return cloudflareAdapter();
+  }
+
+  if (target === "netlify") {
+    const { netlifyAdapter } = await import("@pracht/adapter-netlify");
+    return netlifyAdapter();
   }
 
   const { nodeAdapter } = await import("@pracht/adapter-node");

--- a/examples/docs/src/routes/docs/adapters.md
+++ b/examples/docs/src/routes/docs/adapters.md
@@ -342,6 +342,60 @@ custom Vercel server entry must provide the same export.
 
 ---
 
+## Netlify Functions
+
+The Netlify adapter emits a fetch-style Functions v2 handler, bundles the
+client build for exact static-file serving, and maps ISG to Netlify's durable
+CDN cache.
+
+### Setup
+
+```ts [vite.config.ts]
+import { netlifyAdapter } from "@pracht/adapter-netlify";
+
+export default defineConfig({
+  plugins: [pracht({ adapter: netlifyAdapter() })],
+});
+```
+
+```toml [netlify.toml]
+[build]
+  command = "pnpm build"
+  publish = "dist/client"
+
+[functions]
+  directory = "netlify/functions"
+```
+
+The generated catch-all function owns page URLs so Markdown negotiation and
+route-state requests still reach Pracht. `/assets/*` and `/_pracht/*` bypass
+the function by default. Add app-specific static prefixes with
+`excludedPath`, but do not exclude page URLs.
+
+### Caching and revalidation
+
+SSG documents use `Netlify-CDN-Cache-Control` with durable caching. ISG routes
+use their Pracht time window as the CDN `max-age` and serve stale responses
+while a fresh render completes. Webhook-capable routes receive per-path cache
+tags; authenticated requests to `/__pracht/revalidate` purge those tags.
+
+Shared ISG renders are sanitized before loaders and context factories run, so
+visitor cookies, authorization, query strings, and bodies cannot personalize
+the cached response.
+
+### Local preview and deploy
+
+```sh
+pracht build && netlify dev
+netlify deploy --build --prod
+```
+
+`pracht preview` does not emulate Netlify's Functions or CDN cache behavior.
+Build the generated function before using `netlify dev` for a platform-shaped
+local runtime.
+
+---
+
 ## Node.js
 
 Run pracht as a standard Node.js HTTP server. The adapter handles static file serving, ISG stale-while-revalidate, request translation, and the generated `dist/server/server.js` entry boots the production server directly.
@@ -497,4 +551,4 @@ At the runtime level, an adapter also typically needs to:
 7. Export an entry module generator for the Vite plugin
 
 > [!INFO]
-> See the source of `@pracht/adapter-cloudflare` or `@pracht/adapter-node` in the monorepo for a concrete reference implementation.
+> See the source of `@pracht/adapter-cloudflare`, `@pracht/adapter-netlify`, or `@pracht/adapter-node` in the monorepo for a concrete reference implementation.

--- a/examples/docs/src/routes/docs/adapters.md
+++ b/examples/docs/src/routes/docs/adapters.md
@@ -386,9 +386,11 @@ its own cache variant, while tracking and other unrelated query parameters
 collapse onto the pathname entry. A custom `Netlify-Vary` header takes
 precedence.
 
-Shared ISG renders are sanitized before loaders and context factories run, so
-visitor cookies, authorization, query strings, and bodies cannot personalize
-the cached response.
+Shared ISG renders sanitize both the request and Netlify context before loaders
+and context factories run. Visitor cookies, authorization, query strings,
+bodies, IP/geolocation, request IDs, and arbitrary request-local context cannot
+personalize the cached response. Deployment-wide site/server metadata and
+`waitUntil()` remain available.
 
 ### Local preview and deploy
 

--- a/examples/docs/src/routes/docs/adapters.md
+++ b/examples/docs/src/routes/docs/adapters.md
@@ -377,7 +377,14 @@ the function by default. Add app-specific static prefixes with
 SSG documents use `Netlify-CDN-Cache-Control` with durable caching. ISG routes
 use their Pracht time window as the CDN `max-age` and serve stale responses
 while a fresh render completes. Webhook-capable routes receive per-path cache
-tags; authenticated requests to `/__pracht/revalidate` purge those tags.
+tags, including when they provide a cacheable custom policy; authenticated
+requests to `/__pracht/revalidate` purge those tags. Explicit SSG and ISG cache
+policies remain authoritative.
+
+Cached page HTML sets `Netlify-Vary: query=_data`. Route-state transport keeps
+its own cache variant, while tracking and other unrelated query parameters
+collapse onto the pathname entry. A custom `Netlify-Vary` header takes
+precedence.
 
 Shared ISG renders are sanitized before loaders and context factories run, so
 visitor cookies, authorization, query strings, and bodies cannot personalize

--- a/examples/docs/src/routes/docs/agent-trust.md
+++ b/examples/docs/src/routes/docs/agent-trust.md
@@ -54,7 +54,7 @@ export const app = defineApp({
 });
 ```
 
-Verification happens once per request in `handlePrachtRequest`, using only Web platform APIs — Node, Cloudflare, and Vercel share the implementation. The result surfaces everywhere:
+Verification happens once per request in `handlePrachtRequest`, using only Web platform APIs — Node, Cloudflare, Netlify, and Vercel share the implementation. The result surfaces everywhere:
 
 ```ts [src/capabilities/agent-whoami.ts]
 async run({ context }) {

--- a/examples/docs/src/routes/docs/deployment.md
+++ b/examples/docs/src/routes/docs/deployment.md
@@ -122,6 +122,47 @@ local development runtime.
 
 ---
 
+## Netlify
+
+Deploys through a fetch-style Netlify Functions v2 handler with SSG documents
+and ISG responses stored in Netlify's durable CDN cache.
+
+```ts [vite.config.ts]
+import { defineConfig } from "vite";
+import { pracht } from "@pracht/vite-plugin";
+import { netlifyAdapter } from "@pracht/adapter-netlify";
+
+export default defineConfig({
+  plugins: [pracht({ adapter: netlifyAdapter() })],
+});
+```
+
+```toml [netlify.toml]
+[build]
+  command = "pnpm build"
+  publish = "dist/client"
+
+[functions]
+  directory = "netlify/functions"
+```
+
+```sh
+pracht build && netlify dev
+netlify deploy --build --prod
+```
+
+The generated function preserves Markdown negotiation and client route-state
+requests while hashed assets bypass it. Time-based ISG uses durable
+stale-while-revalidate caching; authenticated webhook revalidation purges
+per-path cache tags. Use `netlifyAdapter({ excludedPath: [...] })` for extra
+static prefixes, but do not exclude page URLs.
+
+`pracht preview` deliberately does not emulate Netlify's Functions and CDN
+behavior; build the generated function before using `netlify dev` for the
+platform-shaped local runtime.
+
+---
+
 ## Custom Context
 
 Generated adapter entries can import a context factory that enriches the context passed to loaders, API routes, and middleware:

--- a/examples/docs/src/routes/docs/env.md
+++ b/examples/docs/src/routes/docs/env.md
@@ -115,6 +115,8 @@ to `Record<string, string | undefined>`.
 
 - **Node** (`@pracht/adapter-node`) — resolves to `process.env`. Available at
   module top level.
+- **Netlify** (`@pracht/adapter-netlify`) — resolves to `process.env`, populated
+  by the Netlify Functions runtime. Available at module top level.
 - **Vercel** (`@pracht/adapter-vercel`) — resolves to `process.env`, which the
   Vercel runtime populates in both Node and edge functions. Available at module
   top level.

--- a/examples/docs/src/routes/docs/migrate-nextjs.md
+++ b/examples/docs/src/routes/docs/migrate-nextjs.md
@@ -21,7 +21,7 @@ Next.js and pracht share many of the same concepts — server rendering, file-ba
 | Rendering modes | Per-segment (`dynamic`, `revalidate`) | Per-route (`ssg`, `ssr`, `isg`, `spa`)   |
 | Middleware      | Single `middleware.ts` at root        | Named middleware, per-route or per-group |
 | API routes      | `app/api/**/route.ts`                 | `src/api/**/*.ts`                        |
-| Deployment      | Vercel-first                          | Adapter-based (Node, Cloudflare, Vercel) |
+| Deployment      | Vercel-first                          | Adapter-based (Node, Cloudflare, Netlify, Vercel) |
 
 ---
 
@@ -339,6 +339,7 @@ Next.js is optimized for Vercel. pracht uses **adapters** to deploy anywhere:
 import { pracht } from "@pracht/vite-plugin";
 import { nodeAdapter } from "@pracht/adapter-node";
 // or: import { cloudflareAdapter } from "@pracht/adapter-cloudflare";
+// or: import { netlifyAdapter } from "@pracht/adapter-netlify";
 // or: import { vercelAdapter } from "@pracht/adapter-vercel";
 
 export default {
@@ -350,6 +351,7 @@ export default {
 | ------------------ | ---------------------------- | ------------------------------------ |
 | Node.js            | `@pracht/adapter-node`       | Express-compatible, ISG revalidation |
 | Cloudflare Workers | `@pracht/adapter-cloudflare` | KV, D1, R2 bindings via context      |
+| Netlify            | `@pracht/adapter-netlify`    | Functions v2, durable CDN caching    |
 | Vercel             | `@pracht/adapter-vercel`     | Edge Functions, Build Output API v3  |
 
 ---

--- a/examples/docs/src/routes/docs/remote-mcp.md
+++ b/examples/docs/src/routes/docs/remote-mcp.md
@@ -63,7 +63,7 @@ Input validation, named middleware, `agentPolicy`, output validation, and the au
 
 The synthesized request carries the same request-bound capability host, so named middleware and capability bodies can compose private non-destructive operations with `invokeCapability()`. Trusted MCP provenance adds two fail-closed rules to ordinary server composition: the nested call re-applies the callee's `agentPolicy` and refuses `destructive` effects before middleware or the body can run. The incoming transport request carries that provenance too, so adapter context that retains it cannot escape the nested-call guard. Every nested attempt audits as `{ transport: "server", via: "mcp" }`, keeping indirect effects and denials attributable to the agent that caused them.
 
-The endpoint is stateless: no session id, no server→client stream, no resumability. That is what the Node, Cloudflare, and Vercel adapters already serve, so the same app runs unchanged on all three.
+The endpoint is stateless: no session id, no server→client stream, no resumability. That is what the Node, Cloudflare, Netlify, and Vercel adapters already serve, so the same app runs unchanged on all four.
 
 ---
 

--- a/examples/docs/src/routes/home.tsx
+++ b/examples/docs/src/routes/home.tsx
@@ -239,7 +239,7 @@ const GET_STARTED_LINKS: { href: string; Icon: Icon; title: string; sub: string 
     href: "/docs/adapters",
     Icon: IconPlug,
     title: "Adapters",
-    sub: "Cloudflare, Vercel, Node",
+    sub: "Cloudflare, Netlify, Vercel, Node",
   },
 ];
 
@@ -259,7 +259,7 @@ export function Component(_props: RouteComponentProps<typeof loader>) {
 
           <p class="hero-sub">
             <strong>pracht</strong> is a Preact framework with <strong>explicit routing</strong>,
-            per-route render modes, and thin adapters for Cloudflare, Vercel, and Node.js.
+            per-route render modes, and thin adapters for Cloudflare, Netlify, Vercel, and Node.js.
           </p>
 
           <div class="hero-actions">

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "type": "module",
   "scripts": {
-    "build": "pnpm -r --filter @pracht/core --filter @pracht/capabilities --filter @pracht/openapi --filter @pracht/vite-plugin --filter @pracht/preact-ssr-precompile --filter @pracht/adapter-node --filter @pracht/adapter-cloudflare --filter @pracht/adapter-vercel --filter @pracht/image --filter @pracht/cli --filter create-pracht run build",
+    "build": "pnpm -r --filter @pracht/core --filter @pracht/capabilities --filter @pracht/openapi --filter @pracht/vite-plugin --filter @pracht/preact-ssr-precompile --filter @pracht/adapter-node --filter @pracht/adapter-cloudflare --filter @pracht/adapter-netlify --filter @pracht/adapter-vercel --filter @pracht/image --filter @pracht/cli --filter create-pracht run build",
     "check": "pnpm build && pnpm typecheck && pnpm test",
     "verify": "node ./scripts/verify.mjs",
     "typecheck": "tsc --noEmit && tsc --noEmit -p packages/cli/test/fixtures/cloudflare-runtime-import && tsc --noEmit -p examples/showcase",

--- a/packages/adapter-cloudflare/test/cache.test.ts
+++ b/packages/adapter-cloudflare/test/cache.test.ts
@@ -249,6 +249,16 @@ describe("preventHeuristicCaching", () => {
     expect(response.headers.get("cloudflare-cdn-cache-control")).toBe("max-age=300");
   });
 
+  it("leaves a user-set netlify-cdn-cache-control untouched", () => {
+    const response = preventHeuristicCaching(
+      getRequest,
+      new Response("{}", { headers: { "netlify-cdn-cache-control": "max-age=300" } }),
+    );
+
+    expect(response.headers.has("cache-control")).toBe(false);
+    expect(response.headers.get("netlify-cdn-cache-control")).toBe("max-age=300");
+  });
+
   it("ignores non-GET/HEAD requests", () => {
     const response = preventHeuristicCaching(
       new Request("https://example.com/api/echo", { method: "POST" }),

--- a/packages/adapter-netlify/LICENSE
+++ b/packages/adapter-netlify/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025-present Resynapse
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/adapter-netlify/README.md
+++ b/packages/adapter-netlify/README.md
@@ -73,10 +73,16 @@ metadata.
 ## SSG and ISG caching
 
 - SSG documents are read from the bundled client output and stored in
-  Netlify's durable cache. Atomic deploys invalidate the cached deployment.
+  Netlify's durable cache. Atomic deploys invalidate the cached deployment. An
+  explicit route cache policy remains authoritative.
 - Time-revalidated ISG routes use their Pracht revalidation interval as the
-  Netlify CDN `max-age`, with stale-while-revalidate enabled.
-- Webhook-revalidated ISG responses carry per-path cache tags.
+  Netlify CDN `max-age`, with stale-while-revalidate enabled. Cacheable custom
+  policies remain authoritative.
+- Cached SSG and ISG HTML uses `Netlify-Vary: query=_data`, preserving the
+  route-state variant while collapsing unrelated query parameters. A custom
+  `Netlify-Vary` header takes precedence.
+- Cacheable webhook-revalidated ISG responses carry per-path cache tags, even
+  when the route provides a custom cache policy.
   `POST /__pracht/revalidate` authenticates with `PRACHT_REVALIDATE_TOKEN` and
   purges those tags through Netlify's Functions API.
 - Shared ISG renders run with a sanitized request: no visitor cookies,

--- a/packages/adapter-netlify/README.md
+++ b/packages/adapter-netlify/README.md
@@ -1,0 +1,92 @@
+# @pracht/adapter-netlify
+
+Netlify Functions v2 adapter for Pracht. It serves SSR and API requests through
+a fetch-style function, keeps prerendered HTML available to Markdown content
+negotiation and client route-state requests, and maps ISG onto Netlify's durable
+CDN cache.
+
+## Install
+
+```bash
+npm install @pracht/adapter-netlify
+```
+
+## Configure Pracht
+
+```ts
+import { defineConfig } from "vite";
+import { pracht } from "@pracht/vite-plugin";
+import { netlifyAdapter } from "@pracht/adapter-netlify";
+
+export default defineConfig({
+  plugins: [pracht({ adapter: netlifyAdapter() })],
+});
+```
+
+The build emits `netlify/functions/pracht.mjs`. Its Functions v2 `config`
+claims page URLs, excludes Pracht's asset directories, and bundles
+`dist/client` plus the generated headers, Markdown, and ISG manifests.
+
+Set Netlify's publish directory to `dist/client`:
+
+```toml
+[build]
+  command = "npm run build"
+  publish = "dist/client"
+
+[functions]
+  directory = "netlify/functions"
+```
+
+Then deploy normally:
+
+```bash
+netlify deploy --build --prod
+```
+
+## Static paths
+
+The function must receive page requests so `Accept: text/markdown` and Pracht
+route-state fetches are not answered with prerendered HTML. Hashed assets and
+`/_pracht/*` bypass the function by default. Add app-specific static prefixes
+without bypassing page URLs:
+
+```ts
+netlifyAdapter({ excludedPath: ["/content/*", "/images/*"] });
+```
+
+Exact static files not excluded from the function are still served correctly;
+the exclusion only avoids a function invocation.
+
+## Context
+
+Generated entries can import an app context factory:
+
+```ts
+netlifyAdapter({ createContextFrom: "/src/server/context.ts" });
+```
+
+The module should export `createContext({ request, context })`. `context` is
+Netlify's Functions v2 context, including `waitUntil()` and site/server
+metadata.
+
+## SSG and ISG caching
+
+- SSG documents are read from the bundled client output and stored in
+  Netlify's durable cache. Atomic deploys invalidate the cached deployment.
+- Time-revalidated ISG routes use their Pracht revalidation interval as the
+  Netlify CDN `max-age`, with stale-while-revalidate enabled.
+- Webhook-revalidated ISG responses carry per-path cache tags.
+  `POST /__pracht/revalidate` authenticates with `PRACHT_REVALIDATE_TOKEN` and
+  purges those tags through Netlify's Functions API.
+- Shared ISG renders run with a sanitized request: no visitor cookies,
+  authorization, query string, or body can enter cached HTML.
+
+Tune the cache windows when needed:
+
+```ts
+netlifyAdapter({
+  staleWhileRevalidate: 86_400,
+  staticMaxAge: 604_800,
+});
+```

--- a/packages/adapter-netlify/README.md
+++ b/packages/adapter-netlify/README.md
@@ -85,8 +85,11 @@ metadata.
   when the route provides a custom cache policy.
   `POST /__pracht/revalidate` authenticates with `PRACHT_REVALIDATE_TOKEN` and
   purges those tags through Netlify's Functions API.
-- Shared ISG renders run with a sanitized request: no visitor cookies,
-  authorization, query string, or body can enter cached HTML.
+- Shared ISG renders use a sanitized request and an allowlisted Netlify
+  context. Visitor cookies, authorization, query strings, bodies, IP address,
+  geolocation, request IDs, and arbitrary request-local context cannot enter
+  cached HTML. Deployment-wide site/server metadata and `waitUntil()` remain
+  available; attempts to mutate cookies fail closed.
 
 Tune the cache windows when needed:
 

--- a/packages/adapter-netlify/package.json
+++ b/packages/adapter-netlify/package.json
@@ -1,0 +1,51 @@
+{
+  "name": "@pracht/adapter-netlify",
+  "version": "0.0.0",
+  "description": "Netlify Functions adapter for deploying Pracht apps with SSR, SSG, ISG, Markdown negotiation, and durable CDN caching.",
+  "keywords": [
+    "pracht",
+    "preact",
+    "netlify",
+    "functions",
+    "adapter",
+    "serverless",
+    "ssr",
+    "ssg",
+    "isg",
+    "vite"
+  ],
+  "license": "MIT",
+  "homepage": "https://github.com/JoviDeCroock/pracht/tree/main/packages/adapter-netlify",
+  "bugs": {
+    "url": "https://github.com/JoviDeCroock/pracht/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/JoviDeCroock/pracht",
+    "directory": "packages/adapter-netlify"
+  },
+  "files": [
+    "dist"
+  ],
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.mts",
+      "default": "./dist/index.mjs"
+    }
+  },
+  "publishConfig": {
+    "provenance": true
+  },
+  "scripts": {
+    "build": "tsdown",
+    "prepublishOnly": "npm run build"
+  },
+  "dependencies": {
+    "@netlify/functions": "^5.3.0",
+    "@pracht/core": "workspace:*"
+  },
+  "peerDependencies": {
+    "vite": "^8.0.0"
+  }
+}

--- a/packages/adapter-netlify/src/index.ts
+++ b/packages/adapter-netlify/src/index.ts
@@ -99,6 +99,22 @@ const DEFAULT_STATIC_MAX_AGE = 31_536_000;
 const ROUTE_STATE_REQUEST_HEADER = "x-pracht-route-state-request";
 const DEFAULT_EXCLUDED_PATHS = ["/assets/*", "/_pracht/*"];
 const ISG_CACHE_TAG = "pracht:isg";
+const SHARED_CONTEXT_FIELDS = [
+  "account",
+  "deploy",
+  "json",
+  "log",
+  "params",
+  "server",
+  "site",
+  "waitUntil",
+] as const;
+const EMPTY_NETLIFY_GEO = Object.freeze({});
+const EMPTY_NETLIFY_COOKIES = Object.freeze({
+  delete: rejectSharedContextCookieMutation,
+  get: () => undefined,
+  set: rejectSharedContextCookieMutation,
+});
 const EXPLICIT_CACHE_POLICY_HEADERS = [
   "cache-control",
   "cdn-cache-control",
@@ -159,9 +175,10 @@ export function createNetlifyHandler<
     // from a request stripped of cookies, authorization, query, and body so the
     // visitor who triggers a cache miss cannot personalize the stored result.
     const renderRequest = isgRoute ? createISGRegenerationRequest(url.pathname, request) : request;
+    const renderContext = isgRoute ? createNetlifyISGContext(context, renderRequest) : context;
     const prachtContext = options.createContext
-      ? await options.createContext({ request: renderRequest, context })
-      : (context as unknown as TContext);
+      ? await options.createContext({ request: renderRequest, context: renderContext })
+      : (renderContext as unknown as TContext);
 
     const response = await handlePrachtRequest({
       app: options.app,
@@ -526,6 +543,34 @@ function resolveCacheOptions(
     ),
     staticMaxAge: positiveInteger(options?.staticMaxAge, DEFAULT_STATIC_MAX_AGE),
   };
+}
+
+function createNetlifyISGContext<TContext extends NetlifyExecutionContext>(
+  context: TContext,
+  request: Request,
+): TContext {
+  const shared: NetlifyExecutionContext = Object.create(null);
+
+  for (const field of SHARED_CONTEXT_FIELDS) {
+    const value = context[field];
+    if (value === undefined) continue;
+    shared[field] = typeof value === "function" ? value.bind(context) : value;
+  }
+
+  // Netlify exposes these values outside the Request object. Mask them as
+  // deliberately as createISGRegenerationRequest() strips visitor headers and
+  // query data, or a context factory could still personalize shared output.
+  shared.cookies = EMPTY_NETLIFY_COOKIES;
+  shared.geo = EMPTY_NETLIFY_GEO;
+  shared.ip = "";
+  shared.requestId = "";
+  shared.url = new URL(request.url);
+
+  return shared as TContext;
+}
+
+function rejectSharedContextCookieMutation(): never {
+  throw new Error("Netlify cookies cannot be changed while rendering a shared ISG response.");
 }
 
 function positiveInteger(value: number | undefined, fallback: number): number {

--- a/packages/adapter-netlify/src/index.ts
+++ b/packages/adapter-netlify/src/index.ts
@@ -99,6 +99,14 @@ const DEFAULT_STATIC_MAX_AGE = 31_536_000;
 const ROUTE_STATE_REQUEST_HEADER = "x-pracht-route-state-request";
 const DEFAULT_EXCLUDED_PATHS = ["/assets/*", "/_pracht/*"];
 const ISG_CACHE_TAG = "pracht:isg";
+const EXPLICIT_CACHE_POLICY_HEADERS = [
+  "cache-control",
+  "cdn-cache-control",
+  "cloudflare-cdn-cache-control",
+  "netlify-cdn-cache-control",
+  "surrogate-control",
+  "vercel-cdn-cache-control",
+] as const;
 
 /**
  * Create a fetch-style Netlify Functions v2 handler.
@@ -368,19 +376,19 @@ function applyNetlifyISGCacheHeaders(
   if (response.status !== 200) return response;
 
   let prepared = stripDangerousSharedCacheHeaders(response, pathname);
-  if (prepared.headers.has("cache-control") || prepared.headers.has("netlify-cdn-cache-control")) {
-    return prepared;
-  }
   if (!isCacheableISGResponse(prepared)) return prepared;
 
   const seconds = getTimeRevalidateSeconds(route.revalidate) ?? cache.staticMaxAge;
   const headers = new Headers(prepared.headers);
-  headers.set(
-    "netlify-cdn-cache-control",
-    `public, durable, max-age=${seconds}, stale-while-revalidate=${cache.staleWhileRevalidate}`,
-  );
-  headers.set("cache-control", "public, max-age=0, must-revalidate");
-  headers.set("netlify-cache-tag", `${ISG_CACHE_TAG},${netlifyRouteCacheTag(pathname)}`);
+  if (!hasExplicitCachePolicy(headers)) {
+    headers.set(
+      "netlify-cdn-cache-control",
+      `public, durable, max-age=${seconds}, stale-while-revalidate=${cache.staleWhileRevalidate}`,
+    );
+    headers.set("cache-control", "public, max-age=0, must-revalidate");
+  }
+  ensureNetlifyPageVary(headers);
+  appendNetlifyCacheTags(headers, [ISG_CACHE_TAG, netlifyRouteCacheTag(pathname)]);
   prepared = cloneResponse(prepared, headers);
   return prepared;
 }
@@ -450,15 +458,43 @@ async function serveStaticFile(
   const headers = applyDefaultSecurityHeaders(
     new Headers({
       "content-type": file.contentType,
-      "cache-control": pathname.startsWith("/assets/")
-        ? "public, max-age=31536000, immutable"
-        : "public, max-age=0, must-revalidate",
-      "netlify-cdn-cache-control": `public, durable, max-age=${staticMaxAge}`,
     }),
   );
   if (file.document) applyHeadersManifest(headers, headersManifest, pathname);
+  if (!hasExplicitCachePolicy(headers)) {
+    headers.set(
+      "cache-control",
+      pathname.startsWith("/assets/")
+        ? "public, max-age=31536000, immutable"
+        : "public, max-age=0, must-revalidate",
+    );
+    headers.set("netlify-cdn-cache-control", `public, durable, max-age=${staticMaxAge}`);
+  }
+  if (file.document) ensureNetlifyPageVary(headers);
   const body = request.method === "HEAD" ? null : await readFile(file.filePath);
   return new Response(body, { headers });
+}
+
+function hasExplicitCachePolicy(headers: Headers): boolean {
+  return EXPLICIT_CACHE_POLICY_HEADERS.some((name) => headers.has(name));
+}
+
+function ensureNetlifyPageVary(headers: Headers): void {
+  if (!headers.has("netlify-vary")) headers.set("netlify-vary", "query=_data");
+}
+
+function appendNetlifyCacheTags(headers: Headers, requiredTags: string[]): void {
+  const tags = (headers.get("netlify-cache-tag") ?? "")
+    .split(",")
+    .map((tag) => tag.trim())
+    .filter(Boolean);
+  const normalized = new Set(tags.map((tag) => tag.toLowerCase()));
+  for (const tag of requiredTags) {
+    if (normalized.has(tag.toLowerCase())) continue;
+    tags.push(tag);
+    normalized.add(tag.toLowerCase());
+  }
+  headers.set("netlify-cache-tag", tags.join(","));
 }
 
 function applyHeadersManifest(

--- a/packages/adapter-netlify/src/index.ts
+++ b/packages/adapter-netlify/src/index.ts
@@ -1,0 +1,556 @@
+import { lstat, readFile, realpath } from "node:fs/promises";
+import { extname, resolve, sep } from "node:path";
+import type { PrachtAdapter } from "@pracht/vite-plugin";
+import type { Plugin } from "vite";
+import {
+  applyDefaultSecurityHeaders,
+  classifyRevalidationSkip,
+  createISGRegenerationRequest,
+  getTimeRevalidateSeconds,
+  handlePrachtRequest,
+  isCacheableISGResponse,
+  isDangerousPrerenderHeader,
+  jsonResponse,
+  matchAppRoute,
+  prefersMarkdown,
+  preventHeuristicCaching,
+  PRACHT_REVALIDATE_ENDPOINT,
+  readRevalidationRequest,
+  RevalidationReport,
+  resolveRevalidationToken,
+  routeSupportsMarkdown,
+  type HandlePrachtRequestOptions,
+  type ISGManifestEntry,
+  type MarkdownManifest,
+  type ModuleRegistry,
+  type PrachtApp,
+  type ResolvedApiRoute,
+  type ResolvedRoute,
+} from "@pracht/core/server";
+
+export type HeadersManifest = Record<string, Record<string, string>>;
+
+export interface NetlifyExecutionContext {
+  waitUntil?(promise: Promise<unknown>): void;
+  [key: string]: unknown;
+}
+
+export interface NetlifyContextArgs<
+  TNetlifyContext extends NetlifyExecutionContext = NetlifyExecutionContext,
+> {
+  request: Request;
+  context: TNetlifyContext;
+}
+
+export interface NetlifyPurgeCacheOptions {
+  tags?: string[];
+}
+
+export type NetlifyPurgeCache = (options?: NetlifyPurgeCacheOptions) => Promise<unknown>;
+
+/** Purge Netlify's cache without making applications depend on the platform SDK directly. */
+export async function purgeNetlifyCache(options?: NetlifyPurgeCacheOptions): Promise<void> {
+  const { purgeCache } = await import("@netlify/functions");
+  await purgeCache(options);
+}
+
+export interface NetlifyCacheOptions {
+  /** Seconds stale ISG output may be served while Netlify refreshes it. Defaults to one year. */
+  staleWhileRevalidate?: number;
+  /** Edge lifetime for immutable-per-deploy SSG documents. Defaults to one year. */
+  staticMaxAge?: number;
+}
+
+export interface NetlifyHandlerOptions<
+  TNetlifyContext extends NetlifyExecutionContext = NetlifyExecutionContext,
+  TContext = TNetlifyContext,
+> {
+  app: PrachtApp;
+  registry?: ModuleRegistry;
+  apiRoutes?: ResolvedApiRoute[];
+  clientEntryUrl?: string;
+  islandsEntryUrl?: string;
+  islandsBootstrapRequired?: boolean;
+  cssManifest?: Record<string, string[]>;
+  jsManifest?: Record<string, string[]>;
+  staticDir?: string;
+  isgManifest?: Record<string, ISGManifestEntry>;
+  headersManifest?: HeadersManifest;
+  /** Exact Markdown-capable routes. Omit only for legacy/custom server entries. */
+  markdownManifest?: MarkdownManifest;
+  createContext?: (args: NetlifyContextArgs<TNetlifyContext>) => TContext | Promise<TContext>;
+  purgeCache?: NetlifyPurgeCache;
+  cache?: NetlifyCacheOptions;
+}
+
+export interface NetlifyAdapterOptions extends NetlifyCacheOptions {
+  /** Vite-resolvable module path exporting `createContext(args)`. */
+  createContextFrom?: string;
+  /** Generated Netlify Function name. Defaults to `pracht`. */
+  functionName?: string;
+  /** Directory where the generated function wrapper is written. */
+  functionsDir?: string;
+  /** Additional paths Netlify should serve directly instead of invoking the function. */
+  excludedPath?: string[];
+}
+
+const DEFAULT_STALE_WHILE_REVALIDATE = 31_536_000;
+const DEFAULT_STATIC_MAX_AGE = 31_536_000;
+const ROUTE_STATE_REQUEST_HEADER = "x-pracht-route-state-request";
+const DEFAULT_EXCLUDED_PATHS = ["/assets/*", "/_pracht/*"];
+const ISG_CACHE_TAG = "pracht:isg";
+
+/**
+ * Create a fetch-style Netlify Functions v2 handler.
+ *
+ * The generated function claims page URLs so negotiated Markdown and route
+ * state requests reach Pracht, while ordinary SSG documents are read from the
+ * bundled client output and cached in Netlify's durable cache.
+ */
+export function createNetlifyHandler<
+  TNetlifyContext extends NetlifyExecutionContext = NetlifyExecutionContext,
+  TContext = TNetlifyContext,
+>(options: NetlifyHandlerOptions<TNetlifyContext, TContext>) {
+  const isgManifest = options.isgManifest ?? {};
+  const headersManifest = options.headersManifest ?? {};
+  const cache = resolveCacheOptions(options.cache);
+
+  return async (request: Request, context: TNetlifyContext): Promise<Response> => {
+    const url = new URL(request.url);
+
+    if (url.pathname === PRACHT_REVALIDATE_ENDPOINT) {
+      return handleNetlifyRevalidation(request, options, isgManifest);
+    }
+
+    const routeStateRequest = isRouteStateRequest(request, url);
+    const wantsMarkdown =
+      prefersMarkdown(request.headers.get("accept")) &&
+      (options.markdownManifest === undefined ||
+        routeSupportsMarkdown(options.markdownManifest, url.pathname));
+    const staticMethod = request.method === "GET" || request.method === "HEAD";
+
+    if (
+      options.staticDir &&
+      staticMethod &&
+      !routeStateRequest &&
+      !wantsMarkdown &&
+      !(url.pathname in isgManifest)
+    ) {
+      const file = await resolveStaticFile(options.staticDir, url.pathname);
+      if (file) {
+        return serveStaticFile(request, file, headersManifest, url.pathname, cache.staticMaxAge);
+      }
+    }
+
+    const isgRoute =
+      staticMethod && !routeStateRequest && !wantsMarkdown && url.pathname in isgManifest
+        ? matchAppRoute(options.app, url.pathname)?.route
+        : undefined;
+
+    // A Netlify CDN response is shared by every visitor. Render ISG documents
+    // from a request stripped of cookies, authorization, query, and body so the
+    // visitor who triggers a cache miss cannot personalize the stored result.
+    const renderRequest = isgRoute ? createISGRegenerationRequest(url.pathname, request) : request;
+    const prachtContext = options.createContext
+      ? await options.createContext({ request: renderRequest, context })
+      : (context as unknown as TContext);
+
+    const response = await handlePrachtRequest({
+      app: options.app,
+      registry: options.registry,
+      request: renderRequest,
+      context: prachtContext,
+      apiRoutes: options.apiRoutes,
+      clientEntryUrl: options.clientEntryUrl,
+      islandsEntryUrl: options.islandsEntryUrl,
+      islandsBootstrapRequired: options.islandsBootstrapRequired,
+      cssManifest: options.cssManifest,
+      jsManifest: options.jsManifest,
+    } satisfies HandlePrachtRequestOptions<TContext>);
+
+    if (isgRoute) {
+      return applyNetlifyISGCacheHeaders(response, isgRoute, url.pathname, cache);
+    }
+
+    return applyNetlifyDynamicCacheHeaders(request, response);
+  };
+}
+
+/** Cache tag for one concrete ISG pathname. */
+export function netlifyRouteCacheTag(pathname: string): string {
+  return `pracht:path:${encodeURIComponent(normalizePathname(pathname))}`;
+}
+
+/** Return the first candidate containing the Pracht client build directory. */
+export async function resolveNetlifyStaticDir(
+  candidates: Array<string | null | undefined>,
+): Promise<string | undefined> {
+  for (const candidate of candidates) {
+    if (!candidate) continue;
+    const root = resolve(candidate);
+    const info = await lstat(root).catch(() => null);
+    if (info?.isDirectory()) return root;
+  }
+  return undefined;
+}
+
+export function createNetlifyServerEntryModule(options: NetlifyAdapterOptions = {}): string {
+  const contextImport = options.createContextFrom
+    ? `import { createContext as createPrachtContext } from ${JSON.stringify(options.createContextFrom)};`
+    : "const createPrachtContext = undefined;";
+
+  return [
+    'import { existsSync, readFileSync } from "node:fs";',
+    'import { dirname, resolve } from "node:path";',
+    'import { fileURLToPath } from "node:url";',
+    'import { createNetlifyHandler, purgeNetlifyCache, resolveNetlifyStaticDir } from "@pracht/adapter-netlify";',
+    contextImport,
+    "",
+    "const serverDir = dirname(fileURLToPath(import.meta.url));",
+    "function readManifest(name, fallback) {",
+    "  for (const file of [",
+    '    resolve(process.cwd(), "dist/server", name),',
+    "    resolve(serverDir, name),",
+    "  ]) {",
+    '    if (existsSync(file)) return JSON.parse(readFileSync(file, "utf-8"));',
+    "  }",
+    "  return fallback;",
+    "}",
+    "const staticDir = await resolveNetlifyStaticDir([",
+    "  process.env.PRACHT_STATIC_DIR,",
+    '  resolve(process.cwd(), "dist/client"),',
+    '  resolve(serverDir, "../client"),',
+    "]);",
+    'const isgManifest = readManifest("isg-manifest.json", {});',
+    'const headersManifest = readManifest("headers-manifest.json", {});',
+    'const markdownManifest = readManifest("markdown-manifest.json", undefined);',
+    "",
+    "const handler = createNetlifyHandler({",
+    "  app: resolvedApp,",
+    "  registry,",
+    "  apiRoutes,",
+    "  clientEntryUrl: clientEntryUrl ?? undefined,",
+    "  islandsEntryUrl: islandsEntryUrl ?? undefined,",
+    "  islandsBootstrapRequired,",
+    "  cssManifest,",
+    "  jsManifest,",
+    "  staticDir,",
+    "  isgManifest,",
+    "  headersManifest,",
+    "  markdownManifest,",
+    "  createContext: createPrachtContext,",
+    "  purgeCache: purgeNetlifyCache,",
+    `  cache: ${JSON.stringify({
+      staleWhileRevalidate: options.staleWhileRevalidate,
+      staticMaxAge: options.staticMaxAge,
+    })},`,
+    "});",
+    "",
+    "export default function handle(request, context) {",
+    "  return handler(request, context);",
+    "}",
+    "",
+  ].join("\n");
+}
+
+/**
+ * Create a Pracht adapter for Netlify Functions v2.
+ *
+ * The adapter emits `netlify/functions/pracht.mjs`, which re-exports the
+ * bundled Pracht server and declares a catch-all path with static asset
+ * exclusions. Set Netlify's publish directory to `dist/client`.
+ */
+export function netlifyAdapter(options: NetlifyAdapterOptions = {}): PrachtAdapter {
+  return {
+    id: "netlify",
+    serverImports: 'import { resolveApp, resolveApiRoutes } from "@pracht/core/server";',
+    createServerEntryModule() {
+      return createNetlifyServerEntryModule(options);
+    },
+    vitePlugins() {
+      return [netlifyFunctionPlugin(options)];
+    },
+  };
+}
+
+function netlifyFunctionPlugin(options: NetlifyAdapterOptions): Plugin {
+  const functionName = options.functionName ?? "pracht";
+  const functionsDir = options.functionsDir ?? "netlify/functions";
+  const excludedPath = [...DEFAULT_EXCLUDED_PATHS, ...(options.excludedPath ?? [])];
+  let root = process.cwd();
+  let isSsrBuild = false;
+
+  return {
+    name: "pracht:adapter-netlify-function",
+    apply: "build",
+    configResolved(config) {
+      root = config.root;
+      isSsrBuild = Boolean(config.build.ssr);
+    },
+    async closeBundle() {
+      if (!isSsrBuild) return;
+      const { mkdir, writeFile } = await import("node:fs/promises");
+      const { join, relative } = await import("node:path");
+      const dir = join(root, functionsDir);
+      const wrapper = join(dir, `${functionName}.mjs`);
+      const serverEntry = relative(dir, join(root, "dist/server/server.js")).replaceAll("\\", "/");
+      const importPath = serverEntry.startsWith(".") ? serverEntry : `./${serverEntry}`;
+      const source = [
+        "// Generated by @pracht/adapter-netlify — do not edit.",
+        `import handler from ${JSON.stringify(importPath)};`,
+        "",
+        "export default handler;",
+        "",
+        `export const config = ${JSON.stringify(
+          {
+            excludedPath,
+            includedFiles: ["dist/client/**", "dist/server/*-manifest.json"],
+            name: functionName,
+            nodeBundler: "esbuild",
+            path: "/*",
+          },
+          null,
+          2,
+        )};`,
+        "",
+      ].join("\n");
+
+      await mkdir(dir, { recursive: true });
+      await writeFile(wrapper, source, "utf-8");
+    },
+  };
+}
+
+async function handleNetlifyRevalidation<TNetlifyContext extends NetlifyExecutionContext, TContext>(
+  request: Request,
+  options: NetlifyHandlerOptions<TNetlifyContext, TContext>,
+  isgManifest: Record<string, ISGManifestEntry>,
+): Promise<Response> {
+  const parsed = await readRevalidationRequest(request, resolveRevalidationToken());
+  if (!parsed.ok) return parsed.response;
+
+  const report = new RevalidationReport();
+  for (const pathname of parsed.paths) {
+    const entry = isgManifest[pathname];
+    const matched = matchAppRoute(options.app, pathname)?.route ?? null;
+    const reason = classifyRevalidationSkip(
+      entry ? { ...entry, render: "isg" } : undefined,
+      Boolean(entry),
+      matched,
+    );
+    if (reason) {
+      report.skipped(pathname, reason);
+      continue;
+    }
+    if (!options.purgeCache) {
+      report.failed(pathname, "cache_purge_unavailable");
+      continue;
+    }
+
+    try {
+      await options.purgeCache({ tags: [netlifyRouteCacheTag(pathname)] });
+      report.revalidated(pathname);
+    } catch (error) {
+      console.error(`ISG webhook revalidation failed for ${pathname}:`, error);
+      report.failed(pathname, "cache_purge_failed");
+    }
+  }
+
+  return jsonResponse(report.toJSON());
+}
+
+function applyNetlifyISGCacheHeaders(
+  response: Response,
+  route: ResolvedRoute,
+  pathname: string,
+  cache: Required<NetlifyCacheOptions>,
+): Response {
+  if (response.status !== 200) return response;
+
+  let prepared = stripDangerousSharedCacheHeaders(response, pathname);
+  if (prepared.headers.has("cache-control") || prepared.headers.has("netlify-cdn-cache-control")) {
+    return prepared;
+  }
+  if (!isCacheableISGResponse(prepared)) return prepared;
+
+  const seconds = getTimeRevalidateSeconds(route.revalidate) ?? cache.staticMaxAge;
+  const headers = new Headers(prepared.headers);
+  headers.set(
+    "netlify-cdn-cache-control",
+    `public, durable, max-age=${seconds}, stale-while-revalidate=${cache.staleWhileRevalidate}`,
+  );
+  headers.set("cache-control", "public, max-age=0, must-revalidate");
+  headers.set("netlify-cache-tag", `${ISG_CACHE_TAG},${netlifyRouteCacheTag(pathname)}`);
+  prepared = cloneResponse(prepared, headers);
+  return prepared;
+}
+
+function applyNetlifyDynamicCacheHeaders(request: Request, response: Response): Response {
+  const prepared = preventHeuristicCaching(request, response);
+  const cacheControl = prepared.headers.get("cache-control");
+  if (
+    prepared.headers.has("netlify-cdn-cache-control") ||
+    !cacheControl ||
+    !/(?:^|,)\s*public\b/i.test(cacheControl)
+  ) {
+    return prepared;
+  }
+
+  const headers = new Headers(prepared.headers);
+  headers.set("netlify-cdn-cache-control", `${cacheControl}, durable`);
+  return cloneResponse(prepared, headers);
+}
+
+function stripDangerousSharedCacheHeaders(response: Response, pathname: string): Response {
+  const dangerous = [...response.headers.keys()].filter(isDangerousPrerenderHeader);
+  if (dangerous.length === 0) return response;
+
+  const headers = new Headers(response.headers);
+  for (const name of dangerous) headers.delete(name);
+  console.error(
+    `Stripped ${dangerous.map((name) => `"${name}"`).join(", ")} from the ISG response for ` +
+      `"${pathname}" before Netlify's shared cache stored it.`,
+  );
+  return cloneResponse(response, headers);
+}
+
+interface StaticFileResult {
+  filePath: string;
+  contentType: string;
+  document: boolean;
+}
+
+async function resolveStaticFile(
+  staticDir: string,
+  pathname: string,
+): Promise<StaticFileResult | null> {
+  const root = resolve(staticDir);
+  const exact = resolveUrlPath(root, pathname);
+  if (exact && (await isContainedFile(root, exact))) {
+    return {
+      contentType: MIME_TYPES[extname(exact)] ?? "application/octet-stream",
+      document: exact.endsWith(".html"),
+      filePath: exact,
+    };
+  }
+
+  const index =
+    pathname === "/" ? resolve(root, "index.html") : resolveUrlPath(root, pathname, "index.html");
+  if (!index || !(await isContainedFile(root, index))) return null;
+  return { contentType: "text/html; charset=utf-8", document: true, filePath: index };
+}
+
+async function serveStaticFile(
+  request: Request,
+  file: StaticFileResult,
+  headersManifest: HeadersManifest,
+  pathname: string,
+  staticMaxAge: number,
+): Promise<Response> {
+  const headers = applyDefaultSecurityHeaders(
+    new Headers({
+      "content-type": file.contentType,
+      "cache-control": pathname.startsWith("/assets/")
+        ? "public, max-age=31536000, immutable"
+        : "public, max-age=0, must-revalidate",
+      "netlify-cdn-cache-control": `public, durable, max-age=${staticMaxAge}`,
+    }),
+  );
+  if (file.document) applyHeadersManifest(headers, headersManifest, pathname);
+  const body = request.method === "HEAD" ? null : await readFile(file.filePath);
+  return new Response(body, { headers });
+}
+
+function applyHeadersManifest(
+  headers: Headers,
+  headersManifest: HeadersManifest,
+  pathname: string,
+): void {
+  const withoutSlash = pathname.replace(/\/$/, "") || "/";
+  const withoutIndex = pathname.replace(/\/index\.html$/, "") || "/";
+  const values =
+    headersManifest[pathname] ?? headersManifest[withoutSlash] ?? headersManifest[withoutIndex];
+  if (!values) return;
+  for (const [name, value] of Object.entries(values)) headers.set(name, value);
+}
+
+function isRouteStateRequest(request: Request, url: URL): boolean {
+  return (
+    request.headers.get(ROUTE_STATE_REQUEST_HEADER) === "1" || url.searchParams.get("_data") === "1"
+  );
+}
+
+function resolveCacheOptions(
+  options: NetlifyCacheOptions | undefined,
+): Required<NetlifyCacheOptions> {
+  return {
+    staleWhileRevalidate: positiveInteger(
+      options?.staleWhileRevalidate,
+      DEFAULT_STALE_WHILE_REVALIDATE,
+    ),
+    staticMaxAge: positiveInteger(options?.staticMaxAge, DEFAULT_STATIC_MAX_AGE),
+  };
+}
+
+function positiveInteger(value: number | undefined, fallback: number): number {
+  if (typeof value !== "number" || !Number.isFinite(value)) return fallback;
+  const integer = Math.floor(value);
+  return integer > 0 ? integer : fallback;
+}
+
+function normalizePathname(pathname: string): string {
+  if (!pathname.startsWith("/")) pathname = `/${pathname}`;
+  return pathname.length > 1 ? pathname.replace(/\/$/, "") : pathname;
+}
+
+function cloneResponse(response: Response, headers: Headers): Response {
+  return new Response(response.body, {
+    headers,
+    status: response.status,
+    statusText: response.statusText,
+  });
+}
+
+function resolveUrlPath(root: string, pathname: string, suffix?: string): string | null {
+  if (pathname.includes("\0") || pathname.includes("\\")) return null;
+  const candidate = suffix ? resolve(root, `.${pathname}`, suffix) : resolve(root, `.${pathname}`);
+  return pathIsInside(root, candidate) ? candidate : null;
+}
+
+async function isContainedFile(root: string, candidate: string): Promise<boolean> {
+  const info = await lstat(candidate).catch(() => null);
+  if (!info?.isFile() || info.isSymbolicLink()) return false;
+  const [rootReal, candidateReal] = await Promise.all([
+    realpath(root).catch(() => root),
+    realpath(candidate).catch(() => null),
+  ]);
+  return candidateReal !== null && pathIsInside(resolve(rootReal), resolve(candidateReal));
+}
+
+function pathIsInside(root: string, candidate: string): boolean {
+  return candidate === root || candidate.startsWith(root.endsWith(sep) ? root : `${root}${sep}`);
+}
+
+const MIME_TYPES: Record<string, string> = {
+  ".atom": "application/atom+xml",
+  ".css": "text/css; charset=utf-8",
+  ".gif": "image/gif",
+  ".html": "text/html; charset=utf-8",
+  ".ico": "image/x-icon",
+  ".jpeg": "image/jpeg",
+  ".jpg": "image/jpeg",
+  ".js": "application/javascript; charset=utf-8",
+  ".json": "application/json; charset=utf-8",
+  ".markdown": "text/markdown; charset=utf-8",
+  ".md": "text/markdown; charset=utf-8",
+  ".otf": "font/otf",
+  ".png": "image/png",
+  ".svg": "image/svg+xml",
+  ".ttf": "font/ttf",
+  ".txt": "text/plain; charset=utf-8",
+  ".webmanifest": "application/manifest+json",
+  ".webp": "image/webp",
+  ".woff": "font/woff",
+  ".woff2": "font/woff2",
+  ".xml": "application/xml; charset=utf-8",
+};

--- a/packages/adapter-netlify/test/index.test.ts
+++ b/packages/adapter-netlify/test/index.test.ts
@@ -1,0 +1,297 @@
+import { mkdtemp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { h } from "preact";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  defineApp,
+  resolveApiRoutes,
+  route,
+  timeRevalidate,
+  webhookRevalidate,
+} from "@pracht/core";
+
+import {
+  createNetlifyHandler,
+  createNetlifyServerEntryModule,
+  netlifyAdapter,
+  netlifyRouteCacheTag,
+  resolveNetlifyStaticDir,
+} from "../src/index.ts";
+
+const tempDirs: string[] = [];
+
+afterEach(async () => {
+  vi.restoreAllMocks();
+  await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { force: true, recursive: true })));
+  delete process.env.PRACHT_REVALIDATE_TOKEN;
+});
+
+async function tempDir(): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), "pracht-netlify-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+describe("createNetlifyServerEntryModule", () => {
+  it("loads build manifests, context, and the Netlify purge helper", () => {
+    const source = createNetlifyServerEntryModule({
+      createContextFrom: "/src/server/context.ts",
+      staleWhileRevalidate: 60,
+      staticMaxAge: 120,
+    });
+
+    expect(source).toContain(
+      'import { createContext as createPrachtContext } from "/src/server/context.ts";',
+    );
+    expect(source).toContain('readManifest("markdown-manifest.json", undefined)');
+    expect(source).toContain("purgeNetlifyCache");
+    expect(source).not.toContain('from "@netlify/functions"');
+    expect(source).toContain('"staleWhileRevalidate":60');
+    expect(source).toContain("islandsBootstrapRequired");
+  });
+});
+
+describe("netlifyAdapter", () => {
+  it("emits a catch-all Functions v2 wrapper with asset exclusions", async () => {
+    const root = await tempDir();
+    const adapter = netlifyAdapter({
+      excludedPath: ["/content/*"],
+      functionName: "site",
+    });
+    const plugin = adapter.vitePlugins?.()[0];
+    expect(plugin).toBeDefined();
+
+    const configResolved = plugin?.configResolved;
+    if (typeof configResolved !== "function") throw new Error("missing configResolved hook");
+    await configResolved.call(
+      {} as never,
+      {
+        root,
+        build: { ssr: true },
+      } as never,
+    );
+    const closeBundle = plugin?.closeBundle;
+    if (typeof closeBundle !== "function") throw new Error("missing closeBundle hook");
+    await closeBundle.call({} as never);
+
+    const source = await readFile(join(root, "netlify/functions/site.mjs"), "utf-8");
+    expect(source).toContain('"path": "/*"');
+    expect(source).toContain('"/assets/*"');
+    expect(source).toContain('"/content/*"');
+    expect(source).toContain('"dist/client/**"');
+    expect(source).toContain('import handler from "../../dist/server/server.js"');
+  });
+});
+
+describe("createNetlifyHandler", () => {
+  const app = defineApp({
+    routes: [
+      route("/guide", "./routes/guide.tsx", { render: "ssg" }),
+      route("/dashboard", "./routes/dashboard.tsx", { render: "ssr" }),
+      route("/pricing", "./routes/pricing.tsx", {
+        render: "isg",
+        revalidate: [timeRevalidate(60), webhookRevalidate()],
+      }),
+    ],
+  });
+  const seenPricingRequests: Request[] = [];
+  const registry = {
+    routeModules: {
+      "/src/routes/guide.tsx": async () => ({
+        default: () => h("main", null, "guide"),
+        loader: () => ({ page: "guide" }),
+        markdown: "# Guide",
+      }),
+      "/src/routes/dashboard.tsx": async () => ({
+        default: () => h("main", null, "dashboard"),
+      }),
+      "/src/routes/pricing.tsx": async () => ({
+        default: () => h("main", null, "pricing"),
+        loader: ({ request }: { request: Request }) => {
+          seenPricingRequests.push(request);
+          return {};
+        },
+      }),
+    },
+  };
+
+  async function createStaticBuild(): Promise<string> {
+    const dir = await tempDir();
+    await mkdir(join(dir, "guide"), { recursive: true });
+    await mkdir(join(dir, "assets"), { recursive: true });
+    await writeFile(join(dir, "index.html"), "<html>home</html>");
+    await writeFile(join(dir, "guide/index.html"), "<html>static guide</html>");
+    await writeFile(join(dir, "assets/app.js"), "export default 1");
+    await writeFile(join(dir, "robots.txt"), "User-agent: *");
+    return dir;
+  }
+
+  it("serves prerendered HTML with route headers and durable caching", async () => {
+    const staticDir = await createStaticBuild();
+    const handler = createNetlifyHandler({
+      app,
+      headersManifest: { "/guide": { "x-route": "guide", vary: "Accept" } },
+      markdownManifest: { "/guide": true },
+      registry,
+      staticDir,
+    });
+
+    const response = await handler(new Request("https://example.com/guide"), {});
+    expect(await response.text()).toBe("<html>static guide</html>");
+    expect(response.headers.get("x-route")).toBe("guide");
+    expect(response.headers.get("vary")).toBe("Accept");
+    expect(response.headers.get("netlify-cdn-cache-control")).toContain("durable");
+  });
+
+  it("serves exact assets with their MIME type when the function receives them", async () => {
+    const staticDir = await createStaticBuild();
+    const handler = createNetlifyHandler({ app, registry, staticDir });
+    const response = await handler(new Request("https://example.com/assets/app.js"), {});
+
+    expect(response.headers.get("content-type")).toContain("application/javascript");
+    expect(response.headers.get("cache-control")).toContain("immutable");
+    expect(await response.text()).toBe("export default 1");
+  });
+
+  it("does not mark unhashed public files immutable", async () => {
+    const staticDir = await createStaticBuild();
+    const handler = createNetlifyHandler({ app, registry, staticDir });
+    const response = await handler(new Request("https://example.com/robots.txt"), {});
+
+    expect(response.headers.get("content-type")).toContain("text/plain");
+    expect(response.headers.get("cache-control")).toBe("public, max-age=0, must-revalidate");
+    expect(await response.text()).toBe("User-agent: *");
+  });
+
+  it("bypasses static HTML for negotiated Markdown and route-state requests", async () => {
+    const staticDir = await createStaticBuild();
+    const handler = createNetlifyHandler({
+      app,
+      markdownManifest: { "/guide": true },
+      registry,
+      staticDir,
+    });
+
+    const markdown = await handler(
+      new Request("https://example.com/guide", {
+        headers: { accept: "text/markdown" },
+      }),
+      {},
+    );
+    expect(markdown.headers.get("content-type")).toContain("text/markdown");
+    expect(await markdown.text()).toBe("# Guide");
+
+    const state = await handler(
+      new Request("https://example.com/guide", {
+        headers: { "x-pracht-route-state-request": "1" },
+      }),
+      {},
+    );
+    await expect(state.json()).resolves.toEqual({ data: { page: "guide" } });
+  });
+
+  it("fails closed against heuristic caching for dynamic SSR", async () => {
+    const handler = createNetlifyHandler({ app, registry });
+    const response = await handler(new Request("https://example.com/dashboard"), {});
+    expect(response.headers.get("cache-control")).toBe("private, no-cache");
+    expect(response.headers.has("netlify-cdn-cache-control")).toBe(false);
+  });
+
+  it("renders ISG from a sanitized request and stamps durable cache metadata", async () => {
+    seenPricingRequests.length = 0;
+    const handler = createNetlifyHandler({
+      app,
+      isgManifest: {
+        "/pricing": {
+          revalidate: [timeRevalidate(60), webhookRevalidate()],
+        },
+      },
+      registry,
+    });
+    const response = await handler(
+      new Request("https://example.com/pricing?visitor=1", {
+        headers: {
+          authorization: "Bearer visitor",
+          cookie: "session=visitor",
+        },
+      }),
+      {},
+    );
+
+    expect(seenPricingRequests).toHaveLength(1);
+    expect(seenPricingRequests[0].url).toBe("https://example.com/pricing");
+    expect(seenPricingRequests[0].headers.get("cookie")).toBeNull();
+    expect(seenPricingRequests[0].headers.get("authorization")).toBeNull();
+    expect(response.headers.get("cache-control")).toBe("public, max-age=0, must-revalidate");
+    expect(response.headers.get("netlify-cdn-cache-control")).toContain("max-age=60");
+    expect(response.headers.get("netlify-cache-tag")).toContain(netlifyRouteCacheTag("/pricing"));
+  });
+
+  it("purges tagged ISG responses through the authenticated webhook", async () => {
+    process.env.PRACHT_REVALIDATE_TOKEN = "secret";
+    const purgeCache = vi.fn(async () => undefined);
+    const handler = createNetlifyHandler({
+      app,
+      isgManifest: {
+        "/pricing": {
+          revalidate: [timeRevalidate(60), webhookRevalidate()],
+        },
+      },
+      purgeCache,
+      registry,
+    });
+    const response = await handler(
+      new Request("https://example.com/__pracht/revalidate", {
+        body: JSON.stringify({ paths: ["/pricing"] }),
+        headers: {
+          authorization: "Bearer secret",
+          "content-type": "application/json",
+        },
+        method: "POST",
+      }),
+      {},
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      failed: [],
+      revalidated: ["/pricing"],
+      skipped: [],
+    });
+    expect(purgeCache).toHaveBeenCalledWith({
+      tags: [netlifyRouteCacheTag("/pricing")],
+    });
+  });
+
+  it("passes Netlify context through createContext", async () => {
+    const apiRoutes = resolveApiRoutes(["/src/api/region.ts"]);
+    const handler = createNetlifyHandler({
+      apiRoutes,
+      app: defineApp({ routes: [] }),
+      createContext: ({ context }) => ({ region: context.region }),
+      registry: {
+        apiModules: {
+          "/src/api/region.ts": async () => ({
+            GET: ({ context }: { context: { region: string } }) =>
+              Response.json({ region: context.region }),
+          }),
+        },
+      },
+    });
+    const response = await handler(new Request("https://example.com/api/region"), {
+      region: "eu-west",
+    });
+    await expect(response.json()).resolves.toEqual({ region: "eu-west" });
+  });
+});
+
+describe("resolveNetlifyStaticDir", () => {
+  it("selects the first existing client directory, including SSR-only builds", async () => {
+    const parent = await tempDir();
+    const missing = join(parent, "missing");
+    const present = await tempDir();
+    await expect(resolveNetlifyStaticDir([missing, present])).resolves.toBe(present);
+  });
+});

--- a/packages/adapter-netlify/test/index.test.ts
+++ b/packages/adapter-netlify/test/index.test.ts
@@ -143,6 +143,27 @@ describe("createNetlifyHandler", () => {
     expect(response.headers.get("x-route")).toBe("guide");
     expect(response.headers.get("vary")).toBe("Accept");
     expect(response.headers.get("netlify-cdn-cache-control")).toContain("durable");
+    expect(response.headers.get("netlify-vary")).toBe("query=_data");
+  });
+
+  it("keeps an explicit SSG cache policy authoritative", async () => {
+    const staticDir = await createStaticBuild();
+    const handler = createNetlifyHandler({
+      app,
+      headersManifest: {
+        "/guide": {
+          "cache-control": "no-store",
+          "netlify-vary": "query=preview",
+        },
+      },
+      registry,
+      staticDir,
+    });
+
+    const response = await handler(new Request("https://example.com/guide"), {});
+    expect(response.headers.get("cache-control")).toBe("no-store");
+    expect(response.headers.has("netlify-cdn-cache-control")).toBe(false);
+    expect(response.headers.get("netlify-vary")).toBe("query=preview");
   });
 
   it("serves exact assets with their MIME type when the function receives them", async () => {
@@ -227,6 +248,60 @@ describe("createNetlifyHandler", () => {
     expect(response.headers.get("cache-control")).toBe("public, max-age=0, must-revalidate");
     expect(response.headers.get("netlify-cdn-cache-control")).toContain("max-age=60");
     expect(response.headers.get("netlify-cache-tag")).toContain(netlifyRouteCacheTag("/pricing"));
+    expect(response.headers.get("netlify-vary")).toBe("query=_data");
+  });
+
+  it("keeps cacheable custom ISG policies tagged for webhook purges", async () => {
+    const handler = createNetlifyHandler({
+      app,
+      isgManifest: {
+        "/pricing": {
+          revalidate: [timeRevalidate(60), webhookRevalidate()],
+        },
+      },
+      registry: {
+        ...registry,
+        routeModules: {
+          ...registry.routeModules,
+          "/src/routes/pricing.tsx": async () => ({
+            default: () => h("main", null, "pricing"),
+            headers: () => ({
+              "cache-control": "public, max-age=600",
+              "netlify-cache-tag": "app:pricing",
+              "netlify-vary": "query=preview",
+            }),
+          }),
+        },
+      },
+    });
+
+    const response = await handler(new Request("https://example.com/pricing"), {});
+    expect(response.headers.get("cache-control")).toBe("public, max-age=600");
+    expect(response.headers.has("netlify-cdn-cache-control")).toBe(false);
+    expect(response.headers.get("netlify-cache-tag")).toBe(
+      `app:pricing,pracht:isg,${netlifyRouteCacheTag("/pricing")}`,
+    );
+    expect(response.headers.get("netlify-vary")).toBe("query=preview");
+  });
+
+  it("does not add a private browser policy beside an explicit Netlify policy", async () => {
+    const handler = createNetlifyHandler({
+      app,
+      registry: {
+        ...registry,
+        routeModules: {
+          ...registry.routeModules,
+          "/src/routes/dashboard.tsx": async () => ({
+            default: () => h("main", null, "dashboard"),
+            headers: () => ({ "netlify-cdn-cache-control": "public, max-age=300" }),
+          }),
+        },
+      },
+    });
+
+    const response = await handler(new Request("https://example.com/dashboard"), {});
+    expect(response.headers.has("cache-control")).toBe(false);
+    expect(response.headers.get("netlify-cdn-cache-control")).toBe("public, max-age=300");
   });
 
   it("purges tagged ISG responses through the authenticated webhook", async () => {

--- a/packages/adapter-netlify/test/index.test.ts
+++ b/packages/adapter-netlify/test/index.test.ts
@@ -251,6 +251,86 @@ describe("createNetlifyHandler", () => {
     expect(response.headers.get("netlify-vary")).toBe("query=_data");
   });
 
+  it("sanitizes visitor-specific Netlify context before shared ISG renders", async () => {
+    const platformContext = {
+      cookies: {
+        delete: vi.fn(),
+        get: vi.fn(() => "visitor-session"),
+        set: vi.fn(),
+      },
+      customVisitorValue: "visitor-specific",
+      geo: { city: "Brussels" },
+      ip: "203.0.113.7",
+      requestId: "visitor-request-id",
+      site: { id: "site-id" },
+      url: new URL("https://example.com/pricing?visitor=1"),
+      waitUntil(this: unknown, _promise: Promise<unknown>) {
+        expect(this).toBe(platformContext);
+      },
+    };
+    let seenContext: Record<string, unknown> | undefined;
+    const handler = createNetlifyHandler({
+      app,
+      createContext: ({ context }) => {
+        seenContext = context;
+        context.waitUntil?.(Promise.resolve());
+        return context;
+      },
+      isgManifest: {
+        "/pricing": {
+          revalidate: [timeRevalidate(60), webhookRevalidate()],
+        },
+      },
+      registry,
+    });
+
+    const response = await handler(
+      new Request("https://example.com/pricing?visitor=1", {
+        headers: { cookie: "session=visitor" },
+      }),
+      platformContext,
+    );
+
+    expect(response.headers.get("netlify-cdn-cache-control")).toContain("public, durable");
+    expect(seenContext).toMatchObject({
+      cookies: expect.any(Object),
+      geo: {},
+      ip: "",
+      requestId: "",
+      site: { id: "site-id" },
+      url: new URL("https://example.com/pricing"),
+    });
+    const sharedCookies = seenContext?.cookies as
+      | { get(name: string): string | undefined }
+      | undefined;
+    expect(sharedCookies?.get("session")).toBeUndefined();
+    expect(seenContext).not.toHaveProperty("customVisitorValue");
+    expect(seenContext).not.toHaveProperty("next");
+    expect(platformContext.cookies.get).not.toHaveBeenCalled();
+  });
+
+  it("rejects cookie mutations while rendering shared ISG output", async () => {
+    const handler = createNetlifyHandler({
+      app,
+      createContext: ({ context }) => {
+        (context.cookies as { set(name: string, value: string): void }).set("session", "value");
+        return context;
+      },
+      isgManifest: {
+        "/pricing": {
+          revalidate: [timeRevalidate(60), webhookRevalidate()],
+        },
+      },
+      registry,
+    });
+
+    await expect(
+      handler(new Request("https://example.com/pricing"), {
+        cookies: { set: vi.fn() },
+      }),
+    ).rejects.toThrow("Netlify cookies cannot be changed while rendering a shared ISG response");
+  });
+
   it("keeps cacheable custom ISG policies tagged for webhook purges", async () => {
     const handler = createNetlifyHandler({
       app,

--- a/packages/adapter-netlify/tsdown.config.ts
+++ b/packages/adapter-netlify/tsdown.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from "tsdown";
+
+export default defineConfig({
+  clean: true,
+  entry: ["src/index.ts"],
+  format: "esm",
+  dts: true,
+  external: [
+    /^@netlify\/functions(\/.*)?$/,
+    /^@pracht\/core(\/.*)?$/,
+    "@pracht/vite-plugin",
+    /^node:/,
+    "vite",
+  ],
+});

--- a/packages/cli/src/authoring-guide.ts
+++ b/packages/cli/src/authoring-guide.ts
@@ -8,7 +8,7 @@ export const AUTHORING_GUIDE = `# Pracht — authoring guide for coding agents
 
 Pracht is a full-stack Preact framework on Vite. Per-route render modes
 (spa | ssr | ssg | isg), optional islands hydration, explicit routing, and
-adapters for Node, Cloudflare Workers, and Vercel.
+adapters for Node, Cloudflare Workers, Netlify, and Vercel.
 
 ## Golden rules
 

--- a/packages/cli/src/commands/preview.ts
+++ b/packages/cli/src/commands/preview.ts
@@ -11,9 +11,9 @@ import { findWranglerConfig } from "../wrangler-config.js";
 import { runBuild } from "./build.js";
 
 const SERVER_ENTRY = "dist/server/server.js";
-const ADAPTER_TARGETS = new Set(["cloudflare", "node", "vercel"]);
+const ADAPTER_TARGETS = new Set(["cloudflare", "netlify", "node", "vercel"]);
 
-export type AdapterTarget = "cloudflare" | "node" | "vercel";
+export type AdapterTarget = "cloudflare" | "netlify" | "node" | "vercel";
 
 export default defineCommand({
   meta: {
@@ -51,8 +51,8 @@ export default defineCommand({
     let target: AdapterTarget | null = skipBuild ? await readBuildTarget(root) : null;
     target ??= detectAdapterTarget(project);
 
-    if (target === "vercel") {
-      printVercelGuidance();
+    if (target === "netlify" || target === "vercel") {
+      printPlatformGuidance(target);
       process.exitCode = 1;
       return;
     }
@@ -63,8 +63,8 @@ export default defineCommand({
       const { buildTarget } = await runBuild(root);
       target = normalizeAdapterTarget(buildTarget) ?? target;
 
-      if (target === "vercel") {
-        printVercelGuidance();
+      if (target === "netlify" || target === "vercel") {
+        printPlatformGuidance(target);
         process.exitCode = 1;
         return;
       }
@@ -121,6 +121,10 @@ export function detectAdapterTarget(project: Pick<ProjectConfig, "rawConfig">): 
     return "vercel";
   }
 
+  if (/\bnetlifyAdapter\s*\(/.test(source) || source.includes("@pracht/adapter-netlify")) {
+    return "netlify";
+  }
+
   return "node";
 }
 
@@ -161,7 +165,24 @@ async function readBuildTarget(root: string): Promise<AdapterTarget | null> {
   }
 }
 
-function printVercelGuidance(): void {
+function printPlatformGuidance(target: "netlify" | "vercel"): void {
+  if (target === "netlify") {
+    console.log(
+      [
+        "",
+        "  The Netlify adapter relies on Netlify Functions and CDN behavior, so `pracht preview` does not emulate it.",
+        "",
+        "  Use Netlify's own local runtime instead:",
+        "",
+        "    pracht build && netlify dev",
+        "",
+        "  To build and deploy with the configured Netlify project, run: netlify deploy --build --prod",
+        "",
+      ].join("\n"),
+    );
+    return;
+  }
+
   console.log(
     [
       "",

--- a/packages/cli/test/fixture-copy.test.ts
+++ b/packages/cli/test/fixture-copy.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from "vitest";
 import { shouldCopyFixtureRelativePath } from "../../../e2e/fixture-copy.ts";
 
 describe("isolated E2E fixture copies", () => {
-  it.each(["dist", ".vercel", ".wrangler", "test-results"])(
+  it.each(["dist", ".netlify", ".vercel", ".wrangler", "netlify", "test-results"])(
     "excludes %s and its children with either path separator",
     (entry) => {
       expect(shouldCopyFixtureRelativePath(entry)).toBe(false);

--- a/packages/cli/test/preview.test.ts
+++ b/packages/cli/test/preview.test.ts
@@ -43,6 +43,22 @@ describe("detectAdapterTarget", () => {
     ).toBe("vercel");
   });
 
+  it("detects the netlify adapter from the factory call", () => {
+    expect(
+      detectAdapterTarget({
+        rawConfig: "export default { plugins: [pracht({ adapter: netlifyAdapter() })] };",
+      }),
+    ).toBe("netlify");
+  });
+
+  it("detects the netlify adapter from the package import", () => {
+    expect(
+      detectAdapterTarget({
+        rawConfig: 'import { netlifyAdapter as adapter } from "@pracht/adapter-netlify";',
+      }),
+    ).toBe("netlify");
+  });
+
   it("detects the node adapter from the factory call", () => {
     expect(
       detectAdapterTarget({
@@ -63,6 +79,7 @@ describe("normalizeAdapterTarget", () => {
   it("accepts the built-in adapter targets", () => {
     expect(normalizeAdapterTarget("node")).toBe("node");
     expect(normalizeAdapterTarget("cloudflare")).toBe("cloudflare");
+    expect(normalizeAdapterTarget("netlify")).toBe("netlify");
     expect(normalizeAdapterTarget("vercel")).toBe("vercel");
   });
 

--- a/packages/framework/src/runtime-headers.ts
+++ b/packages/framework/src/runtime-headers.ts
@@ -120,6 +120,7 @@ const CDN_CACHE_CONTROL_HEADERS = [
   "cache-control",
   "cdn-cache-control",
   "cloudflare-cdn-cache-control",
+  "netlify-cdn-cache-control",
   "surrogate-control",
   "vercel-cdn-cache-control",
 ] as const;

--- a/packages/start/README.md
+++ b/packages/start/README.md
@@ -35,13 +35,14 @@ npm run dev
 node ./packages/start/bin/create-pracht.js
 node ./packages/start/bin/create-pracht.js my-app --adapter=node --skip-install
 node ./packages/start/bin/create-pracht.js my-app --adapter=vercel --skip-install
+node ./packages/start/bin/create-pracht.js my-app --adapter=netlify --skip-install
 node ./packages/start/bin/create-pracht.js my-app --template=tailwind --yes
 node ./packages/start/bin/create-pracht.js my-app --adapter=node --no-tailwind --no-git --yes
 ```
 
 ## Options
 
-- `--adapter=node|cf|vercel` — choose the hosting adapter (default: node).
+- `--adapter=node|cf|netlify|vercel` — choose the hosting adapter (default: node).
 - `--router=manifest|pages` — choose the routing system (default: manifest).
 - `--template=minimal|tailwind` — non-interactive template selection; `minimal` is the default output, `tailwind` is minimal plus Tailwind CSS wiring.
 - `--tailwind` / `--no-tailwind` — enable or disable Tailwind CSS without going through the prompt.

--- a/packages/start/src/index.js
+++ b/packages/start/src/index.js
@@ -14,12 +14,14 @@ export class ValidationError extends Error {
 
 const FALLBACK_VERSION_RANGES = {
   "@pracht/adapter-cloudflare": "^0.5.8",
+  "@pracht/adapter-netlify": "^0.1.0",
   "@pracht/adapter-node": "^0.3.8",
   "@pracht/adapter-vercel": "^0.2.8",
   "@pracht/cli": "^1.9.0",
   "@pracht/core": "^0.12.0",
   "@pracht/vite-plugin": "^0.7.6",
   "@tailwindcss/vite": "^4.1.0",
+  "netlify-cli": "^21.6.0",
   tailwindcss: "^4.1.0",
   typescript: "^6.0.0",
   vercel: "^56.5.0",
@@ -70,6 +72,13 @@ const ADAPTERS = {
     label: "Cloudflare Workers",
     packageName: "@pracht/adapter-cloudflare",
     short: "cf",
+  },
+  netlify: {
+    description: "Netlify Functions with durable CDN caching",
+    id: "netlify",
+    label: "Netlify",
+    packageName: "@pracht/adapter-netlify",
+    short: "netlify",
   },
   vercel: {
     description: "Vercel Edge Functions with prebuilt deploy",
@@ -398,7 +407,7 @@ export function parseArgs(argv) {
       const value = normalizeAdapter(arg.slice("--adapter=".length));
       if (!value) {
         throw new ValidationError(
-          `Invalid adapter: ${arg.slice("--adapter=".length)}. Use node, cf, or vercel.`,
+          `Invalid adapter: ${arg.slice("--adapter=".length)}. Use node, cf, netlify, or vercel.`,
         );
       }
       options.adapter = value;
@@ -452,6 +461,7 @@ async function promptForAdapter(readline) {
   console.log("  1. Node.js");
   console.log("  2. Cloudflare Workers");
   console.log("  3. Vercel");
+  console.log("  4. Netlify");
 
   while (true) {
     const answer = await readline.question("Adapter (1): ");
@@ -461,7 +471,7 @@ async function promptForAdapter(readline) {
       return normalized;
     }
 
-    console.log("Choose 1/2/3 or node/cf/vercel.");
+    console.log("Choose 1/2/3/4 or node/cf/vercel/netlify.");
   }
 }
 
@@ -600,6 +610,10 @@ function normalizeAdapter(value) {
     return "vercel";
   }
 
+  if (normalized === "4" || normalized === "nf" || normalized === "netlify") {
+    return "netlify";
+  }
+
   return null;
 }
 
@@ -639,6 +653,9 @@ async function buildProjectFiles({
   if (adapter.id === "vercel") {
     packagesToResolve.push("vercel");
   }
+  if (adapter.id === "netlify") {
+    packagesToResolve.push("netlify-cli");
+  }
   if (tailwind) {
     packagesToResolve.push("tailwindcss", "@tailwindcss/vite");
   }
@@ -656,7 +673,7 @@ async function buildProjectFiles({
 
   const files = {
     ".gitignore":
-      "dist\nnode_modules\n.wrangler\n.vercel\n.env*\n!.env.example\n.dev.vars\n# Keep .pracht/app-graph.json committed — it is the `pracht plan` snapshot.\n",
+      "dist\nnode_modules\n.netlify\n.wrangler\n.vercel\n.env*\n!.env.example\n.dev.vars\n# Keep .pracht/app-graph.json committed — it is the `pracht plan` snapshot.\n",
     "README.md": createReadme({
       adapter,
       agentTools,
@@ -706,6 +723,10 @@ async function buildProjectFiles({
   if (adapter.id === "cloudflare") {
     files["wrangler.jsonc"] = createWranglerConfig(projectName);
     files["src/env.d.ts"] = createCloudflareEnvDeclaration();
+  }
+
+  if (adapter.id === "netlify") {
+    files["netlify.toml"] = createNetlifyConfig(packageManager);
   }
 
   if (adapter.id === "node") {
@@ -797,6 +818,12 @@ function createPackageJson({ adapter, projectName, tailwind, versions }) {
     devDependencies.wrangler = "^4.81.0";
   }
 
+  if (adapter.id === "netlify") {
+    scripts.deploy = "netlify deploy --build --prod";
+    scripts.preview = "pracht build && netlify dev";
+    devDependencies["netlify-cli"] = versions["netlify-cli"];
+  }
+
   if (adapter.id === "vercel") {
     scripts.deploy = "pracht build && vercel deploy --prebuilt";
     devDependencies.vercel = versions["vercel"];
@@ -829,6 +856,7 @@ function createViteConfig(adapter, router, tailwind) {
   const ADAPTER_IMPORTS = {
     node: { fn: "nodeAdapter", pkg: "@pracht/adapter-node" },
     cloudflare: { fn: "cloudflareAdapter", pkg: "@pracht/adapter-cloudflare" },
+    netlify: { fn: "netlifyAdapter", pkg: "@pracht/adapter-netlify" },
     vercel: { fn: "vercelAdapter", pkg: "@pracht/adapter-vercel" },
   };
 
@@ -1256,6 +1284,23 @@ function createWranglerConfig(projectName) {
   ].join("\n");
 }
 
+function createNetlifyConfig(packageManager) {
+  const buildCommand =
+    packageManager === "npm" || packageManager === "bun"
+      ? `${packageManager} run build`
+      : `${packageManager} build`;
+
+  return [
+    "[build]",
+    `  command = ${JSON.stringify(buildCommand)}`,
+    '  publish = "dist/client"',
+    "",
+    "[functions]",
+    '  directory = "netlify/functions"',
+    "",
+  ].join("\n");
+}
+
 function createCloudflareEnvDeclaration() {
   return [
     'import "@pracht/core";',
@@ -1365,7 +1410,7 @@ function createAgentInstructions({ adapter, agentTools, packageManager, router, 
     `- \`${runCmd} build\` — production build`,
   ];
 
-  if (adapter.id === "node" || adapter.id === "cloudflare") {
+  if (adapter.id === "node" || adapter.id === "cloudflare" || adapter.id === "netlify") {
     lines.push(`- \`${runCmd} preview\` — build and serve the production build locally`);
   }
 
@@ -1373,7 +1418,7 @@ function createAgentInstructions({ adapter, agentTools, packageManager, router, 
     lines.push(`- \`${runCmd} start\` — run the built server`);
   }
 
-  if (adapter.id === "cloudflare" || adapter.id === "vercel") {
+  if (adapter.id === "cloudflare" || adapter.id === "netlify" || adapter.id === "vercel") {
     lines.push(`- \`${runCmd} deploy\` — build and deploy`);
   }
 
@@ -1444,6 +1489,10 @@ function createAgentInstructions({ adapter, agentTools, packageManager, router, 
     lines.push("- `src/env.d.ts` — TypeScript types for Cloudflare bindings");
   }
 
+  if (adapter.id === "netlify") {
+    lines.push("- `netlify.toml` — Netlify build, publish, and functions configuration");
+  }
+
   if (agentTools) {
     lines.push("");
     lines.push("## Agent tooling");
@@ -1509,6 +1558,15 @@ function createReadme({
     lines.push("");
     lines.push(
       "Edit `wrangler.jsonc` to add KV, D1, R2, cron triggers, or other Cloudflare bindings.",
+    );
+  }
+
+  if (adapter.id === "netlify") {
+    lines.push(`- \`${previewCommand}\``);
+    lines.push(`- \`${deployCommand}\``);
+    lines.push("");
+    lines.push(
+      "`netlify.toml` publishes `dist/client` and discovers the Pracht function generated during the build.",
     );
   }
 
@@ -1733,7 +1791,8 @@ Usage:
   create-pracht [directory] [options]
 
 Options:
-  --adapter=node|cf|vercel     Choose hosting adapter (default: node)
+  --adapter=node|cf|netlify|vercel
+                               Choose hosting adapter (default: node)
   --router=manifest|pages      Choose routing system (default: manifest)
   --template=minimal|tailwind  Choose starter template (minimal, or minimal + Tailwind CSS)
   --tailwind / --no-tailwind   Enable or disable Tailwind CSS wiring (default: prompt).

--- a/packages/start/test/index.test.js
+++ b/packages/start/test/index.test.js
@@ -280,6 +280,47 @@ describe("create-pracht", () => {
     expect(ageDays).toBeLessThan(365);
   });
 
+  it("scaffolds a Netlify starter", async () => {
+    const root = await mkdtemp(join(tmpdir(), "pracht-start-netlify-"));
+    const targetDir = join(root, "my-netlify-app");
+
+    await scaffoldProject({
+      adapter: {
+        description: "Netlify Functions with durable CDN caching",
+        id: "netlify",
+        label: "Netlify",
+        packageName: "@pracht/adapter-netlify",
+        short: "netlify",
+      },
+      packageManager: "pnpm",
+      resolveRemoteVersions: false,
+      targetDir,
+    });
+
+    const packageJson = JSON.parse(await readFile(join(targetDir, "package.json"), "utf-8"));
+    const viteConfig = await readFile(join(targetDir, "vite.config.ts"), "utf-8");
+    const netlifyConfig = await readFile(join(targetDir, "netlify.toml"), "utf-8");
+    const gitignore = await readFile(join(targetDir, ".gitignore"), "utf-8");
+
+    expect(packageJson.dependencies).toMatchObject({
+      "@pracht/adapter-netlify": "^0.1.0",
+      "@pracht/core": "^0.12.0",
+    });
+    expect(packageJson.devDependencies["netlify-cli"]).toBe("^21.6.0");
+    expect(packageJson.scripts).toMatchObject({
+      deploy: "netlify deploy --build --prod",
+      preview: "pracht build && netlify dev",
+    });
+    expect(viteConfig).toContain('import { netlifyAdapter } from "@pracht/adapter-netlify";');
+    expect(viteConfig).toContain("adapter: netlifyAdapter()");
+    expect(netlifyConfig).toContain('command = "pnpm build"');
+    expect(netlifyConfig).toContain('publish = "dist/client"');
+    expect(netlifyConfig).toContain('directory = "netlify/functions"');
+    expect(gitignore).toContain(".netlify");
+    expect(existsSync(join(targetDir, "Dockerfile"))).toBe(false);
+    expect(existsSync(join(targetDir, "wrangler.jsonc"))).toBe(false);
+  });
+
   it("scaffolds a vercel starter", async () => {
     const root = await mkdtemp(join(tmpdir(), "pracht-start-vercel-"));
     const targetDir = join(root, "my-vercel-app");

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -43,7 +43,7 @@ export default defineConfig({
     {
       name: "basic",
       testMatch:
-        /basic\.test\.ts|navigation\.test\.ts|node-build\.test\.ts|cloudflare-build\.test\.ts|vercel-build\.test\.ts|pages-isg-build\.test\.ts|client-bundle-strip\.test\.ts|tsrx-build\.test\.ts|islands-build\.test\.ts|env-safety\.test\.ts|not-found\.test\.ts|openapi-cloudflare-dev\.test\.ts/,
+        /basic\.test\.ts|navigation\.test\.ts|node-build\.test\.ts|cloudflare-build\.test\.ts|netlify-build\.test\.ts|vercel-build\.test\.ts|pages-isg-build\.test\.ts|client-bundle-strip\.test\.ts|tsrx-build\.test\.ts|islands-build\.test\.ts|env-safety\.test\.ts|not-found\.test\.ts|openapi-cloudflare-dev\.test\.ts/,
       use: {
         baseURL: e2eUrls.basic,
       },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -56,6 +56,9 @@ importers:
       '@pracht/adapter-cloudflare':
         specifier: workspace:*
         version: link:../../packages/adapter-cloudflare
+      '@pracht/adapter-netlify':
+        specifier: workspace:*
+        version: link:../../packages/adapter-netlify
       '@pracht/adapter-node':
         specifier: workspace:*
         version: link:../../packages/adapter-node
@@ -291,6 +294,18 @@ importers:
       wrangler:
         specifier: ^4.81.0
         version: 4.81.0
+
+  packages/adapter-netlify:
+    dependencies:
+      '@netlify/functions':
+        specifier: ^5.3.0
+        version: 5.3.0
+      '@pracht/core':
+        specifier: workspace:*
+        version: link:../framework
+      vite:
+        specifier: ^8.0.0
+        version: 8.0.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@22.19.17)(esbuild@0.27.3)(yaml@2.9.0)
 
   packages/adapter-node:
     dependencies:
@@ -1283,6 +1298,14 @@ packages:
     peerDependencies:
       '@emnapi/core': ^1.7.1
       '@emnapi/runtime': ^1.7.1
+
+  '@netlify/functions@5.3.0':
+    resolution: {integrity: sha512-FP+xCoZMkMOUsKa4UdG/oiK/2md1/TxuXvqqieaMVMgDbFFMaHI8h0oHCViUY73kPbKV6HyzayaSXGYXKpBSoQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@netlify/types@2.8.0':
+    resolution: {integrity: sha512-8/g0Pt6y6wXj5Ia5eeYLiXhRfWeqZXGXpGFeCiiQdUOem+FPtXdA4+YdGxqzWc7D0AvptKSO01KGeeVWHSu8Kg==}
+    engines: {node: ^18.14.0 || >=20}
 
   '@oxc-project/types@0.122.0':
     resolution: {integrity: sha512-oLAl5kBpV4w69UtFZ9xqcmTi+GENWOcPF7FCrczTiBbmC0ibXxCwyvZGbO39rCVEuLGAZM84DH0pUIyyv/YJzA==}
@@ -4063,6 +4086,12 @@ snapshots:
       '@emnapi/runtime': 1.10.0
       '@tybys/wasm-util': 0.10.3
     optional: true
+
+  '@netlify/functions@5.3.0':
+    dependencies:
+      '@netlify/types': 2.8.0
+
+  '@netlify/types@2.8.0': {}
 
   '@oxc-project/types@0.122.0': {}
 

--- a/skills/pracht-deploy/SKILL.md
+++ b/skills/pracht-deploy/SKILL.md
@@ -3,10 +3,11 @@ name: pracht-deploy
 version: 1.1.0
 description: |
   Pracht deployment guide. Walks through adapter configuration, building, and
-  deploying to Node.js, Cloudflare Workers, or Vercel. Handles wrangler config,
-  Docker and production checklist.
+  deploying to Node.js, Cloudflare Workers, Netlify, or Vercel. Handles platform
+  config, Docker and production checklist.
   Use when asked to "deploy", "set up deployment", "configure adapter",
-  "deploy to cloudflare", "deploy to vercel", or "production build".
+  "deploy to cloudflare", "deploy to netlify", "deploy to vercel", or
+  "production build".
 allowed-tools:
   - Bash
   - Read
@@ -34,6 +35,7 @@ If the pracht MCP server is registered (docs/MCP.md), prefer the `inspect_build`
 | ------------------ | ---------------------------- | ------ |
 | Node.js            | `@pracht/adapter-node`       | Stable |
 | Cloudflare Workers | `@pracht/adapter-cloudflare` | Stable |
+| Netlify            | `@pracht/adapter-netlify`    | Stable |
 | Vercel             | `@pracht/adapter-vercel`     | Stable |
 
 ---
@@ -216,6 +218,46 @@ build-time snapshots and the worker-managed path either way.
 
 ---
 
+## Netlify Deployment
+
+### Setup
+
+1. Ensure `@pracht/adapter-netlify` and `netlify-cli` are installed.
+2. In `vite.config.ts`:
+   ```ts
+   import { pracht } from "@pracht/vite-plugin";
+   import { netlifyAdapter } from "@pracht/adapter-netlify";
+   export default { plugins: [pracht({ adapter: netlifyAdapter() })] };
+   ```
+3. Add `netlify.toml`:
+   ```toml
+   [build]
+     command = "pnpm build"
+     publish = "dist/client"
+
+   [functions]
+     directory = "netlify/functions"
+   ```
+
+### Build, Preview, and Deploy
+
+```bash
+npx pracht build && npx netlify dev
+npx netlify deploy --build --prod
+```
+
+The build emits `netlify/functions/pracht.mjs`. Page requests go through that
+function so Markdown negotiation and route-state requests remain correct;
+hashed assets bypass it. Netlify durable caching implements time-based ISG and
+per-path cache tags implement authenticated webhook revalidation.
+
+`pracht preview` exits with guidance because it cannot emulate Netlify's
+Functions and CDN behavior. Build the generated function before using
+`netlify dev` for the platform-shaped local runtime. Configure
+`PRACHT_REVALIDATE_TOKEN` in Netlify when webhook revalidation is enabled.
+
+---
+
 ## Vercel Deployment
 
 ### Setup
@@ -261,7 +303,7 @@ functions.
 
 1. Read `vite.config.ts` and `package.json` before giving advice.
 2. Run `pracht build` to verify the build succeeds before deploying.
-3. Smoke-test the production runtime before pushing to production. For Node.js and Cloudflare, run `pracht preview`.
+3. Smoke-test the production runtime before pushing to production. For Node.js and Cloudflare, run `pracht preview`; for Netlify, run `pracht build && netlify dev`.
 4. If the user needs an adapter that isn't installed, help them add it (`pnpm add @pracht/adapter-*`).
 5. Don't push to production without the user's explicit confirmation.
 

--- a/skills/pracht-deploy/SKILL.md
+++ b/skills/pracht-deploy/SKILL.md
@@ -249,7 +249,9 @@ npx netlify deploy --build --prod
 The build emits `netlify/functions/pracht.mjs`. Page requests go through that
 function so Markdown negotiation and route-state requests remain correct;
 hashed assets bypass it. Netlify durable caching implements time-based ISG and
-per-path cache tags implement authenticated webhook revalidation.
+per-path cache tags implement authenticated webhook revalidation. Shared ISG
+renders strip visitor-specific request data and Netlify context metadata before
+loaders or context factories run.
 
 `pracht preview` exits with guidance because it cannot emulate Netlify's
 Functions and CDN behavior. Build the generated function before using

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -30,6 +30,7 @@
       "@pracht/preact-ssr-precompile": ["./packages/preact-ssr-precompile/src/index.ts"],
       "@pracht/adapter-node": ["./packages/adapter-node/src/index.ts"],
       "@pracht/adapter-cloudflare": ["./packages/adapter-cloudflare/src/index.ts"],
+      "@pracht/adapter-netlify": ["./packages/adapter-netlify/src/index.ts"],
       "@pracht/adapter-vercel": ["./packages/adapter-vercel/src/index.ts"],
       "@pracht/image": ["./packages/image/src/index.ts"],
       "@pracht/image/node": ["./packages/image/src/node.ts"]


### PR DESCRIPTION
## Summary

- add `@pracht/adapter-netlify`, a first-party Netlify Functions v2 adapter with SSR, SSG, ISG, Markdown negotiation, durable CDN caching, and tag-based webhook revalidation
- generate the catch-all Netlify function during `pracht build`, preserve static asset bypasses, and fail closed for dynamic cache policy
- add Netlify to `create-pracht`, CLI preview guidance, the basic example, public docs, deployment skill, and workspace metadata
- add unit coverage and a production-shaped E2E that builds the basic example and invokes the generated function
- make formatter indentation explicit so nested checkouts do not inherit a parent workspace's EditorConfig

## Testing

- [x] `pnpm run verify` (build, format, lint, typecheck, test, e2e)

## Checklist

- [x] Docs updated if needed
- [x] Skills updated if needed
- [x] Changeset added if published packages changed
