### PR TITLE
feat(core): add link speculation exclusions

### DIFF
--- a/.changeset/speculation-link-exclusions.md
+++ b/.changeset/speculation-link-exclusions.md
@@ -5,11 +5,13 @@
 Speculation rules now exclude individual links. Every emitted rule carries a
 `not: { selector_matches }` clause covering `rel="nofollow"` anchors and the new
 cascading `data-pracht-speculate` attribute — set `"off"` on any element to opt
-its subtree out, `"on"` to re-enable part of it. `<Link speculate={false}>`
+its subtree out, or `"on"` on an anchor to re-enable that link. Container
+opt-outs stay fail-closed at every nesting depth. `<Link speculate={false}>`
 renders the attribute for typed links.
 
 Excluded anchors keep the ordinary SPA path: the JS `prefetch` strategy still
 applies to them, and the client router intercepts their clicks rather than
 waiting for a prerendered document that will never exist. Browser and client
 matching stay aligned for case-insensitive `nofollow` tokens and reactive
-changes to exclusion attributes.
+changes to exclusion attributes. Because JS prefetch is independent, links
+with side effects should also set `prefetch="none"`.

--- a/.changeset/speculation-link-exclusions.md
+++ b/.changeset/speculation-link-exclusions.md
@@ -1,0 +1,15 @@
+---
+"@pracht/core": minor
+---
+
+Speculation rules now exclude individual links. Every emitted rule carries a
+`not: { selector_matches }` clause covering `rel="nofollow"` anchors and the new
+cascading `data-pracht-speculate` attribute — set `"off"` on any element to opt
+its subtree out, `"on"` to re-enable part of it. `<Link speculate={false}>`
+renders the attribute for typed links.
+
+Excluded anchors keep the ordinary SPA path: the JS `prefetch` strategy still
+applies to them, and the client router intercepts their clicks rather than
+waiting for a prerendered document that will never exist. Browser and client
+matching stay aligned for case-insensitive `nofollow` tokens and reactive
+changes to exclusion attributes.

--- a/.changeset/speculation-link-exclusions.md
+++ b/.changeset/speculation-link-exclusions.md
@@ -13,5 +13,6 @@ Excluded anchors keep the ordinary SPA path: the JS `prefetch` strategy still
 applies to them, and the client router intercepts their clicks rather than
 waiting for a prerendered document that will never exist. Browser and client
 matching stay aligned for case-insensitive `nofollow` tokens and reactive
-changes to exclusion attributes. Because JS prefetch is independent, links
-with side effects should also set `prefetch="none"`.
+changes to exclusion attributes anywhere in the document, including `<html>`.
+Because JS prefetch is independent, links with side effects should also set
+`prefetch="none"`.

--- a/.changeset/speculation-link-exclusions.md
+++ b/.changeset/speculation-link-exclusions.md
@@ -3,11 +3,11 @@
 ---
 
 Speculation rules now exclude individual links. Every emitted rule carries a
-`not: { selector_matches }` clause covering `rel="nofollow"` anchors and the new
-cascading `data-pracht-speculate` attribute — set `"off"` on any element to opt
-its subtree out, or `"on"` on an anchor to re-enable that link. Container
-opt-outs stay fail-closed at every nesting depth. `<Link speculate={false}>`
-renders the attribute for typed links.
+`not: { selector_matches }` clause covering `rel="nofollow"` anchors and
+image-map areas plus the new cascading `data-pracht-speculate` attribute — set
+`"off"` on any element to opt its subtree out, or `"on"` on a link to re-enable
+it. Container opt-outs stay fail-closed at every nesting depth.
+`<Link speculate={false}>` renders the attribute for typed links.
 
 Excluded anchors keep the ordinary SPA path: the JS `prefetch` strategy still
 applies to them, and the client router intercepts their clicks rather than

--- a/VISION_MVP.md
+++ b/VISION_MVP.md
@@ -109,7 +109,7 @@ core framework conventions. See
 - **Client hooks**: `useRouteData()`, `useRevalidate()`, `useNavigation()` (pending
   navigation/submission state for progress bars and optimistic UI), `useNavigate()`,
   `useLocation()`, `useSearchParams()`, `useParams()`, `<Form>` component, `<Link>`
-  (with `prefetch`, `preserveScroll`, `viewTransition` props), and imperative
+  (with `prefetch`, `preserveScroll`, `viewTransition`, `speculate` props), and imperative
   `prefetch()`.
 
 ### API Routes

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -509,8 +509,11 @@ router.ts       — client router, hydration bootstrap (imports runtime-context 
 navigation-state.ts — shared useNavigation() store written by router.ts and <Form> (no internal deps)
 scroll-restoration.ts — sessionStorage-backed per-history-entry scroll position store (no internal deps)
 runtime-speculation.ts — builds the `<script type="speculationrules">` payload from
-                         opted-in routes; consumed by runtime-html.ts (server) and
-                         router.ts / prefetch.ts (browser, to skip prerender routes)
+                         opted-in routes, including the anchor-level exclusion
+                         selectors (`rel="nofollow"`, `data-pracht-speculate="off"`);
+                         consumed by runtime-html.ts (server) and router.ts /
+                         prefetch.ts (browser, to skip prerender routes — and to
+                         keep the SPA path for excluded anchors)
 
 hydration.ts    — Preact options hooks for tracking hydration (no internal deps)
 href.ts         — createHref helper layered on buildHref

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -509,8 +509,9 @@ router.ts       — client router, hydration bootstrap (imports runtime-context 
 navigation-state.ts — shared useNavigation() store written by router.ts and <Form> (no internal deps)
 scroll-restoration.ts — sessionStorage-backed per-history-entry scroll position store (no internal deps)
 runtime-speculation.ts — builds the `<script type="speculationrules">` payload from
-                         opted-in routes, including the anchor-level exclusion
-                         selectors (`rel="nofollow"`, `data-pracht-speculate="off"`);
+                         opted-in routes, including the link-level exclusion
+                         selectors for anchors and image-map areas
+                         (`rel="nofollow"`, `data-pracht-speculate="off"`);
                          consumed by runtime-html.ts (server) and router.ts /
                          prefetch.ts (browser, to skip prerender routes — and to
                          keep the SPA path for excluded anchors)

--- a/docs/ROUTING.md
+++ b/docs/ROUTING.md
@@ -1069,12 +1069,12 @@ defineApp({
 
 ### Excluding individual links
 
-Rules match by URL pattern, so every anchor pointing at an opted-in route is a
-candidate. Two things take a link back out:
+Rules match by URL pattern, so every hyperlink (`<a>` or image-map `<area>`)
+pointing at an opted-in route is a candidate. Two things take a link back out:
 
 - `rel="nofollow"` — never speculated, matching the browser's own convention
   for links the page does not vouch for.
-- `data-pracht-speculate="off"` — opts an element and its subtree out. An anchor
+- `data-pracht-speculate="off"` — opts an element and its subtree out. A link
   can set `"on"` to re-enable itself; container-level `"on"` scopes do not
   override an enclosing opt-out, so exclusions remain fail-closed at any depth.
 
@@ -1091,6 +1091,10 @@ candidate. Two things take a link back out:
 ```tsx
 <Link route="logout" speculate={false} prefetch="none">Log out</Link>
 ```
+
+The browser exclusions also cover image-map `<area>` links. Those links retain
+native document navigation because Pracht's client router only intercepts
+anchors.
 
 Reach for both opt-outs on links with side effects — a GET that logs the user
 out, consumes a one-time token, or records a view. A `prerender` speculation

--- a/docs/ROUTING.md
+++ b/docs/ROUTING.md
@@ -337,12 +337,13 @@ first `pracht typegen` run when `src/pracht.d.ts` does not exist yet.
 ### `<Link>` props
 
 Beyond the typed `route`/`params`/`search`/`hash` target props, `<Link>`
-accepts three navigation-behavior props:
+accepts four navigation-behavior props:
 
 ```tsx
 <Link route="product" params={{ id }} prefetch="viewport">Product</Link>
 <Link route="inbox" preserveScroll>Refresh inbox</Link>
 <Link route="gallery" viewTransition>Gallery</Link>
+<Link route="logout" speculate={false}>Log out</Link>
 ```
 
 | Prop             | Type                                              | Behavior                                                                 |
@@ -350,6 +351,7 @@ accepts three navigation-behavior props:
 | `prefetch`       | `"none" \| "intent" \| "viewport" \| "render"`   | Per-link prefetch strategy; overrides the route-level `prefetch` meta    |
 | `preserveScroll` | `boolean`                                         | Keep the current scroll position instead of scrolling to the top        |
 | `viewTransition` | `boolean`                                         | Wrap this navigation's DOM commit in `document.startViewTransition()`   |
+| `speculate`      | `boolean`                                         | Opt this link out of / back into browser [speculation rules](#speculation-rules) |
 
 These props render as `data-pracht-*` attributes on the underlying `<a>`, so
 they also work on plain anchors if you set the attributes yourself.
@@ -1065,6 +1067,48 @@ defineApp({
 });
 ```
 
+### Excluding individual links
+
+Rules match by URL pattern, so every anchor pointing at an opted-in route is a
+candidate. Two things take a link back out:
+
+- `rel="nofollow"` — never speculated, matching the browser's own convention
+  for links the page does not vouch for.
+- `data-pracht-speculate="off"` — opts an element and its subtree out. A nested
+  `"on"` re-enables part of it, and the anchor's own attribute always wins.
+
+```html
+<!-- turn a whole section off, re-enable one link inside it -->
+<nav data-pracht-speculate="off">
+  <a href="/logout">Log out</a>
+  <a href="/inbox" data-pracht-speculate="on">Inbox</a>
+</nav>
+```
+
+`<Link>` takes the same switch as a prop:
+
+```tsx
+<Link route="logout" speculate={false}>Log out</Link>
+```
+
+Reach for this on links with side effects — a GET that logs the user out,
+consumes a one-time token, or records a view. A `prerender` speculation runs
+the destination's JS, so anything the page does on load happens whether or not
+the user ever clicks.
+
+An excluded link keeps the ordinary SPA path: the JS `prefetch` strategy still
+applies to it, and the client router still intercepts the click instead of
+waiting for a prerendered document that will never exist. To stop the JS
+prefetch too, set `prefetch="none"` — the two switches are independent.
+Reactive changes to `rel` or `data-pracht-speculate` update both the browser
+rule match and Pracht's JS viewport/render prefetch handling.
+
+> The exclusions are emitted as a `not: { selector_matches: [...] }` clause on
+> every rule. CSS selectors cannot walk ancestors, so `"nearest ancestor wins"`
+> is approximated: one `"on"` inside an `"off"` re-enables. Alternating the two
+> more than three levels deep is the first case where the browser and the
+> router disagree, and the cost is a speculation the router ignores.
+
 ### How it composes with `prefetch`
 
 `prefetch` (`"hover" | "viewport" | "intent"`) controls the framework's JS-side
@@ -1079,7 +1123,8 @@ SPA navigation completes without a network round-trip.
    the browser fills its HTTP cache with the page HTML.
 
 Routes flagged for `prerender` are excluded from JS hover-prefetch in browsers
-with speculation rules support to avoid double-fetching. In browsers that do not
+with speculation rules support to avoid double-fetching — except on anchors the
+rules exclude, which keep the JS strategy since nothing prerenders them. In browsers that do not
 support speculation rules, the normal JS prefetch and SPA navigation path remain
 active as the fallback. Set both fields explicitly when you want JS prefetch to
 keep running alongside speculation `prefetch`.
@@ -1091,7 +1136,8 @@ rules script with `'inline-speculation-rules'` in `script-src`. See
 ### Browser support
 
 Chromium-based browsers (Chrome / Edge 121+). Pracht emits **document rules**
-(`href_matches` + `eagerness`), which landed in Chrome 121 — earlier versions
+(`href_matches` + `eagerness`, plus `and`/`not`/`selector_matches` for the
+link-level exclusions), which landed in Chrome 121 — earlier versions
 only understood explicit URL-list rules and ignore this script. Firefox and
 Safari ignore it too — the JS `prefetch` strategy continues to work as the
 cross-browser fallback.

--- a/docs/ROUTING.md
+++ b/docs/ROUTING.md
@@ -343,7 +343,7 @@ accepts four navigation-behavior props:
 <Link route="product" params={{ id }} prefetch="viewport">Product</Link>
 <Link route="inbox" preserveScroll>Refresh inbox</Link>
 <Link route="gallery" viewTransition>Gallery</Link>
-<Link route="logout" speculate={false}>Log out</Link>
+<Link route="logout" speculate={false} prefetch="none">Log out</Link>
 ```
 
 | Prop             | Type                                              | Behavior                                                                 |
@@ -1074,8 +1074,9 @@ candidate. Two things take a link back out:
 
 - `rel="nofollow"` — never speculated, matching the browser's own convention
   for links the page does not vouch for.
-- `data-pracht-speculate="off"` — opts an element and its subtree out. A nested
-  `"on"` re-enables part of it, and the anchor's own attribute always wins.
+- `data-pracht-speculate="off"` — opts an element and its subtree out. An anchor
+  can set `"on"` to re-enable itself; container-level `"on"` scopes do not
+  override an enclosing opt-out, so exclusions remain fail-closed at any depth.
 
 ```html
 <!-- turn a whole section off, re-enable one link inside it -->
@@ -1088,13 +1089,13 @@ candidate. Two things take a link back out:
 `<Link>` takes the same switch as a prop:
 
 ```tsx
-<Link route="logout" speculate={false}>Log out</Link>
+<Link route="logout" speculate={false} prefetch="none">Log out</Link>
 ```
 
-Reach for this on links with side effects — a GET that logs the user out,
-consumes a one-time token, or records a view. A `prerender` speculation runs
-the destination's JS, so anything the page does on load happens whether or not
-the user ever clicks.
+Reach for both opt-outs on links with side effects — a GET that logs the user
+out, consumes a one-time token, or records a view. A `prerender` speculation
+runs the destination's JS, while the JS prefetch can run its loader or
+middleware, so either path can have effects before the user clicks.
 
 An excluded link keeps the ordinary SPA path: the JS `prefetch` strategy still
 applies to it, and the client router still intercepts the click instead of
@@ -1103,11 +1104,9 @@ prefetch too, set `prefetch="none"` — the two switches are independent.
 Reactive changes to `rel` or `data-pracht-speculate` update both the browser
 rule match and Pracht's JS viewport/render prefetch handling.
 
-> The exclusions are emitted as a `not: { selector_matches: [...] }` clause on
-> every rule. CSS selectors cannot walk ancestors, so `"nearest ancestor wins"`
-> is approximated: one `"on"` inside an `"off"` re-enables. Alternating the two
-> more than three levels deep is the first case where the browser and the
-> router disagree, and the cost is a speculation the router ignores.
+The exclusions are emitted as a `not: { selector_matches: [...] }` clause on
+every rule. Browser and client matching use the same fail-closed semantics, so
+nested scopes cannot accidentally re-enable speculation.
 
 ### How it composes with `prefetch`
 

--- a/docs/ROUTING.md
+++ b/docs/ROUTING.md
@@ -1102,7 +1102,8 @@ applies to it, and the client router still intercepts the click instead of
 waiting for a prerendered document that will never exist. To stop the JS
 prefetch too, set `prefetch="none"` — the two switches are independent.
 Reactive changes to `rel` or `data-pracht-speculate` update both the browser
-rule match and Pracht's JS viewport/render prefetch handling.
+rule match and Pracht's JS viewport/render prefetch handling, including a
+page-wide opt-out applied to the `<html>` element.
 
 The exclusions are emitted as a `not: { selector_matches: [...] }` clause on
 every rule. Browser and client matching use the same fail-closed semantics, so

--- a/e2e/basic.test.ts
+++ b/e2e/basic.test.ts
@@ -73,9 +73,14 @@ test("home page emits a speculationrules script with opted-in routes", async ({ 
   const prefetchHrefs = rules.prefetch?.flatMap((r) => r.where.and[0].href_matches) ?? [];
   expect(prefetchHrefs).toEqual(expect.arrayContaining(["/", "/pricing", "/products/:id"]));
   expect(rules.prefetch?.[0].eagerness).toBe("moderate");
-  // Anchor-level exclusions ride along on every rule.
+  // Link-level exclusions ride along on every rule.
   expect(rules.prefetch?.[0].where.and[1].not.selector_matches).toEqual(
-    expect.arrayContaining(['a[rel~="nofollow"]', 'a[data-pracht-speculate="off"]']),
+    expect.arrayContaining([
+      'a[rel~="nofollow"]',
+      'area[rel~="nofollow"]',
+      'a[data-pracht-speculate="off"]',
+      'area[data-pracht-speculate="off"]',
+    ]),
   );
 });
 
@@ -175,6 +180,68 @@ test("chrome speculates included links and skips excluded ones", async ({ page }
   await page.waitForTimeout(1500);
 
   expect(speculated).toEqual(["?spec=included"]);
+});
+
+test("chrome skips excluded image-map areas", async ({ page }) => {
+  const speculated: string[] = [];
+  page.on("request", (request) => {
+    if (request.headers()["sec-purpose"] && request.url().includes("area=")) {
+      speculated.push(new URL(request.url()).search);
+    }
+  });
+  await page.goto("/");
+
+  const included = page.waitForRequest(
+    (request) => request.url().includes("area=included") && !!request.headers()["sec-purpose"],
+  );
+  await page.evaluate(() => {
+    const emitted = document.querySelector('script[type="speculationrules"]');
+    if (!emitted?.textContent) throw new Error("Missing emitted speculation rules");
+    const rules = JSON.parse(emitted.textContent) as {
+      prefetch?: Array<{ where: { and: [unknown, { not: { selector_matches: string[] } }] } }>;
+    };
+    const exclusions = rules.prefetch?.[0].where.and[1].not.selector_matches;
+    if (!exclusions) throw new Error("Missing emitted speculation exclusions");
+
+    const map = document.createElement("map");
+    map.name = "speculation-area-map";
+    map.innerHTML = `
+      <area href="/pricing?area=included" data-e2e-area shape="rect" coords="0,0,10,10">
+      <area href="/pricing?area=nofollow" data-e2e-area rel="nofollow" shape="rect" coords="10,0,20,10">
+      <area href="/pricing?area=off" data-e2e-area data-pracht-speculate="off" shape="rect" coords="20,0,30,10">`;
+    document.body.appendChild(map);
+
+    const image = document.createElement("img");
+    image.useMap = "#speculation-area-map";
+    image.width = 30;
+    image.height = 10;
+    image.alt = "Speculation area test";
+    image.src =
+      "data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' width='30' height='10'/>";
+    document.body.appendChild(image);
+
+    const script = document.createElement("script");
+    script.type = "speculationrules";
+    script.textContent = JSON.stringify({
+      prefetch: [
+        {
+          source: "document",
+          where: {
+            and: [
+              { selector_matches: "area[data-e2e-area]" },
+              { not: { selector_matches: exclusions } },
+            ],
+          },
+          eagerness: "immediate",
+        },
+      ],
+    });
+    document.body.appendChild(script);
+  });
+
+  await included;
+  await page.waitForTimeout(1500);
+  expect(speculated).toEqual(["?area=included"]);
 });
 
 // ---------------------------------------------------------------------------

--- a/e2e/basic.test.ts
+++ b/e2e/basic.test.ts
@@ -64,14 +64,112 @@ test("home page emits a speculationrules script with opted-in routes", async ({ 
     .replace(/\\u003c/g, "<")
     .replace(/\\u003e/g, ">")
     .replace(/\\u0026/g, "&");
-  const rules = JSON.parse(decoded) as {
-    prefetch?: Array<{ where: { href_matches: string[] }; eagerness: string }>;
-    prerender?: Array<{ where: { href_matches: string[] }; eagerness: string }>;
+  type Rule = {
+    where: { and: [{ href_matches: string[] }, { not: { selector_matches: string[] } }] };
+    eagerness: string;
   };
+  const rules = JSON.parse(decoded) as { prefetch?: Rule[]; prerender?: Rule[] };
 
-  const prefetchHrefs = rules.prefetch?.flatMap((r) => r.where.href_matches) ?? [];
+  const prefetchHrefs = rules.prefetch?.flatMap((r) => r.where.and[0].href_matches) ?? [];
   expect(prefetchHrefs).toEqual(expect.arrayContaining(["/", "/pricing", "/products/:id"]));
   expect(rules.prefetch?.[0].eagerness).toBe("moderate");
+  // Anchor-level exclusions ride along on every rule.
+  expect(rules.prefetch?.[0].where.and[1].not.selector_matches).toEqual(
+    expect.arrayContaining(['a[rel~="nofollow"]', 'a[data-pracht-speculate="off"]']),
+  );
+});
+
+test("chromium accepts the speculation rules and their exclusion selectors", async ({ page }) => {
+  const messages: string[] = [];
+  page.on("console", (message) => messages.push(message.text()));
+  await page.goto("/");
+
+  const selectors = await page.evaluate(() => {
+    const script = document.querySelector('script[type="speculationrules"]');
+    if (!script?.textContent) return null;
+    const rules = JSON.parse(script.textContent) as {
+      prefetch?: Array<{ where: { and: [unknown, { not: { selector_matches: string[] } }] } }>;
+    };
+    return rules.prefetch?.[0].where.and[1].not.selector_matches ?? null;
+  });
+  expect(selectors).not.toBeNull();
+
+  // Chrome parses the rule set at load; a malformed clause or selector shows up
+  // as a console error naming speculation rules.
+  expect(messages.filter((text) => /speculation/i.test(text))).toEqual([]);
+
+  // The cascade the docs promise, evaluated by a real CSS engine.
+  const verdicts = await page.evaluate((list: string[]) => {
+    const selector = list.join(",");
+    const host = document.createElement("div");
+    host.innerHTML = `
+      <a id="plain" href="/pricing"></a>
+      <a id="nofollow" href="/pricing" rel="nofollow"></a>
+      <a id="self-off" href="/pricing" data-pracht-speculate="off"></a>
+      <nav data-pracht-speculate="off">
+        <a id="scoped-off" href="/pricing"></a>
+        <a id="scoped-on" href="/pricing" data-pracht-speculate="on"></a>
+        <div data-pracht-speculate="on"><a id="nested-on" href="/pricing"></a></div>
+      </nav>
+      <nav data-pracht-speculate="on">
+        <div data-pracht-speculate="off"><a id="nested-off" href="/pricing"></a></div>
+      </nav>`;
+    document.body.appendChild(host);
+    const read = (id: string) => document.getElementById(id)!.matches(selector);
+    const result = {
+      plain: read("plain"),
+      nofollow: read("nofollow"),
+      selfOff: read("self-off"),
+      scopedOff: read("scoped-off"),
+      scopedOn: read("scoped-on"),
+      nestedOn: read("nested-on"),
+      nestedOff: read("nested-off"),
+    };
+    host.remove();
+    return result;
+  }, selectors as string[]);
+
+  expect(verdicts).toEqual({
+    plain: false,
+    nofollow: true,
+    selfOff: true,
+    scopedOff: true,
+    scopedOn: false,
+    nestedOn: false,
+    nestedOff: true,
+  });
+});
+
+test("chrome speculates included links and skips excluded ones", async ({ page }) => {
+  const speculated: string[] = [];
+  page.on("request", (request) => {
+    if (request.headers()["sec-purpose"]) speculated.push(new URL(request.url()).search);
+  });
+  await page.goto("/");
+
+  // Document rules match the live DOM, so anchors added after load count too.
+  await page.evaluate(() => {
+    const host = document.createElement("div");
+    // Distinct query strings so each hover maps to its own prefetch entry.
+    host.innerHTML = `
+      <a id="spec-included" href="/pricing?spec=included">included</a>
+      <a id="spec-off" href="/pricing?spec=off" data-pracht-speculate="off">off</a>
+      <a id="spec-nofollow" href="/pricing?spec=nofollow" rel="nofollow">nofollow</a>`;
+    document.body.appendChild(host);
+  });
+
+  // `prefetch` speculation defaults to `moderate` eagerness — hover triggers it.
+  const prefetched = page.waitForRequest(
+    (request) => request.url().includes("spec=included") && !!request.headers()["sec-purpose"],
+  );
+  await page.locator("#spec-included").hover();
+  await prefetched;
+
+  await page.locator("#spec-off").hover();
+  await page.locator("#spec-nofollow").hover();
+  await page.waitForTimeout(1500);
+
+  expect(speculated).toEqual(["?spec=included"]);
 });
 
 // ---------------------------------------------------------------------------

--- a/e2e/basic.test.ts
+++ b/e2e/basic.test.ts
@@ -98,7 +98,7 @@ test("chromium accepts the speculation rules and their exclusion selectors", asy
   // as a console error naming speculation rules.
   expect(messages.filter((text) => /speculation/i.test(text))).toEqual([]);
 
-  // The cascade the docs promise, evaluated by a real CSS engine.
+  // The fail-closed scope semantics, evaluated by a real CSS engine.
   const verdicts = await page.evaluate((list: string[]) => {
     const selector = list.join(",");
     const host = document.createElement("div");
@@ -110,6 +110,9 @@ test("chromium accepts the speculation rules and their exclusion selectors", asy
         <a id="scoped-off" href="/pricing"></a>
         <a id="scoped-on" href="/pricing" data-pracht-speculate="on"></a>
         <div data-pracht-speculate="on"><a id="nested-on" href="/pricing"></a></div>
+        <div data-pracht-speculate="on">
+          <div data-pracht-speculate="off"><a id="alternating-off" href="/pricing"></a></div>
+        </div>
       </nav>
       <nav data-pracht-speculate="on">
         <div data-pracht-speculate="off"><a id="nested-off" href="/pricing"></a></div>
@@ -124,6 +127,7 @@ test("chromium accepts the speculation rules and their exclusion selectors", asy
       scopedOn: read("scoped-on"),
       nestedOn: read("nested-on"),
       nestedOff: read("nested-off"),
+      alternatingOff: read("alternating-off"),
     };
     host.remove();
     return result;
@@ -135,8 +139,9 @@ test("chromium accepts the speculation rules and their exclusion selectors", asy
     selfOff: true,
     scopedOff: true,
     scopedOn: false,
-    nestedOn: false,
+    nestedOn: true,
     nestedOff: true,
+    alternatingOff: true,
   });
 });
 

--- a/packages/framework/src/prefetch.ts
+++ b/packages/framework/src/prefetch.ts
@@ -254,7 +254,9 @@ export function setupPrefetching(app: ResolvedPrachtApp, warmModules?: ModuleWar
       }
     }
   });
-  mutationObserver.observe(document.body, {
+  // Observe from the document root so a page-wide opt-out on `<html>` is as
+  // reactive as one mounted anywhere inside `<body>`.
+  mutationObserver.observe(document.documentElement, {
     attributes: true,
     attributeFilter: [SPECULATE_ATTRIBUTE, "rel"],
     childList: true,

--- a/packages/framework/src/prefetch.ts
+++ b/packages/framework/src/prefetch.ts
@@ -2,8 +2,12 @@ import { stripBase } from "./base.ts";
 import { matchResolvedRoute } from "./route-matching.ts";
 import { clearPrefetchCache, getCachedRouteState, trimMapToSize } from "./prefetch-cache.ts";
 import { prefetchRouteState } from "./prefetch-api.ts";
-import { PREFETCH_ATTRIBUTE } from "./runtime-constants.ts";
-import { normalizeSpeculation, supportsSpeculationRules } from "./runtime-speculation.ts";
+import { PREFETCH_ATTRIBUTE, SPECULATE_ATTRIBUTE } from "./runtime-constants.ts";
+import {
+  isSpeculationSuppressed,
+  normalizeSpeculation,
+  supportsSpeculationRules,
+} from "./runtime-speculation.ts";
 import type { ModuleWarmFn } from "./prefetch-api.ts";
 import type {
   LinkPrefetchStrategy,
@@ -33,7 +37,8 @@ export { clearPrefetchCache, getCachedRouteState, prefetchRouteState };
 
 export function setupPrefetching(app: ResolvedPrachtApp, warmModules?: ModuleWarmFn): void {
   let hoverTimer: ReturnType<typeof setTimeout> | null = null;
-  const processedAnchors = new WeakSet<HTMLAnchorElement>();
+  const renderPrefetchedAnchors = new WeakSet<HTMLAnchorElement>();
+  const observedAnchors = new WeakSet<HTMLAnchorElement>();
   const matchCache = new Map<string, MatchCacheEntry>();
   const browserSupportsSpeculationRules = supportsSpeculationRules();
 
@@ -77,15 +82,8 @@ export function setupPrefetching(app: ResolvedPrachtApp, warmModules?: ModuleWar
     // prefetching route-state JSON or client modules for them is wasted work.
     const isFullDocumentRoute =
       match?.route.hydration === "islands" || match?.route.hydration === "none";
-    // Routes that opted into `prerender` speculation rules are handled by
-    // the browser end-to-end (full document prerender + click activation).
-    // Suppress JS prefetch for them so we don't double-fetch route state.
-    const spec = match ? normalizeSpeculation(match.route.speculation) : null;
-    const isBrowserPrerenderedRoute = browserSupportsSpeculationRules && spec?.mode === "prerender";
     const strategy: PrefetchStrategy =
-      match && !isFullDocumentRoute && !isBrowserPrerenderedRoute
-        ? (match.route.prefetch ?? "intent")
-        : "none";
+      match && !isFullDocumentRoute ? (match.route.prefetch ?? "intent") : "none";
     const entry = { match, strategy };
     matchCache.set(href, entry);
     trimMapToSize(matchCache, MAX_MATCH_CACHE_ENTRIES);
@@ -102,9 +100,14 @@ export function setupPrefetching(app: ResolvedPrachtApp, warmModules?: ModuleWar
     if (entry.match.route.hydration === "islands" || entry.match.route.hydration === "none") {
       return "none";
     }
+    // Routes that opted into `prerender` speculation rules are handled by the
+    // browser end-to-end (full document prerender + click activation), so JS
+    // prefetch would only double-fetch the route state. Anchors the rules
+    // exclude are never prerendered, so they keep the JS strategy.
     if (
       browserSupportsSpeculationRules &&
-      normalizeSpeculation(entry.match.route.speculation)?.mode === "prerender"
+      normalizeSpeculation(entry.match.route.speculation)?.mode === "prerender" &&
+      !isSpeculationSuppressed(anchor)
     ) {
       return "none";
     }
@@ -183,27 +186,42 @@ export function setupPrefetching(app: ResolvedPrachtApp, warmModules?: ModuleWar
               if (!entry.isIntersecting) continue;
               const anchor = entry.target as HTMLAnchorElement;
               const href = getInternalHref(anchor);
-              if (!href) continue;
+              if (!href || getAnchorStrategy(anchor, href) !== "viewport") {
+                observer?.unobserve(anchor);
+                observedAnchors.delete(anchor);
+                continue;
+              }
               prefetchHref(href);
               observer?.unobserve(anchor);
+              observedAnchors.delete(anchor);
             }
           },
           { rootMargin: "200px" },
         );
 
   function processAnchor(anchor: HTMLAnchorElement): void {
-    if (processedAnchors.has(anchor)) return;
     const href = getInternalHref(anchor);
-    if (!href) return;
-    const strategy = getAnchorStrategy(anchor, href);
-    if (strategy === "render") {
-      processedAnchors.add(anchor);
-      prefetchHref(href);
+    if (!href) {
+      if (observedAnchors.delete(anchor)) observer?.unobserve(anchor);
       return;
     }
-    if (strategy !== "viewport" || !observer) return;
-    processedAnchors.add(anchor);
-    observer.observe(anchor);
+    const strategy = getAnchorStrategy(anchor, href);
+    if (strategy === "render") {
+      if (observedAnchors.delete(anchor)) observer?.unobserve(anchor);
+      if (!renderPrefetchedAnchors.has(anchor)) {
+        renderPrefetchedAnchors.add(anchor);
+        prefetchHref(href);
+      }
+      return;
+    }
+    if (strategy === "viewport" && observer) {
+      if (!observedAnchors.has(anchor)) {
+        observedAnchors.add(anchor);
+        observer.observe(anchor);
+      }
+      return;
+    }
+    if (observedAnchors.delete(anchor)) observer?.unobserve(anchor);
   }
 
   function processAnchors(root: ParentNode): void {
@@ -217,9 +235,18 @@ export function setupPrefetching(app: ResolvedPrachtApp, warmModules?: ModuleWar
 
   processAnchors(document.body);
 
-  // Observe only newly-added DOM subtrees instead of re-scanning the whole document.
+  // Process newly-added subtrees and re-evaluate anchors when an exclusion
+  // changes. Browser document rules react to the same attribute mutations.
   const mutationObserver = new MutationObserver((records) => {
     for (const record of records) {
+      if (record.type === "attributes") {
+        if (record.attributeName === SPECULATE_ATTRIBUTE) {
+          processAnchors(record.target as Element);
+        } else if (record.target instanceof HTMLAnchorElement) {
+          processAnchor(record.target);
+        }
+        continue;
+      }
       for (const node of record.addedNodes) {
         if (node instanceof HTMLElement || node instanceof DocumentFragment) {
           processAnchors(node);
@@ -227,5 +254,10 @@ export function setupPrefetching(app: ResolvedPrachtApp, warmModules?: ModuleWar
       }
     }
   });
-  mutationObserver.observe(document.body, { childList: true, subtree: true });
+  mutationObserver.observe(document.body, {
+    attributes: true,
+    attributeFilter: [SPECULATE_ATTRIBUTE, "rel"],
+    childList: true,
+    subtree: true,
+  });
 }

--- a/packages/framework/src/router.ts
+++ b/packages/framework/src/router.ts
@@ -29,7 +29,11 @@ import {
   PRESERVE_SCROLL_ATTRIBUTE,
   VIEW_TRANSITION_ATTRIBUTE,
 } from "./runtime-constants.ts";
-import { normalizeSpeculation, supportsSpeculationRules } from "./runtime-speculation.ts";
+import {
+  isSpeculationSuppressed,
+  normalizeSpeculation,
+  supportsSpeculationRules,
+} from "./runtime-speculation.ts";
 import {
   createScrollPositionStore,
   generateScrollKey,
@@ -888,9 +892,11 @@ export async function initClientRouter(options: InitClientRouterOptions): Promis
     // If the destination route opted into `prerender` speculation rules, let
     // the browser perform a normal navigation so it can activate the
     // prerendered document. Intercepting here would cancel the activation
-    // and force a redundant SPA fetch of the route-state JSON.
+    // and force a redundant SPA fetch of the route-state JSON. Anchors the
+    // rules exclude (`rel="nofollow"`, `data-pracht-speculate="off"`) have no
+    // prerendered document to activate, so they stay on the SPA path.
     const targetMatch = matchResolvedRoute(app, stripBase(url.pathname) ?? url.pathname);
-    if (targetMatch && supportsSpeculationRules()) {
+    if (targetMatch && supportsSpeculationRules() && !isSpeculationSuppressed(anchor)) {
       const spec = normalizeSpeculation(targetMatch.route.speculation);
       if (spec?.mode === "prerender") return;
     }

--- a/packages/framework/src/runtime-constants.ts
+++ b/packages/framework/src/runtime-constants.ts
@@ -33,7 +33,7 @@ export const PRESERVE_SCROLL_ATTRIBUTE = "data-pracht-preserve-scroll";
 export const VIEW_TRANSITION_ATTRIBUTE = "data-pracht-view-transition";
 
 // Cascading opt-out for browser speculation rules. Set to "off" on any
-// element to exclude the anchors inside it, "on" to re-enable a subtree.
-// Read by the emitted rules (as a `selector_matches` exclusion) and by the
-// client router / prefetch listeners (via `closest()`).
+// element to exclude the anchors inside it; an anchor can set "on" to
+// explicitly re-enable itself. Read by the emitted rules (as a
+// `selector_matches` exclusion) and by the client router / prefetch listeners.
 export const SPECULATE_ATTRIBUTE = "data-pracht-speculate";

--- a/packages/framework/src/runtime-constants.ts
+++ b/packages/framework/src/runtime-constants.ts
@@ -31,3 +31,9 @@ export const NOT_FOUND_ROUTE_PATH = "(not found)";
 export const PREFETCH_ATTRIBUTE = "data-pracht-prefetch";
 export const PRESERVE_SCROLL_ATTRIBUTE = "data-pracht-preserve-scroll";
 export const VIEW_TRANSITION_ATTRIBUTE = "data-pracht-view-transition";
+
+// Cascading opt-out for browser speculation rules. Set to "off" on any
+// element to exclude the anchors inside it, "on" to re-enable a subtree.
+// Read by the emitted rules (as a `selector_matches` exclusion) and by the
+// client router / prefetch listeners (via `closest()`).
+export const SPECULATE_ATTRIBUTE = "data-pracht-speculate";

--- a/packages/framework/src/runtime-hooks.ts
+++ b/packages/framework/src/runtime-hooks.ts
@@ -23,6 +23,7 @@ import {
   PREFETCH_ATTRIBUTE,
   PRESERVE_SCROLL_ATTRIBUTE,
   SAFE_METHODS,
+  SPECULATE_ATTRIBUTE,
   VIEW_TRANSITION_ATTRIBUTE,
 } from "./runtime-constants.ts";
 import {
@@ -136,6 +137,13 @@ export type LinkProps<TRoute extends RouteId = RouteId> = Omit<
      * `document.startViewTransition()` when supported.
      */
     viewTransition?: boolean;
+    /**
+     * Opt this link out of (`false`) or back into (`true`) the browser's
+     * speculation rules, overriding any enclosing
+     * `data-pracht-speculate` scope. Set `false` on links with side effects.
+     * Independent of `prefetch`, which controls the JS route-state prefetch.
+     */
+    speculate?: boolean;
   };
 
 const validatedNativeSubmissions = new WeakSet<HTMLFormElement>();
@@ -231,13 +239,23 @@ export function Link<TRoute extends RouteId>(props: LinkProps<TRoute>) {
     throw new Error("<Link route=...> must render inside a pracht route tree.");
   }
 
-  const { route, params, search, hash, prefetch, preserveScroll, viewTransition, ...anchorProps } =
-    props as unknown as Omit<JSX.HTMLAttributes<HTMLAnchorElement>, "href"> &
-      UntypedRouteTarget & {
-        prefetch?: LinkPrefetchStrategy;
-        preserveScroll?: boolean;
-        viewTransition?: boolean;
-      };
+  const {
+    route,
+    params,
+    search,
+    hash,
+    prefetch,
+    preserveScroll,
+    viewTransition,
+    speculate,
+    ...anchorProps
+  } = props as unknown as Omit<JSX.HTMLAttributes<HTMLAnchorElement>, "href"> &
+    UntypedRouteTarget & {
+      prefetch?: LinkPrefetchStrategy;
+      preserveScroll?: boolean;
+      viewTransition?: boolean;
+      speculate?: boolean;
+    };
 
   // `<Link href="/blog">` is a TypeScript error, but untyped JSX and JS
   // callers reach here with no `route`. Without this the missing id runs the
@@ -257,6 +275,7 @@ export function Link<TRoute extends RouteId>(props: LinkProps<TRoute>) {
     [PREFETCH_ATTRIBUTE]: prefetch,
     [PRESERVE_SCROLL_ATTRIBUTE]: preserveScroll ? "" : undefined,
     [VIEW_TRANSITION_ATTRIBUTE]: viewTransition ? "" : undefined,
+    [SPECULATE_ATTRIBUTE]: speculate === undefined ? undefined : speculate ? "on" : "off",
   } as JSX.HTMLAttributes<HTMLAnchorElement>);
 }
 

--- a/packages/framework/src/runtime-hooks.ts
+++ b/packages/framework/src/runtime-hooks.ts
@@ -140,8 +140,9 @@ export type LinkProps<TRoute extends RouteId = RouteId> = Omit<
     /**
      * Opt this link out of (`false`) or back into (`true`) the browser's
      * speculation rules, overriding any enclosing
-     * `data-pracht-speculate` scope. Set `false` on links with side effects.
-     * Independent of `prefetch`, which controls the JS route-state prefetch.
+     * `data-pracht-speculate="off"` scope. Independent of `prefetch`, which
+     * controls the JS route-state prefetch; disable both on links with side
+     * effects.
      */
     speculate?: boolean;
   };

--- a/packages/framework/src/runtime-speculation.ts
+++ b/packages/framework/src/runtime-speculation.ts
@@ -30,13 +30,13 @@ export interface SpeculationRulesDocument {
 }
 
 /**
- * Anchors the browser must never speculate, regardless of the route patterns
+ * Links the browser must never speculate, regardless of the route patterns
  * a rule matches. Emitted as a `not: { selector_matches }` conjunct on every
  * rule, and mirrored on the client by `isSpeculationSuppressed()`.
  *
  * - `rel="nofollow"` marks a link the page does not vouch for.
- * - `data-pracht-speculate="off"` opts an element and every anchor in its
- *   subtree out. An anchor can explicitly re-enable itself with `"on"`.
+ * - `data-pracht-speculate="off"` opts an element and every hyperlink in its
+ *   subtree out. A link can explicitly re-enable itself with `"on"`.
  *   Container-level `"on"` scopes are deliberately unsupported because CSS
  *   selectors cannot express nearest-ancestor precedence for arbitrarily
  *   nested scopes; keeping `"off"` fail-closed makes the browser and client
@@ -44,12 +44,15 @@ export interface SpeculationRulesDocument {
  */
 export const SPECULATION_EXCLUSION_SELECTORS: readonly string[] = [
   'a[rel~="nofollow"]',
+  'area[rel~="nofollow"]',
   `a[${SPECULATE_ATTRIBUTE}="off"]`,
+  `area[${SPECULATE_ATTRIBUTE}="off"]`,
   `[${SPECULATE_ATTRIBUTE}="off"] a:not([${SPECULATE_ATTRIBUTE}="on"])`,
+  `[${SPECULATE_ATTRIBUTE}="off"] area:not([${SPECULATE_ATTRIBUTE}="on"])`,
 ];
 
 /**
- * True when this anchor is excluded from the emitted speculation rules — the
+ * True when this link is excluded from the emitted speculation rules — the
  * client-side counterpart of `SPECULATION_EXCLUSION_SELECTORS`. The router and
  * prefetch listeners consult it before handing a link to the browser: if the
  * browser will not prerender it, the normal SPA prefetch/navigation path has

--- a/packages/framework/src/runtime-speculation.ts
+++ b/packages/framework/src/runtime-speculation.ts
@@ -35,18 +35,17 @@ export interface SpeculationRulesDocument {
  * rule, and mirrored on the client by `isSpeculationSuppressed()`.
  *
  * - `rel="nofollow"` marks a link the page does not vouch for.
- * - `data-pracht-speculate="off"` opts an element (and its subtree) out; a
- *   nested `"on"` re-enables it, and the anchor's own attribute always wins.
- *   A CSS selector cannot walk ancestors, so "nearest ancestor wins" is
- *   approximated: one `"on"` inside an `"off"` re-enables, which matches
- *   `closest()` for every nesting up to three alternating levels
- *   (`off > on > off > a` is the first case where the two disagree, and it
- *   only costs a speculation the router then ignores).
+ * - `data-pracht-speculate="off"` opts an element and every anchor in its
+ *   subtree out. An anchor can explicitly re-enable itself with `"on"`.
+ *   Container-level `"on"` scopes are deliberately unsupported because CSS
+ *   selectors cannot express nearest-ancestor precedence for arbitrarily
+ *   nested scopes; keeping `"off"` fail-closed makes the browser and client
+ *   agree for every nesting depth.
  */
 export const SPECULATION_EXCLUSION_SELECTORS: readonly string[] = [
   'a[rel~="nofollow"]',
   `a[${SPECULATE_ATTRIBUTE}="off"]`,
-  `[${SPECULATE_ATTRIBUTE}="off"] a:not([${SPECULATE_ATTRIBUTE}="on"], [${SPECULATE_ATTRIBUTE}="off"] [${SPECULATE_ATTRIBUTE}="on"] *)`,
+  `[${SPECULATE_ATTRIBUTE}="off"] a:not([${SPECULATE_ATTRIBUTE}="on"])`,
 ];
 
 /**
@@ -59,8 +58,9 @@ export const SPECULATION_EXCLUSION_SELECTORS: readonly string[] = [
 export function isSpeculationSuppressed(anchor: Element): boolean {
   const rel = anchor.getAttribute("rel");
   if (rel && rel.split(/\s+/).some((token) => token.toLowerCase() === "nofollow")) return true;
-  const scope = anchor.closest(`[${SPECULATE_ATTRIBUTE}]`);
-  return scope?.getAttribute(SPECULATE_ATTRIBUTE) === "off";
+  const ownSetting = anchor.getAttribute(SPECULATE_ATTRIBUTE);
+  if (ownSetting === "on") return false;
+  return anchor.closest(`[${SPECULATE_ATTRIBUTE}="off"]`) !== null;
 }
 
 const DEFAULT_EAGERNESS: Record<SpeculationMode, SpeculationEagerness> = {

--- a/packages/framework/src/runtime-speculation.ts
+++ b/packages/framework/src/runtime-speculation.ts
@@ -1,4 +1,5 @@
 import { PRACHT_BASE } from "./base.ts";
+import { SPECULATE_ATTRIBUTE } from "./runtime-constants.ts";
 import type {
   ResolvedPrachtApp,
   ResolvedRoute,
@@ -9,15 +10,57 @@ import type {
   SpeculationOption,
 } from "./types.ts";
 
+interface HrefMatchesClause {
+  href_matches: string[];
+}
+
+interface ExclusionClause {
+  not: { selector_matches: string[] };
+}
+
 interface SpeculationRule {
   source: "document";
-  where: { href_matches: string[] };
+  where: { and: [HrefMatchesClause, ExclusionClause] };
   eagerness: SpeculationEagerness;
 }
 
 export interface SpeculationRulesDocument {
   prefetch?: SpeculationRule[];
   prerender?: SpeculationRule[];
+}
+
+/**
+ * Anchors the browser must never speculate, regardless of the route patterns
+ * a rule matches. Emitted as a `not: { selector_matches }` conjunct on every
+ * rule, and mirrored on the client by `isSpeculationSuppressed()`.
+ *
+ * - `rel="nofollow"` marks a link the page does not vouch for.
+ * - `data-pracht-speculate="off"` opts an element (and its subtree) out; a
+ *   nested `"on"` re-enables it, and the anchor's own attribute always wins.
+ *   A CSS selector cannot walk ancestors, so "nearest ancestor wins" is
+ *   approximated: one `"on"` inside an `"off"` re-enables, which matches
+ *   `closest()` for every nesting up to three alternating levels
+ *   (`off > on > off > a` is the first case where the two disagree, and it
+ *   only costs a speculation the router then ignores).
+ */
+export const SPECULATION_EXCLUSION_SELECTORS: readonly string[] = [
+  'a[rel~="nofollow"]',
+  `a[${SPECULATE_ATTRIBUTE}="off"]`,
+  `[${SPECULATE_ATTRIBUTE}="off"] a:not([${SPECULATE_ATTRIBUTE}="on"], [${SPECULATE_ATTRIBUTE}="off"] [${SPECULATE_ATTRIBUTE}="on"] *)`,
+];
+
+/**
+ * True when this anchor is excluded from the emitted speculation rules — the
+ * client-side counterpart of `SPECULATION_EXCLUSION_SELECTORS`. The router and
+ * prefetch listeners consult it before handing a link to the browser: if the
+ * browser will not prerender it, the normal SPA prefetch/navigation path has
+ * to keep working.
+ */
+export function isSpeculationSuppressed(anchor: Element): boolean {
+  const rel = anchor.getAttribute("rel");
+  if (rel && rel.split(/\s+/).some((token) => token.toLowerCase() === "nofollow")) return true;
+  const scope = anchor.closest(`[${SPECULATE_ATTRIBUTE}]`);
+  return scope?.getAttribute(SPECULATE_ATTRIBUTE) === "off";
 }
 
 const DEFAULT_EAGERNESS: Record<SpeculationMode, SpeculationEagerness> = {
@@ -90,7 +133,12 @@ export function buildSpeculationRules(
     const list = doc[mode] ?? (doc[mode] = []);
     list.push({
       source: "document",
-      where: { href_matches: patterns },
+      where: {
+        and: [
+          { href_matches: patterns },
+          { not: { selector_matches: [...SPECULATION_EXCLUSION_SELECTORS] } },
+        ],
+      },
       eagerness,
     });
   }

--- a/packages/framework/test/base.test.ts
+++ b/packages/framework/test/base.test.ts
@@ -129,7 +129,7 @@ describe("base-aware speculation rules", () => {
       }),
     );
 
-    expect(buildSpeculationRules(app.routes)?.prerender?.[0].where.href_matches).toEqual([
+    expect(buildSpeculationRules(app.routes)?.prerender?.[0].where.and[0].href_matches).toEqual([
       "/my-project/article/:slug",
     ]);
   });

--- a/packages/framework/test/link-attributes.test.ts
+++ b/packages/framework/test/link-attributes.test.ts
@@ -1,0 +1,49 @@
+// @vitest-environment jsdom
+import { h, render } from "preact";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { defineApp, Link, resolveApp, route } from "../src/index.ts";
+
+describe("<Link> data attributes", () => {
+  let root: HTMLDivElement;
+
+  beforeEach(() => {
+    const app = resolveApp(
+      defineApp({
+        routes: [route("/logout", "./routes/logout.tsx", { id: "logout", render: "ssr" })],
+      }),
+    );
+    globalThis.__PRACHT_ROUTE_DEFINITIONS__ = app.routes;
+    root = document.createElement("div");
+    document.body.appendChild(root);
+  });
+
+  afterEach(() => {
+    render(null, root);
+    root.remove();
+    delete globalThis.__PRACHT_ROUTE_DEFINITIONS__;
+  });
+
+  function renderLink(props: Record<string, unknown>): HTMLAnchorElement {
+    render(h(Link, { route: "logout", ...props } as never, "Log out"), root);
+    return root.querySelector("a") as HTMLAnchorElement;
+  }
+
+  it("omits the speculate attribute when the prop is unset", () => {
+    expect(renderLink({}).hasAttribute("data-pracht-speculate")).toBe(false);
+  });
+
+  it("renders speculate={false} as an opt-out", () => {
+    expect(renderLink({ speculate: false }).getAttribute("data-pracht-speculate")).toBe("off");
+  });
+
+  it("renders speculate as a re-opt-in inside an off scope", () => {
+    expect(renderLink({ speculate: true }).getAttribute("data-pracht-speculate")).toBe("on");
+  });
+
+  it("keeps the speculate and prefetch opt-outs independent", () => {
+    const anchor = renderLink({ speculate: false, prefetch: "none" });
+    expect(anchor.getAttribute("data-pracht-speculate")).toBe("off");
+    expect(anchor.getAttribute("data-pracht-prefetch")).toBe("none");
+  });
+});

--- a/packages/framework/test/prefetch.test.ts
+++ b/packages/framework/test/prefetch.test.ts
@@ -217,6 +217,110 @@ describe("prefetch strategies", () => {
 
     expect(fetchSpy).not.toHaveBeenCalled();
   });
+
+  it("keeps JS prefetch for a nofollow anchor the speculation rules exclude", () => {
+    stubSpeculationRulesSupport(true);
+    const anchor = addAnchor("/prerender-nofollow", { rel: "nofollow" });
+    setupPrefetching(createSpeculationApp("/prerender-nofollow"));
+
+    hover(anchor);
+    vi.advanceTimersByTime(60);
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(fetchSpy.mock.calls[0][0]).toBe("/prerender-nofollow");
+  });
+
+  it('keeps JS prefetch for anchors inside a data-pracht-speculate="off" scope', () => {
+    stubSpeculationRulesSupport(true);
+    const nav = document.createElement("nav");
+    nav.setAttribute("data-pracht-speculate", "off");
+    document.body.appendChild(nav);
+    const anchor = document.createElement("a");
+    anchor.href = "/prerender-scoped-off";
+    nav.appendChild(anchor);
+    setupPrefetching(createSpeculationApp("/prerender-scoped-off"));
+
+    hover(anchor);
+    vi.advanceTimersByTime(60);
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(fetchSpy.mock.calls[0][0]).toBe("/prerender-scoped-off");
+  });
+
+  it("starts render prefetch when a mounted prerender link becomes excluded", async () => {
+    stubSpeculationRulesSupport(true);
+    const nav = document.createElement("nav");
+    document.body.appendChild(nav);
+    const anchor = document.createElement("a");
+    anchor.href = "/prerender-dynamic-off";
+    anchor.setAttribute("data-pracht-prefetch", "render");
+    nav.appendChild(anchor);
+    setupPrefetching(createSpeculationApp("/prerender-dynamic-off"));
+    expect(fetchSpy).not.toHaveBeenCalled();
+
+    nav.setAttribute("data-pracht-speculate", "off");
+    await flushMicrotasks();
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(fetchSpy.mock.calls[0][0]).toBe("/prerender-dynamic-off");
+  });
+
+  it("drops viewport prefetch when an excluded link becomes eligible for prerender", async () => {
+    stubSpeculationRulesSupport(true);
+    let intersectionCallback: IntersectionObserverCallback | undefined;
+    const observe = vi.fn();
+    const unobserve = vi.fn();
+    const fakeObserver: IntersectionObserver = {
+      disconnect: vi.fn(),
+      observe,
+      root: null,
+      rootMargin: "200px",
+      scrollMargin: "0px",
+      takeRecords: vi.fn(() => []),
+      thresholds: [0],
+      unobserve,
+    };
+    vi.stubGlobal(
+      "IntersectionObserver",
+      vi.fn((callback: IntersectionObserverCallback) => {
+        intersectionCallback = callback;
+        return fakeObserver;
+      }),
+    );
+    const anchor = addAnchor("/prerender-dynamic-on", {
+      "data-pracht-prefetch": "viewport",
+      "data-pracht-speculate": "off",
+    });
+    setupPrefetching(createSpeculationApp("/prerender-dynamic-on"));
+    expect(observe).toHaveBeenCalledWith(anchor);
+
+    anchor.setAttribute("data-pracht-speculate", "on");
+    await flushMicrotasks();
+    expect(unobserve).toHaveBeenCalledWith(anchor);
+
+    const emptyRect: DOMRectReadOnly = {
+      bottom: 0,
+      height: 0,
+      left: 0,
+      right: 0,
+      top: 0,
+      width: 0,
+      x: 0,
+      y: 0,
+      toJSON: () => ({}),
+    };
+    const entry: IntersectionObserverEntry = {
+      boundingClientRect: emptyRect,
+      intersectionRatio: 1,
+      intersectionRect: emptyRect,
+      isIntersecting: true,
+      rootBounds: null,
+      target: anchor,
+      time: 0,
+    };
+    intersectionCallback?.([entry], fakeObserver);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
 });
 
 describe("imperative prefetch()", () => {

--- a/packages/framework/test/prefetch.test.ts
+++ b/packages/framework/test/prefetch.test.ts
@@ -92,6 +92,7 @@ describe("prefetch strategies", () => {
   });
 
   afterEach(() => {
+    document.documentElement.removeAttribute("data-pracht-speculate");
     vi.useRealTimers();
     vi.unstubAllGlobals();
     clearPrefetchCache();
@@ -263,6 +264,25 @@ describe("prefetch strategies", () => {
 
     expect(fetchSpy).toHaveBeenCalledTimes(1);
     expect(fetchSpy.mock.calls[0][0]).toBe("/prerender-dynamic-off");
+  });
+
+  it("starts render prefetch when the document root becomes excluded", async () => {
+    stubSpeculationRulesSupport(true);
+    const anchor = addAnchor("/prerender-root-off", {
+      "data-pracht-prefetch": "render",
+    });
+    setupPrefetching(createSpeculationApp("/prerender-root-off"));
+    expect(fetchSpy).not.toHaveBeenCalled();
+
+    document.documentElement.setAttribute("data-pracht-speculate", "off");
+    await flushMicrotasks();
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(fetchSpy.mock.calls[0][0]).toBe("/prerender-root-off");
+
+    document.documentElement.removeAttribute("data-pracht-speculate");
+    await flushMicrotasks();
+    anchor.remove();
   });
 
   it("drops viewport prefetch when an excluded link becomes eligible for prerender", async () => {

--- a/packages/framework/test/router-navigation.test.ts
+++ b/packages/framework/test/router-navigation.test.ts
@@ -12,6 +12,8 @@ import {
 import { clearPrefetchCache } from "../src/prefetch-cache.ts";
 import { PRESERVE_SCROLL_ATTRIBUTE } from "../src/runtime-constants.ts";
 import { HISTORY_STATE_KEY } from "../src/scroll-restoration.ts";
+import { SPECULATE_ATTRIBUTE } from "../src/runtime-constants.ts";
+import type { SpeculationOption } from "../src/types.ts";
 
 function createJsonResponse(body: unknown, init?: ResponseInit): Response {
   return new Response(JSON.stringify(body), {
@@ -41,6 +43,11 @@ function createDeferred<T>(): Deferred<T> {
   return { promise, resolve };
 }
 
+interface RouterOptions {
+  viewTransitions?: boolean;
+  speculation?: SpeculationOption;
+}
+
 describe("navigation UX primitives (client router)", () => {
   let root: HTMLDivElement;
   let fetchSpy: ReturnType<typeof vi.fn>;
@@ -55,19 +62,23 @@ describe("navigation UX primitives (client router)", () => {
     options?: boolean | AddEventListenerOptions;
   }> = [];
 
-  function createRouterApp(options?: { viewTransitions?: boolean }) {
+  function createRouterApp(options?: RouterOptions) {
     return resolveApp(
       defineApp({
         viewTransitions: options?.viewTransitions,
         routes: [
           route("/", "./routes/home.tsx", { id: "home", render: "ssr" }),
-          route("/next", "./routes/next.tsx", { id: "next", render: "ssr" }),
+          route("/next", "./routes/next.tsx", {
+            id: "next",
+            render: "ssr",
+            speculation: options?.speculation,
+          }),
         ],
       }),
     );
   }
 
-  async function initRouter(options?: { viewTransitions?: boolean }): Promise<void> {
+  async function initRouter(options?: RouterOptions): Promise<void> {
     const targets: EventTarget[] = [window, document];
     const originals = targets.map((target) => target.addEventListener.bind(target));
     targets.forEach((target, i) => {
@@ -441,6 +452,60 @@ describe("navigation UX primitives (client router)", () => {
     expect(fetchSpy).toHaveBeenCalled();
     expect(root.textContent).toContain("next");
     expect(window.location.pathname).toBe("/next");
+  });
+
+  describe("prerender speculation hand-off", () => {
+    let originalSupports: PropertyDescriptor | undefined;
+
+    beforeEach(() => {
+      originalSupports = Object.getOwnPropertyDescriptor(HTMLScriptElement, "supports");
+      Object.defineProperty(HTMLScriptElement, "supports", {
+        configurable: true,
+        value: (type: string) => type === "speculationrules",
+      });
+    });
+
+    afterEach(() => {
+      if (originalSupports) {
+        Object.defineProperty(HTMLScriptElement, "supports", originalSupports);
+      } else {
+        delete (HTMLScriptElement as { supports?: unknown }).supports;
+      }
+    });
+
+    /** Clicks a link to the prerender-marked `/next` route and reports whether
+     * the router intercepted the click (SPA nav) or let the browser navigate. */
+    async function clickPrerenderLink(markup: string): Promise<boolean> {
+      fetchSpy.mockImplementation(async () => createJsonResponse({ data: null }));
+      await initRouter({ speculation: "prerender" });
+      document.body.insertAdjacentHTML("beforeend", markup);
+      const anchor = document.getElementById("target") as HTMLAnchorElement;
+      const event = new MouseEvent("click", { bubbles: true, cancelable: true });
+      anchor.dispatchEvent(event);
+      await flush();
+      return event.defaultPrevented;
+    }
+
+    it("leaves the click to the browser so it can activate the prerendered document", async () => {
+      expect(await clickPrerenderLink(`<a id="target" href="/next">next</a>`)).toBe(false);
+      expect(fetchSpy).not.toHaveBeenCalled();
+    });
+
+    it("handles a case-variant nofollow link itself — the rules never prerendered it", async () => {
+      expect(await clickPrerenderLink(`<a id="target" href="/next" rel="NOFOLLOW">next</a>`)).toBe(
+        true,
+      );
+      expect(window.location.pathname).toBe("/next");
+    });
+
+    it("handles a link inside a speculate=off scope itself", async () => {
+      expect(
+        await clickPrerenderLink(
+          `<nav ${SPECULATE_ATTRIBUTE}="off"><a id="target" href="/next">next</a></nav>`,
+        ),
+      ).toBe(true);
+      expect(window.location.pathname).toBe("/next");
+    });
   });
 
   it("sets history.scrollRestoration to manual when supported", async () => {

--- a/packages/framework/test/runtime.test.ts
+++ b/packages/framework/test/runtime.test.ts
@@ -1531,13 +1531,20 @@ describe("handlePrachtRequest speculation rules", () => {
         .replace(/\\u003c/g, "<")
         .replace(/\\u003e/g, ">")
         .replace(/\\u0026/g, "&"),
-    ) as Record<string, Array<{ where: { href_matches: string[] } }>>;
+    ) as Record<
+      string,
+      Array<{
+        where: { and: [{ href_matches: string[] }, { not: { selector_matches: string[] } }] };
+      }>
+    >;
 
-    expect(rules.prefetch?.[0].where.href_matches).toEqual(["/"]);
-    expect(rules.prerender?.[0].where.href_matches).toEqual(["/article/:slug"]);
+    expect(rules.prefetch?.[0].where.and[0].href_matches).toEqual(["/"]);
+    expect(rules.prerender?.[0].where.and[0].href_matches).toEqual(["/article/:slug"]);
+    // Every rule carries the anchor-level exclusions.
+    expect(rules.prefetch?.[0].where.and[1].not.selector_matches).toContain('a[rel~="nofollow"]');
     // The opt-out route is not present in any rule
     const allHrefs = [...(rules.prefetch ?? []), ...(rules.prerender ?? [])].flatMap(
-      (rule) => rule.where.href_matches,
+      (rule) => rule.where.and[0].href_matches,
     );
     expect(allHrefs).not.toContain("/contact");
   });

--- a/packages/framework/test/speculation.test.ts
+++ b/packages/framework/test/speculation.test.ts
@@ -208,16 +208,21 @@ describe("speculation exclusions", () => {
       '<nav data-pracht-speculate="on"><a id="target" href="/x" data-pracht-speculate="off"></a></nav>',
       true,
     ],
-    // Nearest ancestor wins.
+    // Container-level `on` cannot override an enclosing `off`: the emitted
+    // CSS stays fail-closed at every nesting depth.
     [
       '<nav data-pracht-speculate="off"><div data-pracht-speculate="on"><a id="target" href="/x"></a></div></nav>',
-      false,
+      true,
     ],
     [
       '<nav data-pracht-speculate="on"><div data-pracht-speculate="off"><a id="target" href="/x"></a></div></nav>',
       true,
     ],
     ['<nav data-pracht-speculate="on"><a id="target" href="/x"></a></nav>', false],
+    [
+      '<nav data-pracht-speculate="off"><div data-pracht-speculate="on"><section data-pracht-speculate="off"><a id="target" href="/x"></a></section></div></nav>',
+      true,
+    ],
   ];
 
   for (const [markup, suppressed] of cases) {

--- a/packages/framework/test/speculation.test.ts
+++ b/packages/framework/test/speculation.test.ts
@@ -199,6 +199,13 @@ describe("speculation exclusions", () => {
     ['<a id="target" href="/x" rel="nofollowers"></a>', false],
     ['<a id="target" href="/x" data-pracht-speculate="off"></a>', true],
     ['<nav data-pracht-speculate="off"><a id="target" href="/x"></a></nav>', true],
+    ['<map><area id="target" href="/x" rel="nofollow"></map>', true],
+    ['<map><area id="target" href="/x" data-pracht-speculate="off"></map>', true],
+    ['<map data-pracht-speculate="off"><area id="target" href="/x"></map>', true],
+    [
+      '<map data-pracht-speculate="off"><area id="target" href="/x" data-pracht-speculate="on"></map>',
+      false,
+    ],
     // The anchor's own attribute beats an enclosing scope, both ways.
     [
       '<nav data-pracht-speculate="off"><a id="target" href="/x" data-pracht-speculate="on"></a></nav>',

--- a/packages/framework/test/speculation.test.ts
+++ b/packages/framework/test/speculation.test.ts
@@ -1,11 +1,16 @@
+// @vitest-environment jsdom
 import { describe, expect, it } from "vitest";
 
 import { defineApp, group, resolveApp, route } from "../src/index.ts";
 import {
   buildSpeculationRules,
   getAppSpeculationRules,
+  isSpeculationSuppressed,
   normalizeSpeculation,
+  SPECULATION_EXCLUSION_SELECTORS,
 } from "../src/runtime-speculation.ts";
+
+const EXCLUSIONS = { not: { selector_matches: [...SPECULATION_EXCLUSION_SELECTORS] } };
 
 describe("normalizeSpeculation", () => {
   it("expands a string mode to a config object", () => {
@@ -45,7 +50,7 @@ describe("buildSpeculationRules", () => {
       prefetch: [
         {
           source: "document",
-          where: { href_matches: ["/"] },
+          where: { and: [{ href_matches: ["/"] }, EXCLUSIONS] },
           eagerness: "moderate",
         },
       ],
@@ -62,7 +67,7 @@ describe("buildSpeculationRules", () => {
       prerender: [
         {
           source: "document",
-          where: { href_matches: ["/about"] },
+          where: { and: [{ href_matches: ["/about"] }, EXCLUSIONS] },
           eagerness: "conservative",
         },
       ],
@@ -79,7 +84,7 @@ describe("buildSpeculationRules", () => {
       }),
     );
     const rules = buildSpeculationRules(resolved.routes);
-    expect(rules?.prefetch?.[0].where.href_matches).toEqual(["/blog/:slug", "/files/*"]);
+    expect(rules?.prefetch?.[0].where.and[0].href_matches).toEqual(["/blog/:slug", "/files/*"]);
   });
 
   it("escapes URLPattern metacharacters in static segments", () => {
@@ -94,7 +99,7 @@ describe("buildSpeculationRules", () => {
       }),
     );
     const rules = buildSpeculationRules(resolved.routes);
-    expect(rules?.prefetch?.[0].where.href_matches).toEqual([
+    expect(rules?.prefetch?.[0].where.and[0].href_matches).toEqual([
       "/c\\+\\+",
       "/file\\(1\\)",
       "/docs/a\\{b\\}",
@@ -118,7 +123,7 @@ describe("buildSpeculationRules", () => {
     expect(rules?.prerender).toHaveLength(1);
 
     const eager = rules?.prefetch?.find((r) => r.eagerness === "eager");
-    expect(eager?.where.href_matches.sort()).toEqual(["/a", "/b"]);
+    expect(eager?.where.and[0].href_matches.sort()).toEqual(["/a", "/b"]);
   });
 
   it("inherits speculation from a group", () => {
@@ -133,7 +138,7 @@ describe("buildSpeculationRules", () => {
       }),
     );
     const rules = buildSpeculationRules(resolved.routes);
-    expect(rules?.prefetch?.[0].where.href_matches).toEqual(["/docs/intro", "/docs/api"]);
+    expect(rules?.prefetch?.[0].where.and[0].href_matches).toEqual(["/docs/intro", "/docs/api"]);
   });
 
   it("lets a route override an inherited group setting", () => {
@@ -148,8 +153,8 @@ describe("buildSpeculationRules", () => {
       }),
     );
     const rules = buildSpeculationRules(resolved.routes);
-    expect(rules?.prefetch?.[0].where.href_matches).toEqual(["/"]);
-    expect(rules?.prerender?.[0].where.href_matches).toEqual(["/heavy"]);
+    expect(rules?.prefetch?.[0].where.and[0].href_matches).toEqual(["/"]);
+    expect(rules?.prerender?.[0].where.and[0].href_matches).toEqual(["/heavy"]);
   });
 });
 
@@ -164,4 +169,69 @@ describe("getAppSpeculationRules", () => {
     const second = getAppSpeculationRules(resolved);
     expect(first).toBe(second);
   });
+});
+
+describe("speculation exclusions", () => {
+  it("attaches the exclusion selectors to every emitted rule", () => {
+    const resolved = resolveApp(
+      defineApp({
+        routes: [
+          route("/", "./index.tsx", { speculation: "prefetch" }),
+          route("/heavy", "./heavy.tsx", { speculation: "prerender" }),
+        ],
+      }),
+    );
+    const rules = buildSpeculationRules(resolved.routes);
+    for (const rule of [...(rules?.prefetch ?? []), ...(rules?.prerender ?? [])]) {
+      expect(rule.where.and[1]).toEqual(EXCLUSIONS);
+    }
+  });
+
+  // [markup, id of the anchor under test, suppressed?]
+  const cases: Array<[string, boolean]> = [
+    ['<a id="target" href="/x"></a>', false],
+    ['<a id="target" href="/x" rel="nofollow"></a>', true],
+    ['<a id="target" href="/x" rel="noopener nofollow"></a>', true],
+    // HTML rel keywords and the emitted attribute selector are ASCII
+    // case-insensitive, so the client helper must be too.
+    ['<a id="target" href="/x" rel="NOFOLLOW"></a>', true],
+    // `nofollow` is a rel token, not a substring of one.
+    ['<a id="target" href="/x" rel="nofollowers"></a>', false],
+    ['<a id="target" href="/x" data-pracht-speculate="off"></a>', true],
+    ['<nav data-pracht-speculate="off"><a id="target" href="/x"></a></nav>', true],
+    // The anchor's own attribute beats an enclosing scope, both ways.
+    [
+      '<nav data-pracht-speculate="off"><a id="target" href="/x" data-pracht-speculate="on"></a></nav>',
+      false,
+    ],
+    [
+      '<nav data-pracht-speculate="on"><a id="target" href="/x" data-pracht-speculate="off"></a></nav>',
+      true,
+    ],
+    // Nearest ancestor wins.
+    [
+      '<nav data-pracht-speculate="off"><div data-pracht-speculate="on"><a id="target" href="/x"></a></div></nav>',
+      false,
+    ],
+    [
+      '<nav data-pracht-speculate="on"><div data-pracht-speculate="off"><a id="target" href="/x"></a></div></nav>',
+      true,
+    ],
+    ['<nav data-pracht-speculate="on"><a id="target" href="/x"></a></nav>', false],
+  ];
+
+  for (const [markup, suppressed] of cases) {
+    it(`${suppressed ? "suppresses" : "speculates"} ${markup}`, () => {
+      document.body.innerHTML = markup;
+      const anchor = document.getElementById("target");
+      expect(anchor).not.toBeNull();
+      expect(isSpeculationSuppressed(anchor as Element)).toBe(suppressed);
+      // The emitted CSS selectors must reach the same verdict as the client
+      // helper, or the browser and the router disagree about which links are
+      // prerendered.
+      expect((anchor as Element).matches(SPECULATION_EXCLUSION_SELECTORS.join(","))).toBe(
+        suppressed,
+      );
+    });
+  }
 });

--- a/skills/typed-routes/SKILL.md
+++ b/skills/typed-routes/SKILL.md
@@ -107,8 +107,11 @@ same-origin anchor. It also accepts navigation-behavior props:
 `prefetch="none" | "hover" | "intent" | "viewport" | "render"` (per-link
 prefetch strategy, default `"intent"`), `preserveScroll` (keep the scroll
 position), and `viewTransition` (animate the navigation with the View Transitions API
-where supported). There is also an imperative `prefetch()` export and a
-`useNavigation()` hook for pending navigation/submission state.
+where supported). Set `speculate={false}` on links that browser speculation
+rules must not prefetch or prerender, such as GET links with side effects; it
+is independent of the JS `prefetch` strategy. There is also an imperative
+`prefetch()` export and a `useNavigation()` hook for pending
+navigation/submission state.
 
 ### Outside components
 

--- a/skills/typed-routes/SKILL.md
+++ b/skills/typed-routes/SKILL.md
@@ -108,8 +108,9 @@ same-origin anchor. It also accepts navigation-behavior props:
 prefetch strategy, default `"intent"`), `preserveScroll` (keep the scroll
 position), and `viewTransition` (animate the navigation with the View Transitions API
 where supported). Set `speculate={false}` on links that browser speculation
-rules must not prefetch or prerender, such as GET links with side effects; it
-is independent of the JS `prefetch` strategy. There is also an imperative
+rules must not prefetch or prerender. Because it is independent of the JS
+`prefetch` strategy, use both `speculate={false}` and `prefetch="none"` for GET
+links with side effects. There is also an imperative
 `prefetch()` export and a `useNavigation()` hook for pending
 navigation/submission state.
 


### PR DESCRIPTION
## Summary

- Exclude `rel="nofollow"` links and cascading `data-pracht-speculate="off"` scopes from emitted browser speculation rules, including image-map areas.
- Add `<Link speculate>` support while keeping excluded links on the normal SPA navigation and JavaScript prefetch paths.
- Keep browser and client exclusion behavior aligned across dynamic attribute changes, and document the new routing contract.
- Relevant issue: N/A.

## Testing

- [x] `pnpm run verify` (build, format, lint, typecheck, test, e2e)

## Checklist

- [x] Docs updated if needed
- [x] Skills updated if needed
- [x] Changeset added if published packages changed
