### PR TITLE
fix(cli): explain Playwright dependency for generated tests

### DIFF
--- a/.changeset/witty-donkeys-playwright.md
+++ b/.changeset/witty-donkeys-playwright.md
@@ -1,0 +1,5 @@
+---
+"@pracht/cli": patch
+---
+
+Explain the required `@playwright/test` dependency when route generation emits a smoke test in an app that does not have Playwright installed.

--- a/docs/AGENT_WORKFLOW.md
+++ b/docs/AGENT_WORKFLOW.md
@@ -110,6 +110,10 @@ non-error status and renders its heading. Dynamic segments get example values
 matching the `getStaticPaths` stub (`/blog/:slug` → `/blog/example-slug`).
 `--test` forces emission, `--no-test` skips it.
 
+Generated tests import `@playwright/test`. Existing Playwright apps already
+have that dependency; when `--test` forces a smoke test in an app without it,
+the generator prints the install step (`pnpm add -D @playwright/test`).
+
 The point: every LLM-authored route arrives with a falsifiable claim attached.
 "The route exists and renders" is proven by CI, not asserted in a PR description.
 

--- a/examples/docs/src/routes/docs/agent-workflow.md
+++ b/examples/docs/src/routes/docs/agent-workflow.md
@@ -19,7 +19,7 @@ Those are app-graph questions, and pracht resolves the entire app graph — rout
 - **Constraints** declare invariants once; `pracht verify` enforces them deterministically.
 - **`pracht plan`** diffs the resolved graph against a base git ref, so reviewers read an intent-level changelog instead of reverse-engineering it from file diffs.
 - **`pracht report`** assembles the factual half of a PR description from machine truth.
-- **Generated smoke tests** give every scaffolded route a Playwright check for free.
+- **Generated smoke tests** give every scaffolded route an immediate Playwright check.
 - **`pracht llms`** and the MCP server hand agents the framework's conventions directly.
 
 ---
@@ -148,7 +148,7 @@ test("renders /blog/:slug", async ({ page }) => {
 });
 ```
 
-`--test` forces the test even without a detected Playwright setup; `--no-test` skips it. The MCP `generate_route` tool accepts a matching `test` boolean.
+`--test` forces the test even without a detected Playwright setup; `--no-test` skips it. Generated tests import `@playwright/test`, so install it first with `pnpm add -D @playwright/test` when the app does not already use Playwright; the generator prints this follow-up when needed. The MCP `generate_route` tool accepts a matching `test` boolean.
 
 It's a floor, not a ceiling — but it means every agent-scaffolded route starts life with a failing-loudly check instead of zero coverage.
 

--- a/examples/docs/src/routes/docs/cli.md
+++ b/examples/docs/src/routes/docs/cli.md
@@ -135,7 +135,7 @@ pracht generate api --path /health --methods GET,POST
 - Pages-router apps scaffold route files into `src/pages/`.
 - Add `--json` when another tool or agent needs machine-readable output.
 
-`generate route` also emits a Playwright smoke test at `e2e/<route-id>.spec.ts` whenever the app has a Playwright setup (a `playwright.config.*` file or an `e2e/` directory). The test visits the route with example values for dynamic params (`/blog/:slug` → `/blog/example-slug`), asserts the response status is below 400, and checks the `h1` text. `--test` forces the test, `--no-test` skips it.
+`generate route` also emits a Playwright smoke test at `e2e/<route-id>.spec.ts` whenever the app has a Playwright setup (a `playwright.config.*` file or an `e2e/` directory). The test visits the route with example values for dynamic params (`/blog/:slug` → `/blog/example-slug`), asserts the response status is below 400, and checks the `h1` text. `--test` forces the test, `--no-test` skips it. Generated tests import `@playwright/test`; if it is not installed, the generator prints the required follow-up (`pnpm add -D @playwright/test`).
 
 ---
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -130,7 +130,9 @@ pracht llms --write
 Create a new route module. In manifest apps this also updates `src/routes.ts`.
 When the app has a Playwright setup (`playwright.config.*` or an `e2e/`
 directory), a smoke test is emitted at `e2e/<route-id>.spec.ts` as well —
-`--no-test` skips it, `--test` forces it.
+`--no-test` skips it, `--test` forces it. Generated tests import
+`@playwright/test`; when that dependency is absent, the command prints an
+install follow-up (for example, `pnpm add -D @playwright/test`).
 
 ```bash
 pracht generate route --path /dashboard --render ssr --shell app --middleware auth

--- a/packages/cli/src/commands/generate.ts
+++ b/packages/cli/src/commands/generate.ts
@@ -356,6 +356,12 @@ function maybeGenerateSmokeTest(
   const testFile = resolve(project.root, "e2e", `${routeIdFromPath(routePath)}.spec.ts`);
   writeGeneratedFile(testFile, buildRouteSmokeTestSource({ routePath, title }));
   result.created.push(displayPath(project.root, testFile));
+  if (!hasPlaywrightDependency(project.root)) {
+    result.notes ??= [];
+    result.notes.push(
+      "The generated smoke test imports `@playwright/test`, which is not installed yet. Install it with your package manager (for example: npm install --save-dev @playwright/test).",
+    );
+  }
 }
 
 function hasPlaywrightSetup(root: string): boolean {
@@ -369,6 +375,18 @@ function hasPlaywrightSetup(root: string): boolean {
       .map((name) => resolve(root, name))
       .some((file) => existsSync(file)) || existsSync(resolve(root, "e2e"))
   );
+}
+
+function hasPlaywrightDependency(root: string): boolean {
+  try {
+    const packageJson = JSON.parse(readFileSync(resolve(root, "package.json"), "utf-8"));
+    return Boolean(
+      packageJson.dependencies?.["@playwright/test"] ??
+      packageJson.devDependencies?.["@playwright/test"],
+    );
+  } catch {
+    return true; // Unreadable package.json — do not invent package-manager advice.
+  }
 }
 
 function generatePagesRoute({

--- a/packages/cli/test/cli-generate.test.js
+++ b/packages/cli/test/cli-generate.test.js
@@ -109,6 +109,9 @@ describe("@pracht/cli generate", () => {
       runCli(["generate", "route", "--path", "/blog/:slug", "--json"], { cwd: appDir }).stdout,
     );
     expect(result.created).toContain("e2e/blog-slug.spec.ts");
+    expect(result.notes).toEqual([
+      expect.stringContaining("npm install --save-dev @playwright/test"),
+    ]);
 
     const testSource = readFileSync(join(appDir, "e2e/blog-slug.spec.ts"), "utf-8");
     expect(testSource).toContain('test("renders /blog/:slug"');
@@ -118,6 +121,22 @@ describe("@pracht/cli generate", () => {
     // --no-test opts out even when the setup exists.
     runCli(["generate", "route", "--path", "/contact", "--no-test"], { cwd: appDir });
     expect(existsSync(join(appDir, "e2e/contact.spec.ts"))).toBe(false);
+  });
+
+  it("explains the Playwright dependency when --test forces a smoke test", () => {
+    const appDir = createTempDir("pracht-cli-forced-smoke-");
+    writeManifestApp(appDir);
+
+    const result = JSON.parse(
+      runCli(["generate", "route", "--path", "/reports", "--test", "--json"], {
+        cwd: appDir,
+      }).stdout,
+    );
+
+    expect(result.created).toContain("e2e/reports.spec.ts");
+    expect(result.notes).toEqual([
+      expect.stringContaining("The generated smoke test imports `@playwright/test`"),
+    ]);
   });
 
   it("scaffolds pages-router routes without touching a manifest", () => {

--- a/skills/pracht-scaffold/SKILL.md
+++ b/skills/pracht-scaffold/SKILL.md
@@ -53,7 +53,7 @@ pracht generate api --path /health --methods GET,POST
 - `--shell`/`--middleware` names must already be registered in the app manifest — the CLI errors otherwise. Generate the shell/middleware first, then the route that references it.
 - If the pracht MCP server is registered (docs/MCP.md), call the `generate_route`/`generate_shell`/`generate_middleware`/`generate_api` MCP tools instead of Bash — same behavior, structured results.
 - Add `--json` when another agent/tool needs machine-readable output.
-- `generate route` also emits a Playwright smoke test in `e2e/` when the app has a Playwright setup (`playwright.config.*` or an `e2e/` directory). Pass `--no-test` to skip it, `--test` to force it. Keep the generated test — it is the output-level proof the route works.
+- `generate route` also emits a Playwright smoke test in `e2e/` when the app has a Playwright setup (`playwright.config.*` or an `e2e/` directory). Pass `--no-test` to skip it, `--test` to force it. The test imports `@playwright/test`; if that dependency is absent, follow the generator's install note before typechecking. Keep the generated test — it is the output-level proof the route works.
 - Use `pracht inspect routes --json` or `pracht inspect api --json` to confirm current wiring before manual edits when the existing graph matters. `pracht inspect` requires the pracht plugin registered in the project's vite config.
 - If the app has typed routes (`src/pracht-routes.ts` / `.d.ts`) or the user asks for typed links, run `pracht typegen` after adding or renaming routes.
 - If the app commits `.pracht/app-graph.json`, run `pracht plan --write` after changing routes and include the refreshed snapshot — `pracht verify` fails when it is stale.


### PR DESCRIPTION
## Summary

- Explain that generated route smoke tests require `@playwright/test` when the dependency is missing.
- Cover both automatically detected e2e setups and forced `--test` generation, and align CLI docs plus the scaffold skill.
- Relevant issue: N/A.

## Testing

- [x] `pnpm run verify` (build, format, lint, typecheck, test, e2e)

## Checklist

- [x] Docs updated if needed
- [x] Skills updated if needed
- [x] Changeset added if published packages changed