### PR TITLE
Add a static-export option to create-pracht

### DIFF
--- a/.changeset/create-pracht-static.md
+++ b/.changeset/create-pracht-static.md
@@ -1,0 +1,11 @@
+---
+"create-pracht": minor
+---
+
+Add `--adapter=static` for pure static exports.
+
+`create-pracht` offered node, cf, netlify, and vercel, so the only way to start a `@pracht/adapter-static` app was to hand-wire it. `static` is now the fifth adapter, available from the prompt (`5`) and the flag (`--adapter=static`, also `export`).
+
+The static starter differs from the others in one substantive way: it scaffolds **no** `src/api/health.ts`. Every other starter ships that route, and under a static export an API route is a hard build error — so the generated app would have failed its very first `pracht build`. The home route's copy loses its `/api/health` and `src/api/*.ts` references for the same reason and points at browser-side fetching instead, and the README explains the `dist/client` upload, the clean-URL and `404.html` host settings, and which features a static export cannot have.
+
+Both routers are covered; the manifest and pages starters already default to `ssg`, so both build as-is.

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ auth or the agent surface. See [docs/ROUTING.md](docs/ROUTING.md#what-the-pages-
 npm create pracht@latest my-app
 ```
 
-The prompts cover the target directory, hosting adapter (Node.js, Cloudflare Workers, Vercel), router (manifest or pages), and optional Tailwind CSS. For non-interactive runs pass flags instead — e.g. `--template=tailwind` (or `--template=minimal`), `--adapter=node`, `--no-git`, `--yes`. See [packages/start/README.md](packages/start/README.md) for the full list.
+The prompts cover the target directory, hosting adapter (Node.js, Cloudflare Workers, Vercel, Netlify, or a pure static export), router (manifest or pages), and optional Tailwind CSS. For non-interactive runs pass flags instead — e.g. `--template=tailwind` (or `--template=minimal`), `--adapter=node`, `--no-git`, `--yes`. See [packages/start/README.md](packages/start/README.md) for the full list.
 
 The starter gives you:
 

--- a/packages/start/README.md
+++ b/packages/start/README.md
@@ -42,7 +42,9 @@ node ./packages/start/bin/create-pracht.js my-app --adapter=node --no-tailwind -
 
 ## Options
 
-- `--adapter=node|cf|netlify|vercel` — choose the hosting adapter (default: node).
+- `--adapter=node|cf|netlify|vercel|static` — choose the hosting adapter (default: node).
+  `static` scaffolds a pure static export (`@pracht/adapter-static`): no API route is
+  generated, because a static export has no server to answer one.
 - `--router=manifest|pages` — choose the routing system (default: manifest).
 - `--template=minimal|tailwind` — non-interactive template selection; `minimal` is the default output, `tailwind` is minimal plus Tailwind CSS wiring.
 - `--tailwind` / `--no-tailwind` — enable or disable Tailwind CSS without going through the prompt.

--- a/packages/start/src/index.js
+++ b/packages/start/src/index.js
@@ -16,6 +16,7 @@ const FALLBACK_VERSION_RANGES = {
   "@pracht/adapter-cloudflare": "^0.5.8",
   "@pracht/adapter-netlify": "^0.1.0",
   "@pracht/adapter-node": "^0.3.8",
+  "@pracht/adapter-static": "^0.1.0",
   "@pracht/adapter-vercel": "^0.2.8",
   "@pracht/cli": "^1.9.0",
   "@pracht/core": "^0.12.0",
@@ -86,6 +87,13 @@ const ADAPTERS = {
     label: "Vercel",
     packageName: "@pracht/adapter-vercel",
     short: "vercel",
+  },
+  static: {
+    description: "Pure static export — deploy dist/client to any static host",
+    id: "static",
+    label: "Static export",
+    packageName: "@pracht/adapter-static",
+    short: "static",
   },
 };
 
@@ -407,7 +415,7 @@ export function parseArgs(argv) {
       const value = normalizeAdapter(arg.slice("--adapter=".length));
       if (!value) {
         throw new ValidationError(
-          `Invalid adapter: ${arg.slice("--adapter=".length)}. Use node, cf, netlify, or vercel.`,
+          `Invalid adapter: ${arg.slice("--adapter=".length)}. Use node, cf, netlify, vercel, or static.`,
         );
       }
       options.adapter = value;
@@ -462,6 +470,7 @@ async function promptForAdapter(readline) {
   console.log("  2. Cloudflare Workers");
   console.log("  3. Vercel");
   console.log("  4. Netlify");
+  console.log("  5. Static export (no server)");
 
   while (true) {
     const answer = await readline.question("Adapter (1): ");
@@ -471,7 +480,7 @@ async function promptForAdapter(readline) {
       return normalized;
     }
 
-    console.log("Choose 1/2/3/4 or node/cf/vercel/netlify.");
+    console.log("Choose 1/2/3/4/5 or node/cf/vercel/netlify/static.");
   }
 }
 
@@ -614,6 +623,10 @@ function normalizeAdapter(value) {
     return "netlify";
   }
 
+  if (normalized === "5" || normalized === "static" || normalized === "export") {
+    return "static";
+  }
+
   return null;
 }
 
@@ -690,10 +703,15 @@ async function buildProjectFiles({
       tailwind,
       versions,
     }),
-    "src/api/health.ts": createHealthRoute(adapter),
     "vite.config.ts": createViteConfig(adapter, router, tailwind),
     "tsconfig.json": createBaseTSConfig(adapter),
   };
+
+  // A static export has no server, so an API route would be a hard build
+  // error — the starter must not scaffold one it cannot build.
+  if (adapter.id !== "static") {
+    files["src/api/health.ts"] = createHealthRoute(adapter);
+  }
 
   if (agentTools) {
     files["AGENTS.md"] = createAgentInstructions({
@@ -803,6 +821,10 @@ function createPackageJson({ adapter, projectName, tailwind, versions }) {
     scripts.start = "node dist/server/server.js";
   }
 
+  if (adapter.id === "static") {
+    scripts.preview = "pracht preview";
+  }
+
   const devDependencies = {
     "@pracht/cli": versions["@pracht/cli"],
     "@pracht/vite-plugin": versions["@pracht/vite-plugin"],
@@ -858,6 +880,7 @@ function createViteConfig(adapter, router, tailwind) {
     cloudflare: { fn: "cloudflareAdapter", pkg: "@pracht/adapter-cloudflare" },
     netlify: { fn: "netlifyAdapter", pkg: "@pracht/adapter-netlify" },
     vercel: { fn: "vercelAdapter", pkg: "@pracht/adapter-vercel" },
+    static: { fn: "staticAdapter", pkg: "@pracht/adapter-static" },
   };
 
   const info = ADAPTER_IMPORTS[adapter.id] ?? ADAPTER_IMPORTS.node;
@@ -955,7 +978,9 @@ function createHomeRoute(adapter) {
     "    steps: [",
     '      "Edit src/routes/home.tsx to change this page.",',
     '      "Add more routes in src/routes.ts.",',
-    '      "Add API handlers in src/api/*.ts.",',
+    adapter.id === "static"
+      ? '      "Fetch live data from the browser — a static export runs no server.",'
+      : '      "Add API handlers in src/api/*.ts.",',
     "    ],",
     "  };",
     "}",
@@ -974,7 +999,9 @@ function createHomeRoute(adapter) {
     "        ))}",
     "      </ul>",
     '      <p style={{ marginTop: "24px" }}>',
-    "        Check <code>/api/health</code> for a simple API route.",
+    adapter.id === "static"
+      ? "        Run <code>pracht build</code>, then deploy <code>dist/client</code> anywhere."
+      : "        Check <code>/api/health</code> for a simple API route.",
     "      </p>",
     "    </section>",
     "  );",
@@ -1022,7 +1049,9 @@ function createPagesHomeRoute(adapter) {
     "    steps: [",
     '      "Edit src/pages/index.tsx to change this page.",',
     '      "Add more pages in src/pages/.",',
-    '      "Add API handlers in src/api/*.ts.",',
+    adapter.id === "static"
+      ? '      "Fetch live data from the browser — a static export runs no server.",'
+      : '      "Add API handlers in src/api/*.ts.",',
     "    ],",
     "  };",
     "}",
@@ -1041,7 +1070,9 @@ function createPagesHomeRoute(adapter) {
     "        ))}",
     "      </ul>",
     '      <p style={{ marginTop: "24px" }}>',
-    "        Check <code>/api/health</code> for a simple API route.",
+    adapter.id === "static"
+      ? "        Run <code>pracht build</code>, then deploy <code>dist/client</code> anywhere."
+      : "        Check <code>/api/health</code> for a simple API route.",
     "      </p>",
     "    </section>",
     "  );",
@@ -1410,7 +1441,12 @@ function createAgentInstructions({ adapter, agentTools, packageManager, router, 
     `- \`${runCmd} build\` — production build`,
   ];
 
-  if (adapter.id === "node" || adapter.id === "cloudflare" || adapter.id === "netlify") {
+  if (
+    adapter.id === "node" ||
+    adapter.id === "cloudflare" ||
+    adapter.id === "netlify" ||
+    adapter.id === "static"
+  ) {
     lines.push(`- \`${runCmd} preview\` — build and serve the production build locally`);
   }
 
@@ -1574,6 +1610,21 @@ function createReadme({
     lines.push(`- \`${deployCommand}\``);
     lines.push("");
     lines.push("Run the deploy command after linking or logging into your Vercel account.");
+  }
+
+  if (adapter.id === "static") {
+    lines.push(`- \`${previewCommand}\``);
+    lines.push("");
+    lines.push(
+      "`pracht build` writes the whole site to `dist/client`. Upload that directory to any " +
+        "static host — there is no server to run. Configure the host to serve `index.html` " +
+        "for directory URLs and to use `404.html` as its error document.",
+    );
+    lines.push("");
+    lines.push(
+      "A static export runs no server, so API routes, middleware, and `ssr`/`isg` routes are " +
+        "build errors. Fetch live data from the browser instead, or switch to a serverful adapter.",
+    );
   }
 
   lines.push("");
@@ -1791,7 +1842,7 @@ Usage:
   create-pracht [directory] [options]
 
 Options:
-  --adapter=node|cf|netlify|vercel
+  --adapter=node|cf|netlify|vercel|static
                                Choose hosting adapter (default: node)
   --router=manifest|pages      Choose routing system (default: manifest)
   --template=minimal|tailwind  Choose starter template (minimal, or minimal + Tailwind CSS)

--- a/packages/start/test/index.test.js
+++ b/packages/start/test/index.test.js
@@ -280,6 +280,78 @@ describe("create-pracht", () => {
     expect(ageDays).toBeLessThan(365);
   });
 
+  it("scaffolds a static-export starter with no API route", async () => {
+    const root = await mkdtemp(join(tmpdir(), "pracht-start-static-"));
+    const targetDir = join(root, "my-static-app");
+
+    await scaffoldProject({
+      adapter: {
+        description: "Pure static export — deploy dist/client to any static host",
+        id: "static",
+        label: "Static export",
+        packageName: "@pracht/adapter-static",
+        short: "static",
+      },
+      packageManager: "pnpm",
+      resolveRemoteVersions: false,
+      targetDir,
+    });
+
+    const packageJson = JSON.parse(await readFile(join(targetDir, "package.json"), "utf-8"));
+    const viteConfig = await readFile(join(targetDir, "vite.config.ts"), "utf-8");
+    const homeRoute = await readFile(join(targetDir, "src/routes/home.tsx"), "utf-8");
+    const readme = await readFile(join(targetDir, "README.md"), "utf-8");
+
+    expect(packageJson.dependencies).toMatchObject({
+      "@pracht/adapter-static": "^0.1.0",
+      "@pracht/core": "^0.12.0",
+    });
+    expect(packageJson.scripts).toMatchObject({ build: "pracht build", preview: "pracht preview" });
+    expect(packageJson.scripts.start).toBeUndefined();
+    expect(viteConfig).toContain('import { staticAdapter } from "@pracht/adapter-static";');
+    expect(viteConfig).toContain("adapter: staticAdapter()");
+
+    // A static export has no server, so a scaffolded API route would make the
+    // very first `pracht build` fail.
+    expect(existsSync(join(targetDir, "src/api/health.ts"))).toBe(false);
+    expect(homeRoute).not.toContain("/api/health");
+    expect(homeRoute).not.toContain("src/api/*.ts");
+    expect(readme).toContain("dist/client");
+
+    // Both starter routes must be statically renderable.
+    const routes = await readFile(join(targetDir, "src/routes.ts"), "utf-8");
+    expect(routes).toContain('render: "ssg"');
+
+    expect(existsSync(join(targetDir, "Dockerfile"))).toBe(false);
+    expect(existsSync(join(targetDir, "wrangler.jsonc"))).toBe(false);
+    expect(existsSync(join(targetDir, "netlify.toml"))).toBe(false);
+  });
+
+  it("scaffolds a static-export pages-router starter with no API route", async () => {
+    const root = await mkdtemp(join(tmpdir(), "pracht-start-static-pages-"));
+    const targetDir = join(root, "my-static-pages-app");
+
+    await scaffoldProject({
+      adapter: {
+        description: "Pure static export — deploy dist/client to any static host",
+        id: "static",
+        label: "Static export",
+        packageName: "@pracht/adapter-static",
+        short: "static",
+      },
+      packageManager: "pnpm",
+      resolveRemoteVersions: false,
+      router: "pages",
+      targetDir,
+    });
+
+    const home = await readFile(join(targetDir, "src/pages/index.tsx"), "utf-8");
+    expect(existsSync(join(targetDir, "src/api/health.ts"))).toBe(false);
+    expect(home).toContain('export const RENDER_MODE = "ssg";');
+    expect(home).not.toContain("/api/health");
+    expect(home).not.toContain("src/api/*.ts");
+  });
+
   it("scaffolds a Netlify starter", async () => {
     const root = await mkdtemp(join(tmpdir(), "pracht-start-netlify-"));
     const targetDir = join(root, "my-netlify-app");


### PR DESCRIPTION
## Summary

- `create-pracht` offered node, cf, netlify, and vercel, so the only way to start a `@pracht/adapter-static` app was to hand-wire the vite config. `static` is now the fifth adapter — from the prompt (`5`) and the flag (`--adapter=static`, also accepts `export`).
- The static starter differs from the others in one substantive way: **it scaffolds no `src/api/health.ts`**. Every other starter ships that route, and under a static export an API route is a hard build error — so a generated static app would have failed its very first `pracht build`. The home route's copy loses its `/api/health` and `src/api/*.ts` references for the same reason and points at browser-side fetching instead.
- The generated README covers the `dist/client` upload, the clean-URL and `404.html` host settings, and which features a static export cannot have.

Found while dogfooding `@pracht/adapter-static`. Stacked on #308 — merge that first.

Both routers are covered. The manifest starter already defaults to `render: "ssg"` and the pages starter to `RENDER_MODE = "ssg"`, so neither needed a render-mode change.

## Testing

- [x] `pnpm run verify` — see note below
- [x] `packages/start/test/index.test.js` — 42 pass, including two new cases: a manifest static starter (deps, scripts, vite config, **no** `src/api/health.ts`, no `/api/health` copy, `ssg` routes, no Dockerfile/wrangler/netlify config) and a pages-router static starter
- [x] **Scaffolded both variants and ran a real `pracht build` against the workspace packages** — both produce a complete static export (`index.html`, `404.html`, route state, `llms.txt`) with no build errors

Note on verify: this branch was developed in a `git worktree`, where `pnpm run verify` fails on pnpm's dependency-state check before running anything. I ran the equivalent steps directly — `oxfmt --write`, `oxlint --fix`, `node --check`, and the package's vitest suite — plus the end-to-end scaffold-and-build check above. Worth a CI confirmation on merge.

## Checklist

- [x] Docs updated if needed — root `README.md` adapter list, `packages/start/README.md` flag docs (including why no API route is generated)
- [x] Skills updated if needed — N/A (no skill documents `create-pracht` flags)
- [x] Changeset added if published packages changed — `.changeset/create-pracht-static.md` (`create-pracht` minor)

🤖 Generated with [Claude Code](https://claude.com/claude-code)