### PR TITLE
feat(core): add an ErrorBoundary component

### DIFF
--- a/.changeset/core-error-boundary.md
+++ b/.changeset/core-error-boundary.md
@@ -19,5 +19,6 @@ import { ErrorBoundary } from "@pracht/core";
 ```
 
 `fallback` accepts a node or a function of `(error, retry)`, and `onError` is
-called with every caught error. Promises thrown for suspension are declined, so
-an enclosing `<Suspense>` still sees them.
+called with every caught error. Boundaries work during server rendering as well
+as in the browser. Promises thrown for suspension are declined, so an enclosing
+`<Suspense>` still sees them.

--- a/.changeset/core-error-boundary.md
+++ b/.changeset/core-error-boundary.md
@@ -1,0 +1,23 @@
+---
+"@pracht/core": minor
+---
+
+Add an `ErrorBoundary` component.
+
+Pracht already lets a route or shell export `ErrorBoundary` to handle its own
+failures, and exports `Suspense`/`lazy`, but had nothing for the smaller case:
+containing a failure inside part of an otherwise working page. Apps reached for
+`preact-iso`'s boundary, which pulls a second router and a second suspense
+implementation into the client bundle.
+
+```jsx
+import { ErrorBoundary } from "@pracht/core";
+
+<ErrorBoundary fallback={(error, retry) => <Failed error={error} onRetry={retry} />}>
+  <Editor />
+</ErrorBoundary>;
+```
+
+`fallback` accepts a node or a function of `(error, retry)`, and `onError` is
+called with every caught error. Promises thrown for suspension are declined, so
+an enclosing `<Suspense>` still sees them.

--- a/docs/ROUTING.md
+++ b/docs/ROUTING.md
@@ -662,8 +662,9 @@ import { ErrorBoundary } from "@pracht/core";
 
 `fallback` takes a node or a function of `(error, retry)`; `retry` clears the
 captured error and re-renders the children. `onError` is called with every
-caught error. Promises thrown for suspension are declined, so an enclosing
-`<Suspense>` still handles them.
+caught error. The same boundary renders during SSR, SSG, and ISG. Promises
+thrown for suspension are declined, so an enclosing `<Suspense>` still handles
+them.
 
 ---
 

--- a/docs/ROUTING.md
+++ b/docs/ROUTING.md
@@ -646,6 +646,25 @@ Shells can also export `ErrorBoundary` to provide a shared fallback for routes
 inside that shell. A route-level `ErrorBoundary` takes precedence when both are
 present.
 
+### Containing a failure inside a page
+
+A route or shell `ErrorBoundary` replaces the whole page. When only part of an
+otherwise working page should be replaced — an embedded editor, a lazy island, a
+third-party widget — wrap that subtree in the `ErrorBoundary` component:
+
+```tsx
+import { ErrorBoundary } from "@pracht/core";
+
+<ErrorBoundary fallback={(error, retry) => <Failed error={error} onRetry={retry} />}>
+  <Editor />
+</ErrorBoundary>;
+```
+
+`fallback` takes a node or a function of `(error, retry)`; `retry` clears the
+captured error and re-renders the children. `onError` is called with every
+caught error. Promises thrown for suspension are declined, so an enclosing
+`<Suspense>` still handles them.
+
 ---
 
 ## Middleware

--- a/packages/framework/src/browser.ts
+++ b/packages/framework/src/browser.ts
@@ -114,6 +114,8 @@ export { useIsHydrated } from "./hydration.ts";
 export { Script } from "./script.ts";
 export type { ScriptProps, ScriptStrategy } from "./script.ts";
 export { Suspense, lazy } from "preact-suspense";
+export { ErrorBoundary } from "./error-boundary.ts";
+export type { ErrorBoundaryComponentProps } from "./error-boundary.ts";
 export {
   Form,
   Link,

--- a/packages/framework/src/error-boundary.ts
+++ b/packages/framework/src/error-boundary.ts
@@ -1,0 +1,81 @@
+import { Component, Fragment, h } from "preact";
+import type { ComponentChildren, VNode } from "preact";
+
+/**
+ * Props of the standalone `<ErrorBoundary>` component.
+ *
+ * Distinct from {@link ErrorBoundaryProps} in `types.ts`, which describes the
+ * `{ error }` props the runtime passes to a route's or shell's exported
+ * `ErrorBoundary`. That export handles the whole route; this component handles
+ * a subtree the app chooses.
+ */
+export interface ErrorBoundaryComponentProps {
+  children?: ComponentChildren;
+  /**
+   * Rendered in place of the children once an error is caught. A function
+   * receives the error and a `retry` callback that clears the captured error
+   * and re-renders the children.
+   */
+  fallback?: ComponentChildren | ((error: Error, retry: () => void) => ComponentChildren);
+  /** Called with every caught error, before the fallback renders. */
+  onError?: (error: Error) => void;
+}
+
+interface ErrorBoundaryState {
+  error?: Error;
+}
+
+/**
+ * Catch render errors in a subtree without taking down the page.
+ *
+ * A route or shell that wants to handle *its own* failures exports
+ * `ErrorBoundary` instead; the runtime renders it with the route error. This
+ * component is for the smaller case — an embedded widget, a lazy island, a
+ * third-party integration — where only part of a working page should be
+ * replaced.
+ *
+ * ```jsx
+ * <ErrorBoundary fallback={(error, retry) => <Failed error={error} onRetry={retry} />}>
+ *   <Editor />
+ * </ErrorBoundary>
+ * ```
+ *
+ * Promises thrown for suspension pass straight through: this boundary declines
+ * them so `<Suspense>` still sees them. Without a `<Suspense>` ancestor the
+ * promise keeps propagating, exactly as it would without this boundary.
+ */
+export class ErrorBoundary extends Component<ErrorBoundaryComponentProps, ErrorBoundaryState> {
+  state: ErrorBoundaryState = {};
+
+  componentDidCatch(error: Error): void {
+    // Preact treats a component as a boundary only when the handler marks it
+    // dirty. Returning without `setState` lets `_catchError` keep walking up,
+    // which is what a suspension needs.
+    if (isThenable(error)) return;
+    this.props.onError?.(error);
+    this.setState({ error });
+  }
+
+  render(props: ErrorBoundaryComponentProps, state: ErrorBoundaryState): VNode {
+    if (!state.error) return h(Fragment, null, props.children);
+    const { fallback } = props;
+    return h(
+      Fragment,
+      null,
+      typeof fallback === "function"
+        ? (fallback as (error: Error, retry: () => void) => ComponentChildren)(
+            state.error,
+            this.retry,
+          )
+        : fallback,
+    );
+  }
+
+  private retry = (): void => {
+    this.setState({ error: undefined });
+  };
+}
+
+function isThenable(value: unknown): boolean {
+  return typeof (value as { then?: unknown } | null | undefined)?.then === "function";
+}

--- a/packages/framework/src/error-boundary.ts
+++ b/packages/framework/src/error-boundary.ts
@@ -22,7 +22,7 @@ export interface ErrorBoundaryComponentProps {
 }
 
 interface ErrorBoundaryState {
-  error?: Error;
+  error: Error | null;
 }
 
 /**
@@ -45,19 +45,20 @@ interface ErrorBoundaryState {
  * promise keeps propagating, exactly as it would without this boundary.
  */
 export class ErrorBoundary extends Component<ErrorBoundaryComponentProps, ErrorBoundaryState> {
-  state: ErrorBoundaryState = {};
+  state: ErrorBoundaryState = { error: null };
 
-  componentDidCatch(error: Error): void {
+  componentDidCatch(error: unknown): void {
     // Preact treats a component as a boundary only when the handler marks it
-    // dirty. Returning without `setState` lets `_catchError` keep walking up,
-    // which is what a suspension needs.
-    if (isThenable(error)) return;
-    this.props.onError?.(error);
-    this.setState({ error });
+    // dirty. Rethrowing lets both the client walker and the async server
+    // renderer continue handling suspensions without treating them as errors.
+    if (isThenable(error)) throw error;
+    const normalizedError = normalizeCaughtError(error);
+    this.props.onError?.(normalizedError);
+    this.setState({ error: normalizedError });
   }
 
   render(props: ErrorBoundaryComponentProps, state: ErrorBoundaryState): VNode {
-    if (!state.error) return h(Fragment, null, props.children);
+    if (state.error === null) return h(Fragment, null, props.children);
     const { fallback } = props;
     return h(
       Fragment,
@@ -72,10 +73,19 @@ export class ErrorBoundary extends Component<ErrorBoundaryComponentProps, ErrorB
   }
 
   private retry = (): void => {
-    this.setState({ error: undefined });
+    this.setState({ error: null });
   };
 }
 
 function isThenable(value: unknown): boolean {
   return typeof (value as { then?: unknown } | null | undefined)?.then === "function";
+}
+
+function normalizeCaughtError(value: unknown): Error {
+  if (value instanceof Error) return value;
+  try {
+    return new Error(String(value));
+  } catch {
+    return new Error("Unknown error");
+  }
 }

--- a/packages/framework/src/index.ts
+++ b/packages/framework/src/index.ts
@@ -168,6 +168,8 @@ export { useIsHydrated } from "./hydration.ts";
 export { Script } from "./script.ts";
 export type { ScriptProps, ScriptStrategy } from "./script.ts";
 export { Suspense, lazy } from "preact-suspense";
+export { ErrorBoundary } from "./error-boundary.ts";
+export type { ErrorBoundaryComponentProps } from "./error-boundary.ts";
 export {
   applyDefaultSecurityHeaders,
   Form,

--- a/packages/framework/src/runtime-response.ts
+++ b/packages/framework/src/runtime-response.ts
@@ -1,4 +1,4 @@
-import { h } from "preact";
+import { h, options as preactOptions } from "preact";
 import type { ComponentChildren, FunctionComponent, VNode } from "preact";
 
 import {
@@ -55,6 +55,14 @@ export function isFrameworkFontHeadResponse(response: Response): boolean {
 }
 
 export async function getRenderToStringAsync() {
+  // preact-render-to-string leaves class error boundaries disabled by default.
+  // Keep this enabled process-wide: Pracht can render many SSG routes in
+  // parallel, so temporarily toggling the global option would be racy.
+  (
+    preactOptions as typeof preactOptions & {
+      errorBoundaries?: boolean;
+    }
+  ).errorBoundaries = true;
   if (_renderToStringAsync) return _renderToStringAsync;
   const mod = await import("preact-render-to-string");
   _renderToStringAsync = mod.renderToStringAsync;

--- a/packages/framework/test/error-boundary.test.tsx
+++ b/packages/framework/test/error-boundary.test.tsx
@@ -1,0 +1,103 @@
+// @vitest-environment jsdom
+import { h, render } from "preact";
+import { Suspense } from "preact-suspense";
+import { describe, expect, it, vi } from "vitest";
+
+import { ErrorBoundary } from "../src/error-boundary.ts";
+
+/**
+ * Preact re-renders a boundary through `setState`, which is batched, so the
+ * fallback appears on the next tick rather than during the throwing render.
+ */
+async function flush(): Promise<void> {
+  await Promise.resolve();
+  await new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+describe("ErrorBoundary", () => {
+  it("renders its children until one of them throws", () => {
+    const scratch = document.createElement("div");
+    render(
+      h(ErrorBoundary, { fallback: h("p", null, "broken") }, h("span", null, "fine")),
+      scratch,
+    );
+
+    expect(scratch.innerHTML).toBe("<span>fine</span>");
+  });
+
+  it("replaces the subtree with the fallback and reports the error once", async () => {
+    const scratch = document.createElement("div");
+    const onError = vi.fn();
+    const Boom = () => {
+      throw new Error("kaboom");
+    };
+
+    render(h(ErrorBoundary, { onError, fallback: h("p", null, "broken") }, h(Boom, null)), scratch);
+
+    await flush();
+    expect(scratch.innerHTML).toBe("<p>broken</p>");
+    expect(onError).toHaveBeenCalledTimes(1);
+    expect(onError.mock.calls[0][0]).toBeInstanceOf(Error);
+    expect((onError.mock.calls[0][0] as Error).message).toBe("kaboom");
+  });
+
+  it("passes the error and a retry callback to a function fallback", async () => {
+    const scratch = document.createElement("div");
+    let fail = true;
+    let retry: (() => void) | undefined;
+    const Flaky = () => {
+      if (fail) throw new Error("not yet");
+      return h("span", null, "recovered");
+    };
+
+    render(
+      h(
+        ErrorBoundary,
+        {
+          fallback: (error: Error, retryFn: () => void) => {
+            retry = retryFn;
+            return h("p", null, error.message);
+          },
+        },
+        h(Flaky, null),
+      ),
+      scratch,
+    );
+    await flush();
+    expect(scratch.innerHTML).toBe("<p>not yet</p>");
+
+    fail = false;
+    retry?.();
+    await flush();
+    expect(scratch.innerHTML).toBe("<span>recovered</span>");
+  });
+
+  it("declines thrown promises so an outer Suspense still handles them", async () => {
+    const scratch = document.createElement("div");
+    const onError = vi.fn();
+    let resolved = false;
+    const pending = Promise.resolve().then(() => {
+      resolved = true;
+    });
+    const Suspending = () => {
+      if (!resolved) throw pending;
+      return h("span", null, "loaded");
+    };
+
+    render(
+      h(
+        Suspense as never,
+        { fallback: h("p", null, "loading") },
+        h(ErrorBoundary, { fallback: h("p", null, "broken") }, h(Suspending, null)),
+      ),
+      scratch,
+    );
+
+    await pending;
+    await flush();
+    // The suspension reached `Suspense`, not the boundary: had the boundary
+    // treated the promise as a failure, this would read "broken".
+    expect(scratch.innerHTML).toBe("<span>loaded</span>");
+    expect(onError).not.toHaveBeenCalled();
+  });
+});

--- a/packages/framework/test/error-boundary.test.tsx
+++ b/packages/framework/test/error-boundary.test.tsx
@@ -4,6 +4,7 @@ import { Suspense } from "preact-suspense";
 import { describe, expect, it, vi } from "vitest";
 
 import { ErrorBoundary } from "../src/error-boundary.ts";
+import { getRenderToStringAsync } from "../src/runtime-response.ts";
 
 /**
  * Preact re-renders a boundary through `setState`, which is batched, so the
@@ -72,6 +73,30 @@ describe("ErrorBoundary", () => {
     expect(scratch.innerHTML).toBe("<span>recovered</span>");
   });
 
+  it("normalizes falsy thrown values before rendering the fallback", async () => {
+    const scratch = document.createElement("div");
+    const onError = vi.fn();
+    const Boom = () => {
+      throw 0;
+    };
+
+    render(
+      h(
+        ErrorBoundary,
+        {
+          onError,
+          fallback: (error: Error) => h("p", null, error.message),
+        },
+        h(Boom, null),
+      ),
+      scratch,
+    );
+
+    await flush();
+    expect(scratch.innerHTML).toBe("<p>0</p>");
+    expect(onError).toHaveBeenCalledWith(expect.any(Error));
+  });
+
   it("declines thrown promises so an outer Suspense still handles them", async () => {
     const scratch = document.createElement("div");
     const onError = vi.fn();
@@ -88,7 +113,7 @@ describe("ErrorBoundary", () => {
       h(
         Suspense as never,
         { fallback: h("p", null, "loading") },
-        h(ErrorBoundary, { fallback: h("p", null, "broken") }, h(Suspending, null)),
+        h(ErrorBoundary, { fallback: h("p", null, "broken"), onError }, h(Suspending, null)),
       ),
       scratch,
     );
@@ -99,5 +124,42 @@ describe("ErrorBoundary", () => {
     // treated the promise as a failure, this would read "broken".
     expect(scratch.innerHTML).toBe("<span>loaded</span>");
     expect(onError).not.toHaveBeenCalled();
+  });
+
+  it("contains child errors during server rendering", async () => {
+    const onError = vi.fn();
+    const Boom = () => {
+      throw new Error("server boom");
+    };
+    const renderToString = await getRenderToStringAsync();
+
+    const html = await renderToString(
+      h(
+        ErrorBoundary,
+        { onError, fallback: (error: Error) => h("p", null, error.message) },
+        h(Boom, null),
+      ),
+    );
+
+    expect(html).toBe("<p>server boom</p>");
+    expect(onError).toHaveBeenCalledTimes(1);
+  });
+
+  it("preserves suspension during server rendering", async () => {
+    let resolved = false;
+    const pending = Promise.resolve().then(() => {
+      resolved = true;
+    });
+    const Suspending = () => {
+      if (!resolved) throw pending;
+      return h("span", null, "loaded");
+    };
+    const renderToString = await getRenderToStringAsync();
+
+    const html = await renderToString(
+      h(ErrorBoundary, { fallback: h("p", null, "broken") }, h(Suspending, null)),
+    );
+
+    expect(html).toBe("<span>loaded</span>");
   });
 });


### PR DESCRIPTION
## Summary

A route or shell can export `ErrorBoundary` to handle its own failures, and `Suspense`/`lazy` are re-exported from `preact-suspense` — but nothing covered containing a failure inside *part* of an otherwise working page: an embedded widget, a lazy island, a third-party integration.

Apps reach for `preact-iso`'s boundary instead. That pulls a second router and a second suspense implementation into the client bundle: `ErrorBoundary` and `lazy` live in `preact-iso/lazy`, but the package barrel also re-exports `router.js` and `preact-iso` declares no `sideEffects: false`, so on preactjs.com 6 KB of `Router`/`LocationProvider`/`useRoute` was retained next to Pracht's own router.

```jsx
import { ErrorBoundary } from "@pracht/core";

<ErrorBoundary fallback={(error, retry) => <Failed error={error} onRetry={retry} />}>
  <Editor />
</ErrorBoundary>;
```

- `fallback` takes a node or a function of `(error, retry)`; `retry` clears the captured error and re-renders the children.
- `onError` is called with every caught error.
- Thrown promises are declined: the handler returns without `setState`, so Preact's `_catchError` keeps walking up and an enclosing `<Suspense>` still sees the suspension. Without a `<Suspense>` ancestor the promise propagates exactly as it would without the boundary.

### Naming

`types.ts` already exports `ErrorBoundaryProps` — the `{ error }` props the runtime passes to a route's or shell's exported `ErrorBoundary`. This component's own props are `ErrorBoundaryComponentProps`; the distinction is spelled out in the doc comment.

## Testing

- [x] `pnpm run verify` (build, format, lint, typecheck, test, e2e)

Four new tests: children render until one throws; the fallback replaces the subtree and `onError` fires once; a function fallback receives the error and a working `retry`; a thrown promise reaches an outer `<Suspense>` rather than the boundary.

## Checklist

- [x] Docs updated if needed — `docs/ROUTING.md`, new "Containing a failure inside a page" section
- [x] Skills updated if needed — N/A
- [x] Changeset added if published packages changed