### PR TITLE
fix(dev): render loader and render failures in the error overlay

### DIFF
--- a/.changeset/dev-error-overlay-render-failures.md
+++ b/.changeset/dev-error-overlay-render-failures.md
@@ -1,0 +1,24 @@
+---
+"@pracht/core": minor
+"@pracht/vite-plugin": patch
+---
+
+Render loader, middleware, and render failures in the dev error overlay
+instead of a plain-text dump.
+
+`handlePrachtRequest()` answers a page failure that no `ErrorBoundary` claims
+with a `text/plain` body. That is correct for a production adapter and wrong
+for a browser in dev — worst of all for a syntax error in a route file, whose
+compiler diagnostic arrives colourized for a terminal and rendered every
+escape sequence literally, wrapping each character of the offending line in
+`[38;5;249m`.
+
+The dev SSR middleware now captures the raw error through `onRouteError` and
+serves the overlay instead, with clickable stack frames and open-in-editor
+links. `buildErrorOverlayHtml()` strips ANSI escapes from the message and
+stack, keeps multi-line diagnostics readable with `white-space: pre-wrap`, and
+gained `phase`, `loaderFile`, and `shellFile` rows. `onRouteError` receives a
+third `RouteErrorContext` argument carrying that metadata.
+
+A route or shell `ErrorBoundary` still renders its own output, and route-state
+requests still fail as JSON.

--- a/.changeset/dev-error-overlay-render-failures.md
+++ b/.changeset/dev-error-overlay-render-failures.md
@@ -30,3 +30,8 @@ withheld, declares its auto-reload block as a module (`import.meta` is a parse
 error in a classic script, so the block was silently dropped), and no longer
 mangles OSC terminal hyperlinks — the sequence miette, and therefore oxc, emits
 for diagnostic codes.
+
+The handoff now identifies declared route and shell error boundaries explicitly
+instead of inferring them from `Content-Type`, preserves `Server-Timing` on the
+overlay response, and retains a separately wired loader path when that module
+fails during import.

--- a/.changeset/dev-error-overlay-render-failures.md
+++ b/.changeset/dev-error-overlay-render-failures.md
@@ -1,5 +1,5 @@
 ---
-"@pracht/core": minor
+"@pracht/core": patch
 "@pracht/vite-plugin": patch
 ---
 

--- a/.changeset/dev-error-overlay-render-failures.md
+++ b/.changeset/dev-error-overlay-render-failures.md
@@ -22,3 +22,11 @@ third `RouteErrorContext` argument carrying that metadata.
 
 A route or shell `ErrorBoundary` still renders its own output, and route-state
 requests still fail as JSON.
+
+The overlay itself gained fixes found while reviewing this change: it keeps the
+framework's default security headers, honours the runtime's
+`NODE_ENV=production` redaction instead of printing the internals the body just
+withheld, declares its auto-reload block as a module (`import.meta` is a parse
+error in a classic script, so the block was silently dropped), and no longer
+mangles OSC terminal hyperlinks — the sequence miette, and therefore oxc, emits
+for diagnostic codes.

--- a/.changeset/dev-error-overlay-render-failures.md
+++ b/.changeset/dev-error-overlay-render-failures.md
@@ -27,9 +27,10 @@ The overlay itself gained fixes found while reviewing this change: it keeps the
 framework's default security headers, honours the runtime's
 `NODE_ENV=production` redaction instead of printing the internals the body just
 withheld, declares its auto-reload block as a module (`import.meta` is a parse
-error in a classic script, so the block was silently dropped), and no longer
-mangles OSC terminal hyperlinks — the sequence miette, and therefore oxc, emits
-for diagnostic codes.
+error in a classic script, so the block was silently dropped), reloads for both
+ordinary client HMR updates and server-only full reloads, and no longer mangles
+OSC terminal hyperlinks — the sequence miette, and therefore oxc, emits for
+diagnostic codes.
 
 The handoff now identifies declared route and shell error boundaries explicitly
 instead of inferring them from `Content-Type`, preserves `Server-Timing` on the

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -715,10 +715,14 @@ answers them with a `text/plain` body, which is the right answer for a
 production adapter and the wrong one for a browser. The dev middleware
 therefore passes `onRouteError` and swaps that fallback for the overlay
 (`shouldRenderDevErrorOverlay()`). The swap is deliberately narrow — a route
-or shell `ErrorBoundary` produces `text/html` and is left alone, and
-route-state failures are JSON owned by the client router.
-`RouteErrorContext` carries the phase and the route/loader/shell module paths
-into the overlay, since neither is recoverable from a stack trace.
+or shell `ErrorBoundary` is identified explicitly and left alone (even when
+custom shell headers change its content type), and route-state failures are
+JSON owned by the client router. `RouteErrorContext` carries that boundary
+selection plus the phase and route/loader/shell module paths into the overlay,
+since none is reliably recoverable from a stack trace. A loader module path
+comes from the resolved route as a fallback, so a loader that fails during its
+own import is still linked. Overlay responses retain the phase timings already
+collected for the dev `Server-Timing` header.
 
 Three ergonomics features are built in:
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -710,7 +710,24 @@ as `@pracht/core/error-overlay`). The overlay is deliberately not a Preact
 component — it must render even when Preact itself fails — and it is only
 served by the dev middleware, never in production builds.
 
-Two ergonomics features are built in:
+Failures *inside* `handlePrachtRequest()` never escape it: the runtime
+answers them with a `text/plain` body, which is the right answer for a
+production adapter and the wrong one for a browser. The dev middleware
+therefore passes `onRouteError` and swaps that fallback for the overlay
+(`shouldRenderDevErrorOverlay()`). The swap is deliberately narrow — a route
+or shell `ErrorBoundary` produces `text/html` and is left alone, and
+route-state failures are JSON owned by the client router.
+`RouteErrorContext` carries the phase and the route/loader/shell module paths
+into the overlay, since neither is recoverable from a stack trace.
+
+Three ergonomics features are built in:
+
+- **Terminal colour codes are stripped.** oxc, esbuild, and Babel colourize
+  their diagnostics for a TTY, and oxc wraps every character of the offending
+  source line in its own SGR sequence. Rendered as-is in a browser, a syntax
+  error becomes an unreadable wall of `[38;5;249m`. `stripAnsi()` runs over
+  the message and the stack; the message keeps `white-space: pre-wrap` so the
+  caret line still lines up.
 
 - **Open-in-editor links.** `parseStackFrames()` parses V8-style stack
   traces into frames with `file:line:column` locations. App-code frames

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -724,7 +724,7 @@ comes from the resolved route as a fallback, so a loader that fails during its
 own import is still linked. Overlay responses retain the phase timings already
 collected for the dev `Server-Timing` header.
 
-Three ergonomics features are built in:
+Four ergonomics features are built in:
 
 - **Terminal colour codes are stripped.** oxc, esbuild, and Babel colourize
   their diagnostics for a TTY, and oxc wraps every character of the offending
@@ -743,6 +743,13 @@ Three ergonomics features are built in:
   Vite transform queries (`?t=…`, `?pracht-client`), and root-relative
   dev-server URLs (`/src/routes/home.tsx`), which are joined onto the
   project root the dev middleware passes in (`server.config.root`).
+
+- **Fixes reload the overlay.** The inline Vite HMR client reloads for both
+  ordinary updates (`vite:beforeUpdate`) from client-reachable route modules
+  and full reloads (`vite:beforeFullReload`) from server-only loaders or
+  middleware. The listener is a module script because `import.meta.hot` is not
+  valid in a classic script.
+
 - **"Did you mean" wiring errors.** `resolveApp()` fails loudly when a
   route, group, or the `notFound` page references an unknown shell or
   middleware name (including `api.middleware`), and `buildHref()` does the

--- a/docs/DATA_LOADING.md
+++ b/docs/DATA_LOADING.md
@@ -318,8 +318,11 @@ shell modules involved.
 
 Two failures deliberately keep their own response: a route or shell that
 declares an `ErrorBoundary` renders that boundary (it is your app's error
-UI, and dev must not hide it), and `x-pracht-route-state-request` failures
-stay JSON for the client router.
+UI, and dev must not hide it even when custom shell headers override its
+content type), and `x-pracht-route-state-request` failures stay JSON for the
+client router. Overlay responses keep the dev `Server-Timing` phase durations,
+and a separately wired loader remains linked even when its module fails during
+import.
 
 Manifest wiring mistakes fail loudly with a "did you mean" hint. Referencing
 an unregistered shell or middleware name (including `api.middleware`) throws

--- a/docs/DATA_LOADING.md
+++ b/docs/DATA_LOADING.md
@@ -305,11 +305,21 @@ with framework metadata such as `phase`, `routeId`, `routePath`, `routeFile`,
 
 #### Dev error overlay
 
-In dev, uncaught server errors render pracht's full-page error overlay
-instead of a bare 500. Stack frames from your app code (and the reported
-file path) are clickable — they open the file at the exact line and column
-in your editor through Vite's built-in `/__open-in-editor` endpoint. Frames
-from `node_modules` and Node internals are de-emphasized.
+In dev, server errors render pracht's full-page error overlay instead of a
+bare 500 — middleware, loader, and render failures alike, including the
+compiler diagnostic you get from a syntax error in a route file. Terminal
+colour codes are stripped, so a colourized `[PARSE_ERROR]` frame reads as
+source rather than as escape sequences. Stack frames from your app code (and
+the reported file path) are clickable — they open the file at the exact line
+and column in your editor through Vite's built-in `/__open-in-editor`
+endpoint. Frames from `node_modules` and Node internals are de-emphasized.
+The overlay also names the failing `phase` and links the route, loader, and
+shell modules involved.
+
+Two failures deliberately keep their own response: a route or shell that
+declares an `ErrorBoundary` renders that boundary (it is your app's error
+UI, and dev must not hide it), and `x-pracht-route-state-request` failures
+stay JSON for the client router.
 
 Manifest wiring mistakes fail loudly with a "did you mean" hint. Referencing
 an unregistered shell or middleware name (including `api.middleware`) throws

--- a/docs/DATA_LOADING.md
+++ b/docs/DATA_LOADING.md
@@ -314,7 +314,8 @@ the reported file path) are clickable — they open the file at the exact line
 and column in your editor through Vite's built-in `/__open-in-editor`
 endpoint. Frames from `node_modules` and Node internals are de-emphasized.
 The overlay also names the failing `phase` and links the route, loader, and
-shell modules involved.
+shell modules involved. Saving a fix reloads the overlay for both ordinary
+client HMR updates and server-only full reloads.
 
 Two failures deliberately keep their own response: a route or shell that
 declares an `ErrorBoundary` renders that boundary (it is your app's error

--- a/packages/framework/src/error-overlay.ts
+++ b/packages/framework/src/error-overlay.ts
@@ -15,6 +15,16 @@ export interface ErrorOverlayOptions {
   routeId?: string;
   file?: string;
   /**
+   * Request phase the failure came from (`loader`, `render`, `middleware`, …),
+   * shown as a meta row. A loader failure and a render failure look identical
+   * in a stack trace once JSX is compiled away.
+   */
+  phase?: string;
+  /** Loader module path, when the route loads from a separate server file. */
+  loaderFile?: string;
+  /** Shell module path wrapping the failing route. */
+  shellFile?: string;
+  /**
    * Project root (Vite's `server.config.root`). Used to resolve
    * dev-server URL paths such as `/src/routes/home.tsx` to filesystem
    * paths for the open-in-editor links.
@@ -22,6 +32,26 @@ export interface ErrorOverlayOptions {
   root?: string;
   /** Vite deploy base used to reach the dev server's editor endpoint. */
   base?: string;
+}
+
+/**
+ * SGR/CSI escape sequences, as emitted by every compiler that colours its own
+ * diagnostics (oxc, esbuild, Babel). They are meaningless in a browser: a
+ * terminal renders `[31m` as "red", HTML renders it as `[31m`, and oxc
+ * wraps *every character* of the offending source line in its own sequence, so
+ * an uncleaned parse error reads as a wall of `[38;5;249m` noise.
+ */
+// Built from char codes rather than written as a literal: a `\u001B` escape
+// inside a regex literal is a lint error (`no-control-regex`), and suppressing
+// the rule would hide the one place it is genuinely intended.
+const ESCAPE_INTRODUCERS = `${String.fromCharCode(0x1b)}${String.fromCharCode(0x9b)}`;
+const ANSI_ESCAPE = new RegExp(
+  `[${ESCAPE_INTRODUCERS}][[\\]()#;?]*(?:[0-9]{1,4}(?:;[0-9]{0,4})*)?[0-9A-PR-TZcf-ntqry=><]`,
+  "g",
+);
+
+export function stripAnsi(value: string): string {
+  return value.replace(ANSI_ESCAPE, "");
 }
 
 export interface StackFrame {
@@ -141,11 +171,20 @@ export function normalizeStackFile(rawPath: string, root?: string): string | und
 }
 
 export function buildErrorOverlayHtml(options: ErrorOverlayOptions): string {
-  const { message, stack, routeId, file, root } = options;
+  const { routeId, file, root } = options;
+  // Compiler diagnostics arrive colourized for a terminal. Left in place they
+  // render as literal escape sequences around every character of the offending
+  // line — the error becomes unreadable exactly when it matters most.
+  const message = stripAnsi(options.message);
+  const stack = options.stack ? stripAnsi(options.stack) : undefined;
   const openInEditorEndpoint = resolveOpenInEditorEndpoint(options.base);
 
   const stackHtml = stack
     ? `<pre class="stack">${renderStackFrames(parseStackFrames(stack, { root }))}</pre>`
+    : "";
+
+  const phaseHtml = options.phase
+    ? `<div class="meta"><span class="label">Phase</span> <span class="value">${escapeHtml(options.phase)}</span></div>`
     : "";
 
   const routeHtml = routeId
@@ -154,6 +193,18 @@ export function buildErrorOverlayHtml(options: ErrorOverlayOptions): string {
 
   const fileHtml = file
     ? `<div class="meta"><span class="label">File</span> ${renderFileValue(file, root)}</div>`
+    : "";
+
+  // A separate loader file only exists when the manifest wires one, and the
+  // shell is worth naming because a shell throw surfaces on every route that
+  // uses it rather than on the one being requested.
+  const loaderHtml =
+    options.loaderFile && options.loaderFile !== file
+      ? `<div class="meta"><span class="label">Loader</span> ${renderFileValue(options.loaderFile, root)}</div>`
+      : "";
+
+  const shellHtml = options.shellFile
+    ? `<div class="meta"><span class="label">Shell</span> ${renderFileValue(options.shellFile, root)}</div>`
     : "";
 
   return `<!DOCTYPE html>
@@ -202,6 +253,9 @@ export function buildErrorOverlayHtml(options: ErrorOverlayOptions): string {
       color: #ff6b6b;
       margin-bottom: 20px;
       word-break: break-word;
+      /* Compiler diagnostics are multi-line source frames; collapsing their
+         whitespace turns the caret line into gibberish. */
+      white-space: pre-wrap;
     }
     .meta {
       font-size: 13px;
@@ -255,8 +309,11 @@ export function buildErrorOverlayHtml(options: ErrorOverlayOptions): string {
       <span class="title">pracht dev</span>
     </div>
     <div class="message">${escapeHtml(message)}</div>
+    ${phaseHtml}
     ${routeHtml}
     ${fileHtml}
+    ${loaderHtml}
+    ${shellHtml}
     ${stackHtml}
     <div class="hint">Click a stack frame to open it in your editor. Fix the error and save — the page will reload automatically.</div>
   </div>

--- a/packages/framework/src/error-overlay.ts
+++ b/packages/framework/src/error-overlay.ts
@@ -35,7 +35,7 @@ export interface ErrorOverlayOptions {
 }
 
 /**
- * SGR/CSI escape sequences, as emitted by every compiler that colours its own
+ * SGR/CSI/OSC escape sequences, as emitted by every compiler that colours its own
  * diagnostics (oxc, esbuild, Babel). They are meaningless in a browser: a
  * terminal renders `[31m` as "red", HTML renders it as `[31m`, and oxc
  * wraps *every character* of the offending source line in its own sequence, so
@@ -44,9 +44,28 @@ export interface ErrorOverlayOptions {
 // Built from char codes rather than written as a literal: a `\u001B` escape
 // inside a regex literal is a lint error (`no-control-regex`), and suppressing
 // the rule would hide the one place it is genuinely intended.
-const ESCAPE_INTRODUCERS = `${String.fromCharCode(0x1b)}${String.fromCharCode(0x9b)}`;
+const ESC = String.fromCharCode(0x1b);
+const CSI = String.fromCharCode(0x9b);
+const BEL = String.fromCharCode(0x07);
+// OSC (`ESC ] … BEL` / `ESC ] … ESC \\`) has to be matched as its own
+// alternative rather than falling through to the CSI branch. Terminal
+// hyperlinks — which miette, and therefore oxc, emits for diagnostic codes —
+// are OSC 8: matching them with the CSI branch stops at the first letter of
+// the URL and eats it, turning `ESC ] 8 ;; https://…` into `ttps://…` while
+// leaving the terminator behind as a control character.
+const OSC_TERMINATOR = `(?:${BEL}|${ESC}\\\\)`;
+// The payload is anything up to the terminator. Deliberately more permissive
+// than the widely copied `ansi-regex` pattern, which enumerates URL-ish
+// characters and so fails on a payload containing a space (`ESC ] 0 ; window
+// title`) — it then falls through to the CSI branch and eats part of the text.
+// The class excludes both terminator characters, so the match cannot run past
+// the first one and an unterminated OSC simply fails this alternative.
+const OSC_SEQUENCE = `[^${BEL}${ESC}]*${OSC_TERMINATOR}`;
+// `~` belongs in the final-byte class: `ESC [ 3 ~` is a complete sequence, and
+// omitting it leaves a stray `~` in the rendered message.
+const CSI_SEQUENCE = `(?:[0-9]{1,4}(?:;[0-9]{0,4})*)?[0-9A-PR-TZcf-ntqry=><~]`;
 const ANSI_ESCAPE = new RegExp(
-  `[${ESCAPE_INTRODUCERS}][[\\]()#;?]*(?:[0-9]{1,4}(?:;[0-9]{0,4})*)?[0-9A-PR-TZcf-ntqry=><]`,
+  `[${ESC}${CSI}][[\\]()#;?]*(?:${OSC_SEQUENCE}|${CSI_SEQUENCE})`,
   "g",
 );
 
@@ -328,8 +347,11 @@ export function buildErrorOverlayHtml(options: ErrorOverlayOptions): string {
       fetch(${JSON.stringify(openInEditorEndpoint)} + "?file=" + encodeURIComponent(link.getAttribute("data-editor-file")));
     });
   </script>
-  <script>
-    // Auto-reload when Vite triggers a full reload (e.g. file saved after fix)
+  <script type="module">
+    // Auto-reload when Vite triggers a full reload (e.g. file saved after fix).
+    // Must be a module: \`import.meta\` is a parse error in a classic script, so
+    // a plain <script> silently dropped this whole block and the overlay never
+    // reloaded itself after the underlying file was fixed.
     if (import.meta.hot) {
       import.meta.hot.on("vite:beforeFullReload", function () {
         window.location.reload();

--- a/packages/framework/src/error-overlay.ts
+++ b/packages/framework/src/error-overlay.ts
@@ -348,14 +348,17 @@ export function buildErrorOverlayHtml(options: ErrorOverlayOptions): string {
     });
   </script>
   <script type="module">
-    // Auto-reload when Vite triggers a full reload (e.g. file saved after fix).
+    // Auto-reload when Vite publishes either an ordinary HMR update for a
+    // client-reachable route or a full reload for a server-only module.
     // Must be a module: \`import.meta\` is a parse error in a classic script, so
     // a plain <script> silently dropped this whole block and the overlay never
     // reloaded itself after the underlying file was fixed.
     if (import.meta.hot) {
-      import.meta.hot.on("vite:beforeFullReload", function () {
+      var reload = function () {
         window.location.reload();
-      });
+      };
+      import.meta.hot.on("vite:beforeUpdate", reload);
+      import.meta.hot.on("vite:beforeFullReload", reload);
     }
   </script>
 </body>

--- a/packages/framework/src/index.ts
+++ b/packages/framework/src/index.ts
@@ -360,6 +360,7 @@ export type {
   PrachtPhaseTimings,
   PrachtRuntimeDiagnosticPhase,
   PrachtRuntimeDiagnostics,
+  RouteErrorContext,
   RouteStateResult,
   SerializedRouteError,
   StartAppOptions,

--- a/packages/framework/src/runtime-errors.ts
+++ b/packages/framework/src/runtime-errors.ts
@@ -19,6 +19,25 @@ export interface PrachtRuntimeDiagnostics {
   status: number;
 }
 
+/**
+ * Route metadata handed to `onRouteError` alongside the raw error.
+ *
+ * The response body deliberately hides these details outside `debugErrors`,
+ * so a caller that owns the surrounding surface — prerendering, the dev
+ * server's error overlay — would otherwise have to re-derive which route
+ * failed and in which phase. Unlike `PrachtRuntimeDiagnostics` it carries no
+ * status: the error has not been normalized into a response yet.
+ */
+export interface RouteErrorContext {
+  phase: PrachtRuntimeDiagnosticPhase;
+  routeId?: string;
+  routePath?: string;
+  routeFile?: string;
+  loaderFile?: string;
+  shellFile?: string;
+  middlewareFiles?: string[];
+}
+
 export interface SerializedRouteError {
   message: string;
   name: string;

--- a/packages/framework/src/runtime-errors.ts
+++ b/packages/framework/src/runtime-errors.ts
@@ -25,11 +25,14 @@ export interface PrachtRuntimeDiagnostics {
  * The response body deliberately hides these details outside `debugErrors`,
  * so a caller that owns the surrounding surface — prerendering, the dev
  * server's error overlay — would otherwise have to re-derive which route
- * failed and in which phase. Unlike `PrachtRuntimeDiagnostics` it carries no
- * status: the error has not been normalized into a response yet.
+ * failed, in which phase, and whether a declared boundary owns the response.
+ * Unlike `PrachtRuntimeDiagnostics` it carries no status: the error has not
+ * been normalized into a response yet.
  */
 export interface RouteErrorContext {
   phase: PrachtRuntimeDiagnosticPhase;
+  /** Which declared ErrorBoundary will receive the failure, when present. */
+  errorBoundary?: "route" | "shell";
   routeId?: string;
   routePath?: string;
   routeFile?: string;

--- a/packages/framework/src/runtime.ts
+++ b/packages/framework/src/runtime.ts
@@ -1244,9 +1244,19 @@ export async function handlePrachtRequest<TContext>(
       // was still started in parallel, so retain route-scoped error metadata
       // (notably fonts used by the route ErrorBoundary) when it resolves.
       routeModule ??= await routeModulePromise?.catch(() => undefined);
+      // A loader or middleware failure can happen before the shell await in
+      // pageTerminal. Resolve the already-started import here so callers know
+      // whether the response will be rendered by a route/shell ErrorBoundary
+      // instead of having to infer that from mutable response headers.
+      shellModule ??= await shellModulePromise.catch(() => undefined);
 
       options.onRouteError?.(thrownResponseFailure ?? error, requestPath, {
-        loaderFile,
+        errorBoundary: routeModule?.ErrorBoundary
+          ? "route"
+          : shellModule?.ErrorBoundary
+            ? "shell"
+            : undefined,
+        loaderFile: loaderFile ?? match.route.loaderFile,
         middlewareFiles: [...(match.route.middlewareFiles ?? [])],
         phase: currentPhase,
         routeFile: match.route.file,

--- a/packages/framework/src/runtime.ts
+++ b/packages/framework/src/runtime.ts
@@ -10,6 +10,7 @@ import {
   isPrachtHttpError,
   shouldExposeServerErrors,
   type PrachtRuntimeDiagnosticPhase,
+  type RouteErrorContext,
 } from "./runtime-errors.ts";
 import {
   appendVaryHeader,
@@ -325,7 +326,7 @@ export interface HandlePrachtRequestOptions<TContext = unknown> {
    * (prerendering, static export) with a bare status and no cause. Prerender
    * passes this so a failing SSG page can name what actually threw.
    */
-  onRouteError?: (error: unknown, requestPath: string) => void;
+  onRouteError?: (error: unknown, requestPath: string, context?: RouteErrorContext) => void;
 }
 
 export async function handlePrachtRequest<TContext>(
@@ -1244,7 +1245,15 @@ export async function handlePrachtRequest<TContext>(
       // (notably fonts used by the route ErrorBoundary) when it resolves.
       routeModule ??= await routeModulePromise?.catch(() => undefined);
 
-      options.onRouteError?.(thrownResponseFailure ?? error, requestPath);
+      options.onRouteError?.(thrownResponseFailure ?? error, requestPath, {
+        loaderFile,
+        middlewareFiles: [...(match.route.middlewareFiles ?? [])],
+        phase: currentPhase,
+        routeFile: match.route.file,
+        routeId: match.route.id,
+        routePath: match.route.path,
+        shellFile: match.route.shellFile,
+      });
 
       return renderRouteErrorResponse({
         error: thrownResponseFailure ?? error,
@@ -1383,6 +1392,7 @@ export {
   deserializeRouteError,
   type PrachtRuntimeDiagnosticPhase,
   type PrachtRuntimeDiagnostics,
+  type RouteErrorContext,
   type SerializedRouteError,
 } from "./runtime-errors.ts";
 export {

--- a/packages/framework/src/server.ts
+++ b/packages/framework/src/server.ts
@@ -256,6 +256,7 @@ export type {
   PrachtPhaseTimings,
   PrachtRuntimeDiagnosticPhase,
   PrachtRuntimeDiagnostics,
+  RouteErrorContext,
   SerializedRouteError,
 } from "./runtime.ts";
 export type {

--- a/packages/framework/test/error-overlay.test.ts
+++ b/packages/framework/test/error-overlay.test.ts
@@ -338,4 +338,11 @@ describe("overlay auto-reload script", () => {
 
     expect(html).toMatch(/<script type="module">(?:(?!<\/script>)[\s\S])*import\.meta\.hot/);
   });
+
+  it("reloads for ordinary HMR updates and full reloads", () => {
+    const html = buildErrorOverlayHtml({ message: "boom" });
+
+    expect(html).toContain('import.meta.hot.on("vite:beforeUpdate", reload)');
+    expect(html).toContain('import.meta.hot.on("vite:beforeFullReload", reload)');
+  });
 });

--- a/packages/framework/test/error-overlay.test.ts
+++ b/packages/framework/test/error-overlay.test.ts
@@ -294,3 +294,48 @@ describe("route metadata rows", () => {
     expect(html).not.toContain(">Shell</span>");
   });
 });
+
+describe("escape sequences the naive pattern gets wrong", () => {
+  const ESC = "\u001b";
+  const BEL = "\u0007";
+
+  // miette — and therefore oxc — emits OSC 8 terminal hyperlinks for
+  // diagnostic codes. Matching them with the CSI branch stops at the first
+  // letter of the URL and eats it, leaving `ttps://…` plus a stray terminator.
+  it("strips an OSC 8 hyperlink without eating the URL text", () => {
+    const link = `${ESC}]8;;https://oxc.rs/docs/E0001${BEL}E0001${ESC}]8;;${BEL}`;
+
+    expect(stripAnsi(`see ${link} for details`)).toBe("see E0001 for details");
+  });
+
+  it("strips an OSC sequence terminated by ESC backslash", () => {
+    expect(stripAnsi(`a${ESC}]0;window title${ESC}\\b`)).toBe("ab");
+  });
+
+  // `ESC [ 3 ~` is a complete sequence; omitting `~` from the final-byte class
+  // leaves a stray tilde in the rendered message.
+  it("strips a CSI sequence whose final byte is a tilde", () => {
+    expect(stripAnsi(`a${ESC}[3~b`)).toBe("ab");
+  });
+
+  it("leaves a lone escape introducer alone rather than eating the next word", () => {
+    expect(stripAnsi(`unterminated ${ESC}`)).toBe(`unterminated ${ESC}`);
+  });
+
+  it("does not touch bracket-heavy prose", () => {
+    expect(stripAnsi("expected [1] but got (2) at #3; ok?")).toBe(
+      "expected [1] but got (2) at #3; ok?",
+    );
+  });
+});
+
+describe("overlay auto-reload script", () => {
+  // `import.meta` is a parse error in a classic script, so the whole block was
+  // silently dropped and the overlay never reloaded itself after the file was
+  // fixed.
+  it("declares the import.meta.hot block as a module", () => {
+    const html = buildErrorOverlayHtml({ message: "boom" });
+
+    expect(html).toMatch(/<script type="module">(?:(?!<\/script>)[\s\S])*import\.meta\.hot/);
+  });
+});

--- a/packages/framework/test/error-overlay.test.ts
+++ b/packages/framework/test/error-overlay.test.ts
@@ -4,6 +4,7 @@ import {
   buildErrorOverlayHtml,
   normalizeStackFile,
   parseStackFrames,
+  stripAnsi,
 } from "../src/error-overlay.ts";
 
 const STACK_FIXTURE = [
@@ -204,5 +205,92 @@ describe("buildErrorOverlayHtml", () => {
 
     expect(html).toContain("boom");
     expect(html).not.toContain('class="stack"');
+  });
+});
+
+describe("terminal colour codes", () => {
+  // oxc/esbuild colourize their diagnostics for a terminal. The browser has no
+  // terminal: left in place, every character of the offending source line is
+  // wrapped in its own escape sequence and the error is unreadable.
+  const ESC = "\u001b";
+  const ANSI_PARSE_ERROR = [
+    `${ESC}[31m[PARSE_ERROR] ${ESC}[0mExpected a semicolon`,
+    `    ${ESC}[38;5;246m|${ESC}[0m src/routes/pricing.tsx:20:5`,
+  ].join("\n");
+
+  it("strips escape sequences from the message", () => {
+    expect(stripAnsi(ANSI_PARSE_ERROR)).toBe(
+      ["[PARSE_ERROR] Expected a semicolon", "    | src/routes/pricing.tsx:20:5"].join("\n"),
+    );
+  });
+
+  it("leaves text without escape sequences untouched", () => {
+    expect(stripAnsi("loader exploded at [1] of the list")).toBe(
+      "loader exploded at [1] of the list",
+    );
+  });
+
+  it("renders a colourized compiler diagnostic without escape sequences", () => {
+    const html = buildErrorOverlayHtml({ message: ANSI_PARSE_ERROR });
+
+    expect(html).not.toContain(ESC);
+    expect(html).not.toContain("[38;5;246m");
+    expect(html).toContain("[PARSE_ERROR] Expected a semicolon");
+  });
+
+  it("strips escape sequences from the stack as well", () => {
+    const html = buildErrorOverlayHtml({
+      message: "boom",
+      stack: `Error: boom\n    at ${ESC}[36mloader${ESC}[0m (/app/src/routes/home.tsx:1:1)`,
+    });
+
+    expect(html).not.toContain(ESC);
+    expect(html).toContain("/app/src/routes/home.tsx");
+  });
+
+  it("preserves multi-line diagnostics in the rendered message", () => {
+    const html = buildErrorOverlayHtml({ message: "line one\nline two" });
+
+    expect(html).toContain("white-space: pre-wrap");
+    expect(html).toContain("line one\nline two");
+  });
+});
+
+describe("route metadata rows", () => {
+  it("names the failing phase, route file, loader, and shell", () => {
+    const html = buildErrorOverlayHtml({
+      message: "loader exploded",
+      phase: "loader",
+      routeId: "blog-slug",
+      file: "./routes/blog/[slug].tsx",
+      loaderFile: "./server/blog-loader.ts",
+      shellFile: "./shells/public.tsx",
+      root: "/app",
+    });
+
+    expect(html).toContain('>Phase</span> <span class="value">loader<');
+    expect(html).toContain("blog-slug");
+    expect(html).toContain("./routes/blog/[slug].tsx");
+    expect(html).toContain("./server/blog-loader.ts");
+    expect(html).toContain("./shells/public.tsx");
+    expect(html).toContain('data-editor-file="/app/src/server/blog-loader.ts"');
+  });
+
+  it("omits the loader row when the loader is the route file itself", () => {
+    const html = buildErrorOverlayHtml({
+      message: "loader exploded",
+      file: "./routes/home.tsx",
+      loaderFile: "./routes/home.tsx",
+    });
+
+    expect(html).not.toContain(">Loader</span>");
+  });
+
+  it("omits every optional row when nothing is known", () => {
+    const html = buildErrorOverlayHtml({ message: "boom" });
+
+    expect(html).not.toContain(">Phase</span>");
+    expect(html).not.toContain(">Route</span>");
+    expect(html).not.toContain(">Shell</span>");
   });
 });

--- a/packages/framework/test/runtime.test.ts
+++ b/packages/framework/test/runtime.test.ts
@@ -3211,4 +3211,39 @@ describe("onRouteError route context", () => {
 
     expect(context).toMatchObject({ phase: "render", routeId: "home" });
   });
+
+  it("keeps the configured loader path when its module import fails", async () => {
+    const app = defineApp({
+      routes: [
+        route("/", {
+          component: "./routes/home.tsx",
+          loader: "./server/home-loader.ts",
+        }),
+      ],
+    });
+
+    let context: Record<string, unknown> | undefined;
+    await handlePrachtRequest({
+      app,
+      registry: {
+        routeModules: {
+          "./routes/home.tsx": async () => ({ Component: () => null }),
+        },
+        dataModules: {
+          "./server/home-loader.ts": async () => {
+            throw new SyntaxError("loader module did not compile");
+          },
+        },
+      },
+      request: new Request("http://localhost/"),
+      onRouteError: (_error, _requestPath, routeContext) => {
+        context = routeContext as unknown as Record<string, unknown>;
+      },
+    });
+
+    expect(context).toMatchObject({
+      phase: "loader",
+      loaderFile: "./server/home-loader.ts",
+    });
+  });
 });

--- a/packages/framework/test/runtime.test.ts
+++ b/packages/framework/test/runtime.test.ts
@@ -3123,3 +3123,92 @@ describe("handlePrachtRequest pipeline parallelism", () => {
     expect(res.status).toBe(200);
   });
 });
+
+describe("onRouteError route context", () => {
+  it("names the phase, route, loader, shell, and middleware that failed", async () => {
+    const app = defineApp({
+      shells: { public: "./shells/public.tsx" },
+      middleware: { auth: "./middleware/auth.ts" },
+      routes: [
+        route("/blog/:slug", {
+          component: "./routes/blog/[slug].tsx",
+          id: "blog-slug",
+          loader: "./server/blog-loader.ts",
+          middleware: ["auth"],
+          shell: "public",
+        }),
+      ],
+    });
+
+    let captured: unknown;
+    let context: Record<string, unknown> | undefined;
+    const response = await handlePrachtRequest({
+      app,
+      registry: {
+        routeModules: {
+          "./routes/blog/[slug].tsx": async () => ({ Component: () => null }),
+        },
+        shellModules: {
+          "./shells/public.tsx": async () => ({
+            Shell: ({ children }: { children?: unknown }) => children as never,
+          }),
+        },
+        middlewareModules: {
+          "./middleware/auth.ts": async () => ({
+            middleware: (_args: unknown, next: () => Promise<Response>) => next(),
+          }),
+        },
+        dataModules: {
+          "./server/blog-loader.ts": async () => ({
+            loader: () => {
+              throw new Error("loader exploded");
+            },
+          }),
+        },
+      },
+      request: new Request("http://localhost/blog/hello"),
+      onRouteError: (error, _requestPath, routeContext) => {
+        captured = error;
+        context = routeContext as unknown as Record<string, unknown>;
+      },
+    });
+
+    expect(response.status).toBe(500);
+    expect((captured as Error).message).toBe("loader exploded");
+    expect(context).toMatchObject({
+      phase: "loader",
+      routeId: "blog-slug",
+      routePath: "/blog/:slug",
+      routeFile: "./routes/blog/[slug].tsx",
+      loaderFile: "./server/blog-loader.ts",
+      shellFile: "./shells/public.tsx",
+      middlewareFiles: ["./middleware/auth.ts"],
+    });
+  });
+
+  it("reports a render failure as the render phase", async () => {
+    const app = defineApp({
+      routes: [route("/", "./routes/home.tsx", { id: "home" })],
+    });
+
+    let context: Record<string, unknown> | undefined;
+    await handlePrachtRequest({
+      app,
+      registry: {
+        routeModules: {
+          "./routes/home.tsx": async () => ({
+            Component: () => {
+              throw new Error("render exploded");
+            },
+          }),
+        },
+      },
+      request: new Request("http://localhost/"),
+      onRouteError: (_error, _requestPath, routeContext) => {
+        context = routeContext as unknown as Record<string, unknown>;
+      },
+    });
+
+    expect(context).toMatchObject({ phase: "render", routeId: "home" });
+  });
+});

--- a/packages/vite-plugin/src/plugin-dev-ssr.ts
+++ b/packages/vite-plugin/src/plugin-dev-ssr.ts
@@ -213,6 +213,10 @@ export function createDevSSRMiddleware(
       // and the wrong one for a browser in dev, so capture the raw error here
       // and re-render it as the overlay below.
       let routeError: unknown;
+      // An explicit flag rather than `routeError !== undefined`: `throw
+      // undefined` and a bare `Promise.reject()` are real failures that would
+      // otherwise fall through to the plain-text fallback.
+      let capturedRouteError = false;
       let routeErrorContext: RouteErrorContext | undefined;
       const response = await framework.handlePrachtRequest({
         app: serverMod.resolvedApp,
@@ -220,6 +224,7 @@ export function createDevSSRMiddleware(
         request: webRequest,
         debugErrors: true,
         onRouteError: (error: unknown, _requestPath: string, context?: RouteErrorContext) => {
+          capturedRouteError = true;
           routeError = error;
           routeErrorContext = context;
         },
@@ -283,8 +288,9 @@ export function createDevSSRMiddleware(
 
       if (
         shouldRenderDevErrorOverlay({
-          capturedRouteError: routeError !== undefined,
+          capturedRouteError,
           contentType,
+          exposeServerErrors: shouldExposeDevServerErrors(),
           status: response.status,
         })
       ) {
@@ -746,13 +752,33 @@ async function serveDevtools(
 export function shouldRenderDevErrorOverlay(options: {
   capturedRouteError: boolean;
   contentType: string;
+  /**
+   * Mirror of the runtime's `shouldExposeServerErrors()` verdict. `onRouteError`
+   * fires with the raw error regardless of `debugErrors`, so without this the
+   * overlay would print the stack trace and filesystem paths that the runtime
+   * had just refused to put in the response body under `NODE_ENV=production`.
+   */
+  exposeServerErrors: boolean;
   status: number;
 }): boolean {
   return (
     options.capturedRouteError &&
+    options.exposeServerErrors &&
     options.status >= 500 &&
     options.contentType.toLowerCase().startsWith("text/plain")
   );
+}
+
+/**
+ * The dev middleware passes `debugErrors: true` unconditionally, but the
+ * runtime refuses to honor it when `NODE_ENV === "production"` (see
+ * `shouldExposeServerErrors` in @pracht/core) — a dev server started inside a
+ * container that exports `NODE_ENV=production` must not answer with internals.
+ * The overlay is built from the raw error rather than from the runtime's
+ * already-redacted body, so it has to repeat that check.
+ */
+function shouldExposeDevServerErrors(): boolean {
+  return (typeof process !== "undefined" ? process.env?.NODE_ENV : undefined) !== "production";
 }
 
 /**
@@ -793,6 +819,12 @@ async function respondWithErrorOverlay(
   html = await server.transformIndexHtml(url, html);
   res.statusCode = status;
   res.setHeader("content-type", "text/html; charset=utf-8");
+  // The runtime response this replaces carried the framework's default
+  // security headers. Dropping them here would make dev the one surface that
+  // answers a 500 without them.
+  applyDefaultSecurityHeaders(new Headers()).forEach((value, key) => {
+    res.setHeader(key, value);
+  });
   res.end(html);
 }
 

--- a/packages/vite-plugin/src/plugin-dev-ssr.ts
+++ b/packages/vite-plugin/src/plugin-dev-ssr.ts
@@ -9,6 +9,7 @@ import type {
   ResolvedApiRoute,
   ResolvedPrachtApp,
   ResolvedRoute,
+  RouteErrorContext,
 } from "@pracht/core";
 import { applyDefaultSecurityHeaders, resolveRegistryModule } from "@pracht/core";
 import {
@@ -207,11 +208,21 @@ export function createDevSSRMiddleware(
       // Dev-only: collect middleware/loader/render phase durations so the
       // browser Network panel shows them via the Server-Timing header.
       const timings: PrachtPhaseTimings = {};
+      // A route that fails without an ErrorBoundary answers with the runtime's
+      // plain-text fallback. That is the right answer for a production adapter
+      // and the wrong one for a browser in dev, so capture the raw error here
+      // and re-render it as the overlay below.
+      let routeError: unknown;
+      let routeErrorContext: RouteErrorContext | undefined;
       const response = await framework.handlePrachtRequest({
         app: serverMod.resolvedApp,
         registry: serverMod.registry,
         request: webRequest,
         debugErrors: true,
+        onRouteError: (error: unknown, _requestPath: string, context?: RouteErrorContext) => {
+          routeError = error;
+          routeErrorContext = context;
+        },
         clientEntryUrl: withDevBase(CLIENT_BROWSER_PATH),
         islandsEntryUrl: withDevBase(ISLANDS_CLIENT_BROWSER_PATH),
         islandsBootstrapRequired: serverMod.islandsBootstrapRequired === true,
@@ -267,6 +278,25 @@ export function createDevSSRMiddleware(
           res.destroy();
         });
         source.pipe(res);
+        return;
+      }
+
+      if (
+        shouldRenderDevErrorOverlay({
+          capturedRouteError: routeError !== undefined,
+          contentType,
+          status: response.status,
+        })
+      ) {
+        await respondWithErrorOverlay(
+          server,
+          res,
+          url,
+          routeError,
+          routeErrorContext,
+          devBase,
+          response.status,
+        );
         return;
       }
 
@@ -700,6 +730,68 @@ async function serveDevtools(
   let html = devtools.buildDevtoolsHtml(graph, { base: options.base });
   html = await server.transformIndexHtml(options.url, html);
   res.statusCode = 200;
+  res.setHeader("content-type", "text/html; charset=utf-8");
+  res.end(html);
+}
+
+/**
+ * True when a dev response should be replaced by the error overlay.
+ *
+ * The runtime only falls back to `text/plain` for a page render when neither
+ * the route nor its shell declares an ErrorBoundary. When one does, the
+ * response is the app's own error UI (`text/html`) and dev must leave it
+ * alone. Route-state and capability failures are JSON and belong to the
+ * client router, not to a human reading a document.
+ */
+export function shouldRenderDevErrorOverlay(options: {
+  capturedRouteError: boolean;
+  contentType: string;
+  status: number;
+}): boolean {
+  return (
+    options.capturedRouteError &&
+    options.status >= 500 &&
+    options.contentType.toLowerCase().startsWith("text/plain")
+  );
+}
+
+/**
+ * Render a failed page render as the dev error overlay.
+ *
+ * `handlePrachtRequest` answers a render/loader/middleware failure with the
+ * runtime's plain-text fallback whenever no ErrorBoundary claims it. In a
+ * production adapter that is correct — a browser is not the audience. In dev
+ * the browser *is* the audience, and the fallback is at its worst exactly when
+ * it matters most: a compiler diagnostic arrives colourized for a terminal, so
+ * `text/plain` renders every escape sequence literally.
+ */
+async function respondWithErrorOverlay(
+  server: ViteDevServer,
+  res: ServerResponse,
+  url: string,
+  error: unknown,
+  context: RouteErrorContext | undefined,
+  base: string,
+  status: number,
+): Promise<void> {
+  if (error instanceof Error) {
+    server.ssrFixStacktrace(error);
+  }
+
+  const { buildErrorOverlayHtml } = await server.ssrLoadModule("@pracht/core/error-overlay");
+  let html = buildErrorOverlayHtml({
+    message: error instanceof Error ? error.message : String(error),
+    stack: error instanceof Error ? error.stack : undefined,
+    routeId: context?.routeId,
+    file: context?.routeFile,
+    loaderFile: context?.loaderFile,
+    shellFile: context?.shellFile,
+    phase: context?.phase,
+    root: server.config.root,
+    base,
+  });
+  html = await server.transformIndexHtml(url, html);
+  res.statusCode = status;
   res.setHeader("content-type", "text/html; charset=utf-8");
   res.end(html);
 }

--- a/packages/vite-plugin/src/plugin-dev-ssr.ts
+++ b/packages/vite-plugin/src/plugin-dev-ssr.ts
@@ -291,9 +291,11 @@ export function createDevSSRMiddleware(
           capturedRouteError,
           contentType,
           exposeServerErrors: shouldExposeDevServerErrors(),
+          hasErrorBoundary: routeErrorContext?.errorBoundary != null,
           status: response.status,
         })
       ) {
+        const serverTiming = framework.formatServerTimingHeader(timings);
         await respondWithErrorOverlay(
           server,
           res,
@@ -302,6 +304,7 @@ export function createDevSSRMiddleware(
           routeErrorContext,
           devBase,
           response.status,
+          serverTiming,
         );
         return;
       }
@@ -759,11 +762,14 @@ export function shouldRenderDevErrorOverlay(options: {
    * had just refused to put in the response body under `NODE_ENV=production`.
    */
   exposeServerErrors: boolean;
+  /** The runtime found a route or shell ErrorBoundary for this failure. */
+  hasErrorBoundary: boolean;
   status: number;
 }): boolean {
   return (
     options.capturedRouteError &&
     options.exposeServerErrors &&
+    !options.hasErrorBoundary &&
     options.status >= 500 &&
     options.contentType.toLowerCase().startsWith("text/plain")
   );
@@ -799,6 +805,7 @@ async function respondWithErrorOverlay(
   context: RouteErrorContext | undefined,
   base: string,
   status: number,
+  serverTiming: string,
 ): Promise<void> {
   if (error instanceof Error) {
     server.ssrFixStacktrace(error);
@@ -825,6 +832,9 @@ async function respondWithErrorOverlay(
   applyDefaultSecurityHeaders(new Headers()).forEach((value, key) => {
     res.setHeader(key, value);
   });
+  if (serverTiming) {
+    res.setHeader("Server-Timing", serverTiming);
+  }
   res.end(html);
 }
 

--- a/packages/vite-plugin/test/dev-error-overlay.test.ts
+++ b/packages/vite-plugin/test/dev-error-overlay.test.ts
@@ -1,0 +1,145 @@
+import type { IncomingMessage, ServerResponse } from "node:http";
+import { h } from "preact";
+import type { ViteDevServer } from "vite";
+import { describe, expect, it, vi } from "vitest";
+
+import * as frameworkServer from "../../framework/src/server.ts";
+import * as errorOverlay from "../../framework/src/error-overlay.ts";
+import { defineApp, resolveApp, route } from "../../framework/src/app.ts";
+import { createDevSSRMiddleware } from "../src/plugin-dev-ssr.ts";
+import { PRACHT_SERVER_MODULE_ID } from "../src/plugin-assets.ts";
+
+function createRequest(url: string): IncomingMessage {
+  return {
+    headers: { accept: "text/html,application/xhtml+xml", host: "localhost" },
+    method: "GET",
+    url,
+  } as unknown as IncomingMessage;
+}
+
+function createResponse() {
+  const headers: Record<string, string> = {};
+  const state = { body: "", headers, statusCode: 0 };
+  const res = {
+    end(body?: unknown) {
+      state.body = String(body ?? "");
+      state.statusCode = res.statusCode;
+    },
+    setHeader(name: string, value: unknown) {
+      headers[name.toLowerCase()] = String(value);
+    },
+    statusCode: 200,
+  };
+  return { res: res as unknown as ServerResponse, state };
+}
+
+async function render(routeModule: Record<string, unknown>) {
+  const serverMod = {
+    apiRoutes: [],
+    islandsBootstrapRequired: false,
+    registry: { routeModules: { "./routes/boom.tsx": async () => routeModule } },
+    resolvedApp: resolveApp(
+      defineApp({
+        routes: [route("/boom", "./routes/boom.tsx", { id: "boom", render: "ssr" })],
+      }),
+    ),
+  };
+
+  const server = {
+    config: { base: "/", logger: { warn: vi.fn() }, root: "/tmp/pracht-overlay-test" },
+    ssrFixStacktrace: () => {},
+    ssrLoadModule: async (id: string) => {
+      if (id === "@pracht/core/server") return frameworkServer;
+      if (id === "@pracht/core/error-overlay") return errorOverlay;
+      if (id === PRACHT_SERVER_MODULE_ID) return serverMod;
+      throw new Error(`Unexpected ssrLoadModule id: ${id}`);
+    },
+    // The real transform injects the Vite client; the overlay must survive it.
+    transformIndexHtml: async (_url: string, html: string) => html,
+  } as unknown as ViteDevServer;
+
+  const { res, state } = createResponse();
+  await createDevSSRMiddleware(server)(createRequest("/boom"), res, vi.fn());
+  return state;
+}
+
+describe("dev SSR error overlay", () => {
+  it("replaces the runtime's plain-text render failure", async () => {
+    const state = await render({
+      Component: () => {
+        throw new Error("render exploded");
+      },
+    });
+
+    expect(state.statusCode).toBe(500);
+    expect(state.headers["content-type"]).toContain("text/html");
+    expect(state.body).toContain("pracht error");
+    expect(state.body).toContain("render exploded");
+    // The route metadata the runtime knows and a stack trace cannot recover.
+    expect(state.body).toContain("boom");
+  });
+
+  // The runtime response this replaces carried them; dev must not become the
+  // one surface that answers a 500 without them.
+  it("keeps the framework's default security headers", async () => {
+    const state = await render({
+      Component: () => {
+        throw new Error("render exploded");
+      },
+    });
+
+    expect(state.headers["x-content-type-options"]).toBe("nosniff");
+    expect(state.headers["x-frame-options"]).toBe("SAMEORIGIN");
+    expect(state.headers["referrer-policy"]).toBe("strict-origin-when-cross-origin");
+  });
+
+  // `throw undefined` and a bare `Promise.reject()` are real failures. Keying
+  // the swap on `error !== undefined` would drop them back to plain text.
+  it("renders the overlay for a thrown undefined", async () => {
+    const state = await render({
+      loader: () => {
+        // eslint-disable-next-line no-throw-literal
+        throw undefined;
+      },
+      Component: () => null,
+    });
+
+    expect(state.statusCode).toBe(500);
+    expect(state.headers["content-type"]).toContain("text/html");
+    expect(state.body).toContain("pracht error");
+  });
+
+  // An ErrorBoundary render is the app's own error UI, not a framework failure.
+  it("leaves an ErrorBoundary render alone", async () => {
+    const state = await render({
+      Component: () => {
+        throw new Error("render exploded");
+      },
+      ErrorBoundary: ({ error }: { error: Error }) => h("p", { id: "boundary" }, error.message),
+    });
+
+    expect(state.statusCode).toBe(500);
+    expect(state.body).toContain('id="boundary"');
+    expect(state.body).not.toContain("pracht error");
+  });
+
+  // `pracht dev` passes debugErrors unconditionally; the runtime ignores it
+  // under NODE_ENV=production and so must the overlay, or dev in a container
+  // that exports it would print the internals the body just withheld.
+  it("does not render the overlay when the runtime redacts errors", async () => {
+    vi.stubEnv("NODE_ENV", "production");
+    try {
+      const state = await render({
+        Component: () => {
+          throw new Error("render exploded");
+        },
+      });
+
+      expect(state.headers["content-type"]).toContain("text/plain");
+      expect(state.body).not.toContain("pracht error");
+      expect(state.body).not.toContain("render exploded");
+    } finally {
+      vi.unstubAllEnvs();
+    }
+  });
+});

--- a/packages/vite-plugin/test/dev-error-overlay.test.ts
+++ b/packages/vite-plugin/test/dev-error-overlay.test.ts
@@ -33,14 +33,31 @@ function createResponse() {
   return { res: res as unknown as ServerResponse, state };
 }
 
-async function render(routeModule: Record<string, unknown>) {
+async function render(
+  routeModule: Record<string, unknown>,
+  options: { shellModule?: Record<string, unknown> } = {},
+) {
+  const routeDefinition = options.shellModule
+    ? route("/boom", {
+        component: "./routes/boom.tsx",
+        id: "boom",
+        render: "ssr",
+        shell: "plain",
+      })
+    : route("/boom", "./routes/boom.tsx", { id: "boom", render: "ssr" });
   const serverMod = {
     apiRoutes: [],
     islandsBootstrapRequired: false,
-    registry: { routeModules: { "./routes/boom.tsx": async () => routeModule } },
+    registry: {
+      routeModules: { "./routes/boom.tsx": async () => routeModule },
+      shellModules: options.shellModule
+        ? { "./shells/plain.tsx": async () => options.shellModule }
+        : undefined,
+    },
     resolvedApp: resolveApp(
       defineApp({
-        routes: [route("/boom", "./routes/boom.tsx", { id: "boom", render: "ssr" })],
+        routes: [routeDefinition],
+        shells: options.shellModule ? { plain: "./shells/plain.tsx" } : undefined,
       }),
     ),
   };
@@ -77,6 +94,7 @@ describe("dev SSR error overlay", () => {
     expect(state.body).toContain("render exploded");
     // The route metadata the runtime knows and a stack trace cannot recover.
     expect(state.body).toContain("boom");
+    expect(state.headers["server-timing"]).toMatch(/render;dur=/);
   });
 
   // The runtime response this replaces carried them; dev must not become the
@@ -119,6 +137,28 @@ describe("dev SSR error overlay", () => {
     });
 
     expect(state.statusCode).toBe(500);
+    expect(state.body).toContain('id="boundary"');
+    expect(state.body).not.toContain("pracht error");
+  });
+
+  it("leaves an ErrorBoundary alone when shell headers override its content type", async () => {
+    const state = await render(
+      {
+        Component: () => {
+          throw new Error("render exploded");
+        },
+        ErrorBoundary: ({ error }: { error: Error }) => h("p", { id: "boundary" }, error.message),
+      },
+      {
+        shellModule: {
+          Shell: ({ children }: { children?: unknown }) => children,
+          headers: () => ({ "content-type": "text/plain; charset=utf-8" }),
+        },
+      },
+    );
+
+    expect(state.statusCode).toBe(500);
+    expect(state.headers["content-type"]).toContain("text/plain");
     expect(state.body).toContain('id="boundary"');
     expect(state.body).not.toContain("pracht error");
   });

--- a/packages/vite-plugin/test/dev-middleware.test.ts
+++ b/packages/vite-plugin/test/dev-middleware.test.ts
@@ -372,6 +372,7 @@ describe("development error overlay handoff", () => {
         capturedRouteError: true,
         exposeServerErrors: true,
         contentType: "text/plain; charset=utf-8",
+        hasErrorBoundary: false,
         status: 500,
       }),
     ).toBe(true);
@@ -383,6 +384,7 @@ describe("development error overlay handoff", () => {
         capturedRouteError: true,
         exposeServerErrors: true,
         contentType: "Text/Plain; Charset=UTF-8",
+        hasErrorBoundary: false,
         status: 500,
       }),
     ).toBe(true);
@@ -390,12 +392,13 @@ describe("development error overlay handoff", () => {
 
   // A route or shell ErrorBoundary rendered the failure itself. That HTML is
   // the app's own error UI and dev must not replace it.
-  it("leaves an ErrorBoundary render alone", () => {
+  it("leaves an ErrorBoundary render alone regardless of its content type", () => {
     expect(
       shouldRenderDevErrorOverlay({
         capturedRouteError: true,
         exposeServerErrors: true,
-        contentType: "text/html; charset=utf-8",
+        contentType: "text/plain; charset=utf-8",
+        hasErrorBoundary: true,
         status: 500,
       }),
     ).toBe(false);
@@ -408,6 +411,7 @@ describe("development error overlay handoff", () => {
         capturedRouteError: true,
         exposeServerErrors: true,
         contentType: "application/json; charset=utf-8",
+        hasErrorBoundary: false,
         status: 500,
       }),
     ).toBe(false);
@@ -421,6 +425,7 @@ describe("development error overlay handoff", () => {
         capturedRouteError: false,
         exposeServerErrors: true,
         contentType: "text/plain; charset=utf-8",
+        hasErrorBoundary: false,
         status: 500,
       }),
     ).toBe(false);
@@ -429,6 +434,7 @@ describe("development error overlay handoff", () => {
         capturedRouteError: true,
         exposeServerErrors: true,
         contentType: "text/plain; charset=utf-8",
+        hasErrorBoundary: false,
         status: 404,
       }),
     ).toBe(false);
@@ -447,6 +453,7 @@ describe("development error overlay redaction", () => {
         capturedRouteError: true,
         contentType: "text/plain; charset=utf-8",
         exposeServerErrors: false,
+        hasErrorBoundary: false,
         status: 500,
       }),
     ).toBe(false);

--- a/packages/vite-plugin/test/dev-middleware.test.ts
+++ b/packages/vite-plugin/test/dev-middleware.test.ts
@@ -8,6 +8,7 @@ import {
   isEventStreamContentType,
   isDevNotFoundRequest,
   shouldBypassDevSSR,
+  shouldRenderDevErrorOverlay,
 } from "../src/plugin-dev-ssr.ts";
 import { PRACHT_DEV_MODULE_ID } from "../src/plugin-assets.ts";
 
@@ -359,6 +360,70 @@ describe("shouldBypassDevSSR", () => {
       shouldBypassDevSSR("/", {
         headers: { accept: "*/*" },
         method: "GET",
+      }),
+    ).toBe(false);
+  });
+});
+
+describe("development error overlay handoff", () => {
+  it("replaces the runtime's plain-text render failure", () => {
+    expect(
+      shouldRenderDevErrorOverlay({
+        capturedRouteError: true,
+        contentType: "text/plain; charset=utf-8",
+        status: 500,
+      }),
+    ).toBe(true);
+  });
+
+  it("matches the media type case-insensitively", () => {
+    expect(
+      shouldRenderDevErrorOverlay({
+        capturedRouteError: true,
+        contentType: "Text/Plain; Charset=UTF-8",
+        status: 500,
+      }),
+    ).toBe(true);
+  });
+
+  // A route or shell ErrorBoundary rendered the failure itself. That HTML is
+  // the app's own error UI and dev must not replace it.
+  it("leaves an ErrorBoundary render alone", () => {
+    expect(
+      shouldRenderDevErrorOverlay({
+        capturedRouteError: true,
+        contentType: "text/html; charset=utf-8",
+        status: 500,
+      }),
+    ).toBe(false);
+  });
+
+  // Route-state and capability failures are JSON owned by the client router.
+  it("leaves JSON failures alone", () => {
+    expect(
+      shouldRenderDevErrorOverlay({
+        capturedRouteError: true,
+        contentType: "application/json; charset=utf-8",
+        status: 500,
+      }),
+    ).toBe(false);
+  });
+
+  it("leaves plain-text responses that are not render failures alone", () => {
+    // `notFound()`, "Method not allowed", and an app's own text/plain 500 from
+    // an API route never fire the page-render hook.
+    expect(
+      shouldRenderDevErrorOverlay({
+        capturedRouteError: false,
+        contentType: "text/plain; charset=utf-8",
+        status: 500,
+      }),
+    ).toBe(false);
+    expect(
+      shouldRenderDevErrorOverlay({
+        capturedRouteError: true,
+        contentType: "text/plain; charset=utf-8",
+        status: 404,
       }),
     ).toBe(false);
   });

--- a/packages/vite-plugin/test/dev-middleware.test.ts
+++ b/packages/vite-plugin/test/dev-middleware.test.ts
@@ -370,6 +370,7 @@ describe("development error overlay handoff", () => {
     expect(
       shouldRenderDevErrorOverlay({
         capturedRouteError: true,
+        exposeServerErrors: true,
         contentType: "text/plain; charset=utf-8",
         status: 500,
       }),
@@ -380,6 +381,7 @@ describe("development error overlay handoff", () => {
     expect(
       shouldRenderDevErrorOverlay({
         capturedRouteError: true,
+        exposeServerErrors: true,
         contentType: "Text/Plain; Charset=UTF-8",
         status: 500,
       }),
@@ -392,6 +394,7 @@ describe("development error overlay handoff", () => {
     expect(
       shouldRenderDevErrorOverlay({
         capturedRouteError: true,
+        exposeServerErrors: true,
         contentType: "text/html; charset=utf-8",
         status: 500,
       }),
@@ -403,6 +406,7 @@ describe("development error overlay handoff", () => {
     expect(
       shouldRenderDevErrorOverlay({
         capturedRouteError: true,
+        exposeServerErrors: true,
         contentType: "application/json; charset=utf-8",
         status: 500,
       }),
@@ -415,6 +419,7 @@ describe("development error overlay handoff", () => {
     expect(
       shouldRenderDevErrorOverlay({
         capturedRouteError: false,
+        exposeServerErrors: true,
         contentType: "text/plain; charset=utf-8",
         status: 500,
       }),
@@ -422,8 +427,27 @@ describe("development error overlay handoff", () => {
     expect(
       shouldRenderDevErrorOverlay({
         capturedRouteError: true,
+        exposeServerErrors: true,
         contentType: "text/plain; charset=utf-8",
         status: 404,
+      }),
+    ).toBe(false);
+  });
+});
+
+describe("development error overlay redaction", () => {
+  // `pracht dev` passes `debugErrors: true` unconditionally, but the runtime
+  // refuses to honor it under NODE_ENV=production — a dev server started inside
+  // a container that exports it answers with a redacted body. The overlay is
+  // built from the raw error, so it has to repeat that check or it would print
+  // the stack and filesystem paths the runtime had just withheld.
+  it("does not replace a redacted failure with the raw-error overlay", () => {
+    expect(
+      shouldRenderDevErrorOverlay({
+        capturedRouteError: true,
+        contentType: "text/plain; charset=utf-8",
+        exposeServerErrors: false,
+        status: 500,
       }),
     ).toBe(false);
   });


### PR DESCRIPTION
## Summary

- Found while dogfooding a scaffolded app: a syntax error in a route file served `text/plain` full of raw ANSI escape codes, with oxc wrapping *every character* of the offending line in its own `[38;5;249m` sequence. Same for any loader/render throw — a bare message plus a JSON blob, no stack, no overlay. This is the most common error in development producing the worst output in the framework.
- Root cause: the overlay is only reachable from `handleDevError`, i.e. errors that escape the dev SSR middleware. Failures *inside* `handlePrachtRequest()` never escape it — the runtime answers them with its `text/plain` fallback, which is right for a production adapter and wrong for a browser.
- The dev middleware now captures the raw error through `onRouteError` and serves the overlay instead. `buildErrorOverlayHtml()` strips ANSI escapes from message and stack, keeps multi-line compiler frames readable (`white-space: pre-wrap`), and gained **Phase**, **Loader**, and **Shell** rows. `onRouteError` receives a third `RouteErrorContext` argument — neither the failing phase nor the module paths are recoverable from a stack trace.
- The swap is deliberately narrow: a route or shell `ErrorBoundary` still renders its own output (`text/html`), and `x-pracht-route-state-request` failures stay JSON for the client router.
- No issue linked; from the 2026-08-25 adapter dogfood pass.

## Testing

- [x] `pnpm run verify` (build, format, lint, typecheck, test, e2e)

Also dogfooded by hand against `examples/basic` with the dev server running:

| Case | Before | After |
|---|---|---|
| Syntax error in `routes/greeting.tsx` | `text/plain` wall of ANSI codes | overlay, readable oxc source frame, clickable route + shell |
| `throw` in a loader | `text/plain` message + JSON blob | overlay, `Phase loader`, app stack frame linked at `pricing.tsx:4:9` |
| Same route with an `ErrorBoundary` | boundary rendered | boundary rendered (unchanged) |
| `x-pracht-route-state-request` | JSON | JSON (unchanged) |

New unit coverage: ANSI stripping (message + stack + pass-through), multi-line preservation, the new meta rows and their omission rules, `shouldRenderDevErrorOverlay()` across text/plain, text/html, JSON, 404, and no-captured-error, and `onRouteError` context for both a loader and a render failure.

## Checklist

- [x] Docs updated if needed — `docs/DATA_LOADING.md` (the dev-overlay section claimed this already worked), `docs/ARCHITECTURE.md`
- [x] Skills updated if needed — N/A
- [x] Changeset added if published packages changed — `.changeset/dev-error-overlay-render-failures.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)