### PR TITLE
feat(vite-plugin): compile JS prefetching out of the client bundle

### DIFF
--- a/.changeset/client-feature-flags.md
+++ b/.changeset/client-feature-flags.md
@@ -1,0 +1,27 @@
+---
+"@pracht/vite-plugin": minor
+"@pracht/core": minor
+---
+
+Add `pracht({ client: { prefetch: false } })` to compile JS prefetching out of
+the client bundle.
+
+Every internal link is prefetched on hover/focus by default, and the listeners
+that do it live in a chunk the router lazily imports on *every* page. Setting
+each route to `prefetch: "none"` stops the fetching but still ships that chunk:
+`initClientRouter()` reaches the prefetch runtime directly, so no bundler can
+work out that nothing uses it.
+
+```ts
+pracht({ client: { prefetch: false } });
+```
+
+The flag defaults to `true`, so apps that configure nothing are unchanged byte
+for byte. Disabled, a production build of the router runtime drops from 9,917 to
+7,286 gzip bytes (−26.5%); measured end to end on `examples/basic`, whose shared
+client JS includes Preact, a cold load drops from 21,087 to 18,692 gzip bytes
+(−11.4%) and makes one fewer request.
+
+Turning it off makes the router stop honouring `route({ prefetch })` and
+`<Link prefetch>`, and makes the imperative `prefetch()` export a no-op — all
+silently, because the code is gone. Browser speculation rules are unaffected.

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -1,8 +1,9 @@
 # Performance — Bundle Analysis & Budgets
 
-Pracht's core promise is shipping less JavaScript. Two built-in tools keep that
-promise honest as an app grows: `pracht build --analyze` (visibility) and
-per-route client-JS budgets (enforcement).
+Pracht's core promise is shipping less JavaScript. Three built-in tools keep
+that promise honest as an app grows: `pracht build --analyze` (visibility),
+per-route client-JS budgets (enforcement), and `pracht({ client })` for
+compiling out router features the app does not use.
 
 ## Tree-shaking framework imports
 
@@ -44,6 +45,46 @@ Both are covered by budget assertions in `package-tree-shaking.test.ts`. When
 adding a router feature, prefer this shape over a direct import in
 `router.ts` or `runtime-context.ts`: reach it from the export, component, or
 generated module that needs it.
+
+## Switching off JS prefetching
+
+Every internal link is prefetched on hover/focus by default, and the listeners
+that do it live in a chunk the router lazily imports on *every* page. Setting
+each route to `prefetch: "none"` stops the fetching but still ships that chunk —
+the router reaches the prefetch runtime directly, so no bundler can work out
+that nothing uses it. Declare it instead:
+
+```ts
+// vite.config.ts
+import { pracht } from "@pracht/vite-plugin";
+
+export default defineConfig({
+  plugins: [pracht({ client: { prefetch: false } })],
+});
+```
+
+The flag defaults to `true`, so an app that configures nothing behaves exactly
+as before, byte for byte. Disabled, a production build of the router runtime
+drops from 9,917 to 7,286 gzip bytes (−26.5%) with Preact external. End to end
+on `examples/basic`, where the shared client JS also carries Preact, a cold load
+drops from 21,087 to 18,692 gzip bytes (−11.4%) — and one fewer request, since
+the lazily imported chunk is gone.
+
+### What turning it off actually changes
+
+The router stops honouring `route({ prefetch })` and `<Link prefetch>`, and the
+imperative `prefetch()` export becomes a no-op. It does not warn: the code is
+gone. Navigation still works; it just always fetches route state on click.
+
+Browser speculation rules (`route({ speculation })`, `<Link speculate>`) are
+unaffected — they are emitted in the HTML and handled by the browser, not by the
+prefetch runtime.
+
+Scroll restoration and fragment (`#hash`) navigation are deliberately not
+switchable. The popstate handler tells a history traversal apart from an in-page
+fragment navigation by whether the entry carries a router-stamped scroll key, so
+the two are one mechanism rather than two features — removing it would change
+navigation semantics, not just bundle size.
 
 ## `pracht build --analyze`
 

--- a/docs/ROUTING.md
+++ b/docs/ROUTING.md
@@ -359,7 +359,10 @@ they also work on plain anchors if you set the attributes yourself.
 ### Prefetching
 
 Every internal link is prefetched on hover/focus by default (`"intent"`, with a
-50ms debounce). A per-route default can be set via the `prefetch` route meta,
+50ms debounce). An app that wants no JS prefetching at all can compile the whole
+mechanism out with `pracht({ client: { prefetch: false } })` — see
+[PERFORMANCE.md](PERFORMANCE.md#switching-off-js-prefetching). A
+per-route default can be set via the `prefetch` route meta,
 and `<Link prefetch>` overrides it per link:
 
 - `"intent"` — prefetch on hover or keyboard focus (default)

--- a/packages/framework/src/router.ts
+++ b/packages/framework/src/router.ts
@@ -64,6 +64,28 @@ import {
 } from "./runtime-context.ts";
 import type { RouteStateResult } from "./runtime-client-fetch.ts";
 
+/**
+ * JS prefetching, switched off at build time by
+ * `pracht({ client: { prefetch: false } })`.
+ *
+ * The router reaches the prefetch runtime directly — `initClientRouter()`
+ * registers the prefetch target and lazily imports the listeners on every page
+ * — so no bundler can decide on its own that an app does not use it. Gating on
+ * a define turns the branch, the modules only it reaches, and the lazily
+ * imported chunk into dead code.
+ *
+ * The constant is declared here rather than imported from a shared module
+ * because Rollup only folds it into the surrounding branch within one module,
+ * and without that fold the dynamic `import()` survives and its chunk still
+ * ships. The `typeof` guard keeps the module loadable where the define is
+ * absent (unit tests, direct Node imports), so an app that configures nothing
+ * behaves exactly as before.
+ */
+declare const __PRACHT_CLIENT_PREFETCH__: boolean | undefined;
+
+const PREFETCH_ENABLED =
+  typeof __PRACHT_CLIENT_PREFETCH__ === "undefined" || __PRACHT_CLIENT_PREFETCH__ !== false;
+
 interface RouteRenderState {
   Shell: FunctionComponent | null;
   Component: FunctionComponent;
@@ -530,7 +552,7 @@ export async function initClientRouter(options: InitClientRouterOptions): Promis
               cache: "reload",
               signal: abortController.signal,
             })
-          : (getCachedRouteState(target.requestUrl) ??
+          : ((PREFETCH_ENABLED ? getCachedRouteState(target.requestUrl) : undefined) ??
             fetchPrachtRouteState(target.requestUrl, { signal: abortController.signal }));
       } else {
         statePromise = Promise.resolve({
@@ -1014,14 +1036,16 @@ export async function initClientRouter(options: InitClientRouterOptions): Promis
     }
   }
 
-  const warmModules: ModuleWarmFn = (match) => {
-    startRouteImport(match);
-    startShellImport(match);
-  };
-  registerPrefetchTarget(app, warmModules);
-  void import("./prefetch.ts").then(({ setupPrefetching }) => {
-    setupPrefetching(app, warmModules);
-  });
+  if (PREFETCH_ENABLED) {
+    const warmModules: ModuleWarmFn = (match) => {
+      startRouteImport(match);
+      startShellImport(match);
+    };
+    registerPrefetchTarget(app, warmModules);
+    void import("./prefetch.ts").then(({ setupPrefetching }) => {
+      setupPrefetching(app, warmModules);
+    });
+  }
 }
 
 /**

--- a/packages/framework/test/package-tree-shaking.test.ts
+++ b/packages/framework/test/package-tree-shaking.test.ts
@@ -171,6 +171,52 @@ describe("published package tree shaking", () => {
     });
   });
 
+  // `pracht({ client: { prefetch: false } })` compiles the prefetch runtime out
+  // of the client bundle. The router reaches it directly, so only the define
+  // can remove it.
+  describe("__PRACHT_CLIENT_PREFETCH__", () => {
+    // Production shape: the dev-only hydration mismatch warning is dead code in
+    // a real app bundle, so counting it would hide what ships.
+    const PRODUCTION = { "import.meta.env.DEV": "false" };
+
+    const routerBundle = (define: Record<string, string>) =>
+      bundleExport("initClientRouter", {
+        define: { ...PRODUCTION, ...define },
+        entry: clientEntry,
+      });
+
+    it("drops the prefetch runtime, including its lazily imported chunk", async () => {
+      const { code } = await routerBundle({ __PRACHT_CLIENT_PREFETCH__: "false" });
+
+      // `setupPrefetching` lives behind a dynamic import. Rollup only drops the
+      // chunk when the import expression itself is proven dead, so an assertion
+      // on the entry chunk alone would pass while the chunk still shipped.
+      expect(code).not.toContain("setupPrefetching");
+      expect(code).not.toContain("data-pracht-prefetch");
+    });
+
+    it("cuts the router runtime by at least a fifth", async () => {
+      const on = await routerBundle({ __PRACHT_CLIENT_PREFETCH__: "true" });
+      const off = await routerBundle({ __PRACHT_CLIENT_PREFETCH__: "false" });
+
+      expect(off.gzipBytes).toBeLessThanOrEqual(on.gzipBytes * 0.8);
+    });
+
+    it("keeps prefetching when the feature is enabled", async () => {
+      const { code } = await routerBundle({ __PRACHT_CLIENT_PREFETCH__: "true" });
+
+      expect(code).toContain("setupPrefetching");
+    });
+
+    it("costs nothing when the define is absent", async () => {
+      // Unit tests and direct Node imports run without the define. The `typeof`
+      // guard has to keep prefetching on rather than throw.
+      const { code } = await routerBundle({});
+
+      expect(code).toContain("setupPrefetching");
+    });
+  });
+
   // The agent surface is opt-in: a server bundle for an app that registers no
   // capabilities and configures no agents must not contain the capability
   // dispatch or the Web Bot Auth verifier at all.

--- a/packages/vite-plugin/src/index.ts
+++ b/packages/vite-plugin/src/index.ts
@@ -63,6 +63,7 @@ export type { RenderMode };
 export type { PrachtAdapter } from "./plugin-adapter.ts";
 export type {
   LlmsTxtSection,
+  PrachtClientOptions,
   PrachtLlmsTxtOptions,
   PrachtPluginOptions,
 } from "./plugin-options.ts";
@@ -190,6 +191,13 @@ export function pracht(options: PrachtPluginOptions = {}): Plugin[] {
         env.command === "build" && resolved.adapter.staticTarget === true,
       );
 
+      // Declared by the app rather than derived from the manifest, so the
+      // same flags apply in dev — a feature switched off must behave the same
+      // in `pracht dev` as it does in the build that ships.
+      const clientFeatureDefines = {
+        __PRACHT_CLIENT_PREFETCH__: String(resolved.client.prefetch),
+      };
+
       return {
         appType: "custom" as const,
         // Expose PRACHT_PUBLIC_-prefixed vars on import.meta.env (client and
@@ -209,6 +217,7 @@ export function pracht(options: PrachtPluginOptions = {}): Plugin[] {
           __PRACHT_PUBLIC_ENV__: publicEnvDefine,
           __PRACHT_AGENT_SURFACE__: agentSurfaceDefine,
           __PRACHT_STATIC_TARGET__: staticTargetDefine,
+          ...clientFeatureDefines,
         },
         // The vendor split only makes sense for the client bundle; SSR builds
         // that disable code splitting (e.g. webworker targets) reject

--- a/packages/vite-plugin/src/plugin-options.ts
+++ b/packages/vite-plugin/src/plugin-options.ts
@@ -36,7 +36,28 @@ export interface PrachtLlmsTxtOptions {
   exclude?: string[];
 }
 
+/**
+ * Optional client-router features, compiled out of the client bundle when
+ * disabled. Every one defaults to `true`. Turn a feature off only when the app
+ * really does not use it: the router silently stops honouring the
+ * corresponding route options and `<Link>` props.
+ */
+export interface PrachtClientOptions {
+  /**
+   * JS prefetching of route-state JSON and route/shell chunks, driven by
+   * `route({ prefetch })` and `<Link prefetch>`. Off also drops the separate
+   * prefetch chunk the router loads on every page, and makes the imperative
+   * `prefetch()` export a no-op.
+   */
+  prefetch?: boolean;
+}
+
 export interface PrachtPluginOptions {
+  /**
+   * Switch off client-router features the app does not use, so they are
+   * compiled out of the client bundle. See {@link PrachtClientOptions}.
+   */
+  client?: PrachtClientOptions;
   appFile?: string;
   routesDir?: string;
   shellsDir?: string;
@@ -100,7 +121,12 @@ export interface PrachtPluginOptions {
 
 export type ResolvedPrachtPluginOptions = Required<PrachtPluginOptions>;
 
+export const CLIENT_FEATURE_DEFAULTS: Required<PrachtClientOptions> = {
+  prefetch: true,
+};
+
 const DEFAULTS: ResolvedPrachtPluginOptions = {
+  client: CLIENT_FEATURE_DEFAULTS,
   appFile: "/src/routes.ts",
   middlewareDir: "/src/middleware",
   routesDir: "/src/routes",
@@ -131,6 +157,7 @@ export function resolveOptions(options: PrachtPluginOptions): ResolvedPrachtPlug
   if (resolved.llmsTxt === undefined) {
     resolved.llmsTxt = false;
   }
+  resolved.client = resolveClientOptions(options.client);
   resolved.additionalExtensions = normalizeAdditionalExtensions(resolved.additionalExtensions);
   if (!new Set(["spa", "ssr", "ssg", "isg"]).has(resolved.pagesDefaultRender)) {
     throw new Error('pracht({ pagesDefaultRender }) expects "spa", "ssr", "ssg", or "isg".');
@@ -143,6 +170,34 @@ export function resolveOptions(options: PrachtPluginOptions): ResolvedPrachtPlug
   }
   validateBudgets(resolved.budgets);
   validateLlmsTxt(resolved.llmsTxt);
+  return resolved;
+}
+
+function resolveClientOptions(
+  client: PrachtClientOptions | undefined,
+): Required<PrachtClientOptions> {
+  if (client === undefined) return CLIENT_FEATURE_DEFAULTS;
+  if (typeof client !== "object" || client === null) {
+    throw new Error("pracht({ client }) expects an options object.");
+  }
+  const resolved = { ...CLIENT_FEATURE_DEFAULTS };
+  for (const key of Object.keys(CLIENT_FEATURE_DEFAULTS) as Array<keyof PrachtClientOptions>) {
+    const value = client[key];
+    if (value === undefined) continue;
+    if (typeof value !== "boolean") {
+      throw new Error(
+        `pracht({ client: { ${key} } }) expects a boolean, got ${JSON.stringify(value)}.`,
+      );
+    }
+    resolved[key] = value;
+  }
+  const unknown = Object.keys(client).filter((key) => !(key in CLIENT_FEATURE_DEFAULTS));
+  if (unknown.length > 0) {
+    throw new Error(
+      `pracht({ client }) does not accept ${unknown.map((key) => JSON.stringify(key)).join(", ")}. ` +
+        `Known features: ${Object.keys(CLIENT_FEATURE_DEFAULTS).join(", ")}.`,
+    );
+  }
   return resolved;
 }
 

--- a/packages/vite-plugin/test/plugin-build-config.test.ts
+++ b/packages/vite-plugin/test/plugin-build-config.test.ts
@@ -28,8 +28,12 @@ interface BuildConfig {
   };
 }
 
-function runConfigHook(adapter: PrachtAdapter, isSsrBuild: boolean): BuildConfig {
-  const plugin = pracht({ adapter }).find((candidate) => candidate.name === "pracht");
+function runConfigHook(
+  adapter: PrachtAdapter,
+  isSsrBuild: boolean,
+  options: Partial<Parameters<typeof pracht>[0]> = {},
+): BuildConfig {
+  const plugin = pracht({ adapter, ...options }).find((candidate) => candidate.name === "pracht");
   if (!plugin) throw new Error("pracht plugin not found");
   const hook = plugin.config as (
     config: Record<string, unknown>,
@@ -220,6 +224,40 @@ describe("pracht plugin build config", () => {
     expect(config.environments?.ssr?.resolve?.external).toEqual(["node:module"]);
     expect(config.environments?.ssr?.keepProcessEnv).toBeUndefined();
     expect(config.define?.["process.env.NODE_ENV"]).toBeUndefined();
+  });
+
+  it("defines every client feature as enabled by default", () => {
+    const config = runConfigHook(edgeAdapter, false);
+
+    expect(config.define?.__PRACHT_CLIENT_PREFETCH__).toBe("true");
+  });
+
+  it("defines a disabled client feature as false in dev as well as in builds", () => {
+    // The flag is declared by the app rather than derived from the manifest, so
+    // unlike __PRACHT_AGENT_SURFACE__ it must not be forced on outside builds —
+    // `pracht dev` has to behave like the bundle that ships.
+    const built = runConfigHook(edgeAdapter, false, { client: { prefetch: false } });
+    expect(built.define?.__PRACHT_CLIENT_PREFETCH__).toBe("false");
+
+    const plugin = pracht({ adapter: edgeAdapter, client: { prefetch: false } }).find(
+      (candidate) => candidate.name === "pracht",
+    );
+    if (!plugin) throw new Error("pracht plugin not found");
+    const hook = plugin.config as (
+      config: Record<string, unknown>,
+      env: { command: string; mode: string; isSsrBuild: boolean },
+    ) => BuildConfig;
+    const dev = hook.call(
+      plugin as never,
+      {},
+      {
+        command: "serve",
+        mode: "development",
+        isSsrBuild: false,
+      },
+    );
+
+    expect(dev.define?.__PRACHT_CLIENT_PREFETCH__).toBe("false");
   });
 
   it("keeps the vendor manualChunks split on client builds only", () => {

--- a/packages/vite-plugin/test/plugin-options.test.ts
+++ b/packages/vite-plugin/test/plugin-options.test.ts
@@ -29,6 +29,34 @@ describe("resolveOptions additionalExtensions", () => {
   });
 });
 
+describe("resolveOptions client", () => {
+  it("enables every client feature by default", () => {
+    expect(resolveOptions({}).client).toEqual({ prefetch: true });
+  });
+
+  it("applies an explicit override", () => {
+    expect(resolveOptions({ client: { prefetch: false } }).client).toEqual({ prefetch: false });
+  });
+
+  it("treats an explicit undefined as unset rather than as false", () => {
+    expect(resolveOptions({ client: { prefetch: undefined } }).client.prefetch).toBe(true);
+  });
+
+  it("rejects non-boolean feature values", () => {
+    // @ts-expect-error — feature flags are booleans.
+    expect(() => resolveOptions({ client: { prefetch: "no" } })).toThrow(
+      /client: \{ prefetch \} \}\) expects a boolean/,
+    );
+  });
+
+  it("rejects unknown feature names so a typo cannot silently do nothing", () => {
+    // @ts-expect-error — "prefetching" is not a feature.
+    expect(() => resolveOptions({ client: { prefetching: false } })).toThrow(
+      /does not accept "prefetching"/,
+    );
+  });
+});
+
 describe("resolveOptions budgets", () => {
   it("defaults to no budgets", () => {
     expect(resolveOptions({}).budgets).toEqual({});

--- a/skills/audit-bundles/SKILL.md
+++ b/skills/audit-bundles/SKILL.md
@@ -137,6 +137,14 @@ overrides the route-level strategy for a single anchor (and accepts the extra
 option), so a route can stay on `"intent"` while its primary-nav link opts
 into `"viewport"` or `"render"`.
 
+If every route ends up on `"none"`, do not stop there — the prefetch listeners
+still ship, in a chunk the router lazily imports on every page. Recommend
+`pracht({ client: { prefetch: false } })` instead, which compiles the whole
+mechanism out (~2.6 KB gzip and one fewer request). Confirm nothing relies on
+prefetching first: the router silently stops honouring `route({ prefetch })` and
+`<Link prefetch>`, and the imperative `prefetch()` export becomes a no-op. See
+`docs/PERFORMANCE.md#switching-off-js-prefetching`.
+
 ## Step 7: Report
 
 Three sections:


### PR DESCRIPTION
## Summary

- Every internal link is prefetched on hover/focus by default, and the listeners that do it live in a chunk the router lazily imports on *every* page. Setting each route to `prefetch: "none"` stops the fetching but still ships that chunk — `initClientRouter()` reaches the prefetch runtime directly, so no bundler can work out that nothing uses it.
- `pracht({ client: { prefetch: false } })` gates it on a compile-time define, the same pattern the repo already has for `__PRACHT_STATIC_TARGET__` and `__PRACHT_AGENT_SURFACE__`. The branch, the modules only it reaches, and the lazily imported chunk all become dead code.
- No issue linked. Follow-up to #326.

```ts
// vite.config.ts
pracht({ client: { prefetch: false } })
```

The flag defaults to `true`, so an app that configures nothing is unchanged byte for byte (measured: 9,917 gzip either way).

### Measurements

| | Gzip |
| --- | --- |
| Router runtime, prefetch on | 9,917 b |
| Router runtime, prefetch off | 7,286 b (**−2,631, −26.5%**) |
| `examples/basic` cold load, on | 21,087 b |
| `examples/basic` cold load, off | 18,692 b (**−2,395, −11.4%**) — and one fewer request |

Getting the lazy chunk to actually disappear is why the constant is declared inline in `router.ts` rather than imported from a shared module. Rollup only folds it into the surrounding branch within one module, and without that fold the dynamic `import()` survives tree-shaking and the chunk still ships. I measured that failing first — the cross-module version saved only 712 of the 2,631 bytes. There is a test for exactly that (`expect(code).not.toContain("setupPrefetching")` covers all chunks, not just the entry).

### What turning it off changes

The router stops honouring `route({ prefetch })` and `<Link prefetch>`, and the imperative `prefetch()` export becomes a no-op. It does not warn: the code is gone. Navigation still works, it just always fetches route state on click. Browser speculation rules are unaffected — they are emitted in the HTML and handled by the browser, not by the prefetch runtime.

Scroll restoration and fragment (`#hash`) navigation are deliberately *not* switchable, and I would push back on adding them: the popstate handler tells a history traversal apart from an in-page fragment navigation by whether the entry carries a router-stamped scroll key, so the two are one mechanism rather than two features. Removing it would change navigation semantics, not just bundle size.

### Scope note

An earlier revision of this PR also gated `fonts`, `viewTransitions`, and `speculation`. Together those were worth 483 gzip bytes against real behavioural footguns (a route with new fonts would not load them until a full page load), so they are dropped. The `client` option object is kept so more features can be added if one ever justifies it.

### Dogfooding

Built `examples/basic` with `prefetch: false` and drove it in a headless browser: no `prefetch-*.js` chunk is emitted, hovering a link fires zero route-state requests, clicking still performs a client-side navigation (a `window` marker survives forward and back), and there are no console errors.

## Testing

- [x] `pnpm run verify` (build, format, lint, typecheck, test, e2e)

One e2e run hit a 20s timeout on an unrelated prefetch test while four dev servers from other workspaces were running on the same machine; it passes in 1.3s on its own and on a clean full run.

## Checklist

- [x] Docs updated if needed — `docs/PERFORMANCE.md` gains a "Switching off JS prefetching" section; `docs/ROUTING.md` cross-references it from the prefetch section
- [x] Skills updated if needed — `audit-bundles` now recommends the option instead of stopping at per-route `prefetch: "none"`
- [x] Changeset added if published packages changed — `.changeset/client-feature-flags.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
