### PR TITLE
perf(content): defer document payloads to per-document chunks

### DIFF
--- a/.changeset/content-deferred-document-payloads.md
+++ b/.changeset/content-deferred-document-payloads.md
@@ -1,5 +1,7 @@
 ---
 "@pracht/content": minor
+"@pracht/cli": patch
+"create-pracht": patch
 ---
 
 Generated collection snapshots now defer each document's `compiled`, `body`,
@@ -23,3 +25,8 @@ at a time; `all()` loads the collection.
 Malformed documents are still rejected while the snapshot module is generated,
 with the same `documents[n].compiled…` diagnostic path, rather than when the
 page that happens to use them is first rendered.
+
+Server builds now preserve dynamic imports even for webworker targets. New
+Cloudflare projects deploy Pracht's pre-bundled output with `no_bundle: true`
+and a JavaScript `ESModule` rule, and `pracht verify` warns existing Wrangler
+configs that would inline or omit the deferred chunks.

--- a/.changeset/content-deferred-document-payloads.md
+++ b/.changeset/content-deferred-document-payloads.md
@@ -24,9 +24,12 @@ at a time; `all()` loads the collection.
 
 Malformed documents are still rejected while the snapshot module is generated,
 with the same `documents[n].compiled…` diagnostic path, rather than when the
-page that happens to use them is first rendered.
+page that happens to use them is first rendered. Descriptive payload chunk
+names are bounded so deeply nested, valid source paths cannot exceed filesystem
+filename limits during a build.
 
 Server builds now preserve dynamic imports even for webworker targets. New
 Cloudflare projects deploy Pracht's pre-bundled output with `no_bundle: true`
 and a JavaScript `ESModule` rule, and `pracht verify` warns existing Wrangler
-configs that would inline or omit the deferred chunks.
+configs, including named-environment overrides, that would inline or omit the
+deferred chunks.

--- a/.changeset/content-deferred-document-payloads.md
+++ b/.changeset/content-deferred-document-payloads.md
@@ -1,0 +1,25 @@
+---
+"@pracht/content": minor
+---
+
+Generated collection snapshots now defer each document's `compiled`, `body`,
+and `raw` representations to a per-document chunk instead of embedding them in
+the snapshot module.
+
+The snapshot module is imported by loaders, which the bundler hoists into a
+chunk shared by every content-backed route. Inlining the whole collection there
+meant the first request to reach that chunk — including the not-found handler —
+parsed every document in the collection. On a documentation site with a few
+hundred translated pages that is tens of megabytes of JavaScript on a cold
+start.
+
+The snapshot index keeps everything lookup needs (ids, routes, locales,
+frontmatter, source paths), so resolution still runs without touching a chunk
+it has not loaded. Every accessor that hands out a document is already
+asynchronous and now awaits the document's payload, so `document.compiled` is
+still populated and no application code changes. `iterate()` loads one document
+at a time; `all()` loads the collection.
+
+Malformed documents are still rejected while the snapshot module is generated,
+with the same `documents[n].compiled…` diagnostic path, rather than when the
+page that happens to use them is first rendered.

--- a/docs/ADAPTERS.md
+++ b/docs/ADAPTERS.md
@@ -442,7 +442,9 @@ build).
   rebuild. Set `"no_bundle": true` and add an `ESModule` rule covering
   `"**/*.js"` because this output is already bundled by Vite and may contain
   lazy server chunks. The two settings make Wrangler upload those files as
-  separate Worker modules instead of folding them into the entry file.
+  separate Worker modules instead of folding them into the entry file. If a
+  named Wrangler environment overrides either setting, it must preserve the
+  same contract; `pracht verify` checks those effective environment settings.
 - **Local preview**: `pracht preview` runs `pracht build` and then delegates to
   `wrangler dev --port <port>` against the built worker. It requires wrangler
   (in `node_modules` or on PATH) and a wrangler config; it errors with install

--- a/docs/ADAPTERS.md
+++ b/docs/ADAPTERS.md
@@ -439,7 +439,10 @@ build).
   `server.js` also exports for the prerender pass). Point `wrangler.jsonc`'s
   `main` at `dist/server/worker.js` — you own that file, which lets you add
   KV, D1, R2, cron, and any other Cloudflare bindings without losing them on
-  rebuild.
+  rebuild. Set `"no_bundle": true` and add an `ESModule` rule covering
+  `"**/*.js"` because this output is already bundled by Vite and may contain
+  lazy server chunks. The two settings make Wrangler upload those files as
+  separate Worker modules instead of folding them into the entry file.
 - **Local preview**: `pracht preview` runs `pracht build` and then delegates to
   `wrangler dev --port <port>` against the built worker. It requires wrangler
   (in `node_modules` or on PATH) and a wrangler config; it errors with install
@@ -792,6 +795,8 @@ The adapter handles everything — just declare bindings in `wrangler.jsonc`:
 ```jsonc
 {
   "main": "dist/server/worker.js",
+  "no_bundle": true,
+  "rules": [{ "type": "ESModule", "globs": ["**/*.js", "**/*.mjs"] }],
   "kv_namespaces": [{ "binding": "MY_KV", "id": "..." }],
   "d1_databases": [{ "binding": "DB", "database_name": "my-db", "database_id": "..." }],
 }

--- a/docs/CONTENT.md
+++ b/docs/CONTENT.md
@@ -293,12 +293,35 @@ object keys retain their data semantics in the generated module, including
 prototype-named keys such as `__proto__`. Sparse arrays fail the build rather
 than being serialized with their holes changed to `null`.
 
-Each document embeds `raw`, `body`, and `compiled`, so a snapshot costs roughly
-two to three times the content it describes. `defineCollection({ snapshot: {
-raw: false, body: false } })` drops either representation from the generated
-module; both default to true and the authoring collection always keeps them.
-The option is deliberately narrow: `compiled` is what routes render, and
-frontmatter is what they index, so neither can be dropped.
+### Deferred document payloads
+
+A snapshot module carries only an index: ids, routes, locales, frontmatter, and
+source paths. Each document's `raw`, `body`, and `compiled` live in their own
+chunk, which the runtime loads when that document is resolved.
+
+This matters because of where the snapshot module ends up. Loaders import it,
+and the bundler hoists a module shared by several route modules into a chunk
+those routes all load — so an inlined collection is parsed by the first request
+that reaches any content-backed route, including the not-found handler. A
+documentation site with a few hundred translated pages is easily tens of
+megabytes of JavaScript on a cold start.
+
+Nothing in the lookup path is deferred, so resolution never blocks on a chunk it
+has not loaded. Every accessor that returns a document is asynchronous and
+awaits that document's payload, so `document.compiled` is populated exactly as
+before. `iterate()` loads one document at a time, which is what a large
+collection should stream; `all()` loads the collection.
+
+A malformed document is still rejected while the snapshot module is generated —
+not when the page that happens to use it is first rendered — and the diagnostic
+still names `documents[n].compiled…`.
+
+Each document's payload holds `raw`, `body`, and `compiled`, so a collection's
+chunks cost roughly two to three times the content they describe.
+`defineCollection({ snapshot: { raw: false, body: false } })` drops either
+representation entirely; both default to true and the authoring collection
+always keeps them. The option is deliberately narrow: `compiled` is what routes
+render, and frontmatter is what they index, so neither can be dropped.
 
 An omitted field is absent on the snapshot's documents rather than a throwing
 accessor, matching the plain object shape the rest of the runtime API returns.

--- a/docs/CONTENT.md
+++ b/docs/CONTENT.md
@@ -299,6 +299,14 @@ A snapshot module carries only an index: ids, routes, locales, frontmatter, and
 source paths. Each document's `raw`, `body`, and `compiled` live in their own
 chunk, which the runtime loads when that document is resolved.
 
+`prachtContent()` enables server code splitting so webworker builds preserve
+that boundary too. Cloudflare deployments must set `"no_bundle": true` and an
+`ESModule` rule covering `"**/*.js"` in `wrangler.jsonc`: Pracht's Vite output
+is already bundled, and the rule tells Wrangler to upload its chunks as Worker
+modules instead of inlining them into the entry. New `create-pracht` Cloudflare
+projects include both settings, while `pracht verify` warns older configs that
+omit either one.
+
 This matters because of where the snapshot module ends up. Loaders import it,
 and the bundler hoists a module shared by several route modules into a chunk
 those routes all load — so an inlined collection is parsed by the first request

--- a/examples/basic/wrangler.jsonc
+++ b/examples/basic/wrangler.jsonc
@@ -2,6 +2,8 @@
   "$schema": "node_modules/wrangler/config-schema.json",
   "name": "pracht-example-basic",
   "main": "dist/server/worker.js",
+  "no_bundle": true,
+  "rules": [{ "type": "ESModule", "globs": ["**/*.js", "**/*.mjs"] }],
   "compatibility_date": "2026-04-06",
   "workers_dev": true,
   "routes": [

--- a/examples/cloudflare/wrangler.jsonc
+++ b/examples/cloudflare/wrangler.jsonc
@@ -2,6 +2,8 @@
   "$schema": "node_modules/wrangler/config-schema.json",
   "name": "pracht-example-cloudflare",
   "main": "dist/server/worker.js",
+  "no_bundle": true,
+  "rules": [{ "type": "ESModule", "globs": ["**/*.js", "**/*.mjs"] }],
   "compatibility_date": "2026-04-06",
   // Workers Caching: lets Cloudflare serve cached ISG pages without invoking
   // the Worker; pracht sets the Cache-Control/Cache-Tag headers per route.

--- a/examples/docs/wrangler.jsonc
+++ b/examples/docs/wrangler.jsonc
@@ -2,6 +2,13 @@
   "$schema": "node_modules/wrangler/config-schema.json",
   "name": "pracht-docs",
   "main": "dist/server/worker.js",
+  "no_bundle": true,
+  "rules": [
+    {
+      "type": "ESModule",
+      "globs": ["**/*.js", "**/*.mjs"],
+    },
+  ],
   "compatibility_date": "2026-04-06",
   "assets": {
     "binding": "ASSETS",

--- a/examples/pages-router/wrangler.jsonc
+++ b/examples/pages-router/wrangler.jsonc
@@ -3,6 +3,8 @@
   "name": "pracht-pages-router-example",
   "compatibility_date": "2026-08-01",
   "main": "dist/server/worker.js",
+  "no_bundle": true,
+  "rules": [{ "type": "ESModule", "globs": ["**/*.js", "**/*.mjs"] }],
   "assets": {
     "binding": "ASSETS",
     "directory": "dist/client",

--- a/packages/cli/src/verification-checks.ts
+++ b/packages/cli/src/verification-checks.ts
@@ -27,6 +27,7 @@ import {
   findWranglerConfig,
   readWranglerAssetsHtmlHandling,
   readWranglerMainEntries,
+  readWranglerBundleSettings,
 } from "./wrangler-config.js";
 import {
   collectDuplicateRoutePaths,
@@ -941,6 +942,15 @@ function collectCloudflareEntryCheck(project: ProjectConfig, root: string, check
 
   const display = displayPath(root, configFile);
   collectCloudflareTrailingSlashCheck(project, root, configFile, display, checks);
+  const bundling = readWranglerBundleSettings(configFile);
+  if (bundling && (bundling.noBundle !== true || !bundling.hasJavaScriptModuleRule)) {
+    checks.push(
+      createCheck(
+        "warning",
+        `${display} does not preserve Pracht's Vite output as separate Worker modules. Pracht may emit deferred server chunks; Wrangler's default second bundle folds those chunks back into the entry file. Add "no_bundle": true and an ESModule rule whose globs include "**/*.js" so Wrangler uploads the build output unchanged.`,
+      ),
+    );
+  }
 
   for (const entry of readWranglerMainEntries(configFile)) {
     if (!normalizePath(entry.main).endsWith(SERVER_ENTRY_PATH)) continue;

--- a/packages/cli/src/verification-checks.ts
+++ b/packages/cli/src/verification-checks.ts
@@ -942,12 +942,13 @@ function collectCloudflareEntryCheck(project: ProjectConfig, root: string, check
 
   const display = displayPath(root, configFile);
   collectCloudflareTrailingSlashCheck(project, root, configFile, display, checks);
-  const bundling = readWranglerBundleSettings(configFile);
-  if (bundling && (bundling.noBundle !== true || !bundling.hasJavaScriptModuleRule)) {
+  for (const bundling of readWranglerBundleSettings(configFile) ?? []) {
+    if (bundling.noBundle === true && bundling.hasJavaScriptModuleRule) continue;
+    const where = bundling.environment ? ` for environment "${bundling.environment}"` : "";
     checks.push(
       createCheck(
         "warning",
-        `${display} does not preserve Pracht's Vite output as separate Worker modules. Pracht may emit deferred server chunks; Wrangler's default second bundle folds those chunks back into the entry file. Add "no_bundle": true and an ESModule rule whose globs include "**/*.js" so Wrangler uploads the build output unchanged.`,
+        `${display}${where} does not preserve Pracht's Vite output as separate Worker modules. Pracht may emit deferred server chunks; Wrangler's default second bundle folds those chunks back into the entry file. Add "no_bundle": true and an ESModule rule whose globs include "**/*.js" so Wrangler uploads the build output unchanged.`,
       ),
     );
   }

--- a/packages/cli/src/wrangler-config.ts
+++ b/packages/cli/src/wrangler-config.ts
@@ -48,6 +48,99 @@ export interface WranglerAssetsHtmlHandling {
   htmlHandling: string | undefined;
 }
 
+export interface WranglerBundleSettings {
+  /** `undefined` when Wrangler's default bundling remains active. */
+  noBundle: boolean | undefined;
+  /** Whether a module rule preserves Vite's emitted JavaScript chunks as ESM. */
+  hasJavaScriptModuleRule: boolean;
+}
+
+/**
+ * The top-level settings that preserve Vite's server chunks, or `null` when
+ * the file cannot be parsed conservatively. `no_bundle` prevents Wrangler
+ * from folding the chunks into its entry, while the ESModule rule makes
+ * Wrangler upload the `.js` files next to that entry.
+ */
+export function readWranglerBundleSettings(configFile: string): WranglerBundleSettings | null {
+  let source: string;
+  try {
+    source = readFileSync(configFile, "utf-8");
+  } catch {
+    return null;
+  }
+
+  if (configFile.endsWith(".toml")) {
+    let noBundle: boolean | undefined;
+    let table: string | null = null;
+    let ruleType: string | undefined;
+    let ruleGlobs: string[] = [];
+    let hasJavaScriptModuleRule = false;
+    const finishRule = () => {
+      if (ruleType === "ESModule" && ruleGlobs.includes("**/*.js")) {
+        hasJavaScriptModuleRule = true;
+      }
+      ruleType = undefined;
+      ruleGlobs = [];
+    };
+    for (const line of source.split(/\r?\n/)) {
+      const tableMatch = TOML_TABLE_RE.exec(line);
+      if (tableMatch) {
+        finishRule();
+        table = tableMatch[1]!;
+        continue;
+      }
+      if (table === null) {
+        const match = /^\s*no_bundle\s*=\s*(true|false)\s*(?:#.*)?$/.exec(line);
+        if (match) noBundle = match[1] === "true";
+        continue;
+      }
+      if (table !== "rules") continue;
+      const typeMatch = new RegExp(String.raw`^\s*type\s*=\s*${TOML_VALUE}\s*(?:#.*)?$`).exec(line);
+      if (typeMatch) {
+        ruleType = typeMatch[1] ?? typeMatch[2]!;
+        continue;
+      }
+      const globsMatch = /^\s*globs\s*=\s*\[(.*)\]\s*(?:#.*)?$/.exec(line);
+      if (globsMatch) ruleGlobs = readTomlStringArray(globsMatch[1]!);
+    }
+    finishRule();
+    return { noBundle, hasJavaScriptModuleRule };
+  }
+
+  let config: unknown;
+  try {
+    config = JSON.parse(stripJsonComments(source).replace(/,(\s*[}\]])/g, "$1"));
+  } catch {
+    return null;
+  }
+  if (!config || typeof config !== "object") return null;
+
+  const value = (config as Record<string, unknown>).no_bundle;
+  const rules = (config as Record<string, unknown>).rules;
+  const hasJavaScriptModuleRule =
+    Array.isArray(rules) &&
+    rules.some((rule) => {
+      if (!rule || typeof rule !== "object") return false;
+      const candidate = rule as Record<string, unknown>;
+      return (
+        candidate.type === "ESModule" &&
+        Array.isArray(candidate.globs) &&
+        candidate.globs.includes("**/*.js")
+      );
+    });
+  return {
+    noBundle: typeof value === "boolean" ? value : undefined,
+    hasJavaScriptModuleRule,
+  };
+}
+
+function readTomlStringArray(source: string): string[] {
+  const values: string[] = [];
+  const valuePattern = /"([^"]*)"|'([^']*)'/g;
+  for (const match of source.matchAll(valuePattern)) values.push(match[1] ?? match[2]!);
+  return values;
+}
+
 /**
  * The top-level `assets.html_handling` value, or `null` when it cannot be
  * proven — an unreadable file, a parse failure, a TOML config (not parsed
@@ -167,9 +260,10 @@ function stripJsonComments(source: string): string {
   return out;
 }
 
-// Enough TOML for the one key this reads. Deliberately conservative: a shape
-// this does not recognize yields no entry, and callers must treat "no entries"
-// as "unknown" rather than "fine" — see collectCloudflareEntryCheck.
+// Enough TOML for the deployment keys these readers inspect. Deliberately
+// conservative: a shape this does not recognize yields no entry, and callers
+// must treat "no entries" as "unknown" rather than "fine" — see
+// collectCloudflareEntryCheck.
 //
 // `[table]` and `[[array.of.tables]]` headers, both of which may carry a
 // trailing comment. Missing a header would attribute the keys under it to the

--- a/packages/cli/src/wrangler-config.ts
+++ b/packages/cli/src/wrangler-config.ts
@@ -49,6 +49,8 @@ export interface WranglerAssetsHtmlHandling {
 }
 
 export interface WranglerBundleSettings {
+  /** `null` for the default deployment, otherwise the named Wrangler environment. */
+  environment: string | null;
   /** `undefined` when Wrangler's default bundling remains active. */
   noBundle: boolean | undefined;
   /** Whether a module rule preserves Vite's emitted JavaScript chunks as ESM. */
@@ -56,12 +58,13 @@ export interface WranglerBundleSettings {
 }
 
 /**
- * The top-level settings that preserve Vite's server chunks, or `null` when
+ * The effective settings that preserve Vite's server chunks for the default
+ * deployment and every named environment that overrides them, or `null` when
  * the file cannot be parsed conservatively. `no_bundle` prevents Wrangler
  * from folding the chunks into its entry, while the ESModule rule makes
  * Wrangler upload the `.js` files next to that entry.
  */
-export function readWranglerBundleSettings(configFile: string): WranglerBundleSettings | null {
+export function readWranglerBundleSettings(configFile: string): WranglerBundleSettings[] | null {
   let source: string;
   try {
     source = readFileSync(configFile, "utf-8");
@@ -70,15 +73,34 @@ export function readWranglerBundleSettings(configFile: string): WranglerBundleSe
   }
 
   if (configFile.endsWith(".toml")) {
-    let noBundle: boolean | undefined;
-    let table: string | null = null;
+    interface TomlBundleScope {
+      hasNoBundleOverride: boolean;
+      hasRulesOverride: boolean;
+      hasJavaScriptModuleRule: boolean;
+      noBundle: boolean | undefined;
+    }
+    const createScope = (): TomlBundleScope => ({
+      hasNoBundleOverride: false,
+      hasRulesOverride: false,
+      hasJavaScriptModuleRule: false,
+      noBundle: undefined,
+    });
+    const root = createScope();
+    const environments = new Map<string, TomlBundleScope>();
+    const environmentScope = (name: string) => {
+      const scope = environments.get(name) ?? createScope();
+      environments.set(name, scope);
+      return scope;
+    };
+    let settingsScope: TomlBundleScope | undefined = root;
+    let ruleScope: TomlBundleScope | undefined;
     let ruleType: string | undefined;
     let ruleGlobs: string[] = [];
-    let hasJavaScriptModuleRule = false;
     const finishRule = () => {
-      if (ruleType === "ESModule" && ruleGlobs.includes("**/*.js")) {
-        hasJavaScriptModuleRule = true;
+      if (ruleScope && ruleType === "ESModule" && ruleGlobs.includes("**/*.js")) {
+        ruleScope.hasJavaScriptModuleRule = true;
       }
+      ruleScope = undefined;
       ruleType = undefined;
       ruleGlobs = [];
     };
@@ -86,15 +108,47 @@ export function readWranglerBundleSettings(configFile: string): WranglerBundleSe
       const tableMatch = TOML_TABLE_RE.exec(line);
       if (tableMatch) {
         finishRule();
-        table = tableMatch[1]!;
+        settingsScope = undefined;
+        const table = tableMatch[1]!;
+        if (table === "rules") {
+          root.hasRulesOverride = true;
+          ruleScope = root;
+          continue;
+        }
+        const environment = /^env\s*\.\s*([^.\s]+)$/.exec(table)?.[1];
+        if (environment) {
+          settingsScope = environmentScope(environment);
+          continue;
+        }
+        const environmentRules = /^env\s*\.\s*([^.\s]+)\s*\.\s*rules$/.exec(table)?.[1];
+        if (environmentRules) {
+          ruleScope = environmentScope(environmentRules);
+          ruleScope.hasRulesOverride = true;
+        }
         continue;
       }
-      if (table === null) {
+      if (settingsScope) {
         const match = /^\s*no_bundle\s*=\s*(true|false)\s*(?:#.*)?$/.exec(line);
-        if (match) noBundle = match[1] === "true";
+        if (match) {
+          settingsScope.hasNoBundleOverride = true;
+          settingsScope.noBundle = match[1] === "true";
+          continue;
+        }
+        // Inline rule tables are outside this deliberately small parser. Mark
+        // the scope as an override so callers warn instead of inheriting a
+        // top-level rule that Wrangler will replace.
+        if (/^\s*rules\s*=/.test(line)) settingsScope.hasRulesOverride = true;
+      }
+      if (!ruleScope) {
+        const dotted =
+          /^\s*env\s*\.\s*([^.\s]+)\s*\.\s*no_bundle\s*=\s*(true|false)\s*(?:#.*)?$/.exec(line);
+        if (dotted) {
+          const scope = environmentScope(dotted[1]!);
+          scope.hasNoBundleOverride = true;
+          scope.noBundle = dotted[2] === "true";
+        }
         continue;
       }
-      if (table !== "rules") continue;
       const typeMatch = new RegExp(String.raw`^\s*type\s*=\s*${TOML_VALUE}\s*(?:#.*)?$`).exec(line);
       if (typeMatch) {
         ruleType = typeMatch[1] ?? typeMatch[2]!;
@@ -104,7 +158,22 @@ export function readWranglerBundleSettings(configFile: string): WranglerBundleSe
       if (globsMatch) ruleGlobs = readTomlStringArray(globsMatch[1]!);
     }
     finishRule();
-    return { noBundle, hasJavaScriptModuleRule };
+    return [
+      {
+        environment: null,
+        noBundle: root.noBundle,
+        hasJavaScriptModuleRule: root.hasJavaScriptModuleRule,
+      },
+      ...[...environments.entries()]
+        .filter(([, scope]) => scope.hasNoBundleOverride || scope.hasRulesOverride)
+        .map(([environment, scope]) => ({
+          environment,
+          noBundle: scope.hasNoBundleOverride ? scope.noBundle : root.noBundle,
+          hasJavaScriptModuleRule: scope.hasRulesOverride
+            ? scope.hasJavaScriptModuleRule
+            : root.hasJavaScriptModuleRule,
+        })),
+    ];
   }
 
   let config: unknown;
@@ -115,11 +184,12 @@ export function readWranglerBundleSettings(configFile: string): WranglerBundleSe
   }
   if (!config || typeof config !== "object") return null;
 
-  const value = (config as Record<string, unknown>).no_bundle;
-  const rules = (config as Record<string, unknown>).rules;
-  const hasJavaScriptModuleRule =
-    Array.isArray(rules) &&
-    rules.some((rule) => {
+  const root = config as Record<string, unknown>;
+  const value = root.no_bundle;
+  const rules = root.rules;
+  const hasJavaScriptModuleRule = (candidateRules: unknown) =>
+    Array.isArray(candidateRules) &&
+    candidateRules.some((rule) => {
       if (!rule || typeof rule !== "object") return false;
       const candidate = rule as Record<string, unknown>;
       return (
@@ -128,10 +198,36 @@ export function readWranglerBundleSettings(configFile: string): WranglerBundleSe
         candidate.globs.includes("**/*.js")
       );
     });
-  return {
-    noBundle: typeof value === "boolean" ? value : undefined,
-    hasJavaScriptModuleRule,
-  };
+  const settings: WranglerBundleSettings[] = [
+    {
+      environment: null,
+      noBundle: typeof value === "boolean" ? value : undefined,
+      hasJavaScriptModuleRule: hasJavaScriptModuleRule(rules),
+    },
+  ];
+  const environments = root.env;
+  if (environments && typeof environments === "object") {
+    for (const [environment, entry] of Object.entries(environments as Record<string, unknown>)) {
+      if (!entry || typeof entry !== "object") continue;
+      const candidate = entry as Record<string, unknown>;
+      if (!Object.hasOwn(candidate, "no_bundle") && !Object.hasOwn(candidate, "rules")) continue;
+      const environmentNoBundle = candidate.no_bundle;
+      settings.push({
+        environment,
+        noBundle: Object.hasOwn(candidate, "no_bundle")
+          ? typeof environmentNoBundle === "boolean"
+            ? environmentNoBundle
+            : undefined
+          : typeof value === "boolean"
+            ? value
+            : undefined,
+        hasJavaScriptModuleRule: hasJavaScriptModuleRule(
+          Object.hasOwn(candidate, "rules") ? candidate.rules : rules,
+        ),
+      });
+    }
+  }
+  return settings;
 }
 
 function readTomlStringArray(source: string): string[] {

--- a/packages/cli/test/cli-doctor-verify.test.js
+++ b/packages/cli/test/cli-doctor-verify.test.js
@@ -635,6 +635,38 @@ export const app = defineApp({
       ),
     ).toBe(true);
   });
+
+  it("warns when a Wrangler environment overrides safe bundle settings", () => {
+    const appDir = createTempDir("pracht-cli-doctor-cf-env-bundle-");
+    writeCloudflareManifestApp(appDir);
+    writeProjectFile(
+      appDir,
+      "wrangler.jsonc",
+      `{
+  "name": "fixture-app",
+  "main": "dist/server/worker.js",
+  "no_bundle": true,
+  "rules": [{ "type": "ESModule", "globs": ["**/*.js"] }],
+  "env": {
+    "production": { "no_bundle": false }
+  }
+}
+`,
+    );
+
+    const result = runCli(["doctor", "--json"], { cwd: appDir });
+    const report = JSON.parse(result.stdout);
+
+    expect(report.ok).toBe(true);
+    expect(
+      report.checks.some(
+        (check) =>
+          check.status === "warning" &&
+          check.message.includes('environment "production"') &&
+          check.message.includes("deferred server chunks"),
+      ),
+    ).toBe(true);
+  });
   it("warns when a Markdown page is routed with no transform plugin", () => {
     const appDir = createTempDir("pracht-cli-doctor-md-page-");
     writePagesApp(appDir);

--- a/packages/cli/test/cli-doctor-verify.test.js
+++ b/packages/cli/test/cli-doctor-verify.test.js
@@ -544,6 +544,8 @@ export const app = defineApp({
   "name": "fixture-app",
   // "main": "dist/server/server.js",
   "main": "dist/server/worker.js",
+  "no_bundle": true,
+  "rules": [{ "type": "ESModule", "globs": ["**/*.js"] }],
 }
 `,
     );
@@ -593,7 +595,7 @@ export const app = defineApp({
     writeProjectFile(
       appDir,
       "wrangler.toml",
-      'name = "fixture-app"\nmain = "dist/server/worker.js"\n',
+      'name = "fixture-app"\nmain = "dist/server/worker.js"\nno_bundle = true\n[[rules]]\ntype = "ESModule"\nglobs = ["**/*.js", "**/*.mjs"]\n',
     );
 
     const result = runCli(["doctor", "--json"], { cwd: appDir });
@@ -603,6 +605,35 @@ export const app = defineApp({
     // Silence on success: the reader skips wrangler shapes it does not
     // recognize, so a clean pass is "nothing provably wrong", not "verified".
     expect(report.checks.some((check) => check.message.includes("wrangler"))).toBe(false);
+  });
+
+  it("warns when Wrangler would rebundle Pracht's deferred server chunks", () => {
+    const appDir = createTempDir("pracht-cli-doctor-cf-bundle-");
+    writeCloudflareManifestApp(appDir);
+    writeProjectFile(
+      appDir,
+      "wrangler.jsonc",
+      `{
+  "name": "fixture-app",
+  "main": "dist/server/worker.js",
+  "no_bundle": false
+}
+`,
+    );
+
+    const result = runCli(["doctor", "--json"], { cwd: appDir });
+    const report = JSON.parse(result.stdout);
+
+    expect(report.ok).toBe(true);
+    expect(
+      report.checks.some(
+        (check) =>
+          check.status === "warning" &&
+          check.message.includes('"no_bundle": true') &&
+          check.message.includes("ESModule") &&
+          check.message.includes("deferred server chunks"),
+      ),
+    ).toBe(true);
   });
   it("warns when a Markdown page is routed with no transform plugin", () => {
     const appDir = createTempDir("pracht-cli-doctor-md-page-");

--- a/packages/cli/test/wrangler-config.test.ts
+++ b/packages/cli/test/wrangler-config.test.ts
@@ -248,7 +248,7 @@ describe("readWranglerBundleSettings", () => {
           `{ "no_bundle": true, "rules": [{ "type": "ESModule", "globs": ["**/*.js"] }] }`,
         ),
       ),
-    ).toEqual({ noBundle: true, hasJavaScriptModuleRule: true });
+    ).toEqual([{ environment: null, noBundle: true, hasJavaScriptModuleRule: true }]);
     expect(
       readWranglerBundleSettings(
         writeConfig(
@@ -256,13 +256,58 @@ describe("readWranglerBundleSettings", () => {
           `no_bundle = false # let wrangler bundle\n[[rules]]\ntype = "ESModule"\nglobs = ["**/*.js", "**/*.mjs"]\n`,
         ),
       ),
-    ).toEqual({ noBundle: false, hasJavaScriptModuleRule: true });
+    ).toEqual([{ environment: null, noBundle: false, hasJavaScriptModuleRule: true }]);
+  });
+
+  it("applies JSONC and TOML environment overrides to inherited settings", () => {
+    expect(
+      readWranglerBundleSettings(
+        writeConfig(
+          "wrangler.jsonc",
+          `{
+            "no_bundle": true,
+            "rules": [{ "type": "ESModule", "globs": ["**/*.js"] }],
+            "env": {
+              "production": { "no_bundle": false },
+              "preview": { "rules": [{ "type": "Text", "globs": ["**/*.txt"] }] },
+              "inherited": { "name": "app-inherited" }
+            }
+          }`,
+        ),
+      ),
+    ).toEqual([
+      { environment: null, noBundle: true, hasJavaScriptModuleRule: true },
+      { environment: "production", noBundle: false, hasJavaScriptModuleRule: true },
+      { environment: "preview", noBundle: true, hasJavaScriptModuleRule: false },
+    ]);
+    expect(
+      readWranglerBundleSettings(
+        writeConfig(
+          "wrangler.toml",
+          [
+            "no_bundle = true",
+            "[[rules]]",
+            'type = "ESModule"',
+            'globs = ["**/*.js"]',
+            "[env.production]",
+            "no_bundle = false",
+            "[[env.preview.rules]]",
+            'type = "Text"',
+            'globs = ["**/*.txt"]',
+          ].join("\n"),
+        ),
+      ),
+    ).toEqual([
+      { environment: null, noBundle: true, hasJavaScriptModuleRule: true },
+      { environment: "production", noBundle: false, hasJavaScriptModuleRule: true },
+      { environment: "preview", noBundle: true, hasJavaScriptModuleRule: false },
+    ]);
   });
 
   it("distinguishes an omitted setting from an unreadable config", () => {
     expect(
       readWranglerBundleSettings(writeConfig("wrangler.jsonc", `{ "main": "worker.js" }`)),
-    ).toEqual({ noBundle: undefined, hasJavaScriptModuleRule: false });
+    ).toEqual([{ environment: null, noBundle: undefined, hasJavaScriptModuleRule: false }]);
     expect(readWranglerBundleSettings(writeConfig("wrangler.jsonc", `{ nope`))).toBeNull();
   });
 });

--- a/packages/cli/test/wrangler-config.test.ts
+++ b/packages/cli/test/wrangler-config.test.ts
@@ -8,6 +8,7 @@ import {
   findWranglerConfig,
   readWranglerAssetsHtmlHandling,
   readWranglerMainEntries,
+  readWranglerBundleSettings,
   WRANGLER_CONFIG_FILES,
 } from "../src/wrangler-config.ts";
 
@@ -235,5 +236,33 @@ describe("readWranglerAssetsHtmlHandling", () => {
         writeConfig("wrangler.jsonc", `{ "assets": { "html_handling": 3 } }`),
       ),
     ).toEqual({ htmlHandling: undefined });
+  });
+});
+
+describe("readWranglerBundleSettings", () => {
+  it("reads JSONC and TOML settings", () => {
+    expect(
+      readWranglerBundleSettings(
+        writeConfig(
+          "wrangler.jsonc",
+          `{ "no_bundle": true, "rules": [{ "type": "ESModule", "globs": ["**/*.js"] }] }`,
+        ),
+      ),
+    ).toEqual({ noBundle: true, hasJavaScriptModuleRule: true });
+    expect(
+      readWranglerBundleSettings(
+        writeConfig(
+          "wrangler.toml",
+          `no_bundle = false # let wrangler bundle\n[[rules]]\ntype = "ESModule"\nglobs = ["**/*.js", "**/*.mjs"]\n`,
+        ),
+      ),
+    ).toEqual({ noBundle: false, hasJavaScriptModuleRule: true });
+  });
+
+  it("distinguishes an omitted setting from an unreadable config", () => {
+    expect(
+      readWranglerBundleSettings(writeConfig("wrangler.jsonc", `{ "main": "worker.js" }`)),
+    ).toEqual({ noBundle: undefined, hasJavaScriptModuleRule: false });
+    expect(readWranglerBundleSettings(writeConfig("wrangler.jsonc", `{ nope`))).toBeNull();
   });
 });

--- a/packages/content/README.md
+++ b/packages/content/README.md
@@ -200,7 +200,7 @@ than the filesystem-backed authoring collection:
 import docs from "virtual:pracht/content/docs";
 ```
 
-The suffix is the collection `name`. This module embeds the documents and
+The suffix is the collection `name`. This module embeds the document and
 locale/fallback indexes into the server bundle, so it works in Cloudflare,
 Vercel, and dist-only Node deployments without source files or `node:fs`.
 Collection names are matched literally, including names containing `%`; an
@@ -212,9 +212,16 @@ instead of publishing the collection's source, frontmatter, and compiled data
 to browser JavaScript. Keep it inside loaders, middleware, API routes, and
 server capabilities.
 
-A snapshot carries `raw` and `body` alongside `compiled`, roughly two to three
-times the content size. An application that neither negotiates Markdown nor
-searches bodies can drop either from the generated module:
+The snapshot module keeps only lookup metadata. Each document's `raw`, `body`,
+and `compiled` representations live in a deferred per-document chunk that is
+loaded when an asynchronous collection accessor resolves that document.
+`iterate()` loads one document at a time, while `all()` loads the collection.
+This keeps the first request to any content-backed route from parsing every
+document in a shared server chunk.
+
+Those payload chunks still carry roughly two to three times the source content.
+An application that neither negotiates Markdown nor searches bodies can drop
+either representation entirely:
 
 ```ts
 defineCollection({

--- a/packages/content/README.md
+++ b/packages/content/README.md
@@ -219,6 +219,13 @@ loaded when an asynchronous collection accessor resolves that document.
 This keeps the first request to any content-backed route from parsing every
 document in a shared server chunk.
 
+The plugin enables server code splitting for webworker builds as well. A
+Cloudflare deployment must preserve Pracht's pre-bundled output with
+`"no_bundle": true` and an `ESModule` rule covering `"**/*.js"` in
+`wrangler.jsonc`; otherwise Wrangler either bundles the deferred chunks again
+or omits them from the upload. New `create-pracht` projects include both
+settings, and `pracht verify` warns when either is missing.
+
 Those payload chunks still carry roughly two to three times the source content.
 An application that neither negotiates Markdown nor searches bodies can drop
 either representation entirely:

--- a/packages/content/src/runtime.ts
+++ b/packages/content/src/runtime.ts
@@ -8,12 +8,14 @@ import { normalizeRoutePath } from "./route-path.ts";
 import { normalizeSnapshotFields } from "./snapshot.ts";
 import type {
   ContentCollectionSnapshot,
+  ContentDocumentPayload,
   ContentLocaleOptions,
   ContentLookupOptions,
   ContentResolution,
   ContentRouteAlias,
   ContentRuntimeDocument,
   ContentSnapshotCollection,
+  ContentSnapshotDocument,
 } from "./types.ts";
 
 export { contentLoader, markdownRepresentation } from "./integrations.ts";
@@ -30,23 +32,34 @@ export function defineSnapshotCollection<
     throw new TypeError("defineSnapshotCollection() expects a content collection snapshot.");
   }
 
-  const documents: readonly ContentRuntimeDocument<TFrontmatter, TCompiled>[] = Object.freeze(
-    snapshot.documents.map((document) =>
-      Object.freeze({
+  type Entry = ContentSnapshotDocument<TFrontmatter, TCompiled> & { source: string };
+  type Document = ContentRuntimeDocument<TFrontmatter, TCompiled>;
+
+  const entries: readonly Entry[] = Object.freeze(
+    snapshot.documents.map((document) => {
+      if (document.compiled === undefined && typeof document.load !== "function") {
+        throw new TypeError(
+          `defineSnapshotCollection() received a document without compiled output or a loader: ${JSON.stringify(document.relativeSource)}.`,
+        );
+      }
+      return Object.freeze({
         ...document,
-        frontmatter: Object.freeze({ ...document.frontmatter }),
         source: `virtual:pracht/content/${encodeURIComponent(snapshot.name)}/${document.relativeSource}`,
-      }),
-    ),
+      });
+    }),
   );
   const locales = normalizeSnapshotLocales(snapshot.locales);
   const snapshotFields = normalizeSnapshotFields(snapshot.fields);
-  const byId = new Map<string, Map<string, ContentRuntimeDocument<TFrontmatter, TCompiled>>>();
-  const byRoute = new Map<string, Map<string, ContentRuntimeDocument<TFrontmatter, TCompiled>>>();
-  const bySource = new Map<string, ContentRuntimeDocument<TFrontmatter, TCompiled>>();
+  const byId = new Map<string, Map<string, Entry>>();
+  const byRoute = new Map<string, Map<string, Entry>>();
+  const bySource = new Map<string, Entry>();
   const routeAliases = new Map<string, ContentRouteAlias>();
+  // Materialization is memoized per entry rather than per lookup so concurrent
+  // requests for the same document share one chunk load, and a document loaded
+  // during prerender stays loaded for the rest of the build.
+  const materialized = new Map<Entry, Promise<Document>>();
 
-  for (const document of documents) {
+  for (const document of entries) {
     addLookup(byId, document.id, document);
     addLookup(byRoute, document.path, document);
     bySource.set(document.relativeSource, document);
@@ -62,11 +75,13 @@ export function defineSnapshotCollection<
     snapshotFields,
 
     async all() {
-      return documents;
+      return Object.freeze(await Promise.all(entries.map(materialize)));
     },
 
     async *iterate() {
-      yield* documents;
+      // One document in flight at a time: a caller streaming a large collection
+      // should not be forced to hold every deferred chunk in memory at once.
+      for (const entry of entries) yield await materialize(entry);
     },
 
     async getById(id, options) {
@@ -86,7 +101,8 @@ export function defineSnapshotCollection<
     },
 
     async getBySource(source) {
-      return bySource.get(cleanSource(source));
+      const entry = bySource.get(cleanSource(source));
+      return entry && materialize(entry);
     },
 
     ownsSource(source) {
@@ -94,14 +110,34 @@ export function defineSnapshotCollection<
     },
   };
 
+  function materialize(entry: Entry): Promise<Document> {
+    let pending = materialized.get(entry);
+    if (!pending) {
+      pending = loadDocument(entry).catch((error: unknown) => {
+        // A transient chunk-load failure must not poison every later lookup.
+        materialized.delete(entry);
+        throw error;
+      });
+      materialized.set(entry, pending);
+    }
+    return pending;
+  }
+
+  async function loadDocument(entry: Entry): Promise<Document> {
+    const { load, ...document } = entry;
+    const payload = load ? unwrapPayload<TCompiled>(await load(), entry.relativeSource) : undefined;
+    return Object.freeze({
+      ...document,
+      ...payload,
+      frontmatter: Object.freeze({ ...entry.frontmatter }),
+    }) as Document;
+  }
+
   async function resolveLookup(
     kind: "id" | "route",
     key: string,
     options: ContentLookupOptions = {},
-  ): Promise<
-    | ContentResolution<TFrontmatter, TCompiled, ContentRuntimeDocument<TFrontmatter, TCompiled>>
-    | undefined
-  > {
+  ): Promise<ContentResolution<TFrontmatter, TCompiled, Document> | undefined> {
     const directRoute = kind === "route" ? byRoute.get(key) : undefined;
     const alias = kind === "route" && !directRoute ? routeAliases.get(key) : undefined;
     const localized =
@@ -115,9 +151,13 @@ export function defineSnapshotCollection<
       kind === "route" && locales?.routePrefix !== "never",
     );
     for (const locale of resolveLocaleOrder(requestedLocale, options.fallback !== false, locales)) {
-      const document = localized.get(locale ?? NO_LOCALE);
-      if (!document) continue;
-      return { document, fallback: locale !== requestedLocale, requestedLocale };
+      const entry = localized.get(locale ?? NO_LOCALE);
+      if (!entry) continue;
+      return {
+        document: await materialize(entry),
+        fallback: locale !== requestedLocale,
+        requestedLocale,
+      };
     }
     return undefined;
   }
@@ -125,12 +165,28 @@ export function defineSnapshotCollection<
   return Object.freeze(collection);
 }
 
-function addLookup<TFrontmatter extends Record<string, unknown>, TCompiled>(
-  lookup: Map<string, Map<string, ContentRuntimeDocument<TFrontmatter, TCompiled>>>,
+function unwrapPayload<TCompiled>(
+  loaded: ContentDocumentPayload<TCompiled> | { default: ContentDocumentPayload<TCompiled> },
+  relativeSource: string,
+): ContentDocumentPayload<TCompiled> {
+  const payload =
+    loaded && typeof loaded === "object" && "default" in loaded
+      ? (loaded as { default: ContentDocumentPayload<TCompiled> }).default
+      : (loaded as ContentDocumentPayload<TCompiled>);
+  if (!payload || typeof payload !== "object" || !("compiled" in payload)) {
+    throw new TypeError(
+      `Content document ${JSON.stringify(relativeSource)} loaded a payload without compiled output.`,
+    );
+  }
+  return payload;
+}
+
+function addLookup<TEntry extends { locale?: string }>(
+  lookup: Map<string, Map<string, TEntry>>,
   key: string,
-  document: ContentRuntimeDocument<TFrontmatter, TCompiled>,
+  document: TEntry,
 ): void {
-  const localized = lookup.get(key) ?? new Map();
+  const localized = lookup.get(key) ?? new Map<string, TEntry>();
   localized.set(document.locale ?? NO_LOCALE, document);
   lookup.set(key, localized);
 }

--- a/packages/content/src/runtime.ts
+++ b/packages/content/src/runtime.ts
@@ -9,6 +9,7 @@ import { normalizeSnapshotFields } from "./snapshot.ts";
 import type {
   ContentCollectionSnapshot,
   ContentDocumentPayload,
+  ContentDocumentPayloadLoader,
   ContentLocaleOptions,
   ContentLookupOptions,
   ContentResolution,
@@ -32,11 +33,18 @@ export function defineSnapshotCollection<
     throw new TypeError("defineSnapshotCollection() expects a content collection snapshot.");
   }
 
-  type Entry = ContentSnapshotDocument<TFrontmatter, TCompiled> & { source: string };
+  // Generated modules attach loaders after parsing their JSON index. Keep that
+  // non-serializable implementation detail out of the exported authoring
+  // snapshot type, whose documents always carry `compiled` directly.
+  type SnapshotEntry = Omit<ContentSnapshotDocument<TFrontmatter, TCompiled>, "compiled"> & {
+    compiled?: TCompiled;
+    load?: ContentDocumentPayloadLoader<TCompiled>;
+  };
+  type Entry = SnapshotEntry & { source: string };
   type Document = ContentRuntimeDocument<TFrontmatter, TCompiled>;
 
   const entries: readonly Entry[] = Object.freeze(
-    snapshot.documents.map((document) => {
+    (snapshot.documents as readonly SnapshotEntry[]).map((document) => {
       if (document.compiled === undefined && typeof document.load !== "function") {
         throw new TypeError(
           `defineSnapshotCollection() received a document without compiled output or a loader: ${JSON.stringify(document.relativeSource)}.`,

--- a/packages/content/src/types.ts
+++ b/packages/content/src/types.ts
@@ -138,19 +138,11 @@ export type ContentSnapshotOptions = Partial<ContentSnapshotFields>;
 export type ContentSnapshotDocument<
   TFrontmatter extends Record<string, unknown> = Record<string, unknown>,
   TCompiled = string,
-> = Omit<ContentDocument<TFrontmatter, TCompiled>, "body" | "compiled" | "raw" | "source"> & {
+> = Omit<ContentDocument<TFrontmatter, TCompiled>, "body" | "raw" | "source"> & {
   /** Absent when the collection was defined with `snapshot: { body: false }`. */
   body?: string;
   /** Absent when the collection was defined with `snapshot: { raw: false }`. */
   raw?: string;
-  /** Absent when `load` carries the representations instead. */
-  compiled?: TCompiled;
-  /**
-   * Loads the representations kept out of the snapshot index. The Vite plugin
-   * sets it so a collection's compiled output, bodies, and sources land in
-   * per-document chunks rather than in whichever chunk imports the snapshot.
-   */
-  load?: ContentDocumentPayloadLoader<TCompiled>;
 };
 
 /**

--- a/packages/content/src/types.ts
+++ b/packages/content/src/types.ts
@@ -138,18 +138,49 @@ export type ContentSnapshotOptions = Partial<ContentSnapshotFields>;
 export type ContentSnapshotDocument<
   TFrontmatter extends Record<string, unknown> = Record<string, unknown>,
   TCompiled = string,
+> = Omit<ContentDocument<TFrontmatter, TCompiled>, "body" | "compiled" | "raw" | "source"> & {
+  /** Absent when the collection was defined with `snapshot: { body: false }`. */
+  body?: string;
+  /** Absent when the collection was defined with `snapshot: { raw: false }`. */
+  raw?: string;
+  /** Absent when `load` carries the representations instead. */
+  compiled?: TCompiled;
+  /**
+   * Loads the representations kept out of the snapshot index. The Vite plugin
+   * sets it so a collection's compiled output, bodies, and sources land in
+   * per-document chunks rather than in whichever chunk imports the snapshot.
+   */
+  load?: ContentDocumentPayloadLoader<TCompiled>;
+};
+
+/**
+ * The representations a snapshot document can defer. Everything else — ids,
+ * routes, locales, frontmatter — stays in the index so lookup never needs a
+ * chunk it has not loaded.
+ */
+export interface ContentDocumentPayload<TCompiled = string> {
+  compiled: TCompiled;
+  body?: string;
+  raw?: string;
+}
+
+export type ContentDocumentPayloadLoader<TCompiled = string> = () => Promise<
+  ContentDocumentPayload<TCompiled> | { default: ContentDocumentPayload<TCompiled> }
+>;
+
+/**
+ * A document rehydrated from a filesystem-free runtime snapshot. Deferred
+ * representations are already resolved: every accessor that hands one out is
+ * asynchronous, so a caller never observes a half-loaded document.
+ */
+export type ContentRuntimeDocument<
+  TFrontmatter extends Record<string, unknown> = Record<string, unknown>,
+  TCompiled = string,
 > = Omit<ContentDocument<TFrontmatter, TCompiled>, "body" | "raw" | "source"> & {
   /** Absent when the collection was defined with `snapshot: { body: false }`. */
   body?: string;
   /** Absent when the collection was defined with `snapshot: { raw: false }`. */
   raw?: string;
-};
-
-/** A document rehydrated from a filesystem-free runtime snapshot. */
-export type ContentRuntimeDocument<
-  TFrontmatter extends Record<string, unknown> = Record<string, unknown>,
-  TCompiled = string,
-> = ContentSnapshotDocument<TFrontmatter, TCompiled> & {
   /** Stable virtual identity replacing the authoring collection's absolute source path. */
   source: string;
 };

--- a/packages/content/src/vite.ts
+++ b/packages/content/src/vite.ts
@@ -24,6 +24,7 @@ const RESOLVED_CONTENT_MODULE_PREFIX = `\0${CONTENT_MODULE_PREFIX}`;
  */
 const CONTENT_PAYLOAD_MODULE_PREFIX = "virtual:pracht/content-payload/";
 const RESOLVED_CONTENT_PAYLOAD_MODULE_PREFIX = `\0${CONTENT_PAYLOAD_MODULE_PREFIX}`;
+const CONTENT_PAYLOAD_SLUG_MAX_LENGTH = 80;
 export const CONTENT_BUILD_MANIFEST_FILE = "_pracht/content-manifest.json";
 
 export interface ViteContentCollection {
@@ -421,7 +422,12 @@ function payloadModuleId(collection: string, index: number, relativeSource: stri
   const slug = relativeSource
     .replace(/\.[^./]*$/, "")
     .replace(/[^a-zA-Z0-9]+/g, "-")
-    .replace(/^-+|-+$/g, "");
+    .replace(/^-+|-+$/g, "")
+    // Rolldown derives the emitted chunk basename from this suffix. Flattening
+    // an otherwise valid deep source path without a bound can exceed the
+    // filesystem's per-component limit and make the build fail at write time.
+    .slice(0, CONTENT_PAYLOAD_SLUG_MAX_LENGTH)
+    .replace(/-+$/g, "");
   return `${CONTENT_PAYLOAD_MODULE_PREFIX}${encodeURIComponent(collection)}/${index}${slug ? `-${slug}` : ""}`;
 }
 

--- a/packages/content/src/vite.ts
+++ b/packages/content/src/vite.ts
@@ -74,10 +74,18 @@ export function prachtContent(options: PrachtContentOptions): Plugin[] {
   const collections = validateCollections(options);
   const unroutedDocuments = validateUnroutedDocumentPolicy(options.unroutedDocuments);
   const emittedPayloadModules = new Map<ViteContentCollection, ReadonlySet<string>>();
+  const splitCache = new WeakMap<ViteContentCollection, Promise<SplitSnapshot>>();
 
   const transformPlugin: Plugin = {
     name: "pracht:content",
     enforce: "pre",
+
+    buildStart() {
+      // A plugin object can be reused across programmatic Vite builds. Keep the
+      // split stable within one build, but never carry source bytes into the
+      // next build invocation.
+      for (const collection of collections) splitCache.delete(collection);
+    },
 
     resolveId(id) {
       if (id.startsWith(CONTENT_PAYLOAD_MODULE_PREFIX)) {
@@ -100,10 +108,19 @@ export function prachtContent(options: PrachtContentOptions): Plugin[] {
     },
 
     async load(id, loadOptions) {
+      const consumer = this.environment?.config?.consumer;
+      const importedByClient = consumer === "client" || (!consumer && loadOptions?.ssr === false);
       if (id.startsWith(RESOLVED_CONTENT_PAYLOAD_MODULE_PREFIX)) {
+        if (importedByClient) {
+          throw new Error(
+            `[pracht:content] ${JSON.stringify(id.slice(1))} was imported by client code. ` +
+              "Content payload modules are server-only and may contain private source, frontmatter, and compiled data. " +
+              "Read the collection inside loaders, middleware, API routes, or server capabilities instead.",
+          );
+        }
         const target = resolvePayloadId(collections, id.slice(1));
         if (!target) return null;
-        const { payloads } = await splitSnapshot(target.collection);
+        const { payloads } = await splitSnapshot(target.collection, splitCache);
         const payload = payloads[target.index];
         if (!payload) return null;
         // Already validated as JSON while splitting, so a malformed document
@@ -115,15 +132,14 @@ export function prachtContent(options: PrachtContentOptions): Plugin[] {
       const name = decodeURIComponent(id.slice(RESOLVED_CONTENT_MODULE_PREFIX.length));
       const collection = collections.find((candidate) => candidate.name === name);
       if (!collection) return null;
-      const consumer = this.environment?.config?.consumer;
-      if (consumer === "client" || (!consumer && loadOptions?.ssr === false)) {
+      if (importedByClient) {
         throw new Error(
           `[pracht:content] ${JSON.stringify(`virtual:pracht/content/${name}`)} was imported by client code. ` +
             "Content collection snapshots are server-only and may contain private source, frontmatter, and compiled data. " +
             "Read the collection inside loaders, middleware, API routes, or server capabilities instead.",
         );
       }
-      const { index, payloads } = await splitSnapshot(collection);
+      const { index, payloads } = await splitSnapshot(collection, splitCache);
       const lines = [
         `import { defineSnapshotCollection } from "@pracht/content/runtime";`,
         `const snapshot = JSON.parse(${JSON.stringify(serializeSnapshot(index))});`,
@@ -187,7 +203,7 @@ export function prachtContent(options: PrachtContentOptions): Plugin[] {
     },
 
     configureServer(server) {
-      registerInvalidation(server, collections, emittedPayloadModules);
+      registerInvalidation(server, collections, emittedPayloadModules, splitCache);
     },
   };
 
@@ -300,9 +316,7 @@ export function prachtContent(options: PrachtContentOptions): Plugin[] {
   return [transformPlugin, artifactPlugin];
 }
 
-function serializeSnapshot(
-  snapshot: ContentCollectionSnapshot<Record<string, unknown>, unknown>,
-): string {
+function serializeSnapshot(snapshot: ContentCollectionSnapshotIndex): string {
   assertJsonValue(snapshot, "content snapshot", new Set());
   return JSON.stringify(snapshot);
 }
@@ -313,9 +327,21 @@ interface SplitPayload {
 }
 
 interface SplitSnapshot {
-  index: ContentCollectionSnapshot<Record<string, unknown>, unknown>;
+  index: ContentCollectionSnapshotIndex;
   payloads: readonly SplitPayload[];
 }
+
+type ContentSnapshotIndexDocument = Omit<
+  ContentSnapshotDocument<Record<string, unknown>, unknown>,
+  "compiled"
+>;
+
+type ContentCollectionSnapshotIndex = Omit<
+  ContentCollectionSnapshot<Record<string, unknown>, unknown>,
+  "documents"
+> & {
+  documents: readonly ContentSnapshotIndexDocument[];
+};
 
 /**
  * Memoized per collection. `load()` runs once for the snapshot module and once
@@ -326,16 +352,17 @@ interface SplitSnapshot {
  * The entry is dropped whenever a source changes, alongside the module-graph
  * invalidation in `registerInvalidation()`.
  */
-const splitCache = new WeakMap<ViteContentCollection, Promise<SplitSnapshot>>();
-
-function splitSnapshot(collection: ViteContentCollection): Promise<SplitSnapshot> {
-  let pending = splitCache.get(collection);
+function splitSnapshot(
+  collection: ViteContentCollection,
+  cache: WeakMap<ViteContentCollection, Promise<SplitSnapshot>>,
+): Promise<SplitSnapshot> {
+  let pending = cache.get(collection);
   if (!pending) {
     pending = computeSplitSnapshot(collection).catch((error: unknown) => {
-      splitCache.delete(collection);
+      cache.delete(collection);
       throw error;
     });
-    splitCache.set(collection, pending);
+    cache.set(collection, pending);
   }
   return pending;
 }
@@ -358,7 +385,7 @@ async function computeSplitSnapshot(collection: ViteContentCollection): Promise<
       data,
       moduleId: payloadModuleId(snapshot.name, index, document.relativeSource),
     });
-    return rest as ContentSnapshotDocument<Record<string, unknown>, unknown>;
+    return rest as ContentSnapshotIndexDocument;
   });
   return { index: { ...snapshot, documents }, payloads };
 }
@@ -482,6 +509,7 @@ function registerInvalidation(
   server: ViteDevServer,
   collections: readonly ViteContentCollection[],
   emittedPayloadModules: ReadonlyMap<ViteContentCollection, ReadonlySet<string>>,
+  splitCache: WeakMap<ViteContentCollection, Promise<SplitSnapshot>>,
 ): void {
   // Vite only watches its own project root. A collection rooted elsewhere — a
   // monorepo's shared docs directory, say — would never emit an event, leaving

--- a/packages/content/src/vite.ts
+++ b/packages/content/src/vite.ts
@@ -80,6 +80,28 @@ export function prachtContent(options: PrachtContentOptions): Plugin[] {
     name: "pracht:content",
     enforce: "pre",
 
+    configEnvironment(_name, config, environment) {
+      const serverBuild =
+        config.consumer === "server" ||
+        config.build?.ssr === true ||
+        environment.isSsrTargetWebworker === true;
+      if (!serverBuild) return;
+
+      // Rolldown defaults a single-entry server build to one file, including
+      // webworker targets. Preserve dynamic imports so document payloads stay
+      // outside the shared snapshot chunk on every server adapter.
+      const output = config.build?.rollupOptions?.output;
+      return {
+        build: {
+          rollupOptions: {
+            output: Array.isArray(output)
+              ? output.map((candidate) => ({ ...candidate, codeSplitting: true }))
+              : { ...output, codeSplitting: true },
+          },
+        },
+      };
+    },
+
     buildStart() {
       // A plugin object can be reused across programmatic Vite builds. Keep the
       // split stable within one build, but never carry source bytes into the

--- a/packages/content/src/vite.ts
+++ b/packages/content/src/vite.ts
@@ -4,10 +4,26 @@ import type { Connect, Plugin, ViteDevServer } from "vite";
 
 import { artifactFileName } from "./path.ts";
 import { defineSnapshotCollection } from "./runtime.ts";
-import type { ContentArtifact, ContentCollectionSnapshot } from "./types.ts";
+import type {
+  ContentArtifact,
+  ContentCollectionSnapshot,
+  ContentDocumentPayload,
+  ContentSnapshotDocument,
+} from "./types.ts";
 
 const CONTENT_MODULE_PREFIX = "virtual:pracht/content/";
 const RESOLVED_CONTENT_MODULE_PREFIX = `\0${CONTENT_MODULE_PREFIX}`;
+/**
+ * Deferred per-document representations. Keeping them out of the snapshot
+ * module matters because that module is imported by loaders, which the bundler
+ * hoists into a chunk shared by every content-backed route: inlining the whole
+ * collection there puts every document's compiled output, body, and source in
+ * the bundle any one of those routes loads. A documentation site is easily
+ * tens of megabytes of Markdown, all of it parsed on the first request to
+ * reach a shared chunk — including the 404 handler.
+ */
+const CONTENT_PAYLOAD_MODULE_PREFIX = "virtual:pracht/content-payload/";
+const RESOLVED_CONTENT_PAYLOAD_MODULE_PREFIX = `\0${CONTENT_PAYLOAD_MODULE_PREFIX}`;
 export const CONTENT_BUILD_MANIFEST_FILE = "_pracht/content-manifest.json";
 
 export interface ViteContentCollection {
@@ -57,12 +73,16 @@ interface ContentBuildManifest {
 export function prachtContent(options: PrachtContentOptions): Plugin[] {
   const collections = validateCollections(options);
   const unroutedDocuments = validateUnroutedDocumentPolicy(options.unroutedDocuments);
+  const emittedPayloadModules = new Map<ViteContentCollection, ReadonlySet<string>>();
 
   const transformPlugin: Plugin = {
     name: "pracht:content",
     enforce: "pre",
 
     resolveId(id) {
+      if (id.startsWith(CONTENT_PAYLOAD_MODULE_PREFIX)) {
+        return resolvePayloadId(collections, id) === undefined ? null : `\0${id}`;
+      }
       if (!id.startsWith(CONTENT_MODULE_PREFIX)) return null;
       const specifier = id.slice(CONTENT_MODULE_PREFIX.length);
       const exact = collections.find((collection) => collection.name === specifier);
@@ -80,6 +100,17 @@ export function prachtContent(options: PrachtContentOptions): Plugin[] {
     },
 
     async load(id, loadOptions) {
+      if (id.startsWith(RESOLVED_CONTENT_PAYLOAD_MODULE_PREFIX)) {
+        const target = resolvePayloadId(collections, id.slice(1));
+        if (!target) return null;
+        const { payloads } = await splitSnapshot(target.collection);
+        const payload = payloads[target.index];
+        if (!payload) return null;
+        // Already validated as JSON while splitting, so a malformed document
+        // fails when the snapshot module loads rather than whenever the page
+        // that happens to use it is first rendered.
+        return `export default JSON.parse(${JSON.stringify(JSON.stringify(payload.data))});`;
+      }
       if (!id.startsWith(RESOLVED_CONTENT_MODULE_PREFIX)) return null;
       const name = decodeURIComponent(id.slice(RESOLVED_CONTENT_MODULE_PREFIX.length));
       const collection = collections.find((candidate) => candidate.name === name);
@@ -92,14 +123,30 @@ export function prachtContent(options: PrachtContentOptions): Plugin[] {
             "Read the collection inside loaders, middleware, API routes, or server capabilities instead.",
         );
       }
-      const snapshot = await collection.snapshot();
-      const serializedSnapshot = serializeSnapshot(snapshot);
-      return [
+      const { index, payloads } = await splitSnapshot(collection);
+      const lines = [
         `import { defineSnapshotCollection } from "@pracht/content/runtime";`,
-        `const snapshot = JSON.parse(${JSON.stringify(serializedSnapshot)});`,
+        `const snapshot = JSON.parse(${JSON.stringify(serializeSnapshot(index))});`,
+      ];
+      if (payloads.length > 0) {
+        // Recorded synchronously so the dev watcher can invalidate exactly the
+        // payload modules this collection generated, without walking the graph.
+        emittedPayloadModules.set(
+          collection,
+          new Set(payloads.map((payload) => `\0${payload.moduleId}`)),
+        );
+        lines.push(`const documents = snapshot.documents;`);
+        for (const [documentIndex, payload] of payloads.entries()) {
+          lines.push(
+            `documents[${documentIndex}].load = () => import(${JSON.stringify(payload.moduleId)});`,
+          );
+        }
+      }
+      lines.push(
         `export const collection = defineSnapshotCollection(snapshot);`,
         `export default collection;`,
-      ].join("\n");
+      );
+      return lines.join("\n");
     },
 
     async transform(code, id) {
@@ -140,7 +187,7 @@ export function prachtContent(options: PrachtContentOptions): Plugin[] {
     },
 
     configureServer(server) {
-      registerInvalidation(server, collections);
+      registerInvalidation(server, collections, emittedPayloadModules);
     },
   };
 
@@ -260,6 +307,94 @@ function serializeSnapshot(
   return JSON.stringify(snapshot);
 }
 
+interface SplitPayload {
+  data: ContentDocumentPayload<unknown>;
+  moduleId: string;
+}
+
+interface SplitSnapshot {
+  index: ContentCollectionSnapshot<Record<string, unknown>, unknown>;
+  payloads: readonly SplitPayload[];
+}
+
+/**
+ * Memoized per collection. `load()` runs once for the snapshot module and once
+ * per payload module, and every one of those calls needs the same split; the
+ * underlying `collection.snapshot()` re-reads and re-serializes the whole
+ * registry each time it is called.
+ *
+ * The entry is dropped whenever a source changes, alongside the module-graph
+ * invalidation in `registerInvalidation()`.
+ */
+const splitCache = new WeakMap<ViteContentCollection, Promise<SplitSnapshot>>();
+
+function splitSnapshot(collection: ViteContentCollection): Promise<SplitSnapshot> {
+  let pending = splitCache.get(collection);
+  if (!pending) {
+    pending = computeSplitSnapshot(collection).catch((error: unknown) => {
+      splitCache.delete(collection);
+      throw error;
+    });
+    splitCache.set(collection, pending);
+  }
+  return pending;
+}
+
+async function computeSplitSnapshot(collection: ViteContentCollection): Promise<SplitSnapshot> {
+  const snapshot = await collection.snapshot();
+  const payloads: SplitPayload[] = [];
+  const documents = snapshot.documents.map((document, index) => {
+    const { body, compiled, raw, ...rest } = document;
+    const data = {
+      compiled,
+      ...(body === undefined ? {} : { body }),
+      ...(raw === undefined ? {} : { raw }),
+    } as ContentDocumentPayload<unknown>;
+    // Path-compatible with the un-split snapshot so a diagnostic still points
+    // at `documents[3].compiled.html` rather than at a chunk the author never
+    // wrote.
+    assertJsonValue(data, `content snapshot.documents[${index}]`, new Set());
+    payloads.push({
+      data,
+      moduleId: payloadModuleId(snapshot.name, index, document.relativeSource),
+    });
+    return rest as ContentSnapshotDocument<Record<string, unknown>, unknown>;
+  });
+  return { index: { ...snapshot, documents }, payloads };
+}
+
+/**
+ * The trailing slug never identifies anything — `resolvePayloadId()` reads the
+ * leading index — but it is what the bundler names the emitted chunk after, so
+ * a build's output stays greppable instead of being 400 files called `0.js`.
+ */
+function payloadModuleId(collection: string, index: number, relativeSource: string): string {
+  const slug = relativeSource
+    .replace(/\.[^./]*$/, "")
+    .replace(/[^a-zA-Z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+  return `${CONTENT_PAYLOAD_MODULE_PREFIX}${encodeURIComponent(collection)}/${index}${slug ? `-${slug}` : ""}`;
+}
+
+function resolvePayloadId(
+  collections: readonly ViteContentCollection[],
+  id: string,
+): { collection: ViteContentCollection; index: number } | undefined {
+  const specifier = id.slice(CONTENT_PAYLOAD_MODULE_PREFIX.length);
+  const separator = specifier.indexOf("/");
+  if (separator === -1) return undefined;
+  let name: string;
+  try {
+    name = decodeURIComponent(specifier.slice(0, separator));
+  } catch {
+    return undefined;
+  }
+  const collection = collections.find((candidate) => candidate.name === name);
+  if (!collection) return undefined;
+  const index = /^(\d+)(?:-|$)/.exec(specifier.slice(separator + 1))?.[1];
+  return index === undefined ? undefined : { collection, index: Number(index) };
+}
+
 function assertJsonValue(value: unknown, path: string, ancestors: Set<object>): void {
   if (
     value === null ||
@@ -346,6 +481,7 @@ function validateUnroutedDocumentPolicy(value: unknown): UnroutedDocumentPolicy 
 function registerInvalidation(
   server: ViteDevServer,
   collections: readonly ViteContentCollection[],
+  emittedPayloadModules: ReadonlyMap<ViteContentCollection, ReadonlySet<string>>,
 ): void {
   // Vite only watches its own project root. A collection rooted elsewhere — a
   // monorepo's shared docs directory, say — would never emit an event, leaving
@@ -356,14 +492,26 @@ function registerInvalidation(
     }
   }
 
+  const invalidateModuleById = (target: ViteDevServer, moduleId: string) => {
+    const module = target.moduleGraph.getModuleById(moduleId);
+    if (module) target.moduleGraph.invalidateModule(module);
+  };
+
   const invalidate = (file: string) => {
     for (const collection of collections) {
       if (!collection.ownsSource(file)) continue;
       collection.invalidate(file);
-      const module = server.moduleGraph.getModuleById(
+      splitCache.delete(collection);
+      invalidateModuleById(
+        server,
         `${RESOLVED_CONTENT_MODULE_PREFIX}${encodeURIComponent(collection.name)}`,
       );
-      if (module) server.moduleGraph.invalidateModule(module);
+      // Payload modules are separate graph nodes, so invalidating the snapshot
+      // alone would leave development serving the compiled output captured
+      // before the edit.
+      for (const moduleId of emittedPayloadModules.get(collection) ?? []) {
+        invalidateModuleById(server, moduleId);
+      }
     }
   };
   server.watcher.on("add", invalidate);

--- a/packages/content/test/content.test.ts
+++ b/packages/content/test/content.test.ts
@@ -895,6 +895,7 @@ describe("collection integration helpers", () => {
 
     expect(snapshot.fields).toBeUndefined();
     expect(snapshot.documents[0]).toMatchObject({ body: "Body", raw: "Body" });
+    expectTypeOf(snapshot.documents[0].compiled).toEqualTypeOf<string>();
     expect(defineSnapshotCollection(snapshot).snapshotFields).toEqual({ body: true, raw: true });
 
     expect(() => defineCollection({ name: "docs", root, snapshot: null as never })).toThrow(

--- a/packages/content/test/vite.test.ts
+++ b/packages/content/test/vite.test.ts
@@ -453,6 +453,12 @@ describe("prachtContent", () => {
     const output = join(temporaryDirectory, "dist");
     await writeFile(join(temporaryDirectory, "one.md"), "First document");
     await writeFile(join(temporaryDirectory, "two.md"), "Second document");
+    let deepDirectory = temporaryDirectory;
+    for (let index = 0; index < 4; index++) {
+      deepDirectory = join(deepDirectory, `${index}-${"a".repeat(80)}`);
+      await mkdir(deepDirectory);
+    }
+    await writeFile(join(deepDirectory, "deep.md"), "Deep document");
     const collection = defineCollection({ name: "docs", root: temporaryDirectory });
 
     await build({
@@ -483,7 +489,11 @@ describe("prachtContent", () => {
     // ...and none of what it does not.
     expect(entryCode).not.toContain("First document");
     expect(entryCode).not.toContain("Second document");
-    expect(chunks.filter((file) => String(file) !== "docs.js")).toHaveLength(2);
+    expect(entryCode).not.toContain("Deep document");
+    expect(chunks.filter((file) => String(file) !== "docs.js")).toHaveLength(3);
+    expect(
+      chunks.every((file) => Buffer.byteLength(String(file).split("/").at(-1) ?? "") < 255),
+    ).toBe(true);
 
     const runtime = (await import(pathToFileURL(join(output, "docs.js")).href)).default;
     expect(await runtime.getByRoute("/one")).toMatchObject({ compiled: "First document" });

--- a/packages/content/test/vite.test.ts
+++ b/packages/content/test/vite.test.ts
@@ -7,7 +7,7 @@ import { mkdir, mkdtemp, readFile, readdir, realpath, rm, writeFile } from "node
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
-import type { Connect, ViteDevServer } from "vite";
+import type { Connect, Plugin, ViteDevServer } from "vite";
 import { build, createServer as createViteServer } from "vite";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
@@ -26,12 +26,29 @@ function hookHandler<T extends (...args: any[]) => any>(hook: T | { handler: T }
   return typeof hook === "function" ? hook : hook.handler;
 }
 
-/** Read back the snapshot a generated collection module embeds. */
+/** Read back the snapshot index a generated collection module embeds. */
 function loadedSnapshot(result: unknown): Record<string, any> {
   const code =
     typeof result === "string" ? result : ((result as { code?: string } | null)?.code ?? "");
   const serialized = /JSON\.parse\((".*")\)/.exec(code)?.[1];
   if (!serialized) throw new Error("Expected a serialized snapshot");
+  return JSON.parse(JSON.parse(serialized));
+}
+
+/** Module specifiers of the per-document payload chunks a snapshot defers to. */
+function payloadModuleIds(result: unknown): string[] {
+  const code =
+    typeof result === "string" ? result : ((result as { code?: string } | null)?.code ?? "");
+  return [...code.matchAll(/\.load = \(\) => import\("([^"]+)"\)/g)].map((match) => match[1]);
+}
+
+/** Read back one deferred document payload. */
+async function loadedPayload(plugin: Plugin, moduleId: string): Promise<Record<string, any>> {
+  const result = await hookHandler(plugin.load).call({} as never, `\0${moduleId}`);
+  const code =
+    typeof result === "string" ? result : ((result as { code?: string } | null)?.code ?? "");
+  const serialized = /JSON\.parse\((".*")\)/.exec(code)?.[1];
+  if (!serialized) throw new Error("Expected a serialized payload");
   return JSON.parse(JSON.parse(serialized));
 }
 
@@ -154,7 +171,16 @@ describe("prachtContent", () => {
     const code = typeof result === "string" ? result : result?.code;
     expect(code).toContain('from "@pracht/content/runtime"');
     expect(code).toContain("const snapshot = JSON.parse(");
-    expect(code).toContain('\\"body\\":\\"Page\\"');
+    // Source representations move to a per-document chunk; the index keeps
+    // only what lookup needs.
+    expect(code).not.toContain('\\"body\\":\\"Page\\"');
+    const [payloadId] = payloadModuleIds(code);
+    expect(payloadId).toBe("virtual:pracht/content-payload/docs/0-page");
+    expect(await loadedPayload(plugin, payloadId)).toMatchObject({
+      body: "Page",
+      compiled: "Page",
+      raw: "Page",
+    });
     expect(code).not.toContain(temporaryDirectory);
     expect(code).not.toContain("node:fs");
   });
@@ -243,20 +269,24 @@ describe("prachtContent", () => {
     });
     const [plugin] = prachtContent({ collections: [collection] });
 
-    const snapshot = loadedSnapshot(
-      await hookHandler(plugin.load).call({} as never, "\0virtual:pracht/content/docs"),
+    const module = await hookHandler(plugin.load).call(
+      {} as never,
+      "\0virtual:pracht/content/docs",
     );
+    const snapshot = loadedSnapshot(module);
 
     expect(snapshot.fields).toEqual({ body: false, raw: false });
     expect(snapshot.documents).toEqual([
       {
-        compiled: "Body",
         frontmatter: { title: "Page" },
         id: "page",
         path: "/page",
         relativeSource: "page.md",
       },
     ]);
+    expect(await loadedPayload(plugin, payloadModuleIds(module)[0])).toEqual({
+      compiled: "Body",
+    });
   });
 
   it("keeps every source representation in a generated module by default", async () => {
@@ -265,12 +295,13 @@ describe("prachtContent", () => {
     const collection = defineCollection({ name: "docs", root: temporaryDirectory });
     const [plugin] = prachtContent({ collections: [collection] });
 
-    const snapshot = loadedSnapshot(
-      await hookHandler(plugin.load).call({} as never, "\0virtual:pracht/content/docs"),
+    const module = await hookHandler(plugin.load).call(
+      {} as never,
+      "\0virtual:pracht/content/docs",
     );
 
-    expect(snapshot.fields).toBeUndefined();
-    expect(snapshot.documents[0]).toMatchObject({
+    expect(loadedSnapshot(module).fields).toBeUndefined();
+    expect(await loadedPayload(plugin, payloadModuleIds(module)[0])).toMatchObject({
       body: "Body",
       raw: "---\ntitle: Page\n---\nBody",
     });
@@ -339,13 +370,12 @@ describe("prachtContent", () => {
     const configureServer = hookHandler(plugin.configureServer);
     const load = hookHandler(plugin.load);
     let change: ((file: string) => void) | undefined;
-    const runtimeModule = {};
-    const invalidateModule = vi.fn();
+    const invalidated: string[] = [];
     const add = vi.fn();
     const server = {
       moduleGraph: {
-        getModuleById: vi.fn(() => runtimeModule),
-        invalidateModule,
+        getModuleById: (id: string) => ({ id }),
+        invalidateModule: (module: { id: string }) => invalidated.push(module.id),
       },
       watcher: {
         add,
@@ -356,16 +386,68 @@ describe("prachtContent", () => {
     } as unknown as ViteDevServer;
     configureServer.call({} as never, server);
 
+    // Load once so the payload modules this collection defers to are known.
+    await load.call({} as never, "\0virtual:pracht/content/docs");
     await writeFile(source, "Second");
     change?.(source);
     const result = await load.call({} as never, "\0virtual:pracht/content/docs");
     const code = typeof result === "string" ? result : result?.code;
 
-    expect(code).toContain('\\"body\\":\\"Second\\"');
-    expect(invalidateModule).toHaveBeenCalledWith(runtimeModule);
+    expect(await loadedPayload(plugin, payloadModuleIds(code)[0])).toMatchObject({
+      body: "Second",
+    });
+    // Both graph nodes: leaving the payload behind would serve the compiled
+    // output captured before the edit.
+    expect(invalidated).toEqual([
+      "\0virtual:pracht/content/docs",
+      "\0virtual:pracht/content-payload/docs/0-page",
+    ]);
     // A root outside Vite's own project root emits no events until it is
     // watched explicitly, which would serve stale content for the session.
     expect(add).toHaveBeenCalledWith(temporaryDirectory);
+  });
+
+  it("keeps deferred document payloads out of the chunk that imports a snapshot", async () => {
+    temporaryDirectory = await mkdtemp(join(tmpdir(), "pracht-content-vite-"));
+    const output = join(temporaryDirectory, "dist");
+    await writeFile(join(temporaryDirectory, "one.md"), "First document");
+    await writeFile(join(temporaryDirectory, "two.md"), "Second document");
+    const collection = defineCollection({ name: "docs", root: temporaryDirectory });
+
+    await build({
+      configFile: false,
+      logLevel: "silent",
+      plugins: prachtContent({ collections: [collection] }),
+      resolve: {
+        alias: {
+          "@pracht/content/runtime": fileURLToPath(new URL("../src/runtime.ts", import.meta.url)),
+        },
+      },
+      build: {
+        outDir: output,
+        ssr: true,
+        rollupOptions: {
+          input: "virtual:pracht/content/docs",
+          output: { codeSplitting: true },
+        },
+      },
+    });
+
+    const chunks = (await readdir(output, { recursive: true })).filter((file) =>
+      /\.m?js$/.test(String(file)),
+    );
+    const entryCode = await readFile(join(output, "docs.js"), "utf8");
+
+    // The index the entry pays for keeps everything lookup needs...
+    expect(entryCode).toContain("one.md");
+    expect(entryCode).toContain("two.md");
+    // ...and none of what it does not.
+    expect(entryCode).not.toContain("First document");
+    expect(entryCode).not.toContain("Second document");
+    expect(chunks.filter((file) => String(file) !== "docs.js")).toHaveLength(2);
+
+    const runtime = (await import(pathToFileURL(join(output, "docs.js")).href)).default;
+    expect(await runtime.getByRoute("/one")).toMatchObject({ compiled: "First document" });
   });
 
   it("emits deploy-safe headers for production artifacts in the asset namespace", async () => {

--- a/packages/content/test/vite.test.ts
+++ b/packages/content/test/vite.test.ts
@@ -203,6 +203,24 @@ describe("prachtContent", () => {
     ).rejects.toThrow(/collection snapshots are server-only.*private source/i);
   });
 
+  it("rejects deferred payload modules imported directly by client code", async () => {
+    temporaryDirectory = await mkdtemp(join(tmpdir(), "pracht-content-client-payload-"));
+    await writeFile(join(temporaryDirectory, "private.md"), "Private source");
+    const collection = defineCollection({ name: "private", root: temporaryDirectory });
+
+    await expect(
+      build({
+        configFile: false,
+        logLevel: "silent",
+        plugins: prachtContent({ collections: [collection] }),
+        build: {
+          write: false,
+          rollupOptions: { input: "virtual:pracht/content-payload/private/0-private" },
+        },
+      }),
+    ).rejects.toThrow(/content payload modules are server-only.*private source/i);
+  });
+
   it("keeps request-time helpers on the filesystem-free runtime entry", async () => {
     temporaryDirectory = await mkdtemp(join(tmpdir(), "pracht-content-runtime-"));
     const input = join(temporaryDirectory, "entry.ts");
@@ -405,6 +423,29 @@ describe("prachtContent", () => {
     // A root outside Vite's own project root emits no events until it is
     // watched explicitly, which would serve stale content for the session.
     expect(add).toHaveBeenCalledWith(temporaryDirectory);
+  });
+
+  it("does not reuse split payloads across build invocations", async () => {
+    temporaryDirectory = await mkdtemp(join(tmpdir(), "pracht-content-vite-"));
+    const source = join(temporaryDirectory, "page.md");
+    await writeFile(source, "First");
+    const collection = defineCollection({ name: "docs", root: temporaryDirectory });
+    const [plugin] = prachtContent({ collections: [collection] });
+    const buildStart = hookHandler(plugin.buildStart!);
+    const load = hookHandler(plugin.load);
+
+    await buildStart.call({} as never, {} as never);
+    const firstModule = await load.call({} as never, "\0virtual:pracht/content/docs");
+    expect(await loadedPayload(plugin, payloadModuleIds(firstModule)[0])).toMatchObject({
+      body: "First",
+    });
+
+    await writeFile(source, "Second build");
+    await buildStart.call({} as never, {} as never);
+    const secondModule = await load.call({} as never, "\0virtual:pracht/content/docs");
+    expect(await loadedPayload(plugin, payloadModuleIds(secondModule)[0])).toMatchObject({
+      body: "Second build",
+    });
   });
 
   it("keeps deferred document payloads out of the chunk that imports a snapshot", async () => {

--- a/packages/content/test/vite.test.ts
+++ b/packages/content/test/vite.test.ts
@@ -448,7 +448,7 @@ describe("prachtContent", () => {
     });
   });
 
-  it("keeps deferred document payloads out of the chunk that imports a snapshot", async () => {
+  it("keeps deferred document payloads out of a webworker server entry", async () => {
     temporaryDirectory = await mkdtemp(join(tmpdir(), "pracht-content-vite-"));
     const output = join(temporaryDirectory, "dist");
     await writeFile(join(temporaryDirectory, "one.md"), "First document");
@@ -464,13 +464,11 @@ describe("prachtContent", () => {
           "@pracht/content/runtime": fileURLToPath(new URL("../src/runtime.ts", import.meta.url)),
         },
       },
+      ssr: { noExternal: true, target: "webworker" },
       build: {
         outDir: output,
         ssr: true,
-        rollupOptions: {
-          input: "virtual:pracht/content/docs",
-          output: { codeSplitting: true },
-        },
+        rollupOptions: { input: "virtual:pracht/content/docs" },
       },
     });
 

--- a/packages/start/src/index.js
+++ b/packages/start/src/index.js
@@ -1298,6 +1298,11 @@ function createWranglerConfig(projectName) {
     // validates every named export of the deployed entry module and rejects the
     // build metadata (buildTarget, manifests, ...) server.js also exports.
     '  "main": "dist/server/worker.js",',
+    // Pracht's Vite build is the authoritative bundle and may contain lazy
+    // server chunks. A second Wrangler bundle would inline them again; the
+    // module rule makes Wrangler upload those chunks next to the entry.
+    '  "no_bundle": true,',
+    '  "rules": [{ "type": "ESModule", "globs": ["**/*.js", "**/*.mjs"] }],',
     `  "compatibility_date": ${JSON.stringify(compatibilityDate)},`,
     '  "assets": {',
     '    "binding": "ASSETS",',

--- a/packages/start/test/index.test.js
+++ b/packages/start/test/index.test.js
@@ -202,6 +202,9 @@ describe("create-pracht", () => {
     // exports, so the deployed entry has to be the wrapper `pracht build` emits.
     expect(wranglerConfig).toContain('"main": "dist/server/worker.js"');
     expect(wranglerConfig).not.toContain('"main": "dist/server/server.js"');
+    expect(wranglerConfig).toContain('"no_bundle": true');
+    expect(wranglerConfig).toContain('"type": "ESModule"');
+    expect(wranglerConfig).toContain('"**/*.js"');
     expect(existsSync(join(targetDir, "wrangler.jsonc"))).toBe(true);
     expect(existsSync(join(targetDir, "Dockerfile"))).toBe(false);
     expect(existsSync(join(targetDir, ".dockerignore"))).toBe(false);

--- a/skills/pracht-deploy/SKILL.md
+++ b/skills/pracht-deploy/SKILL.md
@@ -133,7 +133,7 @@ pracht build
 npx wrangler deploy
 ```
 
-To smoke-test the built worker locally first, run `pracht preview` — it builds and then delegates to `wrangler dev`, which serves the wrangler config's `main` entry, `dist/server/worker.js`.
+To smoke-test the built worker locally first, run `pracht preview` — it builds and then delegates to `wrangler dev`, which serves the wrangler config's `main` entry, `dist/server/worker.js`. Keep `no_bundle: true` and the JavaScript `ESModule` rule: Pracht's Vite output is already bundled and can contain lazy server chunks that Wrangler must upload separately.
 
 Wrangler owns the Worker's binding environment. Put local-only secrets such as
 `PRACHT_CONFIRMATION_SECRET` and `PRACHT_REVALIDATE_TOKEN` in a gitignored
@@ -151,8 +151,10 @@ pracht build
 npx wrangler dev --config wrangler.local.jsonc --port 3000
 ```
 
-The local config must keep `main: "dist/server/worker.js"` and omit the
-production route. `pracht preview` does not forward Wrangler's `--config` flag.
+The local config must keep `main: "dist/server/worker.js"`, keep
+`no_bundle: true`, include the JavaScript `ESModule` rule, and omit the
+production route. `pracht preview` does not forward Wrangler's `--config`
+flag.
 
 ### Wrangler Configuration
 
@@ -161,6 +163,8 @@ production route. `pracht preview` does not forward Wrangler's `--config` flag.
 {
   "name": "my-pracht-app",
   "main": "dist/server/worker.js",
+  "no_bundle": true,
+  "rules": [{ "type": "ESModule", "globs": ["**/*.js", "**/*.mjs"] }],
   "compatibility_date": "2026-04-06",
   "assets": {
     "binding": "ASSETS",
@@ -170,7 +174,7 @@ production route. `pracht preview` does not forward Wrangler's `--config` flag.
 }
 ```
 
-`"binding": "ASSETS"` and `"run_worker_first": true` are required. Without the binding, the worker's `env.ASSETS` resolves to nothing and the runtime silently falls back to `null` — headers and ISG manifests load empty, so SSG serving, ISG revalidation, and per-route headers all silently no-op. The canonical config lives at `examples/cloudflare/wrangler.jsonc`. If you rename the binding with `assetsBinding` (below), the wrangler `binding` value must match.
+`"no_bundle": true`, the JavaScript `ESModule` rule, `"binding": "ASSETS"`, and `"run_worker_first": true` are required. Without the first two settings, Wrangler either re-bundles Pracht's Vite output and folds lazy server chunks into the entry or omits those chunks from the upload. Without the binding, the worker's `env.ASSETS` resolves to nothing and the runtime silently falls back to `null` — headers and ISG manifests load empty, so SSG serving, ISG revalidation, and per-route headers all silently no-op. The canonical config lives at `examples/cloudflare/wrangler.jsonc`. If you rename the binding with `assetsBinding` (below), the wrangler `binding` value must match.
 
 ### Bindings (KV, D1, R2)
 

--- a/skills/pre-deploy/SKILL.md
+++ b/skills/pre-deploy/SKILL.md
@@ -98,6 +98,10 @@ a markdown summary (graph diff + verify + budgets) worth attaching to it.
   validates every named export of the deploy entry and rejects the build
   metadata (`buildTarget`, manifests, `resolvedApp`, ...) that `server.js`
   exports for the prerender pass.
+- `no_bundle` is `true`, with an `ESModule` rule whose globs include
+  `"**/*.js"`. Pracht's Vite output is already bundled and may contain lazy
+  server chunks; these settings make Wrangler upload the chunks as separate
+  modules instead of folding them into the entry file.
 - `assets.directory` points to `dist/client`.
 - `compatibility_date` is set, and is a date the installed workerd supports.
   It must not be *newer* than the runtime: workerd refuses to start with
@@ -128,8 +132,10 @@ a markdown summary (graph diff + verify + budgets) worth attaching to it.
   gateway with a normalized `cf.cacheKey`; also check that markdown-capable
   routes normalize `Accept` at the gateway when variant fan-out matters.
 - Bundle size: measure what actually deploys — `dist/server/worker.js` plus
-  its `dist/server/server.js` import (wrangler bundles the import graph of
-  `main`; `worker.js` alone is a few lines). Workers limit is ~1 MB
+  its `dist/server/server.js` import and lazy chunks (`no_bundle: true` plus
+  the JavaScript `ESModule` rule uploads the pre-built module graph;
+  `worker.js` alone is a few lines).
+  Workers limit is ~1 MB
   compressed for free tier, ~10 MB on paid. Warn at 80% of the active limit.
 
 ### Vercel (`@pracht/adapter-vercel`)


### PR DESCRIPTION
## Summary

A generated collection snapshot embedded every document's `compiled`, `body`, and `raw`. That module is imported by loaders, and the bundler hoists a module shared by several route modules into a chunk those routes all load — so the whole collection was parsed by the first request to reach *any* content-backed route, including the not-found handler.

This defers those three representations to a per-document chunk, loaded when the document is resolved.

Measured on [preactjs.com](https://github.com/preactjs/preact-www) (410 documents × 11 locales) by recording every `dist/server/**` module Node actually loads while serving one request:

| | before | after |
|---|---:|---:|
| shared `site-*.js` chunk | 20,335,623 B | **160,738 B** |
| JS parsed to serve one 404 | 20,600,308 B | **426,262 B** |
| server chunks | 40 | 450 |
| `dist/server` on disk | 21 MB | 21 MB |

Bytes on disk are unchanged — it is the same serverless function either way. What changes is that 20 MB is no longer parsed on every cold start.

### Not a breaking change

The snapshot index keeps everything lookup needs (ids, routes, locales, frontmatter, source paths), so resolution never blocks on a chunk it has not loaded. Every accessor that hands out a document was already asynchronous and now awaits that document's payload, so `document.compiled` is still populated and no application code changes.

- `iterate()` loads one document at a time — what a large collection should stream.
- `all()` loads the collection.
- `ownsSource()` stays synchronous.
- Malformed documents are still rejected while the snapshot module is generated, with the same `documents[n].compiled…` diagnostic path, rather than when the page that happens to use them is first rendered.
- Dev invalidation covers the payload modules as well as the snapshot; leaving them behind would serve compiled output captured before the edit.

### Types

`ContentSnapshotDocument` (the wire format) gains optional `compiled` and a `load` loader. `ContentRuntimeDocument` — what the public API returns — is decoupled from it and keeps `compiled` required, so no consumer's types change.

## Testing

- [x] `pnpm run verify` (build, format, lint, typecheck, test, e2e)

New coverage: a real SSR build asserting the entry chunk contains the index and none of the document text, that the deferred chunks are emitted, and that the collection still resolves through them. Existing dev-invalidation and snapshot-shape tests updated for the split.

## Checklist

- [x] Docs updated if needed — `docs/CONTENT.md`, new "Deferred document payloads" section
- [x] Skills updated if needed — N/A
- [x] Changeset added if published packages changed