### PR TITLE
Stop publishing framework metadata in static exports

### DIFF
--- a/.changeset/static-output-metadata.md
+++ b/.changeset/static-output-metadata.md
@@ -1,0 +1,11 @@
+---
+"@pracht/cli": patch
+---
+
+Stop publishing framework metadata into a static export's deploy directory.
+
+`pracht build` wrote `_pracht/headers.json` and `_pracht/markdown.json` into `dist/client/` for every adapter. Only the Cloudflare worker reads them from there — it fetches both through its assets binding — while node, netlify, and vercel read the `dist/server/*-manifest.json` copies. A static export has no runtime at all, so for `@pracht/adapter-static` those files were permanently dead bytes in the one directory users upload, and `headers.json` published the app's full route list with each route's header policy.
+
+Static exports now skip both. `dist/server/headers-manifest.json` and `dist/server/markdown-manifest.json` are still written, and remain the reference for mirroring headers into a host's own configuration — the docs and the `pre-deploy` skill now point there. This matches the rule `_pracht/isg.json` already followed: framework metadata only reaches the public client directory when a runtime actually reads it from there.
+
+`_pracht/env-safety.json` is deliberately kept: `pracht verify` reads it from that exact path, and on a successful build it is always an empty findings report (the plugin fails the build otherwise). Cloudflare, node, netlify, and vercel output is unchanged.

--- a/docs/ADAPTERS.md
+++ b/docs/ADAPTERS.md
@@ -1184,11 +1184,14 @@ client-side fetch to an external API instead.
   serve `index.html` for directory URLs; most hosts redirect `/about` →
   `/about/` first (GitHub Pages answers `301`), which the client router and
   prerendered links tolerate.
-- **Headers**: no server means no dynamic headers. `dist/client/_pracht/headers.json`
+- **Headers**: no server means no dynamic headers. `dist/server/headers-manifest.json`
   records the document headers each prerendered route would have carried
   (route/shell `headers()` exports plus pracht's defaults) — mirror the ones
   you care about in the host's header configuration (`_headers` on Netlify,
-  CloudFront response header policies, nginx `add_header`).
+  CloudFront response header policies, nginx `add_header`). It is written to
+  `dist/server/` rather than the deployable `dist/client/`: no static host can
+  act on it, so publishing it would ship the full route list and header policy
+  as dead bytes.
 - **Markdown negotiation**: routes exporting `markdown` rely on server-side
   `Accept` negotiation; a static host always answers with the HTML file. The
   build prints a note when this applies — publish `.md` files under `public/`

--- a/e2e/static-build.test.ts
+++ b/e2e/static-build.test.ts
@@ -617,6 +617,37 @@ test("static export warns when the SPA fallback has no notFound page to render",
   }
 });
 
+test("static export does not publish framework metadata into the deploy directory", () => {
+  test.setTimeout(180_000);
+  const { exampleDir, tempDir } = createTempExampleDir(staticFixtureDir, "pracht-static-meta-");
+
+  try {
+    buildExampleOutput(exampleDir);
+    const clientDir = resolve(exampleDir, "dist/client");
+
+    // Only the Cloudflare worker reads these from the client output. A static
+    // export has no runtime, so publishing them would ship the route list and
+    // header policy as dead bytes in the directory users upload.
+    expect(existsSync(resolve(clientDir, "_pracht/headers.json"))).toBe(false);
+    expect(existsSync(resolve(clientDir, "_pracht/markdown.json"))).toBe(false);
+    expect(existsSync(resolve(clientDir, "_pracht/isg.json"))).toBe(false);
+
+    // Still written for build tooling and deploy reference.
+    expect(existsSync(resolve(exampleDir, "dist/server/headers-manifest.json"))).toBe(true);
+    expect(existsSync(resolve(exampleDir, "dist/server/markdown-manifest.json"))).toBe(true);
+
+    // `pracht verify` reads this from the client output, and on a successful
+    // build it is always an empty findings report.
+    expect(existsSync(resolve(clientDir, "_pracht/env-safety.json"))).toBe(true);
+
+    // The route-state tree is the one thing under _pracht/ a static deploy
+    // genuinely serves.
+    expect(existsSync(resolve(clientDir, "_pracht/state"))).toBe(true);
+  } finally {
+    rmSync(tempDir, { force: true, recursive: true });
+  }
+});
+
 test("static export emits 404.html when a broad dynamic SSG route exists", () => {
   test.setTimeout(180_000);
   const { exampleDir, tempDir } = createTempExampleDir(

--- a/examples/docs/src/routes/docs/adapters.md
+++ b/examples/docs/src/routes/docs/adapters.md
@@ -565,7 +565,7 @@ pracht build      # dist/client/ is the deployable site
 pracht preview    # serves dist/client/ with a tiny static file server
 ```
 
-Pages are emitted as `<path>/index.html` at the percent-decoded path (`/posts/caf%C3%A9` → `posts/café/index.html`), so the host must serve `index.html` for directory URLs (clean URLs). `pracht preview` decodes request segments to that same filesystem spelling. Response headers each prerendered route would have carried are recorded in `dist/client/_pracht/headers.json` — mirror the ones you need in the host's header config. See `docs/ADAPTERS.md` in the repository for host-configuration details and limitations (markdown negotiation, base paths).
+Pages are emitted as `<path>/index.html` at the percent-decoded path (`/posts/caf%C3%A9` → `posts/café/index.html`), so the host must serve `index.html` for directory URLs (clean URLs). `pracht preview` decodes request segments to that same filesystem spelling. Response headers each prerendered route would have carried are recorded in `dist/server/headers-manifest.json` (build tooling, not published) — mirror the ones you need in the host's header config. See `docs/ADAPTERS.md` in the repository for host-configuration details and limitations (markdown negotiation, base paths).
 
 ---
 

--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -322,8 +322,15 @@ export async function runBuild(root: string, options: BuildOptions = {}): Promis
         headersManifestJson,
         "utf-8",
       );
-      mkdirSync(resolve(clientDir, "_pracht"), { recursive: true });
-      writeFileSync(resolve(clientDir, "_pracht/headers.json"), headersManifestJson, "utf-8");
+      // Only the Cloudflare worker reads this from the client output (it
+      // fetches /_pracht/headers.json through the assets binding); every other
+      // target reads dist/server. A static export has no runtime at all, so
+      // publishing it would ship the full route list and header policy as
+      // permanently dead bytes in the deployable directory.
+      if (!isStaticExport) {
+        mkdirSync(resolve(clientDir, "_pracht"), { recursive: true });
+        writeFileSync(resolve(clientDir, "_pracht/headers.json"), headersManifestJson, "utf-8");
+      }
     }
 
     // Always emit this manifest, including for SSR-only apps with no
@@ -336,8 +343,12 @@ export async function runBuild(root: string, options: BuildOptions = {}): Promis
       markdownManifestJson,
       "utf-8",
     );
-    mkdirSync(resolve(clientDir, "_pracht"), { recursive: true });
-    writeFileSync(resolve(clientDir, "_pracht/markdown.json"), markdownManifestJson, "utf-8");
+    // Same as headers.json above: Cloudflare's worker is the only reader of
+    // the client copy, and a static export has no worker.
+    if (!isStaticExport) {
+      mkdirSync(resolve(clientDir, "_pracht"), { recursive: true });
+      writeFileSync(resolve(clientDir, "_pracht/markdown.json"), markdownManifestJson, "utf-8");
+    }
 
     if (Object.keys(isgManifest).length > 0) {
       const isgManifestPath = resolve(root, "dist/server/isg-manifest.json");

--- a/skills/pre-deploy/SKILL.md
+++ b/skills/pre-deploy/SKILL.md
@@ -179,7 +179,7 @@ checklist is about what the *host* must do and what the build cannot enforce.
   page — flag it as a `warn`.
 - **Security headers are not applied.** Every other adapter sets the four
   default security headers at request time; a static host has no request
-  runtime. `dist/client/_pracht/headers.json` records the headers each route
+  runtime. `dist/server/headers-manifest.json` records the headers each route
   *would* have carried — mirror the ones you need in the host's own header
   config (`_headers` on Netlify, CloudFront response header policies, nginx
   `add_header`). This is an `error` for any app handling user input, and


### PR DESCRIPTION
## Summary

- `pracht build` wrote `_pracht/headers.json` and `_pracht/markdown.json` into `dist/client/` for **every** adapter. Only the Cloudflare worker reads them from there (it fetches both through its assets binding); node, netlify, and vercel read the `dist/server/*-manifest.json` copies.
- A static export has no runtime at all, so for `@pracht/adapter-static` those files were permanently dead bytes in the one directory users upload — and `headers.json` published the app's full route list with each route's header policy. `dist/client/` is documented as "the deployable site"; it should not carry build metadata nothing can act on.
- Static exports now skip both. The `dist/server/` manifests are still written and remain the reference for mirroring headers into a host's own config — `docs/ADAPTERS.md`, the docs example, and the `pre-deploy` skill now point there.

This matches the rule `_pracht/isg.json` already followed, which has an explicit comment saying the same thing: framework metadata reaches the public client directory only when a runtime reads it from there.

Found while dogfooding `@pracht/adapter-static`. Stacked on #308 — merge that first.

**`_pracht/env-safety.json` is deliberately kept.** `pracht verify` reads it from that exact path, and on a successful build it is always an empty findings report (the plugin calls `this.error()` when it finds anything, so a build with findings never completes). Removing it would break the env check for static apps to save 36 bytes.

**Scope:** gated on the static target only. The same "why is this in the public directory" argument applies to node/netlify/vercel, but changing those is a wider blast radius than this fix needs — worth a separate discussion.

## Testing

- [x] New e2e regression test in `e2e/static-build.test.ts` asserting a static export has no `headers.json`/`markdown.json`/`isg.json`, still has `env-safety.json` and the route-state tree, and still writes both `dist/server/` manifests
- [x] `skills/skills.test.ts` — 197 pass (it validates the build-output paths referenced in skill docs, which this change repoints)
- [x] `tsc --noEmit` — zero errors in the touched files
- [x] **Built all three affected examples with the modified CLI:**
  - `examples/static` → `_pracht/` contains only `env-safety.json` + `state/`; both `dist/server/` manifests present
  - `examples/cloudflare` → still has `headers.json`, `markdown.json`, `isg.json` (worker reads these at runtime — the important regression check)
  - `examples/basic` (node) → unchanged

Note on verify: developed in a `git worktree`, where `pnpm run verify` fails on pnpm's dependency-state check before running anything. I ran `oxfmt`, `oxlint`, `tsc --noEmit`, the skills suite, and the example builds above directly. The new e2e test was not executed in the worktree (it needs the full workspace install) — it asserts exactly what the example builds confirmed by hand. Worth a CI confirmation on merge.

## Checklist

- [x] Docs updated if needed — `docs/ADAPTERS.md` (static headers section, with the reason it lives in `dist/server/`), `examples/docs/src/routes/docs/adapters.md`
- [x] Skills updated if needed — `skills/pre-deploy/SKILL.md` static section repointed
- [x] Changeset added if published packages changed — `.changeset/static-output-metadata.md` (`@pracht/cli` patch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)