### PR TITLE
fix(cli): stop overwriting build-plugin output for public/ assets

### DIFF
--- a/.changeset/public-dir-plugin-output.md
+++ b/.changeset/public-dir-plugin-output.md
@@ -1,0 +1,5 @@
+---
+"@pracht/cli": patch
+---
+
+Stop overwriting build-plugin output for `public/` assets. `pracht build` copied `public/` over `dist/client/` after the client build had already emitted it, which restored the source files on top of anything a plugin rewrote on the way out — an image optimizer's compressed copies, for instance. Vite now owns that copy alone, so a custom `publicDir` and `build.copyPublicDir` are honoured too. The server build no longer duplicates `public/` into `dist/server/` either, so asset plugins stop paying for a second, discarded pass.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -384,6 +384,21 @@ dist/
     server.js                  # Platform entry module
 ```
 
+### Static assets (`public/`)
+
+Vite copies `publicDir` into the client build's output, and `pracht build` then
+moves that output into `dist/client/`. The CLI never re-copies `public/` itself,
+so two things hold:
+
+- A custom `publicDir` and `build.copyPublicDir: false` behave exactly as they
+  do in a plain Vite build.
+- A plugin that rewrites a copied asset in place (an image optimizer, say, in
+  `closeBundle`) owns the file that ships — nothing restores the source over it.
+
+The server build sets `copyPublicDir: false`: `dist/server/` is build tooling,
+never an asset root, so duplicating `public/` there would only make every asset
+plugin run a second, discarded pass.
+
 ### Optional server JSX precompile
 
 `pracht({ precompileSsrJsx: true })` inserts `@pracht/preact-ssr-precompile`

--- a/e2e/node-build.test.ts
+++ b/e2e/node-build.test.ts
@@ -507,8 +507,10 @@ test("public/ folder assets are copied to dist/client/", async () => {
     const publicDir = resolve(exampleDir, "public");
     mkdirSync(publicDir, { recursive: true });
     writeFileSync(resolve(publicDir, "robots.txt"), "User-agent: *\nAllow: /\n", "utf-8");
+    writeFileSync(resolve(publicDir, "optimizable.txt"), "original\n", "utf-8");
     mkdirSync(resolve(publicDir, "icons"), { recursive: true });
     writeFileSync(resolve(publicDir, "icons/favicon.ico"), "fake-ico", "utf-8");
+    installPublicAssetRewritePlugin(exampleDir);
 
     buildExample(exampleDir, { PRACHT_ADAPTER: "node" });
 
@@ -517,10 +519,62 @@ test("public/ folder assets are copied to dist/client/", async () => {
       "User-agent",
     );
     expect(existsSync(resolve(exampleDir, "dist/client/icons/favicon.ico"))).toBe(true);
+    // An asset-rewriting plugin (an image optimizer, say) owns the copy that
+    // ships: the build must not restore the untouched source over its output.
+    expect(readFileSync(resolve(exampleDir, "dist/client/optimizable.txt"), "utf-8")).toBe(
+      "rewritten\n",
+    );
+    // The server bundle is build tooling, so `public/` is not duplicated into
+    // it -- otherwise every asset plugin pays for a second, discarded pass.
+    expect(existsSync(resolve(exampleDir, "dist/server/robots.txt"))).toBe(false);
   } finally {
     rmSync(tempDir, { force: true, recursive: true });
   }
 });
+
+/**
+ * Adds a build plugin to the copied example that rewrites a `public/` file
+ * after Vite has copied it into the out directory, the way an image optimizer
+ * rewrites compressed images in place.
+ */
+function installPublicAssetRewritePlugin(exampleDir: string): void {
+  writeFileSync(
+    resolve(exampleDir, "rewrite-public-asset.mjs"),
+    [
+      'import { existsSync, writeFileSync } from "node:fs";',
+      'import { resolve } from "node:path";',
+      "",
+      "export function rewritePublicAsset() {",
+      '  let root = "";',
+      '  let outDir = "";',
+      "  return {",
+      '    name: "e2e-rewrite-public-asset",',
+      '    apply: "build",',
+      '    enforce: "post",',
+      "    configResolved(config) {",
+      "      root = config.root;",
+      "      outDir = config.build.outDir;",
+      "    },",
+      "    closeBundle() {",
+      '      const file = resolve(root, outDir, "optimizable.txt");',
+      '      if (existsSync(file)) writeFileSync(file, "rewritten\\n", "utf-8");',
+      "    },",
+      "  };",
+      "}",
+      "",
+    ].join("\n"),
+    "utf-8",
+  );
+
+  const configPath = resolve(exampleDir, "vite.config.ts");
+  const config = readFileSync(configPath, "utf-8")
+    .replace(
+      'import { defineConfig } from "vite";',
+      'import { defineConfig } from "vite";\nimport { rewritePublicAsset } from "./rewrite-public-asset.mjs";',
+    )
+    .replace("    plugins: [", "    plugins: [\n      rewritePublicAsset(),");
+  writeFileSync(configPath, config, "utf-8");
+}
 
 function createTempExampleDir(prefix: string): { exampleDir: string; tempDir: string } {
   const tempRoot = resolve(repoRoot, ".tmp");

--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -133,6 +133,10 @@ export async function runBuild(root: string, options: BuildOptions = {}): Promis
     logLevel,
     build: {
       outDir: "dist/server",
+      // The server bundle is build tooling (prerender + adapter entry), never
+      // the deployed asset root, so a second copy of `public/` here is dead
+      // weight -- and any asset-rewriting plugin would process it twice.
+      copyPublicDir: false,
       rollupOptions: {
         input: "virtual:pracht/server",
       },
@@ -157,10 +161,11 @@ export async function runBuild(root: string, options: BuildOptions = {}): Promis
     }
   }
 
-  const publicDir = resolve(root, "public");
-  if (existsSync(publicDir)) {
-    cpSync(publicDir, clientDir, { recursive: true });
-  }
+  // `public/` is deliberately not re-copied here: the client build already
+  // emitted it (Vite honours a custom `publicDir` and `build.copyPublicDir`
+  // there) and the move above carried it into dist/client. Copying the source
+  // files over that output would overwrite whatever a build plugin rewrote on
+  // the way out -- an image optimizer's compressed copies, for one.
 
   let buildTarget: string | null = null;
   if (existsSync(serverEntry)) {


### PR DESCRIPTION
## Summary

- `pracht build` copied `public/` over `dist/client/` **after** the client build had already emitted it. Vite copies `publicDir` into the client `outDir`, a plugin such as [`vite-plugin-image-optimizer`](https://github.com/FatehAK/vite-plugin-image-optimizer) rewrites those files in place during `closeBundle`, and the CLI then restored the untouched sources on top of that output. Dropping the redundant copy also means a custom `publicDir` and `build.copyPublicDir: false` behave as they do in a plain Vite build, instead of being silently overridden.
- The server build now sets `copyPublicDir: false`. `dist/server/` is build tooling (prerender + adapter entry), never an asset root, so duplicating `public/` there only made every asset plugin pay for a second, discarded pass. Vite 8 copies `publicDir` for SSR builds too, which is why the throwaway directory was the *only* place the optimization survived — exactly the symptom reported.
- Reported in https://github.com/JoviDeCroock/pracht/discussions/312.

Reproduced with the static example + `vite-plugin-image-optimizer` and a `public/hero.png`:

| file | before | after |
| --- | --- | --- |
| `public/hero.png` (source) | 3371 B | 3371 B |
| `dist/client/hero.png` | 3371 B (byte-identical to source) | **2660 B** |
| `dist/server/hero.png` | 2660 B (optimized, then discarded) | not emitted |

Images imported from source were never affected — those flow through `generateBundle` into `dist/client/assets/`.

## Testing

- [x] `pnpm run verify` (build, format, lint, typecheck, test, e2e)
- The existing `public/ folder assets are copied to dist/client/` e2e test gained a build plugin that rewrites a public file in `closeBundle`, plus an assertion that `public/` is no longer duplicated into `dist/server/`. Verified it fails on the pre-fix CLI and passes with the fix.

## Checklist

- [x] Docs updated if needed — new "Static assets (`public/`)" section in `docs/ARCHITECTURE.md`
- [x] Skills updated if needed — N/A, no skill documents this build step
- [x] Changeset added if published packages changed — `.changeset/public-dir-plugin-output.md` (patch, `@pracht/cli`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)