### PR TITLE
Check static-export preconditions in doctor and verify

### DIFF
--- a/.changeset/static-doctor-checks.md
+++ b/.changeset/static-doctor-checks.md
@@ -1,0 +1,11 @@
+---
+"@pracht/cli": patch
+---
+
+`pracht doctor` and `pracht verify` now check static-export preconditions.
+
+Previously both reported "No blocking issues found" for an app whose static build cannot succeed — they printed `Found adapter dependency "@pracht/adapter-static"` and `API route discovery resolved 1 route` in the same run, then passed. The failure only surfaced from `pracht build`, after both the client and server environments had been built.
+
+The resolved app graph already records everything `validateStaticExport` checks, so the same answer is available in about a second. When the configured adapter is `staticAdapter()`, doctor and verify now report routes that render on a server at request time (including an unset `render`, which defaults to SSR), SPA routes with loaders or non-full hydration, route middleware, API routes, and capabilities exposed over HTTP/MCP/WebMCP. Messages mirror the build's wording. A static app with none of them gains a passing check instead of silence.
+
+The app-level `notFound` page's two rules (full hydration, no middleware) stay build-time-only, because the graph snapshot does not carry it. Non-static adapters are unaffected.

--- a/docs/ADAPTERS.md
+++ b/docs/ADAPTERS.md
@@ -1067,6 +1067,13 @@ One shape is a warning rather than an error, because it is only wrong for some
 deploys: a `fallback` document in an app with no `notFound` page and no
 client-routable SPA catch-all (unknown URLs would render blank).
 
+`pracht doctor` and `pracht verify` check most of the same preconditions from
+the resolved app graph, so you do not have to run a full build to find out.
+They cover server-rendered routes, SPA loaders and hydration, route
+middleware, API routes, and network-exposed capabilities. The remaining rules
+— the `notFound` page's hydration and middleware, the Vite `base`, and
+everything about concrete `getStaticPaths()` output — are build-time-only.
+
 ### Client-side navigation without a server
 
 On every other adapter, client navigation fetches route-state JSON from the

--- a/packages/cli/src/verification-graph.ts
+++ b/packages/cli/src/verification-graph.ts
@@ -13,7 +13,9 @@ import {
   type GraphSnapshot,
 } from "./graph-snapshot.js";
 import { listFilesRecursively, resolveProjectPath, type ProjectConfig } from "./project.js";
+import { detectAdapterTarget } from "./commands/preview.js";
 import { createCheck, MODULE_SOURCE_RE, type Check } from "./verification-helpers.js";
+import { collectStaticExportChecks } from "./verification-static.js";
 
 const HEAD_EXPORT_RE =
   /export\s+(?:async\s+)?(?:function|const|let|var)\s+head\b|export\s*\{[^}]*\bhead\b[^}]*\}/;
@@ -29,7 +31,19 @@ export async function collectGraphChecks(project: ProjectConfig, checks: Check[]
   const wantsCapabilityLoad = manifestDeclaresCapabilities(project);
   const wantsApiLoad = projectDeclaresApiRoutes(project);
   const snapshotExists = existsSync(resolve(project.root, GRAPH_SNAPSHOT_PATH));
-  if (!wantsConstraints && !wantsCapabilityLoad && !wantsApiLoad && !snapshotExists) return;
+  // A static export always needs the graph: its preconditions are exactly the
+  // request-runtime features the graph records, and reporting "no blocking
+  // issues" for an app whose static build cannot succeed is the worst outcome.
+  const wantsStaticExport = detectAdapterTarget(project) === "static";
+  if (
+    !wantsConstraints &&
+    !wantsCapabilityLoad &&
+    !wantsApiLoad &&
+    !snapshotExists &&
+    !wantsStaticExport
+  ) {
+    return;
+  }
 
   let live: GraphSnapshot;
   try {
@@ -61,6 +75,7 @@ export async function collectGraphChecks(project: ProjectConfig, checks: Check[]
       ),
     );
   }
+  collectStaticExportChecks(project, live, checks);
   collectConstraintChecks(project, live, checks);
   collectSnapshotChecks(project, live, checks, snapshotExists);
 }

--- a/packages/cli/src/verification-static.ts
+++ b/packages/cli/src/verification-static.ts
@@ -1,0 +1,141 @@
+import type { GraphSnapshot } from "./graph-snapshot.js";
+import type { ProjectConfig } from "./project.js";
+import { detectAdapterTarget } from "./commands/preview.js";
+import { createCheck, type Check } from "./verification-helpers.js";
+
+/**
+ * Static-export preconditions, checked from the resolved app graph.
+ *
+ * `pracht build` already fails closed on every one of these, but only after
+ * building both the client and server environments — and `pracht doctor` /
+ * `pracht verify` previously reported "No blocking issues found" for an app
+ * whose static build cannot succeed. The graph carries the same facts the
+ * build validates (render mode, loaders, hydration, middleware, API routes,
+ * capability transports), so the answer is available in about a second.
+ *
+ * Wording deliberately mirrors `validateStaticExport` in `build-static.ts`, so
+ * a user who sees the check and then the build error reads the same sentence
+ * twice rather than two descriptions of one problem.
+ */
+const SERVERFUL_ADAPTER_HINT =
+  "Use @pracht/adapter-node, @pracht/adapter-cloudflare, or @pracht/adapter-vercel instead, " +
+  'or change the route to render: "ssg" (or loaderless "spa" for client-only pages).';
+
+function list(paths: string[]): string {
+  return paths.join(", ");
+}
+
+export function collectStaticExportChecks(
+  project: ProjectConfig,
+  graph: GraphSnapshot,
+  checks: Check[],
+): void {
+  if (detectAdapterTarget(project) !== "static") return;
+
+  // The graph snapshot carries routes, API routes, and capabilities, but not
+  // the app-level notFound page. Its two static-export rules (full hydration,
+  // no middleware) stay build-time-only checks rather than growing the
+  // snapshot format for them.
+  const routes = graph.routes ?? [];
+  let problems = 0;
+
+  // A missing render mode defaults to SSR at request time.
+  const serverRendered = routes.filter((route) => route.render !== "ssg" && route.render !== "spa");
+  if (serverRendered.length > 0) {
+    problems += 1;
+    checks.push(
+      createCheck(
+        "error",
+        `Static export: these routes render on a server at request time, but a static export has no server: ` +
+          `${list(serverRendered.map((route) => `${route.path} (render: "${route.render ?? "ssr"}")`))}. ` +
+          SERVERFUL_ADAPTER_HINT,
+      ),
+    );
+  }
+
+  const spaWithLoaders = routes.filter(
+    (route) => route.render === "spa" && route.loaderFile !== null,
+  );
+  if (spaWithLoaders.length > 0) {
+    problems += 1;
+    checks.push(
+      createCheck(
+        "error",
+        `Static export: these SPA routes declare server loaders, but a static host cannot run them at request time: ` +
+          `${list(spaWithLoaders.map((route) => route.path))}. ` +
+          "Static SPA routes must be loaderless. Fetch live data from the browser, change the route to SSG " +
+          "for build-time data, or use a serverful adapter.",
+      ),
+    );
+  }
+
+  const spaWithNonFullHydration = routes.filter(
+    (route) => route.render === "spa" && route.hydration !== null && route.hydration !== "full",
+  );
+  if (spaWithNonFullHydration.length > 0) {
+    problems += 1;
+    checks.push(
+      createCheck(
+        "error",
+        `Static export: these SPA routes use non-full hydration, but SPA components render entirely in the browser: ` +
+          `${list(
+            spaWithNonFullHydration.map(
+              (route) => `${route.path} (hydration: "${route.hydration}")`,
+            ),
+          )}. ` +
+          'Remove the hydration option (or set it to "full"), change the route to SSG, or use a serverful adapter.',
+      ),
+    );
+  }
+
+  const routesWithMiddleware = routes.filter((route) => route.middleware.length > 0);
+  if (routesWithMiddleware.length > 0) {
+    problems += 1;
+    checks.push(
+      createCheck(
+        "error",
+        `Static export: these routes use request middleware, but a static host has no request runtime to enforce it: ` +
+          `${list(routesWithMiddleware.map((route) => route.path))}. ` +
+          "Remove the route middleware or use a serverful adapter.",
+      ),
+    );
+  }
+
+  const apiRoutes = graph.api ?? [];
+  if (apiRoutes.length > 0) {
+    problems += 1;
+    checks.push(
+      createCheck(
+        "error",
+        `Static export: API routes need a server to answer requests, but a static export has none: ` +
+          `${list(apiRoutes.map((route) => route.path))}. ` +
+          "Remove them or use a serverful adapter.",
+      ),
+    );
+  }
+
+  const exposedCapabilities = (graph.capabilities ?? []).filter(
+    (capability) => capability.transports.length > 0,
+  );
+  if (exposedCapabilities.length > 0) {
+    problems += 1;
+    checks.push(
+      createCheck(
+        "error",
+        `Static export: these capabilities are exposed over the network, but a static export has no server to serve them: ` +
+          `${list(
+            exposedCapabilities.map(
+              (capability) => `${capability.name} (${capability.transports.join(", ")})`,
+            ),
+          )}. ` +
+          "Server-only capabilities invoked from build-time loaders are fine.",
+      ),
+    );
+  }
+
+  if (problems === 0) {
+    checks.push(
+      createCheck("ok", "Static export preconditions hold (no request-runtime features in use)."),
+    );
+  }
+}

--- a/packages/cli/test/verification-static.test.ts
+++ b/packages/cli/test/verification-static.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, it } from "vitest";
+
+import type { GraphSnapshot } from "../src/graph-snapshot.ts";
+import type { ProjectConfig } from "../src/project.ts";
+import type { Check } from "../src/verification-helpers.ts";
+import { collectStaticExportChecks } from "../src/verification-static.ts";
+
+const STATIC_CONFIG = `
+import { pracht } from "@pracht/vite-plugin";
+import { staticAdapter } from "@pracht/adapter-static";
+export default { plugins: [pracht({ adapter: staticAdapter() })] };
+`;
+
+const NODE_CONFIG = `
+import { pracht } from "@pracht/vite-plugin";
+import { nodeAdapter } from "@pracht/adapter-node";
+export default { plugins: [pracht({ adapter: nodeAdapter() })] };
+`;
+
+function project(rawConfig: string): ProjectConfig {
+  return { rawConfig } as unknown as ProjectConfig;
+}
+
+function graph(overrides: Partial<GraphSnapshot> = {}): GraphSnapshot {
+  return {
+    api: [],
+    capabilities: [],
+    routes: [],
+    ...overrides,
+  } as unknown as GraphSnapshot;
+}
+
+function route(overrides: Record<string, unknown>): GraphSnapshot["routes"][number] {
+  return {
+    hydration: null,
+    loaderFile: null,
+    middleware: [],
+    path: "/",
+    render: "ssg",
+    ...overrides,
+  } as unknown as GraphSnapshot["routes"][number];
+}
+
+function run(rawConfig: string, snapshot: GraphSnapshot): Check[] {
+  const checks: Check[] = [];
+  collectStaticExportChecks(project(rawConfig), snapshot, checks);
+  return checks;
+}
+
+function errors(checks: Check[]): string[] {
+  return checks.filter((check) => check.status === "error").map((check) => check.message);
+}
+
+describe("collectStaticExportChecks", () => {
+  it("does nothing for a non-static adapter", () => {
+    const checks = run(
+      NODE_CONFIG,
+      graph({
+        api: [{ path: "/api/ping" }],
+        routes: [route({ path: "/dashboard", render: "ssr" })],
+      } as Partial<GraphSnapshot>),
+    );
+    expect(checks).toEqual([]);
+  });
+
+  it("passes a static app that uses no request-runtime features", () => {
+    const checks = run(
+      STATIC_CONFIG,
+      graph({
+        routes: [route({ path: "/" }), route({ path: "/app", render: "spa" })],
+      } as Partial<GraphSnapshot>),
+    );
+    expect(errors(checks)).toEqual([]);
+    expect(checks.map((check) => check.status)).toEqual(["ok"]);
+  });
+
+  it("flags routes that render on a server, including an unset render mode", () => {
+    const checks = run(
+      STATIC_CONFIG,
+      graph({
+        routes: [
+          route({ path: "/" }),
+          route({ path: "/dashboard", render: "ssr" }),
+          route({ path: "/pricing", render: "isg" }),
+          route({ path: "/implicit", render: null }),
+        ],
+      } as Partial<GraphSnapshot>),
+    );
+    const [message] = errors(checks);
+    expect(message).toContain('/dashboard (render: "ssr")');
+    expect(message).toContain('/pricing (render: "isg")');
+    expect(message).toContain('/implicit (render: "ssr")');
+    expect(message).not.toContain("/ (");
+  });
+
+  it("flags SPA routes with a loader or non-full hydration", () => {
+    const checks = run(
+      STATIC_CONFIG,
+      graph({
+        routes: [
+          route({ loaderFile: "/src/routes/a.tsx", path: "/with-loader", render: "spa" }),
+          route({ hydration: "islands", path: "/islands", render: "spa" }),
+          route({ hydration: "full", path: "/fine", render: "spa" }),
+        ],
+      } as Partial<GraphSnapshot>),
+    );
+    const messages = errors(checks).join("\n");
+    expect(messages).toContain("/with-loader");
+    expect(messages).toContain('/islands (hydration: "islands")');
+    expect(messages).not.toContain("/fine");
+  });
+
+  it("flags route middleware, API routes, and network-exposed capabilities", () => {
+    const checks = run(
+      STATIC_CONFIG,
+      graph({
+        api: [{ path: "/api/ping" }],
+        capabilities: [
+          { name: "notes.search", transports: ["http"] },
+          { name: "notes.private", transports: [] },
+        ],
+        routes: [route({ middleware: ["/src/middleware/auth.ts"], path: "/gated" })],
+      } as Partial<GraphSnapshot>),
+    );
+    const messages = errors(checks).join("\n");
+    expect(messages).toContain("/gated");
+    expect(messages).toContain("/api/ping");
+    expect(messages).toContain("notes.search (http)");
+    expect(messages).not.toContain("notes.private");
+  });
+
+  it("reports every problem at once rather than stopping at the first", () => {
+    const checks = run(
+      STATIC_CONFIG,
+      graph({
+        api: [{ path: "/api/ping" }],
+        routes: [route({ path: "/dashboard", render: "ssr" })],
+      } as Partial<GraphSnapshot>),
+    );
+    expect(errors(checks)).toHaveLength(2);
+  });
+});


### PR DESCRIPTION
## Summary

- `pracht doctor` and `pracht verify` reported **"No blocking issues found"** for an app whose static build cannot succeed. In a single run they would print `Found adapter dependency "@pracht/adapter-static"` *and* `API route discovery resolved 1 route` — everything needed to know the build was doomed — and then pass. The failure only surfaced from `pracht build`, after both the client and server environments had already been built.
- The resolved app graph records the same facts `validateStaticExport` checks, so the answer costs about a second instead of two Vite builds. When the configured adapter is `staticAdapter()`, both commands now report: routes that render on a server at request time (including an unset `render`, which defaults to SSR), SPA routes with loaders or non-full hydration, route middleware, API routes, and capabilities exposed over HTTP/MCP/WebMCP. Messages mirror the build's wording so the two surfaces read as one.
- A static app with none of these gains a passing check rather than silence.

Found while dogfooding `@pracht/adapter-static`. Stacked on #308 — merge that first.

**Deliberately left build-time-only:** the app-level `notFound` page's rules (full hydration, no middleware), because the graph snapshot does not carry `notFound` and growing the snapshot format for two checks is not worth the migration; and the Vite `base` rule, because doctor would have to infer it from config source rather than a resolved value. Non-static adapters return early and are unaffected.

Before / after on a static app with one API route:

```
 OK    Found adapter dependency "@pracht/adapter-static".
 OK    Loaded 1 discovered API route module into the app graph.
-No blocking issues found.
+ERROR Static export: API routes need a server to answer requests, but a
+      static export has none: /api/ping. Remove them or use a serverful adapter.
+Blocking issues found.
```

## Testing

- [x] `pnpm run verify` (build, format, lint, typecheck, test, e2e)
- [x] New unit tests in `packages/cli/test/verification-static.test.ts` (6 cases: non-static adapter is a no-op, clean static app passes, each failure class, and multiple problems reported at once)
- [x] Manually exercised against a real static app: clean app passes, API route / SSR route / route middleware each reported, and `examples/basic` (node adapter) emits zero static-export checks

## Checklist

- [x] Docs updated if needed — `docs/ADAPTERS.md` notes which preconditions are checkable without a build and which stay build-time-only
- [x] Skills updated if needed — N/A (`pre-deploy` already runs `doctor`/`verify`, so it inherits these checks)
- [x] Changeset added if published packages changed — `.changeset/static-doctor-checks.md` (`@pracht/cli` patch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)