### PR TITLE
fix: keep lazy server chunks independently loadable, scope Netlify _headers

### DIFF
--- a/.changeset/content-deferred-document-payloads.md
+++ b/.changeset/content-deferred-document-payloads.md
@@ -28,14 +28,14 @@ page that happens to use them is first rendered. Descriptive payload chunk
 names are bounded so deeply nested, valid source paths cannot exceed filesystem
 filename limits during a build.
 
-Server builds now preserve dynamic imports even for webworker targets. Deferred
-document payloads remain independent, while unrelated lazy server roots are
-packed with a 256 KiB target size instead of producing one tiny chunk per
-dynamic import. Only modules with no static path to an entry are packed
-together: a module the entry also reaches statically would make the shared
-chunk part of startup, running every module batched alongside it — including
-client-only route modules whose bodies touch `Worker`, `document`, or
-`window` — the moment the server bundle is imported. New
+Server builds now preserve dynamic imports even for webworker targets, so
+deferred document payloads and lazy route modules each stay independently
+loadable. Chunking is left to the bundler's automatic algorithm: a chunk is an
+evaluation unit, so packing unrelated lazy roots together to cut the file count
+would make the first import of any one of them run all of their module bodies,
+and collecting one route's static paths would evaluate every route packed
+alongside it — including client-only ones whose bodies touch `Worker`,
+`document`, or `window`. New
 Cloudflare projects deploy Pracht's pre-bundled output with `no_bundle: true`
 and a JavaScript `ESModule` rule, and `pracht verify` warns existing Wrangler
 configs, including named-environment overrides, that would inline or omit the

--- a/.changeset/content-deferred-document-payloads.md
+++ b/.changeset/content-deferred-document-payloads.md
@@ -31,7 +31,11 @@ filename limits during a build.
 Server builds now preserve dynamic imports even for webworker targets. Deferred
 document payloads remain independent, while unrelated lazy server roots are
 packed with a 256 KiB target size instead of producing one tiny chunk per
-dynamic import. New
+dynamic import. Only modules with no static path to an entry are packed
+together: a module the entry also reaches statically would make the shared
+chunk part of startup, running every module batched alongside it — including
+client-only route modules whose bodies touch `Worker`, `document`, or
+`window` — the moment the server bundle is imported. New
 Cloudflare projects deploy Pracht's pre-bundled output with `no_bundle: true`
 and a JavaScript `ESModule` rule, and `pracht verify` warns existing Wrangler
 configs, including named-environment overrides, that would inline or omit the

--- a/.changeset/netlify-headers-static-scope.md
+++ b/.changeset/netlify-headers-static-scope.md
@@ -1,0 +1,23 @@
+---
+"@pracht/adapter-netlify": patch
+---
+
+Write generated build headers into `dist/client/_headers` only for paths
+Netlify's static layer serves.
+
+The function's Functions v2 config claims `path: "/*"` without `preferStatic`,
+so Netlify invokes it for every request that `excludedPath` does not carve out
+— including requests for prerendered pages that exist in the publish
+directory. Those responses come from the function, which applies the same
+header manifest at runtime, so the matching `_headers` rules never affected a
+response. They were also the bulk of the file: one block per prerendered page
+turned a documentation site's `_headers` into hundreds of dead rules.
+
+Rules that restate a header their exclusion block already applies are dropped
+as well. Netlify concatenates repeated header names across matching rules
+instead of letting the more specific one win, so an artifact under `/assets/*`
+was being served `x-content-type-options: nosniff,nosniff`.
+
+An `excludedPath` pattern the adapter cannot evaluate exactly keeps every rule:
+a redundant block costs bytes, while a missing one costs a statically served
+artifact its media type.

--- a/docs/ADAPTERS.md
+++ b/docs/ADAPTERS.md
@@ -958,11 +958,17 @@ resolution.
 - At the origin root, `/assets/*` (and other `excludedPath` prefixes) bypass
   the function, so the build also writes a `dist/client/_headers` file that
   gives Netlify's static layer the immutable asset policy and the same default
-  security headers the function applies everywhere else. A hand-authored
-  `_headers` copied from Vite's configured `publicDir` wins — including the
-  default `public/_headers` — so pracht skips generating one and warns.
-  Header manifest entries with wildcard or `:placeholder` syntax cannot be
-  expressed exactly: header-less entries are ignored, and entries carrying
+  security headers the function applies everywhere else. Generated build
+  headers join that file only for paths under those exclusions: the function
+  claims `/*` without `preferStatic`, so every other path — including every
+  prerendered page — runs through it and gets the same headers from the
+  manifest at runtime. A rule that repeats what its exclusion block already
+  applies is left out too, because Netlify concatenates repeated header names
+  across matching rules rather than letting the more specific one win. A
+  hand-authored `_headers` copied from Vite's configured `publicDir` wins —
+  including the default `public/_headers` — so pracht skips generating one and
+  warns. Header manifest entries with wildcard or `:placeholder` syntax cannot
+  be expressed exactly: header-less entries are ignored, and entries carrying
   headers are skipped with a build warning rather than broadening the rule.
   Default and prefix-shaped exclusions are also omitted from the function's
   `includedFiles`, keeping large bypassed asset trees outside its bundle. The

--- a/docs/CONTENT.md
+++ b/docs/CONTENT.md
@@ -301,12 +301,11 @@ chunk, which the runtime loads when that document is resolved.
 
 `prachtContent()` enables server code splitting so webworker builds preserve
 that boundary too. Deferred content payloads remain one module per document,
-while unrelated lazy server roots such as route modules are packed into chunks
-with a 256 KiB target size instead of producing one tiny file per dynamic import.
-Only modules the server entry cannot reach statically are packed together — a
-module that is both statically and dynamically imported would pull the shared
-chunk into startup, and a client-only module batched alongside it would then
-run its `Worker` or `document` access when the server bundle loads.
+and lazy route modules keep their own chunks. Packing unrelated lazy roots
+together would cut the file count, but a chunk is an evaluation unit: the first
+import of any module in it runs every module body it holds, so collecting one
+route's static paths would evaluate every route packed alongside it — including
+client-only ones whose bodies touch `Worker` or `document`.
 Cloudflare deployments must set `"no_bundle": true` and an `ESModule` rule
 covering `"**/*.js"` in `wrangler.jsonc`: Pracht's Vite output is already
 bundled, and the rule tells Wrangler to upload its chunks as Worker modules

--- a/docs/CONTENT.md
+++ b/docs/CONTENT.md
@@ -303,6 +303,10 @@ chunk, which the runtime loads when that document is resolved.
 that boundary too. Deferred content payloads remain one module per document,
 while unrelated lazy server roots such as route modules are packed into chunks
 with a 256 KiB target size instead of producing one tiny file per dynamic import.
+Only modules the server entry cannot reach statically are packed together — a
+module that is both statically and dynamically imported would pull the shared
+chunk into startup, and a client-only module batched alongside it would then
+run its `Worker` or `document` access when the server bundle loads.
 Cloudflare deployments must set `"no_bundle": true` and an `ESModule` rule
 covering `"**/*.js"` in `wrangler.jsonc`: Pracht's Vite output is already
 bundled, and the rule tells Wrangler to upload its chunks as Worker modules

--- a/packages/adapter-netlify/README.md
+++ b/packages/adapter-netlify/README.md
@@ -28,7 +28,12 @@ claims page URLs, excludes Pracht's asset directories, and bundles the exact
 `dist/client` files the function can serve plus the generated headers,
 Markdown, and ISG manifests.
 
-Generated header manifest entries become exact `_headers` rules. A path
+Generated header manifest entries become exact `_headers` rules, but only for
+paths Netlify's static layer actually serves. The function claims `/*`, so a
+prerendered page still runs through it and applies the same manifest at
+runtime; only `excludedPath` carve-outs need a rule, and a rule that restates
+what its exclusion block already applies is dropped because Netlify
+concatenates repeated header names instead of overriding them. A path
 containing Netlify wildcard or `:placeholder` syntax cannot be expressed as an
 exact match, so the build warns and skips that entry rather than broadening the
 rule to other paths — the page still deploys, just without its custom headers.

--- a/packages/adapter-netlify/src/index.ts
+++ b/packages/adapter-netlify/src/index.ts
@@ -557,12 +557,52 @@ function isExcludedNetlifyBundlePath(
   });
 }
 
-const STATIC_SECURITY_HEADER_LINES = [
-  "  Permissions-Policy: accelerometer=(), camera=(), geolocation=(), gyroscope=(), magnetometer=(), microphone=(), payment=(), usb=()",
-  "  Referrer-Policy: strict-origin-when-cross-origin",
-  "  X-Content-Type-Options: nosniff",
-  "  X-Frame-Options: SAMEORIGIN",
+const IMMUTABLE_ASSET_CACHE_CONTROL = "public, max-age=31536000, immutable";
+const STATIC_SECURITY_HEADERS: ReadonlyArray<readonly [string, string]> = [
+  [
+    "Permissions-Policy",
+    "accelerometer=(), camera=(), geolocation=(), gyroscope=(), magnetometer=(), microphone=(), payment=(), usb=()",
+  ],
+  ["Referrer-Policy", "strict-origin-when-cross-origin"],
+  ["X-Content-Type-Options", "nosniff"],
+  ["X-Frame-Options", "SAMEORIGIN"],
 ];
+
+/** Headers the generated `_headers` rule for `pattern` already applies. */
+function staticExclusionHeaders(pattern: string): Array<readonly [string, string]> {
+  return [
+    ...(pattern === "/assets/*" ? [["Cache-Control", IMMUTABLE_ASSET_CACHE_CONTROL] as const] : []),
+    ...STATIC_SECURITY_HEADERS,
+  ];
+}
+
+/**
+ * Whether a `_headers` rule for `pathname` can affect a response at all.
+ *
+ * The generated function claims `path: "/*"` without `preferStatic`, so Netlify
+ * invokes it for every request that `excludedPath` does not carve out —
+ * including requests for prerendered pages that exist in the publish
+ * directory. Those responses come from the function, which applies the same
+ * manifest at runtime, so a `_headers` rule for them is dead weight: on a
+ * documentation site it is a rule per page.
+ *
+ * A pattern this cannot evaluate exactly keeps every rule. Netlify's pattern
+ * syntax is richer than the subset understood here, and a redundant rule costs
+ * bytes where a missing one costs a statically served artifact its media type.
+ */
+function servedByNetlifyStaticLayer(pathname: string, excludedPath: string[]): boolean {
+  return (
+    excludedPath.some((pattern) => !isExactNetlifyExclusion(pattern)) ||
+    isExcludedNetlifyBundlePath(pathname, excludedPath, false)
+  );
+}
+
+/** Whether `isExcludedNetlifyBundlePath` decides this pattern exactly. */
+function isExactNetlifyExclusion(pattern: string): boolean {
+  if (pattern === "/*") return true;
+  if (pattern.endsWith("/*")) return !pattern.slice(0, -2).includes("*");
+  return !isNetlifyPathPattern(pattern);
+}
 
 function createNetlifyHeadersFile(
   excludedPath: string[],
@@ -575,15 +615,29 @@ function createNetlifyHeadersFile(
   ];
   for (const pattern of excludedPath) {
     lines.push(pattern);
-    if (pattern === "/assets/*") {
-      lines.push("  Cache-Control: public, max-age=31536000, immutable");
-    }
-    lines.push(...STATIC_SECURITY_HEADER_LINES);
+    for (const [name, value] of staticExclusionHeaders(pattern)) lines.push(`  ${name}: ${value}`);
   }
   for (const pathname of Object.keys(headersManifest).sort()) {
-    const entries = Object.entries(headersManifest[pathname]).sort(([left], [right]) =>
-      left.localeCompare(right),
+    if (!servedByNetlifyStaticLayer(pathname, excludedPath)) continue;
+    // Netlify concatenates repeated header names across matching rules rather
+    // than letting the more specific one win, so a rule that restates what its
+    // pattern already applies turns `nosniff` into `nosniff,nosniff`.
+    const inherited = new Map(
+      excludedPath
+        .filter(
+          (pattern) =>
+            isExactNetlifyExclusion(pattern) &&
+            isExcludedNetlifyBundlePath(pathname, [pattern], false),
+        )
+        .flatMap((pattern) =>
+          staticExclusionHeaders(pattern).map(
+            ([name, value]) => [name.toLowerCase(), value] as const,
+          ),
+        ),
     );
+    const entries = Object.entries(headersManifest[pathname])
+      .filter(([name, value]) => inherited.get(name.toLowerCase()) !== value)
+      .sort(([left], [right]) => left.localeCompare(right));
     if (entries.length === 0) continue;
     lines.push(pathname);
     for (const [name, value] of entries) lines.push(`  ${name}: ${value}`);

--- a/packages/adapter-netlify/test/index.test.ts
+++ b/packages/adapter-netlify/test/index.test.ts
@@ -82,6 +82,7 @@ describe("netlifyAdapter", () => {
           "content-type": "application/json; charset=utf-8",
           "x-content-type-options": "nosniff",
         },
+        "/docs": { "content-type": "text/html; charset=utf-8", vary: "Accept" },
       }),
     );
     const options = {
@@ -144,9 +145,17 @@ describe("netlifyAdapter", () => {
     expect(headersFile).toContain("/content/*");
     expect(headersFile).toContain("  X-Content-Type-Options: nosniff");
     expect(headersFile).toContain("  X-Frame-Options: SAMEORIGIN");
+    // `/assets/*` already applies `X-Content-Type-Options` to this path, and
+    // Netlify concatenates repeated header names across matching rules instead
+    // of letting the more specific one win.
     expect(headersFile).toContain(
-      "/assets/search.data\n  content-type: application/json; charset=utf-8\n  x-content-type-options: nosniff",
+      "/assets/search.data\n  content-type: application/json; charset=utf-8\n",
     );
+    expect(headersFile).not.toContain("  x-content-type-options: nosniff");
+    // `/docs` is not excluded, so the function serves it and applies the same
+    // manifest at runtime. A rule here would be a rule per prerendered page.
+    expect(headersFile).not.toContain("\n/docs\n");
+    expect(headersFile).not.toContain("  vary: Accept");
   });
 
   it("rejects build header rules that could inject _headers entries", async () => {
@@ -169,7 +178,7 @@ describe("netlifyAdapter", () => {
         join(root, "dist/server/headers-manifest.json"),
         JSON.stringify({
           [pathname]: { "cache-control": "public, max-age=60" },
-          "/feed.data": { "content-type": "application/json" },
+          "/assets/feed.data": { "content-type": "application/json" },
         }),
       );
       const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
@@ -183,7 +192,7 @@ describe("netlifyAdapter", () => {
       const headersFile = await readFile(join(root, "dist/client/_headers"), "utf-8");
       expect(headersFile).not.toContain(pathname);
       expect(headersFile).not.toContain("max-age=60");
-      expect(headersFile).toContain("/feed.data\n  content-type: application/json");
+      expect(headersFile).toContain("/assets/feed.data\n  content-type: application/json");
     },
   );
 
@@ -194,7 +203,10 @@ describe("netlifyAdapter", () => {
     // including the header-less ones that were never going to emit a rule.
     await writeFile(
       join(root, "dist/server/headers-manifest.json"),
-      JSON.stringify({ "/docs/a*b": {}, "/feed.data": { "content-type": "application/json" } }),
+      JSON.stringify({
+        "/docs/a*b": {},
+        "/assets/feed.data": { "content-type": "application/json" },
+      }),
     );
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
 
@@ -203,7 +215,25 @@ describe("netlifyAdapter", () => {
     expect(warn).not.toHaveBeenCalled();
     const headersFile = await readFile(join(root, "dist/client/_headers"), "utf-8");
     expect(headersFile).not.toContain("/docs/a*b");
-    expect(headersFile).toContain("/feed.data\n  content-type: application/json");
+    expect(headersFile).toContain("/assets/feed.data\n  content-type: application/json");
+  });
+
+  it("keeps every build header rule when an exclusion pattern is not exactly matchable", async () => {
+    const root = await tempDir();
+    await mkdir(join(root, "dist/server"), { recursive: true });
+    await writeFile(
+      join(root, "dist/server/headers-manifest.json"),
+      JSON.stringify({ "/docs": { "content-type": "text/html; charset=utf-8" } }),
+    );
+
+    // Netlify's pattern syntax is richer than what the adapter evaluates. A
+    // redundant rule costs bytes; a dropped one costs a statically served
+    // artifact its media type, so an unreadable exclusion keeps every rule.
+    await finalizeNetlifyBuild(root, { excludedPath: ["/docs/*.html"] });
+
+    await expect(readFile(join(root, "dist/client/_headers"), "utf-8")).resolves.toContain(
+      "/docs\n  content-type: text/html; charset=utf-8",
+    );
   });
 
   it("rejects malformed headers on paths Netlify cannot match exactly", async () => {
@@ -247,13 +277,13 @@ describe("netlifyAdapter", () => {
     await writeFile(join(root, "public/_headers"), "/unrelated/*\n  X-Custom: 1\n");
     await writeFile(
       join(root, "dist/server/headers-manifest.json"),
-      JSON.stringify({ "/feed.data": { "content-type": "application/json" } }),
+      JSON.stringify({ "/assets/feed.data": { "content-type": "application/json" } }),
     );
 
     await finalizeNetlifyBuild(root);
 
     await expect(readFile(join(root, "dist/client/_headers"), "utf-8")).resolves.toContain(
-      "/feed.data\n  content-type: application/json",
+      "/assets/feed.data\n  content-type: application/json",
     );
   });
 

--- a/packages/content/README.md
+++ b/packages/content/README.md
@@ -220,11 +220,10 @@ This keeps the first request to any content-backed route from parsing every
 document in a shared server chunk.
 
 The plugin enables server code splitting for webworker builds as well. Deferred
-content payloads remain one module per document, while unrelated lazy server
-roots are packed with a 256 KiB target size instead of producing one tiny file
-per dynamic import. Only modules the server entry cannot reach statically are
-packed together, so a module with both static and dynamic importers never drags
-a client-only module into the server's startup path. A Cloudflare deployment must preserve Pracht's
+content payloads remain one module per document, and lazy route modules keep
+their own chunks: a chunk is an evaluation unit, so packing unrelated lazy roots
+together would run every one of their module bodies the first time any of them
+is imported. A Cloudflare deployment must preserve Pracht's
 pre-bundled output with `"no_bundle": true` and an `ESModule` rule covering
 `"**/*.js"` in `wrangler.jsonc`; otherwise Wrangler either bundles the deferred
 chunks again or omits them from the upload. New `create-pracht` projects include

--- a/packages/content/README.md
+++ b/packages/content/README.md
@@ -222,7 +222,9 @@ document in a shared server chunk.
 The plugin enables server code splitting for webworker builds as well. Deferred
 content payloads remain one module per document, while unrelated lazy server
 roots are packed with a 256 KiB target size instead of producing one tiny file
-per dynamic import. A Cloudflare deployment must preserve Pracht's
+per dynamic import. Only modules the server entry cannot reach statically are
+packed together, so a module with both static and dynamic importers never drags
+a client-only module into the server's startup path. A Cloudflare deployment must preserve Pracht's
 pre-bundled output with `"no_bundle": true` and an `ESModule` rule covering
 `"**/*.js"` in `wrangler.jsonc`; otherwise Wrangler either bundles the deferred
 chunks again or omits them from the upload. New `create-pracht` projects include

--- a/packages/content/src/vite.ts
+++ b/packages/content/src/vite.ts
@@ -67,6 +67,76 @@ interface ContentBuildManifest {
   routes?: ContentRoutesManifest;
 }
 
+interface ServerChunkingModuleInfo {
+  readonly isEntry: boolean;
+  readonly importers: readonly string[];
+  readonly dynamicImporters: readonly string[];
+}
+
+interface ServerChunkingContext {
+  getModuleInfo(moduleId: string): ServerChunkingModuleInfo | null;
+}
+
+/**
+ * Decide which server modules may share the batched lazy chunk.
+ *
+ * Having a dynamic importer does not make a module lazy: a route component the
+ * entry also imports statically is loaded the moment the bundle is. Batching
+ * such a module makes the whole group a static dependency of the entry, so
+ * every genuinely lazy module batched alongside it runs at server startup
+ * too — a browser-only module body (`new Worker(...)` at the top level of a
+ * client-only route) then crashes the server on import instead of when that
+ * route is reached. Only modules with no static path to an entry qualify.
+ */
+function createServerLazyGroupName() {
+  // Reachability is derived from the module graph of one build. A plugin
+  // instance outlives a build in watch mode, so the cache is cleared whenever
+  // a new one starts rather than kept for the lifetime of the plugin.
+  const reachesEntry = new Map<string, boolean>();
+
+  const reachesEntryStatically = (id: string, context: ServerChunkingContext): boolean => {
+    const known = reachesEntry.get(id);
+    if (known !== undefined) return known;
+
+    // Walk importers breadth-first. Everything visited on a walk that finds no
+    // entry is unreachable too: its importers are a subset of the ones already
+    // ruled out, so one traversal answers for the whole upstream cone.
+    const visited = new Set([id]);
+    const queue = [id];
+    for (let index = 0; index < queue.length; index++) {
+      const current = queue[index] as string;
+      const cached = reachesEntry.get(current);
+      if (cached === false) continue;
+      // `undefined` marks a module already known to reach an entry; `null`
+      // marks one the bundler will not describe, which may well be an entry
+      // itself. Batching is an optimisation, so guess in the direction that
+      // keeps lazy modules lazy rather than the one that boots them.
+      const info = cached === true ? undefined : context.getModuleInfo(current);
+      if (!info || info.isEntry) {
+        reachesEntry.set(id, true);
+        return true;
+      }
+      for (const importer of info.importers) {
+        if (visited.has(importer)) continue;
+        visited.add(importer);
+        queue.push(importer);
+      }
+    }
+
+    for (const module of visited) reachesEntry.set(module, false);
+    return false;
+  };
+
+  const name = (id: string, context: ServerChunkingContext) =>
+    !id.startsWith(RESOLVED_CONTENT_PAYLOAD_MODULE_PREFIX) &&
+    context.getModuleInfo(id)?.dynamicImporters.length &&
+    !reachesEntryStatically(id, context)
+      ? "pracht-server-lazy"
+      : null;
+
+  return { name, reset: () => reachesEntry.clear() };
+}
+
 /**
  * Reuse content collections for Vite module transforms, live development
  * assets, and client build output. The returned transform and asset plugins
@@ -76,6 +146,7 @@ export function prachtContent(options: PrachtContentOptions): Plugin[] {
   const collections = validateCollections(options);
   const unroutedDocuments = validateUnroutedDocumentPolicy(options.unroutedDocuments);
   const emittedPayloadModules = new Map<ViteContentCollection, ReadonlySet<string>>();
+  const serverLazyGroup = createServerLazyGroupName();
   const splitCache = new WeakMap<ViteContentCollection, Promise<SplitSnapshot>>();
 
   const transformPlugin: Plugin = {
@@ -98,21 +169,11 @@ export function prachtContent(options: PrachtContentOptions): Plugin[] {
       const withServerSplitting = (candidate: object | undefined) => ({
         ...candidate,
         codeSplitting: {
-          groups: [
-            {
-              name: (
-                id: string,
-                context: {
-                  getModuleInfo(moduleId: string): { dynamicImporters: readonly string[] } | null;
-                },
-              ) =>
-                !id.startsWith(RESOLVED_CONTENT_PAYLOAD_MODULE_PREFIX) &&
-                context.getModuleInfo(id)?.dynamicImporters.length
-                  ? "pracht-server-lazy"
-                  : null,
-              maxSize: SERVER_LAZY_CHUNK_MAX_SIZE,
-            },
-          ],
+          // Dependencies are chunked automatically. Pulling them into the group
+          // would drag modules the entry also imports statically into the lazy
+          // chunk, which is exactly what keeps that chunk lazy.
+          includeDependenciesRecursively: false,
+          groups: [{ name: serverLazyGroup.name, maxSize: SERVER_LAZY_CHUNK_MAX_SIZE }],
         },
       });
       return {
@@ -131,6 +192,7 @@ export function prachtContent(options: PrachtContentOptions): Plugin[] {
       // split stable within one build, but never carry source bytes into the
       // next build invocation.
       for (const collection of collections) splitCache.delete(collection);
+      serverLazyGroup.reset();
     },
 
     resolveId(id) {

--- a/packages/content/src/vite.ts
+++ b/packages/content/src/vite.ts
@@ -25,7 +25,6 @@ const RESOLVED_CONTENT_MODULE_PREFIX = `\0${CONTENT_MODULE_PREFIX}`;
 const CONTENT_PAYLOAD_MODULE_PREFIX = "virtual:pracht/content-payload/";
 const RESOLVED_CONTENT_PAYLOAD_MODULE_PREFIX = `\0${CONTENT_PAYLOAD_MODULE_PREFIX}`;
 const CONTENT_PAYLOAD_SLUG_MAX_LENGTH = 80;
-const SERVER_LAZY_CHUNK_MAX_SIZE = 256 * 1024;
 export const CONTENT_BUILD_MANIFEST_FILE = "_pracht/content-manifest.json";
 
 export interface ViteContentCollection {
@@ -67,76 +66,6 @@ interface ContentBuildManifest {
   routes?: ContentRoutesManifest;
 }
 
-interface ServerChunkingModuleInfo {
-  readonly isEntry: boolean;
-  readonly importers: readonly string[];
-  readonly dynamicImporters: readonly string[];
-}
-
-interface ServerChunkingContext {
-  getModuleInfo(moduleId: string): ServerChunkingModuleInfo | null;
-}
-
-/**
- * Decide which server modules may share the batched lazy chunk.
- *
- * Having a dynamic importer does not make a module lazy: a route component the
- * entry also imports statically is loaded the moment the bundle is. Batching
- * such a module makes the whole group a static dependency of the entry, so
- * every genuinely lazy module batched alongside it runs at server startup
- * too — a browser-only module body (`new Worker(...)` at the top level of a
- * client-only route) then crashes the server on import instead of when that
- * route is reached. Only modules with no static path to an entry qualify.
- */
-function createServerLazyGroupName() {
-  // Reachability is derived from the module graph of one build. A plugin
-  // instance outlives a build in watch mode, so the cache is cleared whenever
-  // a new one starts rather than kept for the lifetime of the plugin.
-  const reachesEntry = new Map<string, boolean>();
-
-  const reachesEntryStatically = (id: string, context: ServerChunkingContext): boolean => {
-    const known = reachesEntry.get(id);
-    if (known !== undefined) return known;
-
-    // Walk importers breadth-first. Everything visited on a walk that finds no
-    // entry is unreachable too: its importers are a subset of the ones already
-    // ruled out, so one traversal answers for the whole upstream cone.
-    const visited = new Set([id]);
-    const queue = [id];
-    for (let index = 0; index < queue.length; index++) {
-      const current = queue[index] as string;
-      const cached = reachesEntry.get(current);
-      if (cached === false) continue;
-      // `undefined` marks a module already known to reach an entry; `null`
-      // marks one the bundler will not describe, which may well be an entry
-      // itself. Batching is an optimisation, so guess in the direction that
-      // keeps lazy modules lazy rather than the one that boots them.
-      const info = cached === true ? undefined : context.getModuleInfo(current);
-      if (!info || info.isEntry) {
-        reachesEntry.set(id, true);
-        return true;
-      }
-      for (const importer of info.importers) {
-        if (visited.has(importer)) continue;
-        visited.add(importer);
-        queue.push(importer);
-      }
-    }
-
-    for (const module of visited) reachesEntry.set(module, false);
-    return false;
-  };
-
-  const name = (id: string, context: ServerChunkingContext) =>
-    !id.startsWith(RESOLVED_CONTENT_PAYLOAD_MODULE_PREFIX) &&
-    context.getModuleInfo(id)?.dynamicImporters.length &&
-    !reachesEntryStatically(id, context)
-      ? "pracht-server-lazy"
-      : null;
-
-  return { name, reset: () => reachesEntry.clear() };
-}
-
 /**
  * Reuse content collections for Vite module transforms, live development
  * assets, and client build output. The returned transform and asset plugins
@@ -146,7 +75,6 @@ export function prachtContent(options: PrachtContentOptions): Plugin[] {
   const collections = validateCollections(options);
   const unroutedDocuments = validateUnroutedDocumentPolicy(options.unroutedDocuments);
   const emittedPayloadModules = new Map<ViteContentCollection, ReadonlySet<string>>();
-  const serverLazyGroup = createServerLazyGroupName();
   const splitCache = new WeakMap<ViteContentCollection, Promise<SplitSnapshot>>();
 
   const transformPlugin: Plugin = {
@@ -162,26 +90,21 @@ export function prachtContent(options: PrachtContentOptions): Plugin[] {
 
       // Rolldown defaults a single-entry server build to one file, including
       // webworker targets. Preserve dynamic imports so document payloads stay
-      // outside the shared snapshot chunk on every server adapter. Batch other
-      // lazy roots into bounded chunks instead of emitting one tiny server
-      // chunk for every route or user-authored dynamic import.
+      // outside the shared snapshot chunk on every server adapter.
+      //
+      // Automatic chunking is the only safe policy here. A chunk is an
+      // evaluation unit, so packing unrelated lazy roots together to cut the
+      // file count makes the first import of any one of them run all of their
+      // module bodies: collecting one route's static paths would evaluate
+      // every route batched alongside it, including client-only ones whose
+      // bodies touch `Worker`, `document`, or `window`.
       const output = config.build?.rollupOptions?.output;
-      const withServerSplitting = (candidate: object | undefined) => ({
-        ...candidate,
-        codeSplitting: {
-          // Dependencies are chunked automatically. Pulling them into the group
-          // would drag modules the entry also imports statically into the lazy
-          // chunk, which is exactly what keeps that chunk lazy.
-          includeDependenciesRecursively: false,
-          groups: [{ name: serverLazyGroup.name, maxSize: SERVER_LAZY_CHUNK_MAX_SIZE }],
-        },
-      });
       return {
         build: {
           rollupOptions: {
             output: Array.isArray(output)
-              ? output.map((candidate) => withServerSplitting(candidate))
-              : withServerSplitting(output),
+              ? output.map((candidate) => ({ ...candidate, codeSplitting: true }))
+              : { ...output, codeSplitting: true },
           },
         },
       };
@@ -192,7 +115,6 @@ export function prachtContent(options: PrachtContentOptions): Plugin[] {
       // split stable within one build, but never carry source bytes into the
       // next build invocation.
       for (const collection of collections) splitCache.delete(collection);
-      serverLazyGroup.reset();
     },
 
     resolveId(id) {

--- a/packages/content/test/vite.test.ts
+++ b/packages/content/test/vite.test.ts
@@ -536,6 +536,53 @@ describe("prachtContent", () => {
     expect(await runtime.load(3)).toMatchObject({ default: 3 });
   });
 
+  it("keeps a module with both static and dynamic importers out of the lazy server group", async () => {
+    temporaryDirectory = await mkdtemp(join(tmpdir(), "pracht-content-vite-"));
+    const entry = join(temporaryDirectory, "entry.ts");
+    const output = join(temporaryDirectory, "dist");
+    // `shared.ts` is reachable statically from the entry *and* dynamically.
+    // Grouping it with the genuinely lazy modules would make the whole group a
+    // static dependency of the entry, evaluating browser-only module bodies on
+    // the server the moment the bundle is imported.
+    await writeFile(
+      entry,
+      [
+        `import shared from "./shared.ts";`,
+        `export const eager = shared;`,
+        `export const loadShared = () => import("./shared.ts");`,
+        `export const loadBrowser = () => import("./browser-only.ts");`,
+      ].join("\n"),
+    );
+    await writeFile(join(temporaryDirectory, "shared.ts"), `export default "shared";`);
+    await writeFile(
+      join(temporaryDirectory, "browser-only.ts"),
+      `import shared from "./shared.ts";\nglobalThis.__prachtLazyModuleEvaluated = true;\nexport default shared + "-browser";`,
+    );
+    const collection = defineCollection({ name: "docs", root: temporaryDirectory });
+
+    await build({
+      configFile: false,
+      logLevel: "silent",
+      plugins: prachtContent({ collections: [collection] }),
+      ssr: { noExternal: true, target: "webworker" },
+      build: {
+        outDir: output,
+        ssr: true,
+        rollupOptions: { input: entry },
+      },
+    });
+
+    try {
+      const runtime = await import(pathToFileURL(join(output, "entry.js")).href);
+      expect(runtime.eager).toBe("shared");
+      expect((globalThis as Record<string, unknown>).__prachtLazyModuleEvaluated).toBeUndefined();
+      expect(await runtime.loadBrowser()).toMatchObject({ default: "shared-browser" });
+      expect((globalThis as Record<string, unknown>).__prachtLazyModuleEvaluated).toBe(true);
+    } finally {
+      delete (globalThis as Record<string, unknown>).__prachtLazyModuleEvaluated;
+    }
+  });
+
   it("emits deploy-safe headers for production artifacts in the asset namespace", async () => {
     temporaryDirectory = await mkdtemp(join(tmpdir(), "pracht-content-vite-"));
     await writeFile(join(temporaryDirectory, "page.md"), "Page");

--- a/packages/content/test/vite.test.ts
+++ b/packages/content/test/vite.test.ts
@@ -499,20 +499,25 @@ describe("prachtContent", () => {
     expect(await runtime.getByRoute("/one")).toMatchObject({ compiled: "First document" });
   });
 
-  it("batches unrelated lazy webworker modules into bounded server chunks", async () => {
+  it("keeps independent lazy webworker routes out of each other's chunks", async () => {
     temporaryDirectory = await mkdtemp(join(tmpdir(), "pracht-content-vite-"));
     const entry = join(temporaryDirectory, "entry.ts");
     const output = join(temporaryDirectory, "dist");
+    // A chunk is an evaluation unit: everything in it runs on first import.
+    // Two lazy routes that share one therefore stop being independent, and the
+    // server pays for — or crashes on — a route no request asked for.
     await writeFile(
       entry,
-      `export const load = (index) => [${Array.from(
-        { length: 4 },
-        (_, index) => `() => import("./lazy-${index}.ts")`,
-      ).join(",")}][index]();`,
+      [
+        `export const loadPlain = () => import("./lazy-plain.ts");`,
+        `export const loadBrowser = () => import("./lazy-browser.ts");`,
+      ].join("\n"),
     );
-    for (let index = 0; index < 4; index++) {
-      await writeFile(join(temporaryDirectory, `lazy-${index}.ts`), `export default ${index};`);
-    }
+    await writeFile(join(temporaryDirectory, "lazy-plain.ts"), `export default "plain";`);
+    await writeFile(
+      join(temporaryDirectory, "lazy-browser.ts"),
+      `globalThis.__prachtLazyModuleEvaluated = true;\nexport default "browser";`,
+    );
     const collection = defineCollection({ name: "docs", root: temporaryDirectory });
 
     await build({
@@ -527,13 +532,18 @@ describe("prachtContent", () => {
       },
     });
 
-    const chunks = (await readdir(output, { recursive: true })).filter((file) =>
-      /\.m?js$/.test(String(file)),
-    );
-    expect(chunks).toHaveLength(2);
-    expect(chunks.some((file) => String(file).includes("pracht-server-lazy"))).toBe(true);
-    const runtime = await import(pathToFileURL(join(output, "entry.js")).href);
-    expect(await runtime.load(3)).toMatchObject({ default: 3 });
+    const evaluated = () => (globalThis as Record<string, unknown>).__prachtLazyModuleEvaluated;
+    try {
+      const runtime = await import(pathToFileURL(join(output, "entry.js")).href);
+      expect(evaluated()).toBeUndefined();
+      // Collecting one route's static paths must not evaluate another's.
+      expect(await runtime.loadPlain()).toMatchObject({ default: "plain" });
+      expect(evaluated()).toBeUndefined();
+      expect(await runtime.loadBrowser()).toMatchObject({ default: "browser" });
+      expect(evaluated()).toBe(true);
+    } finally {
+      delete (globalThis as Record<string, unknown>).__prachtLazyModuleEvaluated;
+    }
   });
 
   it("keeps a module with both static and dynamic importers out of the lazy server group", async () => {


### PR DESCRIPTION
## Summary

Fixes found while upgrading preact-www to the RC.

**1. `Worker is not defined` from the server build (`@pracht/content`)**

`perf(content): batch lazy server chunks` packed unrelated lazy roots into a shared `pracht-server-lazy` chunk. Two distinct failures came out of that, and only the second one is really fixable:

- Modules the entry also reached statically were captured, which made the shared chunk part of startup. Importing `server.js` crashed immediately.
- Even with those excluded, **a chunk is an evaluation unit**: everything in it runs on first import. Packing independent lazy roots together made loading one route evaluate the others, so `collectSSGPaths()` on the tutorial route ran the REPL's client-only module body and threw.

No membership rule fixes the second one — the property batching trades away is exactly the one dynamic imports exist to provide. Server chunking goes back to the bundler's automatic algorithm; document payloads and lazy routes each stay independently loadable, which is what the deferred-payload work needed in the first place.

Measured on the docs example, Node adapter, cold Markdown request, three runs each:

| | automatic chunking | batched |
|---|---|---|
| server chunks | 50 | 12 |
| cold request | 102.7 / 102.9 / 107.3 ms | 103.0 / 104.5 / 108.8 ms |
| request RSS delta | 57.6–59.0 MiB | 55.7–57.0 MiB |
| RSS at startup | 58.5 MiB | 60.8 MiB |

The file count was the only thing batching moved. Startup RSS is slightly lower without it, since nothing pulls the group in eagerly.

Regression tests cover both shapes: a module with both static and dynamic importers must not reach startup, and importing the entry — then one lazy route — must not evaluate an unrelated browser-only lazy route.

**2. `_headers` grew from 24 to 1,898 lines (`@pracht/adapter-netlify`)**

Nearly all of those rules were dead. The generated function claims `path: "/*"` without `preferStatic`, so [Netlify invokes it for every request `excludedPath` does not carve out](https://docs.netlify.com/build/functions/configuration) — including prerendered pages that exist in the publish directory. Those responses come from the function, which applies the same header manifest at runtime.

- Build headers join `_headers` only for paths under an exclusion, where the static layer actually serves the file (the case the feature was added for: content artifacts under `/assets/*` needing their media type).
- Rules restating a header their exclusion block already applies are dropped. [Netlify concatenates repeated header names across matching rules](https://answers.netlify.com/t/remove-inherited-header-applied-by-splat-path-in-headers/26263) rather than letting the more specific one win, so an artifact under `/assets/*` was served `x-content-type-options: nosniff,nosniff`.
- An exclusion pattern the adapter cannot evaluate exactly keeps every rule — a redundant block costs bytes, a missing one costs an artifact its media type.
- The docs example's `_headers` goes from 308 lines to 14, and its routes answer with identical headers because the function applies them.

## Testing

- [x] `pnpm run verify` (build, format, lint, typecheck, test, e2e)
- Built `examples/docs` (43 routes, content-backed) against the Cloudflare, Netlify, and Node adapters. Imported the generated Netlify function and served `/`, `/docs/getting-started`, `/docs/recipes/i18n`, and a miss; verified `content-type`, `x-content-type-options`, `x-frame-options`, and `vary` are identical before and after the `_headers` reduction.
- Not deployed to Netlify — that needs credentials this branch does not have, so a real deploy is still worth doing before release.

## Checklist

- [x] Docs updated if needed (`docs/CONTENT.md`, `docs/ADAPTERS.md`, `packages/content/README.md`, `packages/adapter-netlify/README.md`)
- [x] Skills updated if needed — N/A
- [x] Changeset added if published packages changed (`netlify-headers-static-scope`; the chunking correction is folded into the unreleased `content-deferred-document-payloads` changeset that introduced the grouping)

🤖 Generated with [Claude Code](https://claude.com/claude-code)