### PR TITLE
Add first-party SSE helpers and WebSocket ergonomics

### DIFF
--- a/.changeset/dev-sse-streaming.md
+++ b/.changeset/dev-sse-streaming.md
@@ -8,4 +8,6 @@ before writing it out, which never returns for a Server-Sent Events response —
 an SSE endpoint that worked on every production adapter hung forever under
 `pracht dev`. Such responses are now piped through as they are produced, and
 a client disconnect destroys the pipe so `createEventStream()` cleanup
-(keep-alive timers, producer loops) runs in dev exactly as in production.
+(keep-alive timers, producer loops) runs in dev exactly as in production. Media
+type detection is case-insensitive, so valid mixed-case `Content-Type` values
+take the streaming path too.

--- a/.changeset/dev-sse-streaming.md
+++ b/.changeset/dev-sse-streaming.md
@@ -1,0 +1,11 @@
+---
+"@pracht/vite-plugin": patch
+---
+
+Stream `text/event-stream` responses in the dev server instead of buffering
+them. The dev SSR middleware read every response body with `response.text()`
+before writing it out, which never returns for a Server-Sent Events response —
+an SSE endpoint that worked on every production adapter hung forever under
+`pracht dev`. Such responses are now piped through as they are produced, and
+a client disconnect destroys the pipe so `createEventStream()` cleanup
+(keep-alive timers, producer loops) runs in dev exactly as in production.

--- a/.changeset/node-configure-server.md
+++ b/.changeset/node-configure-server.md
@@ -1,0 +1,11 @@
+---
+"@pracht/adapter-node": minor
+---
+
+Add a `configureServerFrom` entry option to `nodeAdapter()`. It names a
+Vite-resolvable module whose `configureServer(server)` export the generated
+entry calls (and awaits) with the underlying `node:http` server after
+`createServer()` and before `listen()`. This is the supported hook for
+attaching a WebSocket server to the `upgrade` event — which Node routes past
+the request handler entirely — without giving up the generated entry. See
+docs/ADAPTERS.md § WebSockets for the full recipe including the Origin check.

--- a/.changeset/streaming-sse-helpers.md
+++ b/.changeset/streaming-sse-helpers.md
@@ -6,7 +6,7 @@ Add first-party streaming helpers: Server-Sent Events and WebSocket ergonomics.
 
 `createEventStream(request, init?)` (exported from `@pracht/core` and
 `@pracht/core/server`) builds an SSE response for API route handlers and
-returns `{ response, send, close, closed }`. It handles the wire format
+returns `{ response, send, close, closed, desiredSize }`. It handles the wire format
 (`send({ data, event?, id?, retry? })` — strings pass through with multi-line
 splitting, other values are JSON-serialized, CR/LF injection through
 `event`/`id` fields is rejected), sets `Content-Type: text/event-stream` with
@@ -16,16 +16,22 @@ and transforming proxies leave the stream alone, and offers a
 timeouts. Cleanup is wired to both disconnect paths a runtime can deliver —
 `request.signal` aborting (workerd, edge) and the response stream being
 cancelled (Node) — after which `send()` returns `false` (the producer's stop
-condition) and the heartbeat timer is cleared. Built on web `ReadableStream`,
-so it works identically on the Node, Cloudflare, and Vercel adapters.
-`serializeEventStreamMessage()` is exported for code that manages its own
-stream.
+condition) and the heartbeat timer is cleared. The heartbeat timer is
+unref'ed on Node so an idle stream never pins the process past
+`server.close()`. `send()` applies no backpressure — `desiredSize` exposes
+the response stream's remaining queue capacity (zero or negative once a
+stalled consumer is buffering, `null` after close) so high-volume producers
+can throttle or drop. Built on web `ReadableStream`, so it works identically
+on the Node, Cloudflare, and Vercel adapters. `serializeEventStreamMessage()`
+is exported for code that manages its own stream.
 
 `useEventSource(url, options?)` (from `@pracht/core` / `@pracht/core/browser`)
 is the client half: a small hook wrapping `EventSource` with auto-cleanup on
 unmount, named-event selection, optional JSON parsing, connection status
 (`connecting` / `open` / `closed`), and `lastEventId`. Pass `null` to stay
-disconnected.
+disconnected. Changing the URL or options starts the new subscription clean —
+`data` and `lastEventId` reset instead of carrying the previous endpoint's
+payload into the new connection.
 
 `isUpgradeRequest(request)` (from `@pracht/core` and `@pracht/core/server`)
 detects a WebSocket handshake (token-wise, case-insensitive `Upgrade` header

--- a/.changeset/streaming-sse-helpers.md
+++ b/.changeset/streaming-sse-helpers.md
@@ -1,0 +1,32 @@
+---
+"@pracht/core": minor
+---
+
+Add first-party streaming helpers: Server-Sent Events and WebSocket ergonomics.
+
+`createEventStream(request, init?)` (exported from `@pracht/core` and
+`@pracht/core/server`) builds an SSE response for API route handlers and
+returns `{ response, send, close, closed }`. It handles the wire format
+(`send({ data, event?, id?, retry? })` — strings pass through with multi-line
+splitting, other values are JSON-serialized, CR/LF injection through
+`event`/`id` fields is rejected), sets `Content-Type: text/event-stream` with
+`Cache-Control: no-store, no-transform` and `X-Accel-Buffering: no` so caches
+and transforming proxies leave the stream alone, and offers a
+`keepAlive: seconds` heartbeat that emits comment lines to defeat proxy idle
+timeouts. Cleanup is wired to both disconnect paths a runtime can deliver —
+`request.signal` aborting (workerd, edge) and the response stream being
+cancelled (Node) — after which `send()` returns `false` (the producer's stop
+condition) and the heartbeat timer is cleared. Built on web `ReadableStream`,
+so it works identically on the Node, Cloudflare, and Vercel adapters.
+`serializeEventStreamMessage()` is exported for code that manages its own
+stream.
+
+`useEventSource(url, options?)` (from `@pracht/core` / `@pracht/core/browser`)
+is the client half: a small hook wrapping `EventSource` with auto-cleanup on
+unmount, named-event selection, optional JSON parsing, connection status
+(`connecting` / `open` / `closed`), and `lastEventId`. Pass `null` to stay
+disconnected.
+
+`isUpgradeRequest(request)` (from `@pracht/core` and `@pracht/core/server`)
+detects a WebSocket handshake (token-wise, case-insensitive `Upgrade` header
+match) so API routes can answer plain HTTP requests with `426`.

--- a/.changeset/streaming-sse-helpers.md
+++ b/.changeset/streaming-sse-helpers.md
@@ -18,7 +18,9 @@ timeouts. Cleanup is wired to both disconnect paths a runtime can deliver —
 cancelled (Node) — after which `send()` returns `false` (the producer's stop
 condition) and the heartbeat timer is cleared. The heartbeat timer is
 unref'ed on Node so an idle stream never pins the process past
-`server.close()`. `send()` applies no backpressure — `desiredSize` exposes
+`server.close()`. Custom headers are validated before the stream registers its
+heartbeat or abort listener, so rejected header input cannot leave unreachable
+lifecycle work behind. `send()` applies no backpressure — `desiredSize` exposes
 the response stream's remaining queue capacity (zero or negative once a
 stalled consumer is buffering, `null` after close) so high-volume producers
 can throttle or drop. Built on web `ReadableStream`, so it works identically
@@ -31,7 +33,7 @@ unmount, named-event selection, optional JSON parsing, connection status
 (`connecting` / `open` / `closed`), and `lastEventId`. Pass `null` to stay
 disconnected. Changing the URL or options starts the new subscription clean —
 `data` and `lastEventId` reset instead of carrying the previous endpoint's
-payload into the new connection.
+payload into the new connection or retaining it after the URL becomes `null`.
 
 `isUpgradeRequest(request)` (from `@pracht/core` and `@pracht/core/server`)
 detects a WebSocket handshake (token-wise, case-insensitive `Upgrade` header

--- a/docs/ADAPTERS.md
+++ b/docs/ADAPTERS.md
@@ -167,45 +167,73 @@ its `upgrade` event, not to the request handler, so a handshake never reaches
 `handler(req, res)` at all. (With no `upgrade` listener attached, Node closes
 those connections.)
 
-Attach a WebSocket server to the same HTTP server instead. The generated entry
-only calls `createServer()` when it is the process entrypoint, so importing
-`handler` and building the server yourself is supported:
+Attach a WebSocket server to the same HTTP server instead. The
+`configureServerFrom` entry option is the supported hook: it names a module
+whose `configureServer(server)` export the generated entry calls (and awaits)
+with the underlying `http.Server` after `createServer()` and before
+`listen()`:
 
-```javascript
-import { createServer } from "node:http";
-import { WebSocketServer } from "ws";
-import { handler } from "./dist/server/server.js";
-
-const server = createServer(handler); // pracht serves ordinary requests
-const wss = new WebSocketServer({ noServer: true });
-
-server.on("upgrade", (req, socket, head) => {
-  // Check the Origin header yourself here: browsers do not apply CORS to
-  // WebSocket, so a cross-site page can otherwise open an authenticated
-  // socket (cross-site WebSocket hijacking). Pracht's own
-  // `api.requireSameOrigin` check cannot help — this never reaches pracht.
-  wss.handleUpgrade(req, socket, head, (ws) => wss.emit("connection", ws, req));
-});
-
-server.listen(3000);
+```typescript
+// vite.config.ts
+nodeAdapter({ configureServerFrom: "/src/server/websockets.ts" });
 ```
+
+```typescript
+// src/server/websockets.ts
+import type { Server } from "node:http";
+import { WebSocketServer } from "ws";
+
+export function configureServer(server: Server) {
+  const wss = new WebSocketServer({ noServer: true });
+
+  server.on("upgrade", (req, socket, head) => {
+    // Check the Origin header yourself here: browsers do not apply CORS to
+    // WebSocket, so a cross-site page can otherwise open an authenticated
+    // socket (cross-site WebSocket hijacking). Pracht's own
+    // `api.requireSameOrigin` check cannot help — this never reaches pracht.
+    if (req.headers.origin !== process.env.PRACHT_ORIGIN) {
+      socket.destroy();
+      return;
+    }
+    wss.handleUpgrade(req, socket, head, (ws) => wss.emit("connection", ws, req));
+  });
+
+  wss.on("connection", (ws) => {
+    ws.on("message", (message) => ws.send(String(message)));
+  });
+}
+```
+
+The generated entry only calls `createServer()` when it is the process
+entrypoint, so importing `handler` and building the server yourself remains
+supported — attach the same `upgrade` listener to your own
+`createServer(handler)` in that case.
 
 For upgrades served *through* pracht's routing (as an API route), use the
 [Cloudflare adapter](#websockets-1). The Vercel adapter cannot serve them
-either.
+either. For server→client streaming that works on every adapter — including
+this one — use Server-Sent Events via `createEventStream()` from
+`@pracht/core/server` (see the Streaming recipe in the docs app,
+`examples/docs/src/routes/docs/recipes-streaming.md`): an SSE response is an
+ordinary streaming `Response`, which the Node handler pipes without any of
+the upgrade machinery.
 
 ### Generated entry options
 
-When using `nodeAdapter()` in `vite.config.ts`, generated entries can import a context factory and tune body limits:
+When using `nodeAdapter()` in `vite.config.ts`, generated entries can import a context factory, tune body limits, and hook the underlying HTTP server:
 
 ```typescript
 nodeAdapter({
   createContextFrom: "/src/server/context.ts",
   maxBodySize: 10 * 1024 * 1024,
+  configureServerFrom: "/src/server/websockets.ts",
 });
 ```
 
 The context module must export `createContext(args)`. Node passes `{ request, req, res }`.
+The configure module must export `configureServer(server)` (sync or async); it
+runs with the `node:http` server before `listen()` when the generated entry is
+the process entrypoint — see [WebSockets](#websockets) above.
 
 ### Entry module
 
@@ -565,9 +593,10 @@ and have the API route forward the upgrade to it:
 ```typescript
 // src/api/ws.ts
 import type { BaseRouteArgs } from "@pracht/core";
+import { isUpgradeRequest } from "@pracht/core/server";
 
 export async function GET({ context, request, url }: BaseRouteArgs) {
-  if (request.headers.get("upgrade") !== "websocket") {
+  if (!isUpgradeRequest(request)) {
     return new Response("Expected a WebSocket upgrade", { status: 426 });
   }
 

--- a/docs/REQUEST_FLOWS.md
+++ b/docs/REQUEST_FLOWS.md
@@ -506,10 +506,33 @@ skipping the header and cache post-processing every other response goes through.
 Response constructor rejects any status below 200 outright. A copied handshake
 is not a degraded handshake; it is a socket nobody holds.
 
+Handlers can use `isUpgradeRequest(request)` from `@pracht/core/server` to
+answer plain HTTP requests to the socket path with `426 Upgrade Required`
+instead of a broken handshake.
+
 The Node and Vercel adapters cannot serve upgrades at all. On Node this is
 structural: `http.Server` delivers upgrades to its `upgrade` event rather than
 to the request handler, so they never reach pracht. See
-[ADAPTERS.md](./ADAPTERS.md#websockets) for the `ws`-alongside-pracht pattern.
+[ADAPTERS.md](./ADAPTERS.md#websockets) for the `ws`-alongside-pracht pattern
+(the Node adapter's `configureServerFrom` entry option).
+
+---
+
+## Server-Sent Events
+
+An SSE response is not a protocol switch — it is an ordinary `200` streaming
+response, so it flows through the standard pipeline on **every** adapter (the
+Node handler pipes the body, workerd and Vercel stream it natively) and keeps
+the default security headers. `createEventStream(request)` from
+`@pracht/core/server` produces the response plus a `send`/`close` pair, stamps
+`Cache-Control: no-store, no-transform` (which also keeps
+`preventHeuristicCaching` off its back and tells transforming proxies to leave
+the framing alone), and wires disconnect cleanup to both signals a runtime can
+deliver: `request.signal` aborting and the body stream being cancelled. In dev,
+the SSR middleware detects `text/event-stream` and pipes instead of buffering —
+buffering would never terminate. The client half is the `useEventSource()`
+hook. End-to-end example: `examples/basic` (`/live` + `src/api/live.ts`);
+recipe: `examples/docs/src/routes/docs/recipes-streaming.md`.
 
 ---
 

--- a/e2e/basic.test.ts
+++ b/e2e/basic.test.ts
@@ -462,6 +462,21 @@ test("GET /api/nonexistent falls through to 404", async ({ request }) => {
 });
 
 // ---------------------------------------------------------------------------
+// Server-Sent Events: /api/live (createEventStream) + /live (useEventSource)
+// ---------------------------------------------------------------------------
+
+test("live page opens an SSE connection and renders streamed events", async ({ page }) => {
+  await page.goto("/live");
+
+  // The hook reports the EventSource lifecycle...
+  await expect(page.getByTestId("live-status")).toHaveText("open", { timeout: 10_000 });
+  // ...and streamed `tick` events reach the DOM. Asserting on tick content
+  // proves the whole chain: createEventStream wire format → dev-server
+  // streaming (not buffering) → EventSource parse → JSON option → render.
+  await expect(page.getByTestId("live-tick")).toContainText("tick", { timeout: 10_000 });
+});
+
+// ---------------------------------------------------------------------------
 // Hydration
 // ---------------------------------------------------------------------------
 

--- a/examples/basic/src/api/live.ts
+++ b/examples/basic/src/api/live.ts
@@ -1,0 +1,28 @@
+import type { BaseRouteArgs } from "@pracht/core";
+import { createEventStream } from "@pracht/core/server";
+
+/**
+ * Server-Sent Events endpoint: one `tick` event per second, forever. The
+ * `send()` return value is the producer's stop condition — it flips to
+ * `false` the moment the client disconnects (tab closed, navigation away,
+ * curl interrupted), which also clears the keep-alive timer.
+ */
+export function GET({ request }: BaseRouteArgs) {
+  const stream = createEventStream(request, { keepAlive: 15 });
+
+  let tick = 0;
+  const timer = setInterval(() => {
+    tick += 1;
+    const delivered = stream.send({
+      data: { now: new Date().toISOString(), tick },
+      event: "tick",
+      id: String(tick),
+    });
+    if (!delivered) {
+      console.log(`[live] client disconnected after ${tick - 1} ticks; producer stopped`);
+      clearInterval(timer);
+    }
+  }, 1000);
+
+  return stream.response;
+}

--- a/examples/basic/src/pracht-routes.ts
+++ b/examples/basic/src/pracht-routes.ts
@@ -28,6 +28,10 @@ export const routes = [
     path: "/gallery",
   },
   {
+    id: "live",
+    path: "/live",
+  },
+  {
     id: "dashboard",
     path: "/dashboard",
   },

--- a/examples/basic/src/pracht.d.ts
+++ b/examples/basic/src/pracht.d.ts
@@ -41,6 +41,12 @@ declare module "@pracht/core" {
         search: SearchParamsInput;
         data: RouteLoaderData<typeof import("./routes/gallery")>;
       };
+      "live": {
+        path: "/live";
+        params: Record<never, never>;
+        search: SearchParamsInput;
+        data: RouteLoaderData<typeof import("./routes/live")>;
+      };
       "dashboard": {
         path: "/dashboard";
         params: Record<never, never>;
@@ -74,6 +80,11 @@ declare module "@pracht/core" {
         path: "/api/health";
         params: Record<never, never>;
         methods: ApiRouteMethodMap<typeof import("./api/health")>;
+      };
+      "/api/live": {
+        path: "/api/live";
+        params: Record<never, never>;
+        methods: ApiRouteMethodMap<typeof import("./api/live")>;
       };
     };
   }

--- a/examples/basic/src/routes.ts
+++ b/examples/basic/src/routes.ts
@@ -82,6 +82,10 @@ export const app = defineApp({
         id: "gallery",
         render: "ssr",
       }),
+      route("/live", () => import("./routes/live.tsx"), {
+        id: "live",
+        render: "ssr",
+      }),
     ]),
     group({ shell: "app", middleware: ["auth"] }, [
       route("/dashboard", () => import("./routes/dashboard.tsx"), {

--- a/examples/basic/src/routes/live.tsx
+++ b/examples/basic/src/routes/live.tsx
@@ -1,0 +1,38 @@
+import { useEventSource } from "@pracht/core";
+
+interface TickPayload {
+  now: string;
+  tick: number;
+}
+
+/**
+ * Consumes the `/api/live` Server-Sent Events endpoint with the
+ * `useEventSource` hook. The connection opens on mount and closes on
+ * unmount — navigate away and the server's producer loop stops.
+ */
+export function Component() {
+  const { data, status } = useEventSource<TickPayload>("/api/live", {
+    event: "tick",
+    json: true,
+  });
+
+  return (
+    <section>
+      <h1>Live events</h1>
+      <p>
+        This page subscribes to <code>/api/live</code>, a Server-Sent Events endpoint built with
+        <code> createEventStream()</code>, via the <code>useEventSource()</code> hook.
+      </p>
+      <p>
+        Connection: <strong data-testid="live-status">{status}</strong>
+      </p>
+      <p data-testid="live-tick">
+        {data ? `tick ${data.tick} at ${data.now}` : "waiting for the first event"}
+      </p>
+    </section>
+  );
+}
+
+export function head() {
+  return { title: "Live events" };
+}

--- a/examples/cloudflare/src/api/live.ts
+++ b/examples/cloudflare/src/api/live.ts
@@ -1,0 +1,28 @@
+import type { BaseRouteArgs } from "@pracht/core";
+import { createEventStream } from "@pracht/core/server";
+
+/**
+ * Server-Sent Events endpoint: one `tick` event per second, forever. The
+ * `send()` return value is the producer's stop condition — it flips to
+ * `false` the moment the client disconnects (tab closed, navigation away,
+ * curl interrupted), which also clears the keep-alive timer.
+ */
+export function GET({ request }: BaseRouteArgs) {
+  const stream = createEventStream(request, { keepAlive: 15 });
+
+  let tick = 0;
+  const timer = setInterval(() => {
+    tick += 1;
+    const delivered = stream.send({
+      data: { now: new Date().toISOString(), tick },
+      event: "tick",
+      id: String(tick),
+    });
+    if (!delivered) {
+      console.log(`[live] client disconnected after ${tick - 1} ticks; producer stopped`);
+      clearInterval(timer);
+    }
+  }, 1000);
+
+  return stream.response;
+}

--- a/examples/cloudflare/src/pracht-routes.ts
+++ b/examples/cloudflare/src/pracht-routes.ts
@@ -24,6 +24,14 @@ export const routes = [
     path: "/long",
   },
   {
+    id: "fragment",
+    path: "/fragment",
+  },
+  {
+    id: "live",
+    path: "/live",
+  },
+  {
     id: "dashboard",
     path: "/dashboard",
   },

--- a/examples/cloudflare/src/routes.ts
+++ b/examples/cloudflare/src/routes.ts
@@ -34,6 +34,7 @@ export const app = defineApp({
       route("/slow", () => import("./routes/slow.tsx"), { id: "slow", render: "ssr" }),
       route("/long", () => import("./routes/long.tsx"), { id: "long", render: "ssr" }),
       route("/fragment", () => import("./routes/fragment.tsx"), { id: "fragment", render: "ssr" }),
+      route("/live", () => import("./routes/live.tsx"), { id: "live", render: "ssr" }),
     ]),
     group({ shell: "app", middleware: ["auth"] }, [
       route("/dashboard", () => import("./routes/dashboard.tsx"), {

--- a/examples/cloudflare/src/routes/live.tsx
+++ b/examples/cloudflare/src/routes/live.tsx
@@ -1,0 +1,38 @@
+import { useEventSource } from "@pracht/core";
+
+interface TickPayload {
+  now: string;
+  tick: number;
+}
+
+/**
+ * Consumes the `/api/live` Server-Sent Events endpoint with the
+ * `useEventSource` hook. The connection opens on mount and closes on
+ * unmount — navigate away and the server's producer loop stops.
+ */
+export function Component() {
+  const { data, status } = useEventSource<TickPayload>("/api/live", {
+    event: "tick",
+    json: true,
+  });
+
+  return (
+    <section>
+      <h1>Live events</h1>
+      <p>
+        This page subscribes to <code>/api/live</code>, a Server-Sent Events endpoint built with
+        <code> createEventStream()</code>, via the <code>useEventSource()</code> hook.
+      </p>
+      <p>
+        Connection: <strong data-testid="live-status">{status}</strong>
+      </p>
+      <p data-testid="live-tick">
+        {data ? `tick ${data.tick} at ${data.now}` : "waiting for the first event"}
+      </p>
+    </section>
+  );
+}
+
+export function head() {
+  return { title: "Live events" };
+}

--- a/examples/docs/src/routes.ts
+++ b/examples/docs/src/routes.ts
@@ -152,6 +152,10 @@ export const app = defineApp({
         id: "recipes-logging",
         render: "ssg",
       }),
+      route("/docs/recipes/streaming", () => import("./routes/docs/recipes-streaming.md"), {
+        id: "recipes-streaming",
+        render: "ssg",
+      }),
       route("/docs/recipes/fullstack-cloudflare", "./routes/docs/recipes-fullstack-cloudflare.md", {
         id: "recipes-fullstack-cloudflare",
         render: "ssg",

--- a/examples/docs/src/routes/docs/recipes-fullstack-cloudflare.md
+++ b/examples/docs/src/routes/docs/recipes-fullstack-cloudflare.md
@@ -3,8 +3,8 @@ title: Full-Stack Cloudflare
 lead: Build a full-stack app on Cloudflare with D1 (SQLite), KV, and R2. This recipe covers project setup, database migrations, and wiring bindings into your loaders and API routes.
 breadcrumb: Full-Stack Cloudflare
 prev:
-  href: /docs/recipes/logging
-  title: Logging
+  href: /docs/recipes/streaming
+  title: Streaming
 next:
   href: /docs/recipes/fullstack-vercel
   title: Full-Stack Vercel

--- a/examples/docs/src/routes/docs/recipes-logging.md
+++ b/examples/docs/src/routes/docs/recipes-logging.md
@@ -6,8 +6,8 @@ prev:
   href: /docs/recipes/testing
   title: Testing
 next:
-  href: /docs/recipes/fullstack-cloudflare
-  title: Full-Stack Cloudflare
+  href: /docs/recipes/streaming
+  title: Streaming
 ---
 
 ## Recommended Shape

--- a/examples/docs/src/routes/docs/recipes-streaming.md
+++ b/examples/docs/src/routes/docs/recipes-streaming.md
@@ -1,0 +1,225 @@
+---
+title: Streaming
+lead: Push live updates to the browser with first-party Server-Sent Events helpers — createEventStream on the server, useEventSource in components — and wire WebSockets per adapter.
+breadcrumb: Streaming
+prev:
+  href: /docs/recipes/logging
+  title: Logging
+next:
+  href: /docs/recipes/fullstack-cloudflare
+  title: Full-Stack Cloudflare
+---
+
+## Server-Sent Events
+
+For server→client streaming — live dashboards, progress updates, notification
+feeds, LLM token streams — Server-Sent Events are the simplest tool that works
+on **every adapter**: it is an ordinary HTTP response that never ends, so Node,
+Cloudflare Workers, and Vercel all stream it without platform-specific code.
+The browser side is plain `EventSource`, which even reconnects automatically.
+
+Reach for [WebSockets](#websockets) only when the *client* also needs to push a
+continuous stream of messages; for occasional client→server writes, a normal
+API `POST` next to an SSE stream is simpler and works everywhere.
+
+### The API route
+
+`createEventStream(request, init?)` from `@pracht/core/server` returns the
+`Response` to hand back plus `send` and `close`:
+
+```ts [src/api/live.ts]
+import type { BaseRouteArgs } from "@pracht/core";
+import { createEventStream } from "@pracht/core/server";
+
+export function GET({ request }: BaseRouteArgs) {
+  const stream = createEventStream(request, { keepAlive: 15 });
+
+  let tick = 0;
+  const timer = setInterval(() => {
+    tick += 1;
+    const delivered = stream.send({
+      data: { now: new Date().toISOString(), tick },
+      event: "tick",
+      id: String(tick),
+    });
+    // send() returns false once the client is gone — stop producing.
+    if (!delivered) clearInterval(timer);
+  }, 1000);
+
+  return stream.response;
+}
+```
+
+What the helper takes care of:
+
+- **Wire format.** `send({ data, event?, id?, retry? })` serializes the SSE
+  frame: strings pass through (multi-line values become one `data:` line per
+  line), everything else is `JSON.stringify`ed. `event:`/`id:` values
+  containing CR/LF are rejected — a newline there would let untrusted input
+  forge extra protocol lines.
+- **Disconnect cleanup.** Both disconnect paths a runtime can deliver are
+  wired: `request.signal` aborting (Cloudflare, Vercel Edge) and the response
+  stream being cancelled (the Node adapter tears the pipe down when the client
+  hangs up). Either way `send()` starts returning `false` and the keep-alive
+  timer is cleared — use the return value as your producer's stop condition.
+- **Headers.** `Content-Type: text/event-stream`, plus
+  `Cache-Control: no-store, no-transform` and `X-Accel-Buffering: no` so
+  shared caches never store the stream and compressing/buffering proxies
+  (nginx and friends) leave the framing alone.
+- **Proxy idle timeouts.** `keepAlive: 15` emits a comment line
+  (`:keep-alive`) every 15 seconds so load balancers with idle timeouts keep
+  the connection open.
+
+Try it with curl (`-N` disables curl's own buffering):
+
+```bash
+curl -N http://localhost:5173/api/live
+# event: tick
+# id: 1
+# data: {"now":"2026-08-12T09:30:00.000Z","tick":1}
+#
+# event: tick
+# id: 2
+# ...
+```
+
+One thing the helper deliberately does not do: apply backpressure. Messages
+sent faster than the client reads them buffer in the stream. SSE frames are
+small, so this is fine for event feeds; throttle in your producer if you are
+pushing serious volume.
+
+### The component
+
+`useEventSource(url, options?)` wraps `EventSource`: it connects on mount,
+disconnects on unmount (which is exactly when the server's `send()` starts
+returning `false`), tracks connection state, and optionally JSON-parses
+payloads. Pass `null` as the URL to stay disconnected — handy for gating the
+subscription on user state.
+
+```tsx [src/routes/live.tsx]
+import { useEventSource } from "@pracht/core";
+
+export function Component() {
+  const { data, status } = useEventSource<{ now: string; tick: number }>("/api/live", {
+    event: "tick", // listen for the named event; omit for unnamed messages
+    json: true,
+  });
+
+  return (
+    <section>
+      <p>Connection: {status /* "connecting" | "open" | "closed" */}</p>
+      <p>{data ? `tick ${data.tick} at ${data.now}` : "waiting for the first event"}</p>
+    </section>
+  );
+}
+```
+
+The browser reconnects dropped SSE connections on its own (tune the delay by
+sending `retry:`), so `status` may bounce between `"open"` and `"connecting"`
+on a flaky network without any code on your part. During SSR the hook renders
+`{ status: "connecting" }` and never connects — the subscription is
+client-only by nature.
+
+The working example lives in the repo's `examples/basic` app: route `/live`,
+endpoint `src/api/live.ts`.
+
+## WebSockets
+
+A WebSocket upgrade is request handling with a platform-specific ending, so
+where it lives depends on the adapter. The framework ships one shared helper —
+`isUpgradeRequest(request)` from `@pracht/core/server` — and a same-origin
+guard: browsers do not apply CORS to WebSocket, so pracht blocks cross-origin
+upgrade requests by default (`api.requireSameOrigin`).
+
+### Cloudflare
+
+The Cloudflare adapter serves upgrades **through** pracht routing: an API
+route returns the `101` handshake response and the runtime passes it through
+untouched (identity-preserved — the `webSocket` handle survives). For
+connection state, forward to a Durable Object:
+
+```ts [src/api/ws.ts]
+import type { BaseRouteArgs } from "@pracht/core";
+import { isUpgradeRequest } from "@pracht/core/server";
+
+interface Env {
+  CHAT_ROOM: DurableObjectNamespace;
+}
+
+export function GET({ request, context }: BaseRouteArgs<{ env: Env }>) {
+  if (!isUpgradeRequest(request)) {
+    return new Response("Expected a WebSocket upgrade", { status: 426 });
+  }
+  const room = context.env.CHAT_ROOM.get(context.env.CHAT_ROOM.idFromName("lobby"));
+  return room.fetch(request);
+}
+```
+
+```ts [src/server/chat-room.ts]
+import { DurableObject } from "cloudflare:workers";
+
+export class ChatRoom extends DurableObject {
+  override fetch(_request: Request): Response {
+    const { 0: client, 1: server } = new WebSocketPair();
+    this.ctx.acceptWebSocket(server); // hibernation-friendly
+    return new Response(null, { status: 101, webSocket: client });
+  }
+
+  override webSocketMessage(_ws: WebSocket, message: string | ArrayBuffer) {
+    for (const peer of this.ctx.getWebSockets()) peer.send(String(message));
+  }
+}
+```
+
+Upgrades work in `pracht dev` the same way they do in production. See the
+[Adapters reference](/docs/adapters) for the wrangler wiring.
+
+### Node
+
+Node's `http.Server` delivers upgrade requests to its `upgrade` event, never
+to the request handler, so a handshake structurally cannot reach pracht.
+Attach a WebSocket server (e.g. [`ws`](https://github.com/websockets/ws))
+alongside pracht instead. The Node adapter's `configureServerFrom` option
+hands you the underlying `http.Server` before `listen()`:
+
+```ts [vite.config.ts]
+nodeAdapter({
+  configureServerFrom: "/src/server/websockets.ts",
+});
+```
+
+```ts [src/server/websockets.ts]
+import type { Server } from "node:http";
+import { WebSocketServer } from "ws";
+
+export function configureServer(server: Server) {
+  const wss = new WebSocketServer({ noServer: true });
+
+  server.on("upgrade", (req, socket, head) => {
+    // Browsers do not apply CORS to WebSocket, and this path never reaches
+    // pracht's own same-origin guard — check Origin yourself or any page on
+    // the web can open an authenticated socket (cross-site hijacking).
+    const origin = req.headers.origin;
+    if (origin !== process.env.PRACHT_ORIGIN) {
+      socket.destroy();
+      return;
+    }
+    wss.handleUpgrade(req, socket, head, (ws) => wss.emit("connection", ws, req));
+  });
+
+  wss.on("connection", (ws) => {
+    ws.on("message", (message) => ws.send(String(message)));
+  });
+}
+```
+
+`configureServer` may be async; it runs when the generated entry is the
+process entrypoint. If you import `handler` and build the server yourself,
+attach the listener the same way on your own `createServer(handler)`.
+
+### Vercel
+
+The Vercel adapter cannot serve WebSocket upgrades (serverless and edge
+functions terminate them upstream). Use [Server-Sent Events](#server-sent-events)
+for server→client streaming, or a hosted realtime service for bidirectional
+messaging.

--- a/examples/docs/src/routes/docs/recipes-streaming.md
+++ b/examples/docs/src/routes/docs/recipes-streaming.md
@@ -84,9 +84,36 @@ curl -N http://localhost:5173/api/live
 ```
 
 One thing the helper deliberately does not do: apply backpressure. Messages
-sent faster than the client reads them buffer in the stream. SSE frames are
-small, so this is fine for event feeds; throttle in your producer if you are
-pushing serious volume.
+sent faster than the client reads them buffer in the stream — without bound.
+SSE frames are small, so this is fine for event feeds; a producer pushing
+serious volume should watch `stream.desiredSize` (the response stream's
+remaining queue capacity, `null` once closed) and pause or drop messages while
+it is zero or negative:
+
+```ts
+const size = stream.desiredSize;
+if (size === null) break; // stream closed — stop producing
+if (size <= 0) continue; // consumer stalled — drop this frame
+stream.send({ data: frame });
+```
+
+Two more things worth knowing before you ship an SSE endpoint:
+
+- **Producer lifetime is yours.** The handler returns `stream.response`
+  immediately; middleware wrapping the route (a `try`/`finally` around
+  `next()`, a duration logger) completes then too, while the stream stays
+  open. Key your producer's shutdown on `send()` returning `false` (or
+  `stream.closed`), not on middleware finishing. And prefer `request` over
+  the handler's `signal` argument for anything long-lived — that signal is a
+  request-phase timeout, not the stream's lifetime.
+- **Resuming after reconnects.** The browser replays the last `id:` it saw in
+  a `Last-Event-ID` request header when it reconnects. Send meaningful ids
+  and read the header to resume instead of restarting:
+
+  ```ts
+  const lastEventId = request.headers.get("last-event-id");
+  // Replay everything after lastEventId, then continue live.
+  ```
 
 ### The component
 
@@ -118,7 +145,16 @@ The browser reconnects dropped SSE connections on its own (tune the delay by
 sending `retry:`), so `status` may bounce between `"open"` and `"connecting"`
 on a flaky network without any code on your part. During SSR the hook renders
 `{ status: "connecting" }` and never connects — the subscription is
-client-only by nature.
+client-only by nature. Changing `url` (or the options) tears the connection
+down and starts the new subscription clean: `data` and `lastEventId` reset to
+`undefined` rather than showing the previous endpoint's payload.
+
+Each `useEventSource` call owns one `EventSource` connection. Two components
+subscribing to the same URL open two connections — and over HTTP/1.1 browsers
+allow only ~6 connections per origin, *shared with every other request to
+your app*, so a handful of SSE subscriptions can starve the page. Lift a
+shared subscription into a parent (context or props), and serve production
+traffic over HTTP/2/3 where the limit does not apply.
 
 The working example lives in the repo's `examples/basic` app: route `/live`,
 endpoint `src/api/live.ts`.

--- a/examples/docs/src/routes/docs/recipes-streaming.md
+++ b/examples/docs/src/routes/docs/recipes-streaming.md
@@ -120,8 +120,8 @@ Two more things worth knowing before you ship an SSE endpoint:
 `useEventSource(url, options?)` wraps `EventSource`: it connects on mount,
 disconnects on unmount (which is exactly when the server's `send()` starts
 returning `false`), tracks connection state, and optionally JSON-parses
-payloads. Pass `null` as the URL to stay disconnected — handy for gating the
-subscription on user state.
+payloads. Pass `null` as the URL to stay disconnected and clear the previous
+payload/id — handy for gating the subscription on user state.
 
 ```tsx [src/routes/live.tsx]
 import { useEventSource } from "@pracht/core";

--- a/examples/docs/src/shells/docs.tsx
+++ b/examples/docs/src/shells/docs.tsx
@@ -25,6 +25,7 @@ import {
   IconSparkles,
   IconPresentationAnalytics,
   IconActivity,
+  IconBroadcast,
   IconShieldCheck,
   IconWorldBolt,
   IconPhoto,
@@ -93,6 +94,7 @@ const NAV = [
       { href: "/docs/recipes/view-transitions", Icon: IconSparkles, title: "View Transitions" },
       { href: "/docs/recipes/testing", Icon: IconTestPipe, title: "Testing" },
       { href: "/docs/recipes/logging", Icon: IconActivity, title: "Logging" },
+      { href: "/docs/recipes/streaming", Icon: IconBroadcast, title: "Streaming" },
       {
         href: "/docs/recipes/fullstack-cloudflare",
         Icon: IconCloud,

--- a/packages/adapter-node/src/node-entry.ts
+++ b/packages/adapter-node/src/node-entry.ts
@@ -7,6 +7,17 @@ export interface NodeServerEntryModuleOptions {
   createContextFrom?: string;
   /** Maximum request body size in bytes. Defaults to 1 MiB. */
   maxBodySize?: number;
+  /**
+   * Vite-resolvable module path exporting `configureServer(server)`. The
+   * generated entry calls it (and awaits it) with the underlying `node:http`
+   * server after `createServer()` and before `listen()`, when the entry is
+   * run as the process entrypoint. This is the hook for everything pracht's
+   * request handler cannot see — chiefly attaching a WebSocket server to the
+   * `upgrade` event, which Node routes past the request handler entirely.
+   * See docs/ADAPTERS.md § WebSockets for the full recipe including the
+   * Origin check.
+   */
+  configureServerFrom?: string;
 }
 
 export function createNodeServerEntryModule(options: NodeServerEntryModuleOptions = {}): string {
@@ -15,6 +26,9 @@ export function createNodeServerEntryModule(options: NodeServerEntryModuleOption
   const contextImport = options.createContextFrom
     ? `import { createContext as createPrachtContext } from ${JSON.stringify(options.createContextFrom)};`
     : "const createPrachtContext = undefined;";
+  const configureServerImport = options.configureServerFrom
+    ? `import { configureServer as configurePrachtServer } from ${JSON.stringify(options.configureServerFrom)};`
+    : "const configurePrachtServer = undefined;";
 
   return [
     'import { existsSync, readFileSync } from "node:fs";',
@@ -23,6 +37,7 @@ export function createNodeServerEntryModule(options: NodeServerEntryModuleOption
     'import { fileURLToPath, pathToFileURL } from "node:url";',
     'import { createNodeRequestHandler } from "@pracht/adapter-node";',
     contextImport,
+    configureServerImport,
     "",
     "const serverDir = dirname(fileURLToPath(import.meta.url));",
     'const staticDir = resolve(serverDir, "../client");',
@@ -60,6 +75,7 @@ export function createNodeServerEntryModule(options: NodeServerEntryModuleOption
     "const entryHref = process.argv[1] ? pathToFileURL(process.argv[1]).href : null;",
     "if (entryHref && import.meta.url === entryHref) {",
     "  const server = createServer(handler);",
+    "  if (configurePrachtServer) await configurePrachtServer(server);",
     `  const port = Number(process.env.PORT ?? ${port});`,
     "  server.listen(port, () => {",
     "    console.log(`pracht node server listening on http://localhost:${port}`);",

--- a/packages/adapter-node/test/index.test.ts
+++ b/packages/adapter-node/test/index.test.ts
@@ -91,6 +91,25 @@ describe("createNodeServerEntryModule", () => {
     expect(source).toContain("islandsEntryUrl: islandsEntryUrl ?? undefined");
     expect(source).toContain("islandsBootstrapRequired");
   });
+
+  it("imports and awaits a configureServer module before listen()", () => {
+    const source = createNodeServerEntryModule({
+      configureServerFrom: "/src/server/websockets.ts",
+    });
+
+    expect(source).toContain(
+      'import { configureServer as configurePrachtServer } from "/src/server/websockets.ts";',
+    );
+    const configureIndex = source.indexOf("await configurePrachtServer(server)");
+    const listenIndex = source.indexOf("server.listen(");
+    expect(configureIndex).toBeGreaterThan(-1);
+    expect(listenIndex).toBeGreaterThan(configureIndex);
+  });
+
+  it("stubs configureServer out when the option is not set", () => {
+    const source = createNodeServerEntryModule();
+    expect(source).toContain("const configurePrachtServer = undefined;");
+  });
 });
 
 describe("createNodeRequestHandler", () => {

--- a/packages/framework/src/browser.ts
+++ b/packages/framework/src/browser.ts
@@ -78,6 +78,20 @@ export type { PrachtPublicEnv, PrachtServerEnv, PublicEnvOf } from "./env.ts";
 // `callCapability` to produce `useCapability`. It must be reachable from the
 // browser entry — that is the one the client build resolves `@pracht/core` to.
 export { createUseCapability, type CapabilityHookResult } from "./capability-hook.ts";
+export {
+  createEventStream,
+  serializeEventStreamMessage,
+  type EventStream,
+  type EventStreamInit,
+  type EventStreamMessage,
+} from "./event-stream.ts";
+export { isUpgradeRequest } from "./upgrade.ts";
+export {
+  useEventSource,
+  type EventSourceState,
+  type EventSourceStatus,
+  type UseEventSourceOptions,
+} from "./event-source-hook.ts";
 export { forwardRef } from "./forwardRef.ts";
 export { useIsHydrated } from "./hydration.ts";
 export { Suspense, lazy } from "preact-suspense";

--- a/packages/framework/src/event-source-hook.ts
+++ b/packages/framework/src/event-source-hook.ts
@@ -64,7 +64,11 @@ export function useEventSource<T = string>(
   useEffect(() => {
     if (href == null || typeof EventSource === "undefined") {
       setState((previous) =>
-        previous.status === "closed" ? previous : { ...previous, status: "closed" },
+        previous.status === "closed" &&
+        previous.data === undefined &&
+        previous.lastEventId === undefined
+          ? previous
+          : { data: undefined, lastEventId: undefined, status: "closed" },
       );
       return;
     }

--- a/packages/framework/src/event-source-hook.ts
+++ b/packages/framework/src/event-source-hook.ts
@@ -34,7 +34,12 @@ const CLOSED_READY_STATE = 2;
 /**
  * Subscribe to a Server-Sent Events endpoint (see `createEventStream` on the
  * server side). The connection opens on mount and closes automatically on
- * unmount or when `url`/options change. Pass `null` to stay disconnected —
+ * unmount or when `url`/options change; a changed subscription starts clean
+ * (`data`/`lastEventId` reset) so one endpoint's payload is never shown as
+ * another's. Each hook instance opens its own connection — remember browsers
+ * cap concurrent HTTP/1.1 connections per origin (6 in practice), so share
+ * one subscription via context/props rather than mounting many for one URL.
+ * Pass `null` to stay disconnected —
  * useful to gate the subscription on user state. During SSR it renders as
  * `{ status: "connecting" }` (or `"closed"` for a `null` URL) and never
  * connects.
@@ -64,8 +69,16 @@ export function useEventSource<T = string>(
       return;
     }
 
+    // A new subscription starts from a clean slate: carrying the previous
+    // endpoint's `data`/`lastEventId` into a different `url` (or a different
+    // named event) would present another stream's payload as this one's. On
+    // first mount this is a no-op — the initial state already looks like this.
     setState((previous) =>
-      previous.status === "connecting" ? previous : { ...previous, status: "connecting" },
+      previous.status === "connecting" &&
+      previous.data === undefined &&
+      previous.lastEventId === undefined
+        ? previous
+        : { data: undefined, lastEventId: undefined, status: "connecting" },
     );
     const source = new EventSource(href, { withCredentials });
 

--- a/packages/framework/src/event-source-hook.ts
+++ b/packages/framework/src/event-source-hook.ts
@@ -28,6 +28,31 @@ export interface EventSourceState<T> {
   lastEventId: string | undefined;
 }
 
+interface EventSourceSubscription {
+  href: string | null;
+  event: string;
+  json: boolean;
+  withCredentials: boolean;
+}
+
+interface InternalEventSourceState<T> {
+  state: EventSourceState<T>;
+  subscription: EventSourceSubscription;
+}
+
+function sameSubscription(left: EventSourceSubscription, right: EventSourceSubscription): boolean {
+  return (
+    left.href === right.href &&
+    left.event === right.event &&
+    left.json === right.json &&
+    left.withCredentials === right.withCredentials
+  );
+}
+
+function emptyState<T>(status: EventSourceStatus): EventSourceState<T> {
+  return { data: undefined, lastEventId: undefined, status };
+}
+
 /** `EventSource.CLOSED` — inlined so mocks without the constant still work. */
 const CLOSED_READY_STATE = 2;
 
@@ -54,21 +79,30 @@ export function useEventSource<T = string>(
 ): EventSourceState<T> {
   const { event = "message", json = false, withCredentials = false } = options;
   const href = url == null ? null : String(url);
+  const subscription: EventSourceSubscription = { event, href, json, withCredentials };
 
-  const [state, setState] = useState<EventSourceState<T>>({
-    data: undefined,
-    lastEventId: undefined,
-    status: href == null ? "closed" : "connecting",
+  const [current, setCurrent] = useState<InternalEventSourceState<T>>({
+    state: emptyState(href == null ? "closed" : "connecting"),
+    subscription,
   });
+
+  // Effects run after render. If the subscription changed, returning
+  // `current.state` here would paint the previous endpoint's payload for one
+  // frame before the cleanup/reset below runs. Derive the clean public state
+  // synchronously while the effect catches the internal state up.
+  const state = sameSubscription(current.subscription, subscription)
+    ? current.state
+    : emptyState<T>(href == null ? "closed" : "connecting");
 
   useEffect(() => {
     if (href == null || typeof EventSource === "undefined") {
-      setState((previous) =>
-        previous.status === "closed" &&
-        previous.data === undefined &&
-        previous.lastEventId === undefined
+      setCurrent((previous) =>
+        sameSubscription(previous.subscription, subscription) &&
+        previous.state.status === "closed" &&
+        previous.state.data === undefined &&
+        previous.state.lastEventId === undefined
           ? previous
-          : { data: undefined, lastEventId: undefined, status: "closed" },
+          : { state: emptyState("closed"), subscription },
       );
       return;
     }
@@ -77,24 +111,34 @@ export function useEventSource<T = string>(
     // endpoint's `data`/`lastEventId` into a different `url` (or a different
     // named event) would present another stream's payload as this one's. On
     // first mount this is a no-op — the initial state already looks like this.
-    setState((previous) =>
-      previous.status === "connecting" &&
-      previous.data === undefined &&
-      previous.lastEventId === undefined
+    setCurrent((previous) =>
+      sameSubscription(previous.subscription, subscription) &&
+      previous.state.status === "connecting" &&
+      previous.state.data === undefined &&
+      previous.state.lastEventId === undefined
         ? previous
-        : { data: undefined, lastEventId: undefined, status: "connecting" },
+        : { state: emptyState("connecting"), subscription },
     );
     const source = new EventSource(href, { withCredentials });
 
     const onOpen = (): void => {
-      setState((previous) => ({ ...previous, status: "open" }));
+      setCurrent((previous) =>
+        sameSubscription(previous.subscription, subscription)
+          ? { ...previous, state: { ...previous.state, status: "open" } }
+          : previous,
+      );
     };
     // EventSource reconnects on its own; `error` only means "gone for good"
     // once the readyState reaches CLOSED.
     const onError = (): void => {
       const status: EventSourceStatus =
         source.readyState === CLOSED_READY_STATE ? "closed" : "connecting";
-      setState((previous) => (previous.status === status ? previous : { ...previous, status }));
+      setCurrent((previous) => {
+        if (!sameSubscription(previous.subscription, subscription)) return previous;
+        return previous.state.status === status
+          ? previous
+          : { ...previous, state: { ...previous.state, status } };
+      });
     };
     const onMessage = (messageEvent: MessageEvent): void => {
       let data: T;
@@ -108,11 +152,18 @@ export function useEventSource<T = string>(
       } else {
         data = messageEvent.data as T;
       }
-      setState((previous) => ({
-        ...previous,
-        data,
-        lastEventId: messageEvent.lastEventId || undefined,
-      }));
+      setCurrent((previous) =>
+        sameSubscription(previous.subscription, subscription)
+          ? {
+              ...previous,
+              state: {
+                ...previous.state,
+                data,
+                lastEventId: messageEvent.lastEventId || undefined,
+              },
+            }
+          : previous,
+      );
     };
 
     source.addEventListener("open", onOpen);
@@ -120,7 +171,9 @@ export function useEventSource<T = string>(
     source.addEventListener(event, onMessage as EventListener);
 
     return () => {
-      // Closing also drops the listeners; no state updates after this point.
+      source.removeEventListener("open", onOpen);
+      source.removeEventListener("error", onError);
+      source.removeEventListener(event, onMessage as EventListener);
       source.close();
     };
   }, [href, event, json, withCredentials]);

--- a/packages/framework/src/event-source-hook.ts
+++ b/packages/framework/src/event-source-hook.ts
@@ -1,0 +1,112 @@
+import { useEffect, useState } from "preact/hooks";
+
+export type EventSourceStatus = "connecting" | "open" | "closed";
+
+export interface UseEventSourceOptions {
+  /**
+   * Named SSE event to listen for (the server's `event:` field). Defaults to
+   * unnamed messages (`"message"`).
+   */
+  event?: string;
+  /** `JSON.parse` incoming data. Malformed payloads are dropped with a warning. */
+  json?: boolean;
+  /** Send cookies on cross-origin connections (the `EventSource` option). */
+  withCredentials?: boolean;
+}
+
+export interface EventSourceState<T> {
+  /** The most recent message payload, or `undefined` before the first one. */
+  data: T | undefined;
+  /**
+   * `"connecting"` while the browser establishes (or re-establishes — the
+   * browser reconnects automatically) the connection, `"open"` while it is
+   * live, `"closed"` when it gave up, was disabled with a `null` URL, or is
+   * rendering on the server.
+   */
+  status: EventSourceStatus;
+  /** The `lastEventId` of the most recent message (the server's `id:` field). */
+  lastEventId: string | undefined;
+}
+
+/** `EventSource.CLOSED` — inlined so mocks without the constant still work. */
+const CLOSED_READY_STATE = 2;
+
+/**
+ * Subscribe to a Server-Sent Events endpoint (see `createEventStream` on the
+ * server side). The connection opens on mount and closes automatically on
+ * unmount or when `url`/options change. Pass `null` to stay disconnected —
+ * useful to gate the subscription on user state. During SSR it renders as
+ * `{ status: "connecting" }` (or `"closed"` for a `null` URL) and never
+ * connects.
+ *
+ * ```tsx
+ * const { data, status } = useEventSource<{ now: number }>("/api/live", { json: true });
+ * ```
+ */
+export function useEventSource<T = string>(
+  url: string | URL | null | undefined,
+  options: UseEventSourceOptions = {},
+): EventSourceState<T> {
+  const { event = "message", json = false, withCredentials = false } = options;
+  const href = url == null ? null : String(url);
+
+  const [state, setState] = useState<EventSourceState<T>>({
+    data: undefined,
+    lastEventId: undefined,
+    status: href == null ? "closed" : "connecting",
+  });
+
+  useEffect(() => {
+    if (href == null || typeof EventSource === "undefined") {
+      setState((previous) =>
+        previous.status === "closed" ? previous : { ...previous, status: "closed" },
+      );
+      return;
+    }
+
+    setState((previous) =>
+      previous.status === "connecting" ? previous : { ...previous, status: "connecting" },
+    );
+    const source = new EventSource(href, { withCredentials });
+
+    const onOpen = (): void => {
+      setState((previous) => ({ ...previous, status: "open" }));
+    };
+    // EventSource reconnects on its own; `error` only means "gone for good"
+    // once the readyState reaches CLOSED.
+    const onError = (): void => {
+      const status: EventSourceStatus =
+        source.readyState === CLOSED_READY_STATE ? "closed" : "connecting";
+      setState((previous) => (previous.status === status ? previous : { ...previous, status }));
+    };
+    const onMessage = (messageEvent: MessageEvent): void => {
+      let data: T;
+      if (json) {
+        try {
+          data = JSON.parse(messageEvent.data as string) as T;
+        } catch {
+          console.warn(`[pracht] useEventSource(${href}): dropped non-JSON message`);
+          return;
+        }
+      } else {
+        data = messageEvent.data as T;
+      }
+      setState((previous) => ({
+        ...previous,
+        data,
+        lastEventId: messageEvent.lastEventId || undefined,
+      }));
+    };
+
+    source.addEventListener("open", onOpen);
+    source.addEventListener("error", onError);
+    source.addEventListener(event, onMessage as EventListener);
+
+    return () => {
+      // Closing also drops the listeners; no state updates after this point.
+      source.close();
+    };
+  }, [href, event, json, withCredentials]);
+
+  return state;
+}

--- a/packages/framework/src/event-stream.ts
+++ b/packages/framework/src/event-stream.ts
@@ -41,6 +41,16 @@ export interface EventStream {
   close(): void;
   /** True once the stream closed or the client disconnected. */
   readonly closed: boolean;
+  /**
+   * Remaining capacity in the response stream's internal queue, straight from
+   * `ReadableStreamDefaultController.desiredSize`: positive while the consumer
+   * keeps up, zero or negative once sent messages sit unread (each unread
+   * message lowers it by one), `null` after the stream closed. `send()` never
+   * applies backpressure — a stalled consumer buffers without bound — so a
+   * producer pushing serious volume should check this and pause or drop when
+   * it goes negative.
+   */
+  readonly desiredSize: number | null;
 }
 
 /**
@@ -184,6 +194,12 @@ export function createEventStream(request: Request, init: EventStreamInit = {}):
     heartbeat = setInterval(() => {
       enqueue(":keep-alive\n\n");
     }, init.keepAlive * 1000);
+    // On Node an interval holds the event loop open. The client's socket
+    // already keeps the process alive while anyone is listening, so the timer
+    // itself must not: an un-consumed stream (or one torn down after
+    // `server.close()`) would otherwise pin the process forever. A no-op on
+    // runtimes where `setInterval` returns a number.
+    (heartbeat as unknown as { unref?: () => void }).unref?.();
   }
 
   if (request.signal.aborted) {
@@ -212,6 +228,15 @@ export function createEventStream(request: Request, init: EventStreamInit = {}):
     close,
     get closed(): boolean {
       return closed;
+    },
+    get desiredSize(): number | null {
+      if (closed || controller === null) return null;
+      try {
+        return controller.desiredSize;
+      } catch {
+        // The runtime released the controller (errored stream).
+        return null;
+      }
     },
   };
 }

--- a/packages/framework/src/event-stream.ts
+++ b/packages/framework/src/event-stream.ts
@@ -135,6 +135,19 @@ export function createEventStream(request: Request, init: EventStreamInit = {}):
     throw new Error(`createEventStream keepAlive must be a positive number of seconds`);
   }
 
+  // Validate every caller-controlled header before allocating the stream or
+  // registering lifecycle side effects. If validation throws after the
+  // heartbeat starts, the caller never receives an EventStream to close and
+  // the unreachable timer would keep enqueueing forever.
+  const headers = new Headers({
+    "cache-control": "no-store, no-transform",
+    "content-type": "text/event-stream; charset=utf-8",
+    "x-accel-buffering": "no",
+  });
+  if (init.headers) {
+    applyHeaders(headers, init.headers);
+  }
+
   const encoder = new TextEncoder();
   let controller: ReadableStreamDefaultController<Uint8Array> | null = null;
   let heartbeat: ReturnType<typeof setInterval> | undefined;
@@ -206,15 +219,6 @@ export function createEventStream(request: Request, init: EventStreamInit = {}):
     close();
   } else {
     request.signal.addEventListener("abort", onAbort, { once: true });
-  }
-
-  const headers = new Headers({
-    "cache-control": "no-store, no-transform",
-    "content-type": "text/event-stream; charset=utf-8",
-    "x-accel-buffering": "no",
-  });
-  if (init.headers) {
-    applyHeaders(headers, init.headers);
   }
 
   return {

--- a/packages/framework/src/event-stream.ts
+++ b/packages/framework/src/event-stream.ts
@@ -1,0 +1,217 @@
+import { applyHeaders } from "./runtime-headers.ts";
+
+/**
+ * One Server-Sent Events message. `data` is the only required field: strings
+ * are sent as-is (multi-line values become one `data:` line per line, exactly
+ * as the SSE wire format requires), anything else is `JSON.stringify`ed.
+ */
+export interface EventStreamMessage {
+  /** Payload. Strings pass through; other values are JSON-serialized. */
+  data: unknown;
+  /** Optional event name, dispatched to `addEventListener(event)` listeners. */
+  event?: string;
+  /** Optional event id, exposed as `lastEventId` and replayed by browsers in `Last-Event-ID`. */
+  id?: string;
+  /** Optional reconnection delay hint in milliseconds. */
+  retry?: number;
+}
+
+export interface EventStreamInit {
+  /**
+   * Emit a comment line (`:keep-alive`) every `keepAlive` seconds so proxies
+   * and load balancers with idle timeouts keep the connection open. Off when
+   * omitted. The timer is cleared as soon as the stream closes or the client
+   * disconnects.
+   */
+  keepAlive?: number;
+  /** Extra headers merged over the SSE defaults. */
+  headers?: HeadersInit;
+}
+
+export interface EventStream {
+  /** The streaming `Response` to return from the API route handler. */
+  response: Response;
+  /**
+   * Serialize and enqueue one message. Returns `false` — instead of throwing —
+   * once the stream is closed or the client has disconnected, so producer
+   * loops can use the return value as their stop condition.
+   */
+  send(message: EventStreamMessage): boolean;
+  /** End the stream. Idempotent; also clears the keep-alive timer. */
+  close(): void;
+  /** True once the stream closed or the client disconnected. */
+  readonly closed: boolean;
+}
+
+/**
+ * Matches every line break the SSE parser recognizes (CRLF, CR, LF), so a
+ * multi-line payload round-trips: the client's EventSource joins consecutive
+ * `data:` lines with `\n`.
+ */
+const SSE_LINE_BREAK_RE = /\r\n|\r|\n/;
+
+function assertSafeSseField(field: "event" | "id", value: string): void {
+  // A CR or LF inside `event:`/`id:` would terminate the field early and turn
+  // the remainder into attacker-controlled protocol lines — the SSE analogue
+  // of header response-splitting. `id` additionally must not contain NUL:
+  // the spec makes receivers ignore such ids, so it can only be a mistake.
+  if (/[\r\n]/.test(value) || (field === "id" && value.includes("\0"))) {
+    throw new Error(`Refused to serialize SSE "${field}" field containing CR, LF, or NUL`);
+  }
+}
+
+/**
+ * Serialize one message into its SSE wire format. Exported for tests and for
+ * code that manages its own stream but wants the framing exactly right.
+ */
+export function serializeEventStreamMessage(message: EventStreamMessage): string {
+  let out = "";
+
+  if (message.event !== undefined) {
+    assertSafeSseField("event", message.event);
+    out += `event: ${message.event}\n`;
+  }
+  if (message.id !== undefined) {
+    assertSafeSseField("id", message.id);
+    out += `id: ${message.id}\n`;
+  }
+  if (message.retry !== undefined) {
+    if (!Number.isInteger(message.retry) || message.retry < 0) {
+      throw new Error(`SSE "retry" must be a non-negative integer of milliseconds`);
+    }
+    out += `retry: ${message.retry}\n`;
+  }
+
+  const text =
+    typeof message.data === "string"
+      ? message.data
+      : // `JSON.stringify` yields `undefined` for `undefined`, functions, and
+        // symbols; an empty `data:` line still dispatches the event.
+        (JSON.stringify(message.data) ?? "");
+  for (const line of text.split(SSE_LINE_BREAK_RE)) {
+    out += `data: ${line}\n`;
+  }
+
+  return `${out}\n`;
+}
+
+/**
+ * Create a Server-Sent Events stream for an API route handler.
+ *
+ * ```ts
+ * export function GET({ request }: BaseRouteArgs) {
+ *   const stream = createEventStream(request, { keepAlive: 15 });
+ *   const timer = setInterval(() => {
+ *     if (!stream.send({ data: { now: Date.now() } })) clearInterval(timer);
+ *   }, 1000);
+ *   return stream.response;
+ * }
+ * ```
+ *
+ * Built on the web `ReadableStream`, so it behaves identically on Node,
+ * Cloudflare Workers, and Vercel Edge. Cleanup is wired to both disconnect
+ * signals a runtime can deliver: `request.signal` aborting (workerd, edge)
+ * and the response stream being cancelled (the Node adapter destroys the
+ * piped stream when the client hangs up). Either one closes the stream,
+ * clears the keep-alive timer, and makes `send()` return `false`.
+ *
+ * The response carries `Cache-Control: no-store, no-transform` so shared
+ * caches never buffer or store it and compression/transforming proxies leave
+ * the framing alone, plus `X-Accel-Buffering: no` for nginx-style reverse
+ * proxies that buffer streamed responses by default.
+ */
+export function createEventStream(request: Request, init: EventStreamInit = {}): EventStream {
+  if (init.keepAlive !== undefined && !(Number.isFinite(init.keepAlive) && init.keepAlive > 0)) {
+    throw new Error(`createEventStream keepAlive must be a positive number of seconds`);
+  }
+
+  const encoder = new TextEncoder();
+  let controller: ReadableStreamDefaultController<Uint8Array> | null = null;
+  let heartbeat: ReturnType<typeof setInterval> | undefined;
+  let closed = false;
+
+  // Shared teardown for every close path. Does not touch the controller:
+  // after a cancel or an errored stream there is nothing left to close.
+  function markClosed(): void {
+    if (closed) return;
+    closed = true;
+    if (heartbeat !== undefined) {
+      clearInterval(heartbeat);
+      heartbeat = undefined;
+    }
+    request.signal.removeEventListener("abort", onAbort);
+  }
+
+  function close(): void {
+    if (closed) return;
+    markClosed();
+    try {
+      controller?.close();
+    } catch {
+      // The stream already errored or the runtime closed it first.
+    }
+  }
+
+  function onAbort(): void {
+    close();
+  }
+
+  function enqueue(text: string): boolean {
+    if (closed || controller === null) return false;
+    try {
+      controller.enqueue(encoder.encode(text));
+      return true;
+    } catch {
+      // The consumer is gone but `cancel()` has not fired (or fired between
+      // the check above and the enqueue). Treat it as a disconnect.
+      markClosed();
+      return false;
+    }
+  }
+
+  const stream = new ReadableStream<Uint8Array>({
+    start(c) {
+      controller = c;
+    },
+    cancel() {
+      // The client went away: the Node adapter destroys the piped stream on
+      // response close and workerd cancels it directly.
+      markClosed();
+    },
+  });
+
+  if (init.keepAlive !== undefined && !request.signal.aborted) {
+    heartbeat = setInterval(() => {
+      enqueue(":keep-alive\n\n");
+    }, init.keepAlive * 1000);
+  }
+
+  if (request.signal.aborted) {
+    close();
+  } else {
+    request.signal.addEventListener("abort", onAbort, { once: true });
+  }
+
+  const headers = new Headers({
+    "cache-control": "no-store, no-transform",
+    "content-type": "text/event-stream; charset=utf-8",
+    "x-accel-buffering": "no",
+  });
+  if (init.headers) {
+    applyHeaders(headers, init.headers);
+  }
+
+  return {
+    response: new Response(stream, { headers, status: 200 }),
+    send(message: EventStreamMessage): boolean {
+      // Serialize before the closed check so field-injection mistakes throw
+      // loudly even on a stream that already ended.
+      const serialized = serializeEventStreamMessage(message);
+      return enqueue(serialized);
+    },
+    close,
+    get closed(): boolean {
+      return closed;
+    },
+  };
+}

--- a/packages/framework/src/index.ts
+++ b/packages/framework/src/index.ts
@@ -132,6 +132,20 @@ export {
   setCapabilityApprovalPrincipalResolver,
 } from "./runtime-approval.ts";
 export type { MemoryApprovalStoreOptions } from "./runtime-approval.ts";
+export {
+  createEventStream,
+  serializeEventStreamMessage,
+  type EventStream,
+  type EventStreamInit,
+  type EventStreamMessage,
+} from "./event-stream.ts";
+export { isUpgradeRequest } from "./upgrade.ts";
+export {
+  useEventSource,
+  type EventSourceState,
+  type EventSourceStatus,
+  type UseEventSourceOptions,
+} from "./event-source-hook.ts";
 export { forwardRef } from "./forwardRef.ts";
 export { useIsHydrated } from "./hydration.ts";
 export { Suspense, lazy } from "preact-suspense";

--- a/packages/framework/src/server.ts
+++ b/packages/framework/src/server.ts
@@ -102,6 +102,14 @@ export {
   routeSupportsMarkdown,
 } from "./runtime-negotiation.ts";
 export type { MarkdownManifest } from "./runtime-negotiation.ts";
+export {
+  createEventStream,
+  serializeEventStreamMessage,
+  type EventStream,
+  type EventStreamInit,
+  type EventStreamMessage,
+} from "./event-stream.ts";
+export { isUpgradeRequest } from "./upgrade.ts";
 export { resolveRegistryModule } from "./runtime-manifest.ts";
 export { createCapabilityTestHost } from "./testing-capabilities.ts";
 export type {

--- a/packages/framework/src/upgrade.ts
+++ b/packages/framework/src/upgrade.ts
@@ -1,0 +1,27 @@
+/**
+ * True when `request` is a WebSocket upgrade handshake (`Upgrade: websocket`).
+ *
+ * Use it at the top of an API route that serves WebSockets to reject plain
+ * HTTP requests with `426 Upgrade Required` instead of hanging them:
+ *
+ * ```ts
+ * export function GET({ request }: BaseRouteArgs) {
+ *   if (!isUpgradeRequest(request)) {
+ *     return new Response("Expected a WebSocket upgrade", { status: 426 });
+ *   }
+ *   // Cloudflare: new WebSocketPair() / forward to a Durable Object.
+ * }
+ * ```
+ *
+ * The `Upgrade` header is a comma-separated protocol list, so this matches
+ * `websocket` as a token (case-insensitively) rather than comparing the raw
+ * header value. Note the framework's same-origin guard for upgrades
+ * (`api.requireSameOrigin`, on by default) runs before any API route —
+ * browsers do not apply CORS to WebSocket, so keep that guard on unless you
+ * check `Origin` yourself.
+ */
+export function isUpgradeRequest(request: Request): boolean {
+  const upgrade = request.headers.get("upgrade");
+  if (!upgrade) return false;
+  return upgrade.split(",").some((protocol) => protocol.trim().toLowerCase() === "websocket");
+}

--- a/packages/framework/test/event-source-hook.test.ts
+++ b/packages/framework/test/event-source-hook.test.ts
@@ -206,6 +206,29 @@ describe("useEventSource", () => {
     expect(source(1).closed).toBe(false);
   });
 
+  it("resets data and lastEventId when the url changes — no stale payload from the old endpoint", async () => {
+    const rerender = await renderHook("/api/a");
+    source(0).emitOpen();
+    source(0).emitMessage("message", "from-a", "a-7");
+    await flush();
+    expect(latest).toMatchObject({ data: "from-a", lastEventId: "a-7", status: "open" });
+
+    await rerender("/api/b");
+
+    // The new subscription starts clean: endpoint A's payload must not be
+    // presented as endpoint B's while B connects.
+    expect(latest).toMatchObject({
+      data: undefined,
+      lastEventId: undefined,
+      status: "connecting",
+    });
+
+    source(1).emitOpen();
+    source(1).emitMessage("message", "from-b", "b-1");
+    await flush();
+    expect(latest).toMatchObject({ data: "from-b", lastEventId: "b-1", status: "open" });
+  });
+
   it("disconnects when the url becomes null", async () => {
     const rerender = await renderHook("/api/live");
     await rerender(null);

--- a/packages/framework/test/event-source-hook.test.ts
+++ b/packages/framework/test/event-source-hook.test.ts
@@ -244,6 +244,29 @@ describe("useEventSource", () => {
     expect(latest).toEqual({ data: undefined, lastEventId: undefined, status: "closed" });
   });
 
+  it("never renders the previous payload after the subscription changes", async () => {
+    function Probe(props: { url: string | null }) {
+      latest = useEventSource(props.url);
+      return h("span", null, latest.data === undefined ? "empty" : String(latest.data));
+    }
+
+    render(h(Probe, { url: "/api/private-a" }), root);
+    await flush();
+    source().emitMessage("message", "private-a", "a-1");
+    await flush();
+    expect(root.textContent).toBe("private-a");
+
+    // The new props render before the passive effect can close/reset the old
+    // subscription. The public state must nevertheless be clean immediately,
+    // so another user or endpoint never paints the previous payload.
+    render(h(Probe, { url: null }), root);
+    expect(root.textContent).toBe("empty");
+    expect(latest).toEqual({ data: undefined, lastEventId: undefined, status: "closed" });
+
+    await flush();
+    expect(source().closed).toBe(true);
+  });
+
   it("survives an unmount race before the connection ever opens", async () => {
     await renderHook("/api/live");
     // Unmount immediately — no open, no message ever arrived. The only

--- a/packages/framework/test/event-source-hook.test.ts
+++ b/packages/framework/test/event-source-hook.test.ts
@@ -229,12 +229,19 @@ describe("useEventSource", () => {
     expect(latest).toMatchObject({ data: "from-b", lastEventId: "b-1", status: "open" });
   });
 
-  it("disconnects when the url becomes null", async () => {
+  it("disconnects and clears the previous payload when the url becomes null", async () => {
     const rerender = await renderHook("/api/live");
+    source().emitMessage("message", "private-payload", "live-7");
+    await flush();
+    expect(latest).toMatchObject({
+      data: "private-payload",
+      lastEventId: "live-7",
+    });
+
     await rerender(null);
 
     expect(source().closed).toBe(true);
-    expect(latest).toMatchObject({ status: "closed" });
+    expect(latest).toEqual({ data: undefined, lastEventId: undefined, status: "closed" });
   });
 
   it("survives an unmount race before the connection ever opens", async () => {

--- a/packages/framework/test/event-source-hook.test.ts
+++ b/packages/framework/test/event-source-hook.test.ts
@@ -1,0 +1,227 @@
+// @vitest-environment jsdom
+import { h, render } from "preact";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useEventSource, type EventSourceState } from "../src/event-source-hook.ts";
+
+/**
+ * jsdom ships no EventSource; a scripted stand-in records instances and lets
+ * tests dispatch protocol events by hand.
+ */
+class MockEventSource {
+  static instances: MockEventSource[] = [];
+
+  static CONNECTING = 0;
+  static OPEN = 1;
+  static CLOSED = 2;
+
+  url: string;
+  withCredentials: boolean;
+  readyState = MockEventSource.CONNECTING;
+  closed = false;
+
+  private listeners = new Map<string, Set<EventListener>>();
+
+  constructor(url: string, init?: EventSourceInit) {
+    this.url = url;
+    this.withCredentials = init?.withCredentials ?? false;
+    MockEventSource.instances.push(this);
+  }
+
+  addEventListener(type: string, listener: EventListener): void {
+    let set = this.listeners.get(type);
+    if (!set) {
+      set = new Set();
+      this.listeners.set(type, set);
+    }
+    set.add(listener);
+  }
+
+  removeEventListener(type: string, listener: EventListener): void {
+    this.listeners.get(type)?.delete(listener);
+  }
+
+  close(): void {
+    this.closed = true;
+    this.readyState = MockEventSource.CLOSED;
+  }
+
+  emitOpen(): void {
+    this.readyState = MockEventSource.OPEN;
+    this.dispatch("open", new Event("open"));
+  }
+
+  emitError(options: { terminal?: boolean } = {}): void {
+    this.readyState = options.terminal ? MockEventSource.CLOSED : MockEventSource.CONNECTING;
+    this.dispatch("error", new Event("error"));
+  }
+
+  emitMessage(type: string, data: string, lastEventId = ""): void {
+    if (this.closed) throw new Error("emitMessage on a closed source");
+    this.dispatch(type, new MessageEvent(type, { data, lastEventId }));
+  }
+
+  private dispatch(type: string, event: Event): void {
+    for (const listener of this.listeners.get(type) ?? []) listener(event);
+  }
+}
+
+/** Flush microtasks, requestAnimationFrame, and Preact effects/re-renders. */
+async function flush(): Promise<void> {
+  await Promise.resolve();
+  await new Promise<void>((r) => requestAnimationFrame(() => r()));
+  await Promise.resolve();
+  await new Promise<void>((r) => requestAnimationFrame(() => r()));
+  await new Promise<void>((r) => setTimeout(r, 0));
+}
+
+describe("useEventSource", () => {
+  let root: HTMLDivElement;
+  let latest: EventSourceState<unknown> | undefined;
+
+  async function renderHook(
+    url: string | null,
+    options?: Parameters<typeof useEventSource>[1],
+  ): Promise<(nextUrl: string | null) => Promise<void>> {
+    function Probe(props: { url: string | null }) {
+      latest = useEventSource(props.url, options);
+      return null;
+    }
+    const rerender = async (nextUrl: string | null) => {
+      render(h(Probe, { url: nextUrl }), root);
+      await flush();
+    };
+    await rerender(url);
+    return rerender;
+  }
+
+  function source(index = 0): MockEventSource {
+    const instance = MockEventSource.instances[index];
+    if (!instance) throw new Error(`no MockEventSource instance ${index}`);
+    return instance;
+  }
+
+  beforeEach(() => {
+    vi.stubGlobal("EventSource", MockEventSource);
+    MockEventSource.instances = [];
+    root = document.createElement("div");
+    document.body.appendChild(root);
+    latest = undefined;
+  });
+
+  afterEach(() => {
+    render(null, root);
+    root.remove();
+    vi.unstubAllGlobals();
+  });
+
+  it("connects on mount and tracks open status", async () => {
+    await renderHook("/api/live");
+
+    expect(MockEventSource.instances).toHaveLength(1);
+    expect(source().url).toBe("/api/live");
+    expect(latest).toMatchObject({ data: undefined, status: "connecting" });
+
+    source().emitOpen();
+    await flush();
+    expect(latest).toMatchObject({ status: "open" });
+  });
+
+  it("delivers unnamed messages as raw strings by default", async () => {
+    await renderHook("/api/live");
+    source().emitMessage("message", "hello", "42");
+
+    await flush();
+    expect(latest).toMatchObject({ data: "hello", lastEventId: "42" });
+  });
+
+  it("parses JSON payloads with json: true and drops malformed ones", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    await renderHook("/api/live", { json: true });
+
+    source().emitMessage("message", '{"n":1}');
+    await flush();
+    expect(latest).toMatchObject({ data: { n: 1 } });
+
+    source().emitMessage("message", "not json");
+    await flush();
+    // Previous data survives a malformed frame.
+    expect(latest).toMatchObject({ data: { n: 1 } });
+    expect(warn).toHaveBeenCalledOnce();
+  });
+
+  it("listens only to the configured named event", async () => {
+    await renderHook("/api/live", { event: "tick" });
+
+    source().emitMessage("message", "ignored");
+    await flush();
+    expect(latest).toMatchObject({ data: undefined });
+
+    source().emitMessage("tick", "taken");
+    await flush();
+    expect(latest).toMatchObject({ data: "taken" });
+  });
+
+  it("passes withCredentials through", async () => {
+    await renderHook("/api/live", { withCredentials: true });
+    expect(source().withCredentials).toBe(true);
+  });
+
+  it("reports reconnecting errors as connecting and terminal errors as closed", async () => {
+    await renderHook("/api/live");
+    source().emitOpen();
+    await flush();
+
+    // The 404/network-failure shape: the browser retries, then gives up.
+    source().emitError();
+    await flush();
+    expect(latest).toMatchObject({ status: "connecting" });
+
+    source().emitError({ terminal: true });
+    await flush();
+    expect(latest).toMatchObject({ status: "closed" });
+  });
+
+  it("stays closed with a null url and opens nothing", async () => {
+    await renderHook(null);
+    expect(MockEventSource.instances).toHaveLength(0);
+    expect(latest).toMatchObject({ status: "closed" });
+  });
+
+  it("closes the connection on unmount", async () => {
+    await renderHook("/api/live");
+    render(null, root);
+    await flush();
+
+    expect(source().closed).toBe(true);
+  });
+
+  it("swaps connections when the url changes and closes the old one first", async () => {
+    const rerender = await renderHook("/api/a");
+    await rerender("/api/b");
+
+    expect(MockEventSource.instances).toHaveLength(2);
+    expect(source(0).closed).toBe(true);
+    expect(source(1).url).toBe("/api/b");
+    expect(source(1).closed).toBe(false);
+  });
+
+  it("disconnects when the url becomes null", async () => {
+    const rerender = await renderHook("/api/live");
+    await rerender(null);
+
+    expect(source().closed).toBe(true);
+    expect(latest).toMatchObject({ status: "closed" });
+  });
+
+  it("survives an unmount race before the connection ever opens", async () => {
+    await renderHook("/api/live");
+    // Unmount immediately — no open, no message ever arrived. The only
+    // observable requirement: the source is closed and a straggler event
+    // dispatched by a sloppy mock afterwards does not throw.
+    render(null, root);
+    await flush();
+    expect(source().closed).toBe(true);
+    expect(() => source().emitOpen()).not.toThrow();
+  });
+});

--- a/packages/framework/test/event-stream.test.ts
+++ b/packages/framework/test/event-stream.test.ts
@@ -108,6 +108,20 @@ describe("createEventStream", () => {
     ).toThrow(/x-evil/);
   });
 
+  it("validates custom headers before starting keep-alive lifecycle side effects", () => {
+    const setInterval = vi.spyOn(globalThis, "setInterval");
+
+    expect(() =>
+      createEventStream(createRequest(), {
+        headers: { "x-evil": "a\r\nset-cookie: b" },
+        keepAlive: 1,
+      }),
+    ).toThrow(/x-evil/);
+
+    expect(setInterval).not.toHaveBeenCalled();
+    setInterval.mockRestore();
+  });
+
   it("streams sent messages and closes the body on close()", async () => {
     const stream = createEventStream(createRequest());
     expect(stream.send({ data: "one" })).toBe(true);

--- a/packages/framework/test/event-stream.test.ts
+++ b/packages/framework/test/event-stream.test.ts
@@ -1,0 +1,235 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { createEventStream, serializeEventStreamMessage } from "../src/event-stream.ts";
+
+function createRequest(signal?: AbortSignal): Request {
+  return new Request("http://localhost/api/live", { signal });
+}
+
+/** Read every chunk currently in the stream until it closes. */
+async function readToEnd(response: Response): Promise<string> {
+  const reader = response.body!.getReader();
+  const decoder = new TextDecoder();
+  let out = "";
+  for (;;) {
+    const { done, value } = await reader.read();
+    if (done) return out + decoder.decode();
+    out += decoder.decode(value, { stream: true });
+  }
+}
+
+/** Read exactly one chunk. */
+async function readChunk(reader: ReadableStreamDefaultReader<Uint8Array>): Promise<string> {
+  const { done, value } = await reader.read();
+  expect(done).toBe(false);
+  return new TextDecoder().decode(value);
+}
+
+describe("serializeEventStreamMessage", () => {
+  it("serializes a plain string payload", () => {
+    expect(serializeEventStreamMessage({ data: "hello" })).toBe("data: hello\n\n");
+  });
+
+  it("splits multi-line data into one data: line per line, across CRLF, CR, and LF", () => {
+    expect(serializeEventStreamMessage({ data: "a\nb\r\nc\rd" })).toBe(
+      "data: a\ndata: b\ndata: c\ndata: d\n\n",
+    );
+  });
+
+  it("JSON-serializes non-string payloads", () => {
+    expect(serializeEventStreamMessage({ data: { count: 2 } })).toBe('data: {"count":2}\n\n');
+    expect(serializeEventStreamMessage({ data: 42 })).toBe("data: 42\n\n");
+    expect(serializeEventStreamMessage({ data: null })).toBe("data: null\n\n");
+  });
+
+  it("serializes undefined and unserializable data as an empty data line", () => {
+    expect(serializeEventStreamMessage({ data: undefined })).toBe("data: \n\n");
+    expect(serializeEventStreamMessage({ data: () => {} })).toBe("data: \n\n");
+  });
+
+  it("orders event, id, and retry fields before the data lines", () => {
+    expect(serializeEventStreamMessage({ data: "d", event: "tick", id: "7", retry: 1500 })).toBe(
+      "event: tick\nid: 7\nretry: 1500\ndata: d\n\n",
+    );
+  });
+
+  it("refuses CR/LF injection through the event field", () => {
+    expect(() => serializeEventStreamMessage({ data: "x", event: "tick\ndata: forged" })).toThrow(
+      /event/,
+    );
+    expect(() => serializeEventStreamMessage({ data: "x", event: "tick\r" })).toThrow(/event/);
+  });
+
+  it("refuses CR/LF and NUL injection through the id field", () => {
+    expect(() => serializeEventStreamMessage({ data: "x", id: "1\nretry: 1" })).toThrow(/id/);
+    expect(() => serializeEventStreamMessage({ data: "x", id: "1\0" })).toThrow(/id/);
+  });
+
+  it("refuses non-integer and negative retry values", () => {
+    expect(() => serializeEventStreamMessage({ data: "x", retry: 1.5 })).toThrow(/retry/);
+    expect(() => serializeEventStreamMessage({ data: "x", retry: -1 })).toThrow(/retry/);
+    expect(() => serializeEventStreamMessage({ data: "x", retry: Number.NaN })).toThrow(/retry/);
+  });
+
+  it("newlines inside JSON payloads stay escaped, so they cannot split the frame", () => {
+    expect(serializeEventStreamMessage({ data: { text: "a\nb" } })).toBe(
+      'data: {"text":"a\\nb"}\n\n',
+    );
+  });
+});
+
+describe("createEventStream", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("responds with SSE headers that defeat caching, buffering, and transforms", () => {
+    const { response, close } = createEventStream(createRequest());
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toBe("text/event-stream; charset=utf-8");
+    expect(response.headers.get("cache-control")).toBe("no-store, no-transform");
+    expect(response.headers.get("x-accel-buffering")).toBe("no");
+    close();
+  });
+
+  it("merges custom headers over the defaults", () => {
+    const { response, close } = createEventStream(createRequest(), {
+      headers: { "cache-control": "no-cache, no-transform", "x-custom": "1" },
+    });
+    expect(response.headers.get("cache-control")).toBe("no-cache, no-transform");
+    expect(response.headers.get("x-custom")).toBe("1");
+    expect(response.headers.get("content-type")).toBe("text/event-stream; charset=utf-8");
+    close();
+  });
+
+  it("rejects CR/LF in custom header values", () => {
+    expect(() =>
+      createEventStream(createRequest(), { headers: { "x-evil": "a\r\nset-cookie: b" } }),
+    ).toThrow(/x-evil/);
+  });
+
+  it("streams sent messages and closes the body on close()", async () => {
+    const stream = createEventStream(createRequest());
+    expect(stream.send({ data: "one" })).toBe(true);
+    expect(stream.send({ data: { n: 2 }, event: "tick" })).toBe(true);
+    stream.close();
+
+    await expect(readToEnd(stream.response)).resolves.toBe(
+      'data: one\n\nevent: tick\ndata: {"n":2}\n\n',
+    );
+  });
+
+  it("send() returns false after close() and close() is idempotent", () => {
+    const stream = createEventStream(createRequest());
+    stream.close();
+    stream.close();
+    expect(stream.closed).toBe(true);
+    expect(stream.send({ data: "late" })).toBe(false);
+  });
+
+  it("still throws on malformed fields after close, instead of silently returning false", () => {
+    const stream = createEventStream(createRequest());
+    stream.close();
+    expect(() => stream.send({ data: "x", event: "a\nb" })).toThrow(/event/);
+  });
+
+  it("closes when the request aborts (client disconnect on workerd/edge)", async () => {
+    const controller = new AbortController();
+    const stream = createEventStream(createRequest(controller.signal));
+    expect(stream.send({ data: "before" })).toBe(true);
+
+    controller.abort();
+
+    expect(stream.closed).toBe(true);
+    expect(stream.send({ data: "after" })).toBe(false);
+    // The body ends: a consumer's read loop terminates.
+    await expect(readToEnd(stream.response)).resolves.toBe("data: before\n\n");
+  });
+
+  it("is born closed when the request signal is already aborted", async () => {
+    const controller = new AbortController();
+    controller.abort();
+    const stream = createEventStream(createRequest(controller.signal));
+
+    expect(stream.closed).toBe(true);
+    expect(stream.send({ data: "x" })).toBe(false);
+    await expect(readToEnd(stream.response)).resolves.toBe("");
+  });
+
+  it("treats body cancellation as a disconnect (Node adapter destroying the pipe)", async () => {
+    const stream = createEventStream(createRequest());
+    expect(stream.send({ data: "x" })).toBe(true);
+
+    await stream.response.body!.cancel();
+
+    expect(stream.closed).toBe(true);
+    expect(stream.send({ data: "y" })).toBe(false);
+  });
+
+  it("emits keep-alive comment lines on the configured interval", async () => {
+    vi.useFakeTimers();
+    const stream = createEventStream(createRequest(), { keepAlive: 15 });
+    const reader = stream.response.body!.getReader();
+
+    vi.advanceTimersByTime(15_000);
+    await expect(readChunk(reader)).resolves.toBe(":keep-alive\n\n");
+    vi.advanceTimersByTime(15_000);
+    await expect(readChunk(reader)).resolves.toBe(":keep-alive\n\n");
+
+    stream.close();
+    await expect(reader.read()).resolves.toMatchObject({ done: true });
+  });
+
+  it("stops the keep-alive timer on close, abort, and cancel — no timer leaks", async () => {
+    vi.useFakeTimers();
+    const setInterval = vi.spyOn(globalThis, "setInterval");
+    const clearInterval = vi.spyOn(globalThis, "clearInterval");
+
+    const closed = createEventStream(createRequest(), { keepAlive: 1 });
+    closed.close();
+
+    const aborter = new AbortController();
+    const aborted = createEventStream(createRequest(aborter.signal), { keepAlive: 1 });
+    aborter.abort();
+    expect(aborted.closed).toBe(true);
+
+    const cancelled = createEventStream(createRequest(), { keepAlive: 1 });
+    await cancelled.response.body!.cancel();
+
+    expect(setInterval).toHaveBeenCalledTimes(3);
+    expect(clearInterval).toHaveBeenCalledTimes(3);
+
+    // And a cleared timer emits nothing.
+    vi.advanceTimersByTime(60_000);
+    await expect(readToEnd(closed.response)).resolves.toBe("");
+  });
+
+  it("does not start a keep-alive timer for a request that is already aborted", () => {
+    vi.useFakeTimers();
+    const setInterval = vi.spyOn(globalThis, "setInterval");
+    const controller = new AbortController();
+    controller.abort();
+
+    createEventStream(createRequest(controller.signal), { keepAlive: 1 });
+
+    expect(setInterval).not.toHaveBeenCalled();
+  });
+
+  it("rejects nonsensical keepAlive values", () => {
+    for (const keepAlive of [0, -5, Number.NaN, Number.POSITIVE_INFINITY]) {
+      expect(() => createEventStream(createRequest(), { keepAlive })).toThrow(/keepAlive/);
+    }
+  });
+
+  it("buffers messages sent before the consumer starts reading", async () => {
+    const stream = createEventStream(createRequest());
+    for (let i = 0; i < 100; i += 1) {
+      expect(stream.send({ data: String(i) })).toBe(true);
+    }
+    stream.close();
+
+    const body = await readToEnd(stream.response);
+    expect(body.startsWith("data: 0\n\n")).toBe(true);
+    expect(body.endsWith("data: 99\n\n")).toBe(true);
+  });
+});

--- a/packages/framework/test/event-stream.test.ts
+++ b/packages/framework/test/event-stream.test.ts
@@ -221,6 +221,51 @@ describe("createEventStream", () => {
     }
   });
 
+  it("unrefs the keep-alive timer so an idle stream cannot pin the Node process", () => {
+    const setIntervalSpy = vi.spyOn(globalThis, "setInterval");
+    const stream = createEventStream(createRequest(), { keepAlive: 1 });
+
+    const timer = setIntervalSpy.mock.results[0]!.value as { hasRef?: () => boolean };
+    // Node's Timeout reports ref state via hasRef(); after unref() the timer
+    // no longer holds the event loop open. (On runtimes where setInterval
+    // returns a number the unref call is a no-op and this assertion is moot.)
+    expect(typeof timer.hasRef).toBe("function");
+    expect(timer.hasRef!()).toBe(false);
+
+    stream.close();
+  });
+
+  it("exposes desiredSize so producers can observe a stalled consumer", async () => {
+    const stream = createEventStream(createRequest());
+    // Default queuing strategy: high-water mark 1, counted in chunks.
+    expect(stream.desiredSize).toBe(1);
+
+    stream.send({ data: "one" });
+    expect(stream.desiredSize).toBe(0);
+    stream.send({ data: "two" });
+    // Negative: unread messages are buffering — the signal to throttle.
+    expect(stream.desiredSize).toBeLessThan(0);
+
+    const reader = stream.response.body!.getReader();
+    await reader.read();
+    await reader.read();
+    expect(stream.desiredSize).toBe(1);
+
+    stream.close();
+    expect(stream.desiredSize).toBe(null);
+  });
+
+  it("reports desiredSize null after a disconnect (abort or cancel)", async () => {
+    const aborter = new AbortController();
+    const aborted = createEventStream(createRequest(aborter.signal));
+    aborter.abort();
+    expect(aborted.desiredSize).toBe(null);
+
+    const cancelled = createEventStream(createRequest());
+    await cancelled.response.body!.cancel();
+    expect(cancelled.desiredSize).toBe(null);
+  });
+
   it("buffers messages sent before the consumer starts reading", async () => {
     const stream = createEventStream(createRequest());
     for (let i = 0; i < 100; i += 1) {

--- a/packages/framework/test/websocket.test.ts
+++ b/packages/framework/test/websocket.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import { defineApp, handlePrachtRequest, resolveApiRoutes, route } from "../src/index.ts";
+import { isUpgradeRequest } from "../src/upgrade.ts";
 import {
   isProtocolSwitchResponse,
   withDefaultSecurityHeaders,
@@ -22,6 +23,36 @@ function createUpgradeResponse(): Response & { webSocket: unknown } {
 }
 
 const routeStateOptions = { isRouteStateRequest: false };
+
+describe("isUpgradeRequest", () => {
+  it("matches a WebSocket handshake", () => {
+    const request = new Request("http://localhost/api/ws", {
+      headers: { connection: "Upgrade", upgrade: "websocket" },
+    });
+    expect(isUpgradeRequest(request)).toBe(true);
+  });
+
+  it("matches case-insensitively and inside a protocol list", () => {
+    expect(
+      isUpgradeRequest(new Request("http://localhost/", { headers: { upgrade: "WebSocket" } })),
+    ).toBe(true);
+    expect(
+      isUpgradeRequest(
+        new Request("http://localhost/", { headers: { upgrade: "h2c, websocket" } }),
+      ),
+    ).toBe(true);
+  });
+
+  it("rejects plain requests and non-websocket upgrades", () => {
+    expect(isUpgradeRequest(new Request("http://localhost/"))).toBe(false);
+    expect(
+      isUpgradeRequest(new Request("http://localhost/", { headers: { upgrade: "h2c" } })),
+    ).toBe(false);
+    expect(
+      isUpgradeRequest(new Request("http://localhost/", { headers: { upgrade: "websocket2" } })),
+    ).toBe(false);
+  });
+});
 
 describe("isProtocolSwitchResponse", () => {
   it("detects a 101 handshake", () => {

--- a/packages/vite-plugin/src/plugin-dev-ssr.ts
+++ b/packages/vite-plugin/src/plugin-dev-ssr.ts
@@ -26,6 +26,10 @@ export const DEVTOOLS_PATH = "/_pracht";
 export const DEVTOOLS_JSON_PATH = "/_pracht.json";
 export const LLMS_TXT_PATH = "/llms.txt";
 
+export function isEventStreamContentType(contentType: string): boolean {
+  return contentType.split(";", 1)[0]?.trim().toLowerCase() === "text/event-stream";
+}
+
 export function createDevSSRMiddleware(
   server: ViteDevServer,
   options: { maxBodySize?: number; llmsTxt?: boolean } = {},
@@ -179,7 +183,7 @@ export function createDevSSRMiddleware(
       // through untouched, and cancel the source when the client disconnects
       // so `createEventStream()` cleanup (keep-alive timers, producer loops)
       // runs in dev exactly as it does in production.
-      if (response.body && contentType.includes("text/event-stream")) {
+      if (response.body && isEventStreamContentType(contentType)) {
         res.statusCode = response.status;
         response.headers.forEach((value: string, key: string) => {
           res.setHeader(key, value);

--- a/packages/vite-plugin/src/plugin-dev-ssr.ts
+++ b/packages/vite-plugin/src/plugin-dev-ssr.ts
@@ -1,5 +1,6 @@
 import { existsSync, readFileSync } from "node:fs";
 import type { IncomingMessage, ServerResponse } from "node:http";
+import { Readable } from "node:stream";
 import { join, resolve } from "node:path";
 import type { Connect, EnvironmentModuleNode, ViteDevServer } from "vite";
 import type {
@@ -171,6 +172,36 @@ export function createDevSSRMiddleware(
       // `<script type="module" src="/@vite/client">` as its body, and so did
       // redirects.
       const contentType = response.headers.get("content-type") ?? "";
+
+      // A Server-Sent Events response never ends, so buffering it through
+      // `response.text()` below would hang the request forever — dev would
+      // diverge from every production adapter, all of which stream. Pipe it
+      // through untouched, and cancel the source when the client disconnects
+      // so `createEventStream()` cleanup (keep-alive timers, producer loops)
+      // runs in dev exactly as it does in production.
+      if (response.body && contentType.includes("text/event-stream")) {
+        res.statusCode = response.status;
+        response.headers.forEach((value: string, key: string) => {
+          res.setHeader(key, value);
+        });
+        const source = Readable.fromWeb(response.body as Parameters<typeof Readable.fromWeb>[0]);
+        // The client may already have hung up while the handler ran; `close`
+        // has then already fired and the listener below would never run,
+        // leaving the stream (and its keep-alive timer) alive forever.
+        if (res.destroyed || res.writableEnded) {
+          source.destroy();
+          return;
+        }
+        res.on("close", () => {
+          if (!res.writableFinished) source.destroy();
+        });
+        source.on("error", () => {
+          res.destroy();
+        });
+        source.pipe(res);
+        return;
+      }
+
       let body = await response.text();
 
       if (contentType.includes("text/html")) {

--- a/packages/vite-plugin/test/dev-middleware.test.ts
+++ b/packages/vite-plugin/test/dev-middleware.test.ts
@@ -4,9 +4,18 @@ import {
   collectDevCssUrls,
   createDevCssManifest,
   injectDevCssLinks,
+  isEventStreamContentType,
   isDevNotFoundRequest,
   shouldBypassDevSSR,
 } from "../src/plugin-dev-ssr.ts";
+
+describe("development streaming response detection", () => {
+  it("recognizes the SSE media type case-insensitively", () => {
+    expect(isEventStreamContentType("text/event-stream; charset=utf-8")).toBe(true);
+    expect(isEventStreamContentType("Text/Event-Stream; Charset=UTF-8")).toBe(true);
+    expect(isEventStreamContentType("application/json")).toBe(false);
+  });
+});
 
 function moduleNode(url: string, type: "js" | "css" = "js", importedModules: any[] = []): any {
   return { importedModules: new Set(importedModules), type, url };

--- a/skills/pracht-scaffold/SKILL.md
+++ b/skills/pracht-scaffold/SKILL.md
@@ -161,6 +161,16 @@ export function GET({ params, url }: ApiRouteArgs) {
 - Use `request.json()`, `request.formData()`, etc. for body parsing.
 - Always return `Response` objects (typically `Response.json()`).
 - Dynamic segments use bracket syntax in filenames: `[id].ts`, `[...slug].ts`.
+- For live server→client updates, use Server-Sent Events:
+  `createEventStream(request, { keepAlive: 15 })` from `@pracht/core/server`
+  returns `{ response, send, close }` — return `response`, push with
+  `send({ data, event?, id? })`, and stop producing when `send()` returns
+  `false` (client disconnected). Consume in components with
+  `useEventSource(url, { json: true })` from `@pracht/core`. Works on all
+  adapters. For WebSockets use `isUpgradeRequest(request)` plus the
+  per-adapter recipes in `docs/ADAPTERS.md` (Cloudflare: API route + Durable
+  Object; Node: `nodeAdapter({ configureServerFrom })`; Vercel: unsupported —
+  use SSE).
 
 ## Wiring Into the Manifest (manual fallback only)
 


### PR DESCRIPTION
## Summary

First-party streaming support: a Server-Sent Events helper pair that works on every adapter, plus WebSocket ergonomics per adapter.

- **`createEventStream(request, init?)`** (`@pracht/core` / `@pracht/core/server`): returns `{ response, send, close, closed }` for API route handlers. Handles the SSE wire format (`send({ data, event?, id?, retry? })` — strings pass through with multi-line splitting, other values JSON-serialized, CR/LF injection through `event`/`id` rejected as the SSE analogue of response-splitting), stamps `Content-Type: text/event-stream` + `Cache-Control: no-store, no-transform` + `X-Accel-Buffering: no`, and offers a `keepAlive: seconds` comment-line heartbeat against proxy idle timeouts. Cleanup is wired to both disconnect paths a runtime can deliver — `request.signal` abort (workerd/edge) and body-stream cancellation (Node pipe teardown) — after which `send()` returns `false` (the producer's stop condition) and the heartbeat timer is cleared. Built on web `ReadableStream`; no Node-only APIs. `serializeEventStreamMessage()` exported for custom streams.
- **`useEventSource(url, options?)`**: tiny tree-shakeable hook wrapping `EventSource` — auto-cleanup on unmount, named-event selection, optional JSON parsing, `connecting`/`open`/`closed` status, `lastEventId`, `null` URL to stay disconnected, SSR-safe.
- **`isUpgradeRequest(request)`**: token-wise case-insensitive `Upgrade: websocket` detection so API routes answer plain HTTP with `426`.
- **`nodeAdapter({ configureServerFrom })`**: the generated entry imports and awaits `configureServer(server)` with the underlying `http.Server` before `listen()` — the supported hook for attaching `ws` to the `upgrade` event Node routes past the request handler.
- **Dev-server fix (`@pracht/vite-plugin`)**: the dev SSR middleware buffered every body via `response.text()`, so an SSE endpoint that worked on all production adapters hung forever under `pracht dev`. It now pipes `text/event-stream` responses and cancels the stream on client disconnect (including the already-disconnected race).

**Dogfooded end-to-end** (per feature requirements): `/live` + `/api/live` added to `examples/basic` and `examples/cloudflare`. Verified on Node dev, Node production build (`node dist/server/server.js`), and workerd dev via curl (headers + wire format), headless browser (status `open`, ticks incrementing, zero console errors), and server-side producer-stop logs on curl disconnect, full-page navigation, and SPA navigation. Dogfooding is what surfaced the dev buffering bug and an already-disconnected pipe race, both fixed here.

**Adversarial passes covered by tests**: disconnect mid-stream (producer stops, keepAlive timer cleared — asserted via `setInterval`/`clearInterval` counts), `send()` after close, CRLF/NUL injection through `event`/`id`, escaped newlines in JSON payloads, pre-aborted signals, slow-consumer buffering semantics (documented as no-backpressure), 404/terminal EventSource errors, unmount race before open.

Scope cuts (noted, deliberate): no Vercel-deployment live test (SSE there is an ordinary streaming `Response`; covered by design + unit tests); no live workerd disconnect-log capture (mechanism unit-tested; workerd curl/browser flows verified); no backpressure in the SSE helper (documented — inherent to SSE helpers, throttle in the producer); WebSockets ship as helpers + per-adapter recipes, not an abstraction, per the feature brief.

Docs: new Streaming recipe in the docs app (`/docs/recipes/streaming`, registered in nav + prev/next chain), `docs/ADAPTERS.md` (Node `configureServerFrom` recipe with Origin check, Cloudflare `isUpgradeRequest`, SSE pointer), `docs/REQUEST_FLOWS.md` (SSE flow section + upgrade-helper pointer), `skills/pracht-scaffold` API-route guidance.

Changesets: `@pracht/core` minor, `@pracht/adapter-node` minor, `@pracht/vite-plugin` patch.

No linked issue: N/A

## Testing

- [x] `pnpm run verify` (build, format, lint, typecheck, test, e2e)

## Checklist

- [x] Docs updated if needed
- [x] Skills updated if needed
- [x] Changeset added if published packages changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)