### PR TITLE
Fix duplicated Pracht runtime in development SSR

### DIFF
--- a/.changeset/dev-ssr-single-runtime-instance.md
+++ b/.changeset/dev-ssr-single-runtime-instance.md
@@ -1,0 +1,16 @@
+---
+"@pracht/vite-plugin": patch
+---
+
+Keep `@pracht/*` packages inlined in the dev SSR environment, not just in SSR
+builds. `pracht dev` renders through `ssrLoadModule("@pracht/core/server")`,
+which Vite always inlines, while an app's own `import { useLocation } from
+"@pracht/core"` is a bare node_modules id Vite externalizes to a native Node
+import. Apps that install Pracht from the registry therefore rendered with two
+copies of the runtime in the same request: the document was rendered with the
+inlined copy's `RouteDataContext.Provider`, and every component read the
+externalized copy's context. `useLocation()` fell back to `/`, `useParams()` to
+`{}`, and `useRouteData()` to `undefined` during development SSR, and the page
+hydrated into a mismatch — while production builds, which already inlined these
+packages, were correct. Workspace-linked installs were inlined either way and
+never saw it.

--- a/packages/vite-plugin/src/index.ts
+++ b/packages/vite-plugin/src/index.ts
@@ -277,7 +277,19 @@ export function pracht(options: PrachtPluginOptions = {}): Plugin[] {
               },
             }
           : {}),
-        ...(!isEdge && isSSRBuild
+        // Dev needs this as badly as the build does. `pracht dev` renders
+        // through `ssrLoadModule("@pracht/core/server")`, which Vite always
+        // inlines, while the app's own `import { useLocation } from
+        // "@pracht/core"` is a bare node_modules id that Vite externalizes to
+        // a native Node import. That is two copies of the runtime in one
+        // render: the document is rendered with the inlined copy's
+        // `RouteDataContext.Provider`, and every app component reads the
+        // externalized copy's context — a different `createContext()` object,
+        // so `useLocation()`/`useParams()`/`useRouteData()` all fall back to
+        // their empty defaults server-side and the page hydrates into a
+        // mismatch. Workspace-linked installs (the examples here) are inlined
+        // either way and never saw it; a published install always does.
+        ...((!isEdge && isSSRBuild) || env.command === "serve"
           ? {
               ssr: {
                 noExternal: [PRACHT_SSR_NO_EXTERNAL],

--- a/packages/vite-plugin/test/pracht-ssr-no-external.test.ts
+++ b/packages/vite-plugin/test/pracht-ssr-no-external.test.ts
@@ -1,0 +1,71 @@
+import { resolveConfig } from "vite";
+import { describe, expect, it } from "vitest";
+
+import { pracht, type PrachtAdapter } from "../src/index.ts";
+
+const nodeAdapter: PrachtAdapter = {
+  id: "node",
+  serverImports: "",
+  createServerEntryModule: () => "export default {};",
+};
+
+function matches(
+  noExternal: boolean | string | RegExp | Array<string | RegExp> | undefined,
+  id: string,
+): boolean {
+  if (noExternal === true) return true;
+  const entries = Array.isArray(noExternal) ? noExternal : [noExternal];
+  return entries.some((entry) =>
+    entry instanceof RegExp ? entry.test(id) : typeof entry === "string" && entry === id,
+  );
+}
+
+// Asserting on the *resolved* config: the bug this guards against is the dev
+// SSR environment holding a second copy of the runtime. `pracht dev` renders
+// through `ssrLoadModule("@pracht/core/server")` — always inlined — while the
+// app's own `import { useLocation } from "@pracht/core"` is a bare
+// node_modules id Vite would externalize to a native Node import. Two copies
+// means two `createContext()` objects, so the document renders with one
+// provider and every component reads the other one's empty default.
+describe("pracht runtime noExternal", () => {
+  it("keeps @pracht packages inlined in the dev ssr environment", async () => {
+    const config = await resolveConfig(
+      { configFile: false, logLevel: "silent", plugins: [pracht({ adapter: nodeAdapter })] },
+      "serve",
+    );
+
+    expect(matches(config.environments.ssr?.resolve.noExternal, "@pracht/core")).toBe(true);
+    expect(matches(config.environments.ssr?.resolve.noExternal, "@pracht/content")).toBe(true);
+  });
+
+  it("keeps @pracht packages inlined in a node ssr build", async () => {
+    const config = await resolveConfig(
+      {
+        build: { ssr: true },
+        configFile: false,
+        logLevel: "silent",
+        plugins: [pracht({ adapter: nodeAdapter })],
+      },
+      "build",
+    );
+
+    expect(matches(config.environments.ssr?.resolve.noExternal, "@pracht/core")).toBe(true);
+  });
+
+  it("keeps a user's own noExternal entries", async () => {
+    const config = await resolveConfig(
+      {
+        configFile: false,
+        logLevel: "silent",
+        plugins: [pracht({ adapter: nodeAdapter })],
+        ssr: { noExternal: ["some-esm-only-package"] },
+      },
+      "serve",
+    );
+
+    expect(matches(config.environments.ssr?.resolve.noExternal, "some-esm-only-package")).toBe(
+      true,
+    );
+    expect(matches(config.environments.ssr?.resolve.noExternal, "@pracht/core")).toBe(true);
+  });
+});

--- a/skills/pracht-debug/SKILL.md
+++ b/skills/pracht-debug/SKILL.md
@@ -72,6 +72,14 @@ Work through these in order, stopping when you find the root cause:
   - Date/time rendering differences
   - Browser-only APIs used during SSR (`window`, `document`, `localStorage`)
   - Conditional rendering based on client state
+  - Two copies of `@pracht/core` in the SSR module graph. The tell is that
+    `useLocation()` returns `/`, `useParams()` returns `{}`, and
+    `useRouteData()` returns `undefined` in the server-rendered HTML for
+    *every* page, while the hydrated client is correct — the provider and the
+    hooks hold different `createContext()` objects. The plugin prevents this by
+    keeping `@pracht/*` in `ssr.noExternal` (dev and build alike); listing a
+    `@pracht/*` package in `ssr.external` overrides that and brings the split
+    back.
 - **Missing shell**: Referencing an unregistered shell name throws at manifest resolution — `Unknown shell "..." for route "...". Did you mean "..."? Registered shells: ...` — and shows up in the dev error overlay as soon as the server loads the manifest. Verify the shell is registered in `defineApp({ shells: { ... } })` and assigned to the route/group.
 - **404 page**: Route not matched — check manifest wiring (step 1). In `pracht dev`, unmatched navigations render a dev-only 404 page listing every registered route with its render mode; compare the requested path against that table. The route table is also printed on dev-server startup and available via `pracht inspect routes`. Apps that declare `defineApp({ notFound })` render their own 404 page instead (in dev and production alike), so the route table is not shown — check `pracht inspect routes` directly. A 404 on a URL you *do* expect to work usually means the loader threw `notFound()`, not that matching failed.
 


### PR DESCRIPTION
## Summary

- Keep `@pracht/*` packages in Vite dev SSR `noExternal` so route context providers and hooks use one runtime instance.
- Add resolved-config regression coverage and document the duplicated-runtime symptom in the debug skill.
- Relevant issue: N/A.

## Testing

- [x] `pnpm run verify` (build, format, lint, typecheck, test, e2e)

## Checklist

- [x] Docs updated if needed
- [x] Skills updated if needed
- [x] Changeset added if published packages changed