### PR TITLE
feat(skills): cover content, images, capabilities, openapi, and the agent surface

### DIFF
--- a/.changeset/agent-surface-content-skills.md
+++ b/.changeset/agent-surface-content-skills.md
@@ -1,0 +1,15 @@
+---
+"create-pracht": patch
+---
+
+Add five skills to the seeded catalog: `/add-content`, `/add-images`,
+`/add-capabilities`, `/add-openapi`, and `/audit-agent-surface`.
+
+`@pracht/content`, `@pracht/markdown`, `@pracht/image`, `@pracht/capabilities`,
+and `@pracht/openapi` shipped without a skill, so an agent wiring any of them
+had to rediscover the plugin order, the server-only snapshot boundary, the
+loader-per-target matrix, the inline-literal constraint on `expose`/`effect`,
+and the destructive confirmation gate from the docs each time.
+`/audit-agent-surface` reports what agents can actually reach — capability
+exposure, `agents` trust config, `llms.txt`, Markdown negotiation, OpenAPI —
+and confirms an app that wants no agent surface pays nothing for one.

--- a/examples/docs/src/routes/docs/agent-skills.md
+++ b/examples/docs/src/routes/docs/agent-skills.md
@@ -1,6 +1,6 @@
 ---
 title: Agent Skills
-lead: pracht ships 28 Claude Code skills for scaffolding, auditing, testing, and deploying apps. They are published at stable URLs with a signed discovery manifest, seeded into new apps by `create-pracht`, and pair with the built-in MCP server.
+lead: pracht ships 33 Claude Code skills for scaffolding, auditing, testing, and deploying apps. They are published at stable URLs with a signed discovery manifest, seeded into new apps by `create-pracht`, and pair with the built-in MCP server.
 breadcrumb: Agent Skills
 prev:
   href: /docs/agent-workflow
@@ -17,9 +17,9 @@ Every skill is a single `SKILL.md` — frontmatter (`name`, `version`, `descript
 | Category                | Skills                                                                                                                                                                                        |
 | ----------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Framework & migration   | `/pracht-scaffold`, `/pracht-debug`, `/pracht-deploy`, `/migrate-nextjs`, `/upgrade-pracht`                                                                                                     |
-| Audit & review          | `/audit-loaders`, `/audit-shells`, `/audit-islands`, `/audit-auth`, `/audit-csrf`, `/audit-headers`, `/audit-secrets`, `/audit-redirects`, `/audit-deps`, `/audit-bundles`, `/audit-seo`, `/audit-a11y`, `/tune-render-mode`, `/pre-deploy` |
+| Audit & review          | `/audit-loaders`, `/audit-shells`, `/audit-islands`, `/audit-auth`, `/audit-csrf`, `/audit-headers`, `/audit-secrets`, `/audit-redirects`, `/audit-deps`, `/audit-bundles`, `/audit-seo`, `/audit-a11y`, `/audit-agent-surface`, `/tune-render-mode`, `/pre-deploy` |
 | Testing scaffolds       | `/scaffold-tests`, `/scaffold-e2e`, `/pracht-test-api`                                                                                                                                          |
-| App primitives          | `/add-auth`, `/add-db`, `/add-i18n`, `/add-observability`, `/typed-routes`, `/configure-isg`                                                                                                    |
+| App primitives          | `/add-auth`, `/add-db`, `/add-i18n`, `/add-observability`, `/add-content`, `/add-images`, `/add-capabilities`, `/add-openapi`, `/typed-routes`, `/configure-isg`                                 |
 
 The source of truth lives in the repo's [skills/ directory](https://github.com/JoviDeCroock/pracht/tree/main/skills), with per-skill descriptions in [skills/README.md](https://github.com/JoviDeCroock/pracht/blob/main/skills/README.md). Instead of globbing `src/`, the skills read the resolved app graph via `pracht inspect routes|api|build --json`, so they account for groups, inheritance, and both routers.
 

--- a/skills/README.md
+++ b/skills/README.md
@@ -38,6 +38,7 @@ collide with other skill packs installed in the same app.
 | `/audit-bundles`    | Per-route client payload size and code-splitting recommendations.   |
 | `/audit-seo`        | `head()` coverage, OG cards, sitemap, robots.txt.                   |
 | `/audit-a11y`       | Per-route axe-core run with WCAG 2.1 AA defaults.                   |
+| `/audit-agent-surface` | Inventory what agents can reach: capability exposure, `agents` trust config, `llms.txt`, OpenAPI. |
 | `/tune-render-mode` | Recommend SSG/ISG/SSR/SPA per route based on loader contents.       |
 | `/pre-deploy`       | Adapter-aware pre-deployment checklist.                             |
 
@@ -57,6 +58,10 @@ collide with other skill packs installed in the same app.
 | `/add-db`             | Wire Drizzle ORM (D1, PlanetScale, Neon, Postgres, ...).          |
 | `/add-i18n`           | Wire `@pracht/i18n`: locale routing, dictionaries, hreflang.      |
 | `/add-observability`  | Wire Sentry / OpenTelemetry plus Web Vitals.                      |
+| `/add-content`        | Wire `@pracht/content` / `@pracht/markdown`: collections, Markdown routes, artifacts. |
+| `/add-images`         | Wire `@pracht/image`: `<Image>`, per-target loaders, static variants. |
+| `/add-capabilities`   | Expose typed operations to agents over HTTP, WebMCP, and remote MCP. |
+| `/add-openapi`        | Wire `@pracht/openapi`: OpenAPI 3.1 document plus optional reference UI. |
 | `/typed-routes`       | Generate and adopt route-id based typed links/navigation.         |
 | `/configure-isg`      | Wire ISG revalidation (time + webhook) per adapter.               |
 

--- a/skills/add-capabilities/SKILL.md
+++ b/skills/add-capabilities/SKILL.md
@@ -1,0 +1,260 @@
+---
+name: add-capabilities
+version: 1.0.0
+description: |
+  Expose an app operation as a typed pracht capability: one contract (JSON
+  Schema input/output, effect class, named middleware, server-only `run()`)
+  projected into direct server invocation, an HTTP endpoint, a WebMCP page
+  tool, and a remote MCP tool. Wires `@pracht/capabilities`, the manifest
+  registration, `defineApp({ agents })` (Web Bot Auth, confirmation,
+  remote MCP), typed clients, `<Form capability>`, and `pracht eval` scenarios.
+  Use when asked to "add a capability", "expose this to agents", "add an MCP
+  tool", "make my app agent-callable", "add WebMCP", "serve remote MCP", or
+  "let an agent create a note".
+allowed-tools:
+  - Bash
+  - Read
+  - Write
+  - Edit
+  - Grep
+  - Glob
+  - AskUserQuestion
+---
+
+# Pracht Add Capabilities
+
+A capability is a protocol-neutral operation (`docs/CAPABILITIES.md`). Every
+projection runs the identical pipeline, so rules never diverge per transport:
+
+```text
+input validation → named middleware chain → run() → output validation
+```
+
+Registration is opt-in and private by default: no loader or API route is ever
+inferred as a capability, and an app that registers none ships no agent surface
+at all (the build drops ~15 KB gzip of dispatch and verifier code).
+
+## Step 1: Decide the contract before writing code
+
+Settle these with `AskUserQuestion` when the request is vague:
+
+- **Name** — dot-separated segments (`notes.search`); this is the agent-visible
+  identity and the MCP tool name (dots become underscores).
+- **Effect** — `read`, `write`, or `destructive`. This drives confirmation
+  gating, client revalidation, and MCP annotations. Classify honestly.
+- **Exposure** — private (omit `expose`), `http`, `webmcp` (requires `http`),
+  `mcp`. Capabilities are manifest-router only; the pages router has no
+  manifest to register them in.
+- **Authorization** — which named middleware runs, and whether the endpoint
+  requires a verified agent (`agentPolicy: "require"`).
+
+Exposure matrix the runtime, `defineCapability()`, and `pracht verify` all
+enforce:
+
+| Effect | `http` | `webmcp` | `mcp` |
+| ------ | ------ | -------- | ----- |
+| `read` / `write` | yes | yes (needs `http`) | yes (needs `agents.mcp`) |
+| `destructive` | yes — always confirmation-gated | rejected | rejected |
+
+## Step 2: Install and scaffold
+
+`create-pracht` does not add the package, because an app without capabilities
+should not carry it:
+
+```bash
+npm install @pracht/capabilities
+pracht generate capability --name notes.search --effect read --expose http,webmcp \
+  --description "Find notes whose title or body matches the query."
+```
+
+The generator writes `src/capabilities/notes-search.ts` with `expose`,
+`effect`, and `input` as inline literals and registers the name in the
+manifest. `--description` is required whenever `--expose` is set — that text is
+the contract an agent reads. It refuses the combinations the runtime rejects
+anyway. The MCP `generate_capability` tool does the same thing.
+
+If dispatch answers `500 internal_error` and `pracht inspect capabilities`
+prints capabilities as `unreadable`, the package is missing — that is the
+symptom.
+
+## Step 3: Write the capability
+
+```ts
+// src/capabilities/notes-search.ts
+import { defineCapability, type CapabilityRunArgs } from "@pracht/capabilities";
+import { searchNotes } from "../server/notes-store.ts";
+
+interface SearchInput {
+  query: string;
+  limit: number;
+}
+
+export default defineCapability({
+  title: "Search notes",
+  description: "Find notes whose title or body matches the query.",
+  input: {
+    type: "object",
+    properties: {
+      query: { type: "string", minLength: 1 },
+      limit: { type: "integer", minimum: 1, maximum: 20, default: 10 },
+    },
+    required: ["query"],
+    additionalProperties: false,
+  },
+  output: {
+    type: "object",
+    properties: { notes: { type: "array", items: { type: "object" } } },
+    required: ["notes"],
+  },
+  effect: "read",
+  middleware: ["auth"],            // names from the app manifest
+  expose: { http: true, webmcp: true },
+  // agentPolicy: "require",       // verified Web Bot Auth agents only
+  async run({ input, context, request, signal }: CapabilityRunArgs<SearchInput>) {
+    return { notes: searchNotes(input.query, input.limit) };
+  },
+});
+```
+
+Schema rules that bite:
+
+- Only a **subset** of JSON Schema is accepted: `type`, `properties`,
+  `required`, `additionalProperties`, `items` (single schema), `enum`, `const`,
+  `minimum`, `maximum`, `minLength`, `maxLength`, `default`, plus `title` and
+  `description`. `oneOf`, `anyOf`, `allOf`, `$ref`, `pattern`, `format`, and
+  tuple `items` throw at definition time — a keyword the validator would ignore
+  could widen what an exposed capability accepts.
+- Inputs and outputs are JSON data only. `File`, `Blob`, `Date`, `Map`,
+  `undefined`, and cycles are rejected — keep uploads in API routes.
+- `expose`, `effect`, and (for webmcp) `input` must be **inline literals**: the
+  browser projection is built by static analysis, and an imported constant or
+  spread fails the build.
+- MCP exposure additionally requires both schemas rooted at `type: "object"`.
+- Annotate `run()` with `CapabilityRunArgs<Input>` so TypeScript still infers
+  the output; `defineCapability<Input>` alone leaves the output `unknown`.
+
+## Step 4: Register it, and configure `agents` only if needed
+
+```ts
+// src/routes.ts
+export const app = defineApp({
+  capabilities: {
+    "notes.search": () => import("./capabilities/notes-search.ts"),
+  },
+  agents: {
+    // Verified agent identity (public keys — safe in the manifest).
+    webBotAuth: { policy: "observe", directories: ["https://signature-agent.cloudflare.com"] },
+    // Destructive prepare/commit tuning.
+    confirmation: { ttlSeconds: 120 },
+    // Remote MCP endpoint; without this, `expose.mcp` serves nothing.
+    mcp: { serverInfo: { name: "notes", version: "1.0.0" }, instructions: "…" },
+  },
+  routes: [/* … */],
+});
+```
+
+Each `agents` sub-option is independent — add only what the app uses. Web Bot
+Auth `policy: "require"` gates capability HTTP endpoints (not pages or API
+routes) with `401 agent_required`; `agentPolicy: "require"` on a capability
+fails closed even when `webBotAuth` is unconfigured.
+
+## Step 5: Destructive capabilities
+
+`destructive` (delete, publish, pay, send, change access) is HTTP-only and
+every dispatch is gated:
+
+1. Set `PRACHT_CONFIRMATION_SECRET` in the server environment (or call
+   `setCapabilityConfirmationSecret()` from `@pracht/core/server`). Without it,
+   calls fail closed with `403 confirmation_unavailable` and `pracht verify`
+   fails — verify reads the environment, so the variable must be set even when
+   the app registers the secret programmatically.
+2. A call without a token answers `409 confirmation_required` with a token
+   bound to principal + capability + canonical input + expiry.
+3. The commit repeats the call with byte-identical input plus the confirmation
+   header.
+
+Be honest about what this buys, and say so to the user
+(`docs/AGENT_TRUST.md`): stateless HMAC cannot prevent replay inside the TTL,
+the calling agent can hand the token straight back to itself, and without Web
+Bot Auth or `setCapabilityApprovalPrincipalResolver()` both phases run as
+`"anonymous"`. Register a `CapabilityApprovalStore` for exactly-once commits,
+and `confirmation: { mode: "human" }` for a real human decision — that mode
+fails closed without both a store and an authenticated principal. Any store
+backing it needs atomic conditional writes (D1, Durable Objects, Postgres,
+Redis — not Cloudflare KV).
+
+## Step 6: Call it
+
+```ts
+// Server: loaders, API routes, middleware — works for private capabilities too.
+import { invokeCapability } from "@pracht/core/server";
+const result = await invokeCapability("notes.search", { query: "roadmap" }, { request, context, signal });
+```
+
+```ts
+// Browser: generated, typed, http-exposed names only.
+import { capabilities, useCapability } from "virtual:pracht/capabilities";
+const result = await capabilities.notes.search({ query: "roadmap" });
+```
+
+```tsx
+// One contract for the human form and the agent tool.
+<Form capability="notes.create" onCapabilityResult={(result) => { /* … */ }}>
+  <input name="title" />
+  <button type="submit">Create</button>
+</Form>
+```
+
+- Prefer a loader + `invokeCapability()` for data a page needs on load;
+  `useCapability()` dispatches on interaction, never during render.
+- After a successful non-`read` call the route's data revalidates
+  automatically (`revalidate: false` opts out).
+- Capability modules are server-only: importing one from client code is a build
+  error, because nothing would strip `run()` and its database client out of the
+  browser bundle.
+
+## Step 7: Types, inspection, and proof
+
+```bash
+pracht typegen                 # emits src/pracht-capabilities.d.ts
+pracht inspect capabilities --json
+pracht verify --json           # contract, exposure, and projection checks
+pracht eval --start "pracht preview"
+```
+
+Once the declaration exists the compiler rejects unknown names, bad input,
+browser calls to private capabilities, destructive calls without
+`prepare`/`confirm`, and runtime-computed names (assert
+`as HttpCapabilityName`). Re-run `pracht typegen --check` in CI.
+
+`pracht eval` runs JSON scenarios against the live HTTP projection and exits 1
+on a failed expectation — the repeatable answer to "can an agent actually
+finish this task?". Steps can reference earlier results
+(`$steps[0].error.confirmationToken`) and a scenario-level `signAs` block signs
+every step as a verified agent. `createCapabilityTestHost()` from
+`@pracht/core` covers the same pipeline in unit tests without a server.
+
+For an audit of what the whole agent surface currently exposes, run
+`/audit-agent-surface`.
+
+## Rules
+
+1. Never expose a `destructive` capability over `webmcp` or `mcp`, and never
+   reclassify a destructive operation as `write` to escape the confirmation
+   gate.
+2. Never widen a schema (drop `required`, open `additionalProperties`, raise a
+   `maximum`) without saying so — `pracht plan` reports it as a widening of the
+   agent-reachable surface for a reason.
+3. Keep `expose`, `effect`, and `input` as inline literals.
+4. Put authentication, authorization, and rate limiting in named middleware —
+   the framework ships no rate limiting, no write-idempotency helper, and no
+   result-size budget. Bound outputs with a `limit` input and a schema
+   `maximum`.
+5. Design `write` inputs to be safely repeatable; agents retry, and only
+   `destructive` calls are token-gated.
+6. Never register an app-wide approval endpoint or UI without your own
+   authorization — who may approve is an application decision.
+7. Re-run `pracht typegen` after changing a schema, name, or exposure, and
+   `pracht verify` before committing.
+
+$ARGUMENTS

--- a/skills/add-content/SKILL.md
+++ b/skills/add-content/SKILL.md
@@ -1,0 +1,246 @@
+---
+name: add-content
+version: 1.0.0
+description: |
+  Wire `@pracht/content` (and the official `@pracht/markdown` compiler) into a
+  pracht app: one collection registry that owns source discovery, routes,
+  locales, compilation, static artifacts (`llms.txt`, raw source), and the
+  server-only runtime snapshot loaders and capabilities read. Covers Markdown
+  and MDX route modules, relative-image handling, route reconciliation, and the
+  Cloudflare chunking requirements.
+  Use when asked to "add a blog", "set up docs", "render markdown pages",
+  "add MDX", "content collections", "publish llms.txt from my content", or
+  "why is my markdown route 404ing".
+allowed-tools:
+  - Bash
+  - Read
+  - Write
+  - Edit
+  - Grep
+  - Glob
+  - AskUserQuestion
+---
+
+# Pracht Add Content Collections
+
+`@pracht/content` is the optional, **server-only** content layer
+(`docs/CONTENT.md`). It exists so a content-heavy app has *one* registry
+instead of two readers that drift — route modules reading source through Vite,
+and sitemap/`llms.txt`/search plugins scanning the filesystem again.
+`@pracht/markdown` is the opinionated Markdown route-module compiler on top of
+it (`packages/markdown/README.md`).
+
+Nothing here is on by default: adding a collection publishes no source and
+creates no agent surface until you add artifacts or capabilities.
+
+## Step 1: Pick the shape
+
+Ask with `AskUserQuestion` when it is not obvious from the repo:
+
+| Situation | Wiring |
+| --------- | ------ |
+| Markdown/MDX files that should *be* pages | `@pracht/markdown` → `defineMarkdownCollection()` |
+| Content that feeds loaders, search, or an API — never a page | `@pracht/content` → `defineCollection()` with `unroutedDocuments: "ignore"` |
+| An app-specific compiler (custom AST, page model, search record) | `defineCollection({ compile, module })` |
+
+Also settle: collection root directory, `routeBase`, whether documents are
+localized, and whether relative images appear in the Markdown.
+
+## Step 2: Install
+
+```bash
+pnpm add @pracht/content
+pnpm add @pracht/markdown @pracht/image   # Markdown route modules
+pnpm add -D sharp                          # only when documents embed local images
+```
+
+`sharp` runs at build/dev time only and never ships to a runtime bundle.
+
+## Step 3: Define the collection outside the vite config
+
+Put the collection in its own module (`content.ts`) so the vite config, build
+plugins, and tests import the same object:
+
+```ts
+// content.ts
+import { llmsTxtArtifacts, rawContentArtifacts } from "@pracht/content";
+import { defineMarkdownCollection } from "@pracht/markdown";
+
+export const docs = defineMarkdownCollection({
+  name: "docs",
+  root: new URL("./src/routes/docs", import.meta.url),
+  routeBase: "/docs",
+  // locales: { default: "en", supported: ["en", "fr"] },
+  // images: { placeholder: "blur" },      // default "empty" — keeps CSP unchanged
+  // snapshot: { raw: false },             // drop a representation you never read
+  artifacts: [
+    rawContentArtifacts({ path: (document) => `${document.path}.md` }),
+    llmsTxtArtifacts({
+      title: "Product docs",
+      origin: "https://example.com",
+      sections: [{ heading: "Docs", match: "/docs" }],
+    }),
+  ],
+});
+```
+
+Without `sources`, the registry scans `root` recursively for `.md`/`.mdx`;
+`index` files collapse to their directory. Pass explicit
+`{ id, path, source, locale }` entries when routes must not be inferred.
+Duplicate ids, routes, sources, or artifact paths throw at definition time
+rather than letting file order pick a winner.
+
+## Step 4: Register the plugins (order matters)
+
+```ts
+// vite.config.ts
+import { prachtContent } from "@pracht/content/vite";
+import { prachtImage } from "@pracht/image/vite";
+import { pracht } from "@pracht/vite-plugin";
+import { defineConfig } from "vite";
+import { docs } from "./content";
+
+export default defineConfig({
+  plugins: [
+    prachtContent({ collections: [docs] }), // one call, every collection
+    prachtImage(),                          // relative Markdown images
+    pracht(),
+  ],
+});
+```
+
+Register **all** collections through a single `prachtContent()` call — the
+plugin owns one internal build manifest and rejects a second registration.
+
+## Step 5: Point routes at the documents
+
+Markdown modules are ordinary route modules (they export `Component`, `head()`,
+and the raw `markdown` string for `Accept: text/markdown` negotiation):
+
+```ts
+route("/docs/routing", () => import("./routes/docs/routing.md"), {
+  id: "routing",
+  render: "ssg",
+});
+```
+
+Sources and routes are still two readers, so `pracht build` reconciles them and
+names every document (and generated locale alias) that no route serves — a
+document without a route still reaches `llms.txt` and `rawContentArtifacts()`
+while the page answers 404. The default policy is `"warn"`:
+
+```ts
+prachtContent({ collections: [docs], unroutedDocuments: "error" });
+```
+
+Use `"error"` for a docs site, `"ignore"` for a data-only collection. On a
+static export a dynamic SSG route only covers the concrete paths
+`getStaticPaths()` returns, and a dynamic SPA route only covers deep links when
+`staticAdapter({ fallback })` emits one. `pracht verify` cannot do this check —
+it reads the vite config as text — so run a build before believing the routing
+is complete.
+
+## Step 6: Read the collection at request time
+
+Loaders, middleware, API routes, and capabilities must import the **generated
+snapshot**, not the filesystem-backed authoring object:
+
+```ts
+import { contentLoader } from "@pracht/content/runtime";
+import docs from "virtual:pracht/content/docs";
+
+export const loader = contentLoader(docs, {
+  select: (document) => ({ html: document.compiled, title: document.frontmatter.title }),
+});
+```
+
+- The virtual module is **server-only**; a retained client import fails the
+  build instead of shipping source, frontmatter, and compiled values to the
+  browser.
+- Every accessor is async: each document's `raw`/`body`/`compiled` lives in its
+  own deferred chunk, so the first content-backed request does not parse the
+  whole collection. `iterate()` streams one document at a time; `all()` loads
+  everything.
+- `contentLoader()` uses the matched, base-free `pathname`, and answers
+  unmatchable pathnames (`/docs/%2e%2e`) with its not-found path instead of
+  failing the request.
+- `markdownRepresentation(document, "raw" | "body")` produces the server-only
+  `markdown` export for content negotiation — it throws when `snapshot` dropped
+  the field you selected.
+- Frontmatter and compiled values must be JSON-serializable; the build names
+  the offending value path otherwise.
+
+Add types once: `"types": ["@pracht/markdown/client", "@pracht/content/virtual"]`
+in tsconfig (or triple-slash references in any `.d.ts`).
+
+## Step 7: Artifacts and the two llms.txt files
+
+`llmsTxtArtifacts()` (collection-driven, curated, can emit an `llms-full.txt`)
+is **not** the same as the core `llmsTxt` plugin option (app-graph driven,
+`docs/LLMS_TXT.md`). Both default to `/llms.txt`, and enabling both fails the
+build rather than silently overwriting — pick one, or give the collection a
+distinct `summaryPath`. A third, unrelated file is `pracht llms`, which prints
+the *authoring guide* for coding agents; `pracht llms --write` drops it in the
+app root, which is exactly the confusing filename collision to avoid in an app
+that publishes its own index.
+
+Localization trap: a string `section.match` is compared against the
+**locale-neutral** route, so `match: "/docs"` indexes only the default locale
+while `rawContentArtifacts()` publishes every translation. Pass a `match`
+function to index one locale deliberately.
+
+Artifact paths are preflighted: canonical ASCII segments only, no overlap with
+`publicDir`, bundle output, prerendered pages, request-time page/API paths,
+concrete ISG paths, the `/_pracht` namespace, or Netlify's `/_headers` and
+`/_redirects`.
+
+## Step 8: Deployment notes
+
+- **Cloudflare** — deferred content chunks require `"no_bundle": true` and an
+  `ESModule` rule covering `"**/*.js"` in `wrangler.jsonc`; `pracht verify`
+  warns when either is missing. New `create-pracht` projects have both.
+- **Content type headers** — explicit artifact `contentType` values flow into
+  the production headers manifest and are applied by the Node, Cloudflare,
+  Netlify, and Vercel adapters.
+- **Bundle cost** — payload chunks carry roughly two to three times the source
+  bytes. `snapshot: { raw: false }` or `{ body: false }` drops a representation
+  the app never reads; `compiled` and frontmatter cannot be dropped.
+
+## Step 9: Optional agent surface
+
+`@pracht/content/capabilities` exports `createContentPageCapability()` and
+`createContentSearchCapability()`, which return `input`/`output`/`run` fields.
+Keep the literal `defineCapability({ ... })` in the app so `pracht verify` can
+audit exposure and policy statically — see `/add-capabilities`. Both helpers
+read `document.body` and refuse a body-free snapshot when constructed.
+
+## Step 10: Verify
+
+```bash
+pracht build          # reconciliation warnings + artifact preflight
+pracht verify --json
+pracht typegen        # after route ids or paths change
+```
+
+Then load a content route in `pracht dev`, edit a source file, and confirm the
+watcher invalidates it (collection roots outside Vite's project root are added
+to the watcher explicitly).
+
+## Rules
+
+1. **Compiled Markdown is executed as HTML, unsanitized.** The generated route
+   module renders through `dangerouslySetInnerHTML`. Only compile
+   repo-authored, reviewed content; sanitize in `parse` or `render` (e.g.
+   `sanitize-html`) before compiling anything from a CMS, a database, or a
+   user.
+2. Never import a capability-facing or loader-facing collection from client
+   code — import `virtual:pracht/content/<name>` inside server code only.
+3. One `prachtContent()` call, with every collection in it.
+4. Do not enable the core `llmsTxt` option and a collection `/llms.txt`
+   artifact at the same time.
+5. Adding a collection must not publish raw source implicitly — add
+   `rawContentArtifacts()` only when publishing sources is intended.
+6. Never overwrite an existing `vite.config.ts`, `wrangler.jsonc`, or content
+   module — diff first and confirm collisions with `AskUserQuestion`.
+
+$ARGUMENTS

--- a/skills/add-images/SKILL.md
+++ b/skills/add-images/SKILL.md
@@ -1,0 +1,206 @@
+---
+name: add-images
+version: 1.0.0
+description: |
+  Wire `@pracht/image` into a pracht app: the CLS-safe zero-runtime `<Image>`
+  component, the right loader for the deployment target (built-in sharp
+  endpoint, Cloudflare Image Resizing, Vercel Image Optimization, or
+  passthrough), build-time `?pracht` imports with blur placeholders, prebuilt
+  static WebP variants, and the security settings the optimization endpoint
+  needs.
+  Use when asked to "add images", "optimize images", "responsive images",
+  "set up next/image equivalent", "enable Cloudflare image resizing", "add blur
+  placeholders", or "my images cause layout shift".
+allowed-tools:
+  - Bash
+  - Read
+  - Write
+  - Edit
+  - Grep
+  - Glob
+  - AskUserQuestion
+---
+
+# Pracht Add Images
+
+`@pracht/image` splits the problem the way next/image does: the `<Image>`
+component decides *which widths* to render, a loader decides *what URL* serves
+each width (`docs/IMAGES.md`). The component renders a plain `<img>` — SSR-safe,
+zero hydration, works with `hydration: "none"`.
+
+## Step 1: Choose the backend for the deployment target
+
+If the pracht MCP server is registered (see docs/MCP.md), prefer its tools
+(`inspect_routes`, `inspect_build`, `doctor`, `verify`) over shelling out.
+
+```bash
+pracht inspect build --json   # adapterTarget (requires a prior `pracht build`)
+```
+
+| Target | Loader | Notes |
+| ------ | ------ | ----- |
+| Node | `defaultLoader` + the built-in endpoint | needs `sharp`; put a CDN in front |
+| Cloudflare | `cloudflareLoader` | Image Resizing must be enabled on the zone; sharp does not run on Workers |
+| Vercel | `vercelLoader` | needs an `images` section in the project config; Vercel only serves widths listed in `images.sizes` |
+| Static host | `passthroughLoader` | no image service — srcset is omitted |
+| Any target, no runtime service | `?pracht&pracht-static` imports | prebuilt WebP variants, no loader involved |
+
+Confirm the choice with `AskUserQuestion` when the app deploys to more than one
+target — a per-target `configureImage()` behind an env flag is the usual answer
+(`examples/basic` does exactly this).
+
+## Step 2: Install
+
+```bash
+pnpm add @pracht/image
+pnpm add sharp              # only for the built-in Node endpoint
+pnpm add -D sharp           # only for `?pracht` imports / static variants
+```
+
+sharp stays an optional peer dependency; the vite plugin fails with an install
+hint when a `?pracht` import needs it, and the endpoint answers 500 with the
+same hint at runtime.
+
+## Step 3: Configure the loader once
+
+Put `configureImage()` where both the server and the browser evaluate it — the
+top of `src/routes.ts` is the canonical spot:
+
+```ts
+import { cloudflareLoader, configureImage } from "@pracht/image";
+
+configureImage({
+  loader: cloudflareLoader,
+  // deviceSizes: [640, 750, 828, 1080, 1200, 1920, 2048, 3840],
+  // imageSizes: [16, 32, 48, 64, 96, 128, 256, 384],
+  // quality: 75,
+});
+```
+
+`createDefaultLoader("/my/endpoint")` builds a default-style loader for a custom
+endpoint path. Root-absolute endpoints pick up Vite's deploy `base`
+automatically; provider loaders (`cloudflareLoader`, `vercelLoader`)
+deliberately stay at the origin root.
+
+## Step 4: Render images
+
+```tsx
+import { Image } from "@pracht/image";
+
+<Image
+  src="/banner.jpg"
+  alt="Product banner"
+  width={1200}
+  height={280}
+  sizes="(max-width: 1200px) 100vw, 1200px"
+  priority
+/>;
+```
+
+- `alt` is required — use `alt=""` for decorative images.
+- `width`/`height` are required unless `fill`; they reserve space and prevent
+  layout shift. Missing dimensions log a `console.error` in dev.
+- `sizes` (or `fill`) switches the srcset to `w` descriptors across
+  `deviceSizes`; a fixed image gets `1x`/`2x` candidates snapped to the
+  breakpoint list so caches stay small.
+- `priority` on above-the-fold images swaps `loading="lazy"` +
+  `decoding="async"` for `loading="eager"` + `fetchpriority="high"`. Use it for
+  the LCP image only.
+- `fill` positions the image absolutely inside the nearest positioned ancestor
+  and defaults `sizes` to `100vw`; pair with `style={{ objectFit: "cover" }}`.
+
+## Step 5: Build-time imports and static variants
+
+Register the plugin — the main `pracht()` plugin does **not** include it:
+
+```ts
+// vite.config.ts
+import { prachtImage } from "@pracht/image/vite";
+
+export default { plugins: [prachtImage(), pracht({ /* … */ })] };
+```
+
+```tsx
+import hero from "./hero.jpg?pracht";                 // { src, width, height, blurDataURL }
+import banner from "./banner.jpg?pracht&pracht-static"; // + prebuilt WebP variants
+
+<Image src={hero} alt="Hero" placeholder="blur" />;
+<Image src={banner} alt="Banner" sizes="(max-width: 960px) 100vw, 960px" />;
+```
+
+- Dimensions come from sharp metadata with EXIF orientation applied, so a
+  rotated portrait reports its *display* size.
+- `blurDataURL` is an 8px WebP data URI generated at build time. SVGs skip it,
+  animated GIFs blur their first frame.
+- `pracht-static` emits content-hashed WebP files at `staticWidths`, takes
+  precedence over the global loader, and is cached in Vite's `cacheDir` keyed by
+  source bytes. It requires an **absolute** Vite `base`; SVG and animated
+  sources pass through unchanged.
+- Root-relative `publicDir` imports keep stable public URLs and bypass the
+  runtime loader.
+- Types: `"types": ["@pracht/image/client"]` in tsconfig, or a triple-slash
+  reference in any `.d.ts`.
+
+`@pracht/markdown` uses `?pracht&pracht-static` automatically for relative
+Markdown images and renders them with `getImageProps()` — see `/add-content`.
+
+## Step 6: Mount the optimization endpoint (Node-compatible runtimes only)
+
+```ts
+// src/api/_pracht/image.ts
+import { createImageHandler } from "@pracht/image/node";
+
+const imageHandler = createImageHandler({
+  // Required in every environment, including dev. Your own env var, not a
+  // framework one — set it to the app's public origin and use the same value
+  // as nodeAdapter({ canonicalOrigin }).
+  localOrigin: process.env.PRACHT_ORIGIN,
+  // remotePatterns: [{ protocol: "https", hostname: "*.example.com", pathname: "/uploads" }],
+  // allowedWidths: [640, 1280],   // required when configureImage() customizes the breakpoints
+});
+
+export const GET = imageHandler;
+export const HEAD = imageHandler;
+```
+
+That file maps to `/api/_pracht/image`, exactly what `defaultLoader` targets —
+no further configuration. The endpoint negotiates WebP via `Accept` (pass
+`formats: ["image/avif", "image/webp"]` for AVIF), never enlarges beyond the
+source, passes SVG/GIF through, and answers
+`Cache-Control: public, max-age=14400, must-revalidate` with `Vary: Accept`.
+
+## Step 7: Verify
+
+```bash
+pracht dev            # set PRACHT_ORIGIN to the exact origin it prints
+pracht build
+pracht verify --json
+```
+
+Check in the browser: the `<img>` carries `srcset`/`sizes`, the LCP image is
+`fetchpriority="high"`, and no layout shift occurs on reload. Then run
+`/audit-bundles` and `/audit-seo` if image work was part of a performance pass.
+
+## Rules
+
+1. Never leave `localOrigin` unset — relative sources are resolved only against
+   it, so a forged `Host` cannot turn the endpoint into an open proxy. The
+   handler answers 500 until it is configured, including in dev.
+2. Always allowlist remote hosts with `remotePatterns`; never proxy arbitrary
+   URLs.
+3. When `configureImage()` customizes `deviceSizes`/`imageSizes`, pass the
+   matching `allowedWidths` — the endpoint rejects widths outside its allowlist
+   by design, and skipping this silently breaks the srcset.
+4. Do not use `priority` on more than the one above-the-fold image per route.
+5. `placeholder="blur"` writes an inline `style` attribute: a CSP without
+   `style-src-attr 'unsafe-inline'` silently drops it (and `fill` positioning),
+   and `img-src` must include `data:`. See `docs/CSP.md`.
+6. Platform loaders generate URLs that only resolve on the deployed platform —
+   fall back to `passthroughLoader` behind `import.meta.env.DEV` for local
+   previews.
+7. Use an immutable one-year `cacheControl` only when every source URL is
+   content-addressed.
+8. Never overwrite an existing `vite.config.ts`, image API route, or
+   `configureImage()` call — diff first and confirm with `AskUserQuestion`.
+
+$ARGUMENTS

--- a/skills/add-openapi/SKILL.md
+++ b/skills/add-openapi/SKILL.md
@@ -1,0 +1,211 @@
+---
+name: add-openapi
+version: 1.0.0
+description: |
+  Wire `@pracht/openapi` into a pracht app: generate an OpenAPI 3.1 document
+  from existing `defineApi()` routes, attach the response contracts that cannot
+  be inferred with `defineOpenApi()`, serve an optional Scalar or Swagger
+  reference UI, handle deploy-base and CSP concerns, and turn warnings into a
+  CI completeness gate.
+  Use when asked to "add OpenAPI", "generate an API spec", "add Swagger",
+  "publish API docs", "add a reference UI", or "document my API routes".
+allowed-tools:
+  - Bash
+  - Read
+  - Write
+  - Edit
+  - Grep
+  - Glob
+  - AskUserQuestion
+---
+
+# Pracht Add OpenAPI
+
+`@pracht/openapi` is an opt-in companion package (`docs/OPENAPI.md`). Ordinary
+`defineApi()` routes keep their authoring, runtime behavior, and `apiFetch()`
+type inference — the package only reads the resolved server graph and owns its
+own descriptor.
+
+## Step 1: Inventory the API first
+
+If the pracht MCP server is registered (see `docs/MCP.md`), prefer its tools
+(`inspect_api`, `inspect_routes`, `doctor`, `verify`) over shelling out.
+
+```bash
+pracht inspect api --json   # endpoint paths, methods, hasDefaultHandler
+```
+
+Note two things before generating anything:
+
+- **Default-export handlers** are not expanded — their supported methods cannot
+  be inferred honestly. Split them into named method exports if they belong in
+  the document.
+- **Catch-all paths** become a single `{path}` parameter and emit a warning
+  about slash encoding.
+
+Ask the user whether the document should be public, and whether they want a
+reference UI at all (`ui: false` is the default).
+
+## Step 2: Install and register the plugin
+
+```bash
+pnpm add @pracht/openapi
+```
+
+```ts
+// vite.config.ts — the companion plugin goes after pracht()
+import { prachtOpenApi } from "@pracht/openapi/vite";
+import { pracht } from "@pracht/vite-plugin";
+import { defineConfig } from "vite";
+
+export default defineConfig({
+  plugins: [
+    pracht(),
+    prachtOpenApi({
+      info: {
+        title: "Acme API",
+        version: "1.0.0",
+        description: "Public HTTP API for Acme.",
+      },
+      ui: "scalar", // or "swagger", an object, or omit for no UI
+    }),
+  ],
+});
+```
+
+This reserves `/openapi.json` and (with a UI) `/docs`. Both are live in the
+Vite dev server; `pracht build` writes `dist/client/openapi.json` and
+`dist/client/docs/index.html`, which Node, Cloudflare, Netlify, and Vercel serve
+through their existing static-asset paths. Paths are configurable via
+`documentPath` and `ui.path`; the document path **must** end in `.json` so
+static hosts assign the right media type.
+
+Reserved paths shadow app routes: development logs a warning on a collision and
+production generation replaces the colliding public/build file and reports the
+replacement. Grep the manifest and `public/` for `/docs` before enabling the UI
+on an app that already documents itself there.
+
+## Step 3: Attach the metadata that cannot be inferred
+
+Paths, methods, path params, and convertible request validators come from the
+routes. Status codes and payload shapes cannot be recovered from an arbitrary
+`Response` or an erased TypeScript type — declare them:
+
+```ts
+import { defineApi, json } from "@pracht/core";
+import { defineOpenApi } from "@pracht/openapi";
+
+export const POST = defineOpenApi(
+  defineApi({
+    body: createItemSchema,
+    handler: ({ body }) => json({ id: createItem(body) }, { status: 201 }),
+  }),
+  {
+    operationId: "createItem",
+    summary: "Create an item",
+    tags: ["items"],
+    responses: {
+      201: { description: "Item created", body: itemSchema },
+    },
+  },
+);
+```
+
+`defineOpenApi()` mutates and returns the same handler — validation, dispatch,
+and client inference stay with pracht. Generation adds the framework-known 400
+and 422 validation responses itself, marks a request body optional when the
+validator accepts the empty-body `undefined`, and emits a valid undocumented
+`default` response plus a scoped warning when the contract is unknown.
+
+## Step 4: Shared document metadata
+
+```ts
+prachtOpenApi({
+  info: { title: "Acme API", version: "1.0.0" },
+  document: {
+    servers: [
+      { url: "https://api.example.com", description: "Production" },
+      { url: "http://localhost:3000", description: "Local development" },
+    ],
+    tags: [{ name: "items", description: "Item lifecycle" }],
+    components: {
+      securitySchemes: {
+        bearerAuth: { type: "http", scheme: "bearer", bearerFormat: "JWT" },
+      },
+    },
+    security: [{ bearerAuth: [] }],
+  },
+});
+```
+
+A security scheme referenced by an operation's `security` must exist in
+`document.components.securitySchemes`. `document.security` applies globally; set
+`security: []` on an operation to mark it public.
+
+**Deploy base:** with Vite `base: "/app/"`, the UI loads its document from
+`/app/openapi.json`, and generation adds `servers: [{ url: "/app" }]` when
+`document.servers` is omitted so "Try it out" reaches base-prefixed routes. An
+explicit `document.servers` always wins, including an empty array.
+
+## Step 5: Make it a CI gate
+
+Conversion failures are warnings by default, so one unsupported handler does not
+erase the document. Once every public operation has an explicit response
+contract, tighten it:
+
+```ts
+prachtOpenApi({ info: { title: "Acme API", version: "1.0.0" }, failOnWarnings: true });
+```
+
+Any warning then fails the dev request and `pracht build`. There is no dedicated
+diff/check command yet — deterministic build output plus `failOnWarnings` is how
+drift is caught.
+
+## Step 6: UI provider, CDN, and CSP
+
+- `ui: "scalar"` — modern reference with request examples and an API client.
+- `ui: "swagger"` — Swagger UI, with deep links on and the remote validator
+  disabled so internal documents are never sent to `validator.swagger.io`.
+- Both shells load pinned browser assets from jsDelivr. Apps with offline
+  requirements or a no-third-party-CDN policy should self-host and override
+  (`scriptUrl` for both providers, `styleUrl` for Swagger), copying the pinned
+  distribution into `public/vendor/`.
+- The shell also contains a small inline bootstrap script. A strict CSP must
+  allow that exact script by hash (and the asset origin), or the page must be
+  replaced with an app-owned route following the app's nonce policy —
+  self-hosting the bundle alone does not fix an inline-script ban. See
+  `docs/CSP.md` and `/audit-headers`.
+
+## Step 7: Verify
+
+```bash
+pracht dev             # GET /openapi.json and the UI path
+pracht build
+pracht verify --json
+```
+
+Confirm the document parses, every intended operation is present with a real
+response contract, and no `500`-only `default` responses remain for public
+endpoints. Then run `/audit-headers` if a CSP is in place and
+`/audit-agent-surface` if the document is part of a deliberate agent-facing
+surface.
+
+## Rules
+
+1. Treat the document and UI as public unless the hosting layer protects the
+   emitted static files. No secrets, internal hostnames, or credentials in
+   descriptions or examples.
+2. Never embed an OAuth client secret in UI configuration — browser-delivered
+   configuration is observable by every visitor.
+3. Keep the UI and JSON on the same origin.
+4. "Try it out" sends real requests: mutation endpoints must carry the same
+   authentication, authorization, CSRF, rate-limit, and confirmation policies as
+   any other client.
+5. Set a sane static cache policy for the document; immutable caching is wrong
+   unless the URL is versioned or deployments purge it.
+6. Do not document a capability HTTP projection here — capability endpoints are
+   not included in generation yet (`/add-capabilities` owns that contract).
+7. Never overwrite an existing `vite.config.ts` or a hand-written
+   `public/openapi.json` — diff first and confirm with `AskUserQuestion`.
+
+$ARGUMENTS

--- a/skills/audit-agent-surface/SKILL.md
+++ b/skills/audit-agent-surface/SKILL.md
@@ -1,0 +1,202 @@
+---
+name: audit-agent-surface
+version: 1.0.0
+description: |
+  Inventory everything in a pracht app that agents can reach — capabilities and
+  their exposure (HTTP, WebMCP, remote MCP), the `agents` trust configuration,
+  the destructive confirmation gate, `llms.txt`, Markdown negotiation, and the
+  OpenAPI document — then report where the surface is wider than intended or
+  missing a guard. Also confirms an app that wants no agent surface is actually
+  paying nothing for one.
+  Use when asked to "audit the agent surface", "what can agents do on my site",
+  "is my MCP endpoint safe", "check capability exposure", "did this PR widen
+  what agents can reach", or "make sure we ship no agent surface".
+allowed-tools:
+  - Bash
+  - Read
+  - Grep
+  - Glob
+---
+
+# Pracht Audit Agent Surface
+
+Pracht's agent surface is opt-in end to end (`docs/CAPABILITIES.md`,
+`docs/AGENT_TRUST.md`, `docs/REMOTE_MCP.md`). State that baseline before
+auditing the opt-outs:
+
+- No loader or API route is ever inferred as a capability; a capability without
+  `expose` is unreachable over the network.
+- `destructive` capabilities may only be exposed over HTTP, and every dispatch
+  is confirmation-gated.
+- Remote MCP rejects cookie-bearing and browser-originated requests, and
+  filters destructive capabilities again at serve time.
+- An app that registers neither capabilities nor `agents` has the dispatch path
+  and Web Bot Auth verifier dropped from its server bundle at build time.
+
+This skill reports; it never mutates. Prerequisites: `pracht inspect` needs a
+vite config registering the pracht plugin. If the pracht MCP server is
+registered (see `docs/MCP.md`), prefer its tools (`inspect_capabilities`,
+`inspect_routes`, `inspect_api`, `doctor`, `verify`) over shelling out.
+
+## Step 1: Inventory the declared surface
+
+```bash
+pracht inspect capabilities --json   # name, effect, transports, HTTP path, middleware, schemas
+pracht inspect routes --json         # markdown negotiation, hydration, middleware
+pracht inspect api --json
+pracht verify --json                 # contract, exposure, and projection checks
+```
+
+Build the inventory table: capability → effect → transports → HTTP path →
+middleware → `agentPolicy`. A capability reported as `unreadable` means
+`@pracht/capabilities` is not installed; treat it as an `error` and stop
+reasoning about its policy until it loads.
+
+Read the manifest's `agents` block and record which of `webBotAuth`,
+`confirmation`, and `mcp` are configured, plus the MCP endpoint path.
+
+## Step 2: Exposure vs. intent
+
+For every exposed capability, ask whether the exposure is deliberate:
+
+- `expose.mcp` set but no `agents.mcp` configured — declared, served by
+  nothing. `pracht verify` warns; report it so the intent gets resolved.
+- `expose.mcp` set on an operation whose authorization relies on a browser
+  session — remote MCP rejects cookies, so the only credentials it sees are the
+  forwarded `Authorization` header and `context.agent`. A middleware chain that
+  reads a session cookie authorizes nobody there.
+- `expose.webmcp` — the in-page agent acts as the signed-in user in their tab.
+  Confirm that is intended for every one, and that the route's hydration is not
+  `"none"` (which registers no tools).
+- Private capabilities used as building blocks: `invokeCapability()` runs their
+  named middleware but **not** app-level `api.middleware`. Their named
+  middleware is the only authorization seam — flag private capabilities with an
+  empty `middleware` list that touch sensitive data.
+- Custom `expose.http.path` values that land outside `/api/**` and therefore
+  escape path-scoped middleware or host rules.
+
+## Step 3: The destructive gate
+
+- Every `destructive` capability must be HTTP-only. `webmcp`/`mcp` on one is
+  rejected by the framework — if you find it in source, the build is failing.
+- `PRACHT_CONFIRMATION_SECRET` must be set in the server environment for each
+  deployment target (build environment too on Vercel, since it becomes the
+  bypass token there). Missing → every destructive call answers
+  `403 confirmation_unavailable`.
+- Record the honest limits in the report: the stateless HMAC token is replayable
+  within its TTL (default 120 s), the calling agent can hand the token back to
+  itself, and without Web Bot Auth or
+  `setCapabilityApprovalPrincipalResolver()` both phases run as `"anonymous"`.
+  Flag `confirmation: { singleUse: true }` used as if it were durable — it is a
+  per-instance in-memory cache, lost on restart.
+- If an approval store is registered, confirm its backend supports atomic
+  conditional writes (D1, Durable Objects, Postgres, Redis — **not** Cloudflare
+  KV) and that all replicas share it: with a store registered, a token whose
+  proposal is unknown is refused, so a per-instance store breaks commits.
+- `confirmation: { mode: "human" }` without both a store and an authenticated
+  principal fails closed — check both exist.
+
+## Step 4: Identity and policy
+
+- `agents.webBotAuth.policy: "require"` gates capability HTTP endpoints only —
+  pages and API routes are not gated. Flag any assumption that it protects
+  pages.
+- `directories` is an allowlist; an empty one means no directory fetching at all
+  (deliberate SSRF protection). Flag a directory origin that is not the agent
+  ecosystem endpoint the app intends to trust.
+- `agentPolicy: "require"` on a capability while `webBotAuth` is unconfigured
+  answers 401 for every caller — a loud misconfiguration, report as `error`.
+- Note the replay property: Pracht's stateless verifier does not enforce `nonce`
+  uniqueness, and the default covered components (`@authority`,
+  `signature-agent`) bind a signature to a host, not to a method, path, or body.
+  Treat a verified identity as authentication, not per-request authorization.
+- Confirm an audit hook exists (`setCapabilityAuditHook()` or
+  `onCapabilityAudit`) — without one there is no record of who called what.
+
+## Step 5: The discovery surface
+
+- `llmsTxt` in the vite config: every listed path is a URL the app *invites* an
+  agent to fetch. Cross-check the `exclude` list against routes behind auth
+  middleware, internal tooling, and deliberate error routes — nothing about a
+  middleware tells the framework whether it gates or merely logs, so an
+  auth-gated route missing from `exclude` is a `warn` (see `docs/LLMS_TXT.md`).
+  Capabilities appear there with their effect class; destructive ones are
+  annotated `requires confirmation`.
+- A collection-driven `llmsTxtArtifacts()` (see `/add-content`) is a second
+  generator with its own coverage — compare what each publishes.
+- Routes exporting `markdown` or declaring `markdown: true` serve a Markdown
+  representation to agents. Confirm the Markdown variant is not more permissive
+  than the HTML page (it carries `Vary: Accept`, so it is separately cached).
+- An enabled OpenAPI document (`/openapi.json`, `dist/client/openapi.json`) is
+  public unless the host protects it — check descriptions and examples for
+  internal hostnames or credentials, and that "Try it out" mutation endpoints
+  carry real authentication.
+- `/.well-known/http-message-signatures-directory` and the MCP endpoint path
+  should both be intentional; the MCP endpoint stays active with an empty
+  capability graph.
+
+## Step 6: Did this change widen the surface?
+
+```bash
+pracht plan --json --base origin/main
+```
+
+`widensAgentSurface` and the `!` capability lines answer the question a route
+diff cannot: a new exposure, a destructive capability reclassified out of the
+gate, an `agentPolicy` downgraded from `require`, dropped middleware, a
+loosened input schema (dropped `required`, opened `additionalProperties`, raised
+bound), or newly enabled `agents.mcp`. Report every widening explicitly, with
+the before/after. A stale snapshot makes this useless — `pracht verify` fails
+on staleness, so trust it only when verify passes.
+
+## Step 7: The no-agent-surface case
+
+When the app is supposed to have none:
+
+- Confirm the manifest registers no `capabilities` and no `agents`. That lets
+  the build define the surface away (~15 KB gzip of an example server bundle).
+- Analysis is one-sided: a spread, a regex literal, or otherwise opaque syntax
+  in the manifest leaves the define unset and keeps the runtime in the bundle.
+  Flag manifest constructs that defeat the static read.
+- Confirm `llmsTxt` is off if the app should not advertise itself, and that no
+  route sets `markdown: true`.
+- `create-pracht --no-agent-tools` controls the *scaffolded developer* tooling
+  (`.mcp.json`, skills) — it has nothing to do with the deployed agent surface.
+  Do not conflate them in the report.
+
+## Step 8: Report
+
+| Surface | Item | Reach | Guard | Severity |
+| ------- | ---- | ----- | ----- | -------- |
+
+Severities:
+
+- `error` — destructive capability reachable without a configured confirmation
+  secret; `agentPolicy: "require"` with no `webBotAuth`; capability module
+  unreadable; MCP-exposed capability whose only authorization is a cookie
+  session; approval store on a backend without conditional writes.
+- `warn` — auth-gated route advertised in `llms.txt`; `expose.mcp` with no
+  `agents.mcp`; exposed capability with no named middleware; unbounded output
+  (no `limit`/`maximum`); no audit hook; `singleUse` treated as durable.
+- `info` — exposure that is intentional and guarded, recorded so the reviewer
+  sees the whole surface in one place; framework gaps that are deployment
+  responsibilities (rate limiting, write idempotency, result-size limits).
+
+## Rules
+
+1. Report only — never change exposure, policy, or configuration. Propose the
+   diff and let the owner apply it.
+2. Never call a destructive capability to test it, not even the prepare phase,
+   against anything but a local throwaway environment.
+3. Do not treat client-declared signals as trust: the `webmcp` transport marker
+   is informational, and only MCP dispatch state is trustworthy for
+   attributing nested effects.
+4. Distinguish `pracht mcp` (the development-time stdio server exposing the app
+   *graph* to coding agents) from the deployed `/mcp` endpoint exposing the app's
+   *operations*. They have different threat models.
+5. State the framework guarantee before each finding so the reader can tell an
+   opt-out from a hole.
+6. Pair with `/audit-auth`, `/audit-csrf`, and `/audit-secrets` — this skill
+   owns agent reachability, not general request authorization.
+
+$ARGUMENTS

--- a/skills/skills.test.ts
+++ b/skills/skills.test.ts
@@ -64,6 +64,12 @@ const GLOBAL_CLI_FLAGS = new Set(["help", "version"]);
 //   keep the canonical server manifests private to build tooling
 // - Vite client manifest: build.ts / build-metadata.ts read
 //   "dist/client/.vite/manifest.json"
+// - Generated llms.txt: build.ts writes "dist/client/llms.txt" when the plugin's
+//   llmsTxt option is enabled (docs/LLMS_TXT.md)
+// - OpenAPI companion output: @pracht/openapi's vite plugin emits its document
+//   as a client asset ("dist/client/openapi.json" at the default documentPath)
+//   and, with a UI, the reference shell under dist/client/<ui path>/index.html
+//   (covered by the prerendered-HTML pattern below)
 // - Prerendered route HTML: build.ts writes "<route>/index.html" under
 //   dist/client (routeToStaticHtmlPath in build-shared.ts)
 // - Vercel Build Output API: build-shared.ts writeVercelBuildOutput emits
@@ -76,6 +82,7 @@ const BUILD_OUTPUT_PATTERNS: RegExp[] = [
   /^dist\/client\/_pracht\/?$/,
   /^dist\/client\/_pracht\/(?:headers\.json|isg\.json)$/,
   /^dist\/client\/\.vite\/manifest\.json$/,
+  /^dist\/client\/(?:llms\.txt|openapi\.json)$/,
   // Static export fixed artifacts: the notFound document and the opt-in SPA
   // fallback (`staticAdapter({ fallback })`, conventionally 200.html).
   /^dist\/client\/(?:404|200)\.html$/,


### PR DESCRIPTION
## Summary

- Mining recent Claude and Codex sessions in this repo surfaced five shipped surfaces with no skill coverage — `@pracht/content`/`@pracht/markdown`, `@pracht/image`, `@pracht/capabilities`, `@pracht/openapi`, and the agent trust layer — which is exactly where the same questions kept being re-derived (mdx support, content bundle cost, Cloudflare image resizing, "is our agentic surface opt-in", the OpenAPI flow).
- Adds `/add-content`, `/add-images`, `/add-capabilities`, `/add-openapi`, and the read-only `/audit-agent-surface`, which inventories what agents can actually reach (capability exposure, `agents` trust config, `llms.txt`, Markdown negotiation, OpenAPI) and confirms an app that wants no agent surface pays nothing for one.
- Updates `skills/README.md` and the public `docs/agent-skills` catalog page (28 → 33), and allowlists `dist/client/llms.txt` and `dist/client/openapi.json` in the drift guard with the emitting code named in the comment.
- No issue.

## Testing

- [x] `pnpm run verify` (build, format, lint, typecheck, test, e2e)

## Checklist

- [x] Docs updated if needed
- [x] Skills updated if needed
- [x] Changeset added if published packages changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)