### PR TITLE
feat(core): add defer() and use() for deferred loader values

### DIFF
--- a/.changeset/deferred-loader-values.md
+++ b/.changeset/deferred-loader-values.md
@@ -1,0 +1,13 @@
+---
+"@pracht/core": minor
+---
+
+Add `defer()` and `use()` for deferred loader values.
+
+A loader can now mark slow fields with `defer(promise)` instead of awaiting them
+inline, and components read them with `use()` inside a `<Suspense>` boundary.
+Independent deferred fields resolve concurrently rather than in series. Every
+render mode still resolves deferred values before the response is written, so
+this is additive — a route that does not call `defer()` is unchanged. The API is
+the finished one: when the streaming renderer lands, `render: "ssr"` will flush
+the shell before deferred values settle without any change to route source.

--- a/.changeset/deferred-loader-values.md
+++ b/.changeset/deferred-loader-values.md
@@ -8,6 +8,7 @@ A loader can now mark slow fields with `defer(promise)` instead of awaiting them
 inline, and components read them with `use()` inside a `<Suspense>` boundary.
 Independent deferred fields resolve concurrently rather than in series. Every
 render mode still resolves deferred values before the response is written, so
-this is additive — a route that does not call `defer()` is unchanged. The API is
-the finished one: when the streaming renderer lands, `render: "ssr"` will flush
-the shell before deferred values settle without any change to route source.
+this is additive — a route that does not call `defer()` is unchanged. Eager
+promise rejections remain handled until the runtime reads them. When the
+streaming renderer lands, SSR routes will flush the shell before deferred values
+settle without any change to route source.

--- a/.changeset/deferred-loader-values.md
+++ b/.changeset/deferred-loader-values.md
@@ -8,7 +8,4 @@ A loader can now mark slow fields with `defer(promise)` instead of awaiting them
 inline, and components read them with `use()` inside a `<Suspense>` boundary.
 Independent deferred fields resolve concurrently rather than in series. Every
 render mode still resolves deferred values before the response is written, so
-this is additive — a route that does not call `defer()` is unchanged. Eager
-promise rejections remain handled until the runtime reads them. When the
-streaming renderer lands, SSR routes will flush the shell before deferred values
-settle without any change to route source.
+this is additive — a route that does not call `defer()` is unchanged.

--- a/.changeset/prefetch-intent-catchup.md
+++ b/.changeset/prefetch-intent-catchup.md
@@ -1,0 +1,5 @@
+---
+"@pracht/core": patch
+---
+
+Catch hover prefetch intent that begins while the lazy listener runtime loads.

--- a/docs/DATA_LOADING.md
+++ b/docs/DATA_LOADING.md
@@ -157,9 +157,9 @@ Read a deferred value with `use()` inside a `<Suspense>` boundary:
 
 ```tsx
 import { Suspense, use } from "@pracht/core";
-import type { Deferred } from "@pracht/core";
+import type { Deferred, RouteComponentProps } from "@pracht/core";
 
-export default function Product({ data }) {
+export default function Product({ data }: RouteComponentProps<typeof loader>) {
   return (
     <article>
       <h1>{data.product.name}</h1>

--- a/docs/DATA_LOADING.md
+++ b/docs/DATA_LOADING.md
@@ -141,9 +141,10 @@ import { defer } from "@pracht/core";
 import type { LoaderArgs } from "@pracht/core";
 
 export async function loader({ params }: LoaderArgs) {
+  const reviews = defer(getReviews(params.id));
   return {
-    product: await getProduct(params.id),   // awaited
-    reviews: defer(getReviews(params.id)),  // deferred
+    product: await getProduct(params.id), // overlaps with reviews
+    reviews,
   };
 }
 ```

--- a/docs/DATA_LOADING.md
+++ b/docs/DATA_LOADING.md
@@ -203,10 +203,10 @@ a correctness bug.
 
 #### Rules
 
-- **A deferred value may not redirect or set headers.** By the time it settles,
-  the response status and headers are already decided. Auth checks belong in
-  middleware or in the awaited part of the loader — which is the existing
-  pracht convention.
+- **A deferred value may not redirect, throw `PrachtHttpError`, or set response
+  status or headers.** By the time it settles, the response status and headers
+  are already decided. Auth checks belong in middleware or in the awaited part
+  of the loader — which is the existing pracht convention.
 - **`head()` and `headers()` see awaited data only.** Both run before the
   render and receive the resolved loader result, so metadata cannot depend on a
   value whose whole point is arriving late.
@@ -216,6 +216,9 @@ a correctness bug.
   nothing streams yet, but write boundaries to that shape now.
 - Pass the un-awaited call. `defer(await getReviews(id))` throws, because it
   defeats the point silently.
+- Return the marker from an enumerable data property. A deferred value hidden
+  behind a getter cannot be discovered without eagerly invoking every loader
+  getter, so it throws if it reaches serialization unresolved.
 
 ### Redirecting from a loader
 

--- a/docs/DATA_LOADING.md
+++ b/docs/DATA_LOADING.md
@@ -131,6 +131,91 @@ For SPA routes, the initial HTML can still include the matched shell and an
 optional shell `Loading` export so the page is not blank before the route-state
 request resolves.
 
+### Deferred values — `defer()` and `use()`
+
+A loader that awaits everything is only as fast as its slowest call. Wrap the
+slow fields in `defer()` to keep them out of that critical path:
+
+```typescript
+import { defer } from "@pracht/core";
+import type { LoaderArgs } from "@pracht/core";
+
+export async function loader({ params }: LoaderArgs) {
+  return {
+    product: await getProduct(params.id),   // awaited
+    reviews: defer(getReviews(params.id)),  // deferred
+  };
+}
+```
+
+The marker sits on the value, not around the return, so the object keeps its
+shape and the type records exactly which fields defer. A route that never calls
+`defer()` behaves and serializes exactly as before.
+
+Read a deferred value with `use()` inside a `<Suspense>` boundary:
+
+```tsx
+import { Suspense, use } from "@pracht/core";
+import type { Deferred } from "@pracht/core";
+
+export default function Product({ data }) {
+  return (
+    <article>
+      <h1>{data.product.name}</h1>
+      <Suspense fallback={<ReviewsSkeleton />}>
+        <Reviews reviews={data.reviews} />
+      </Suspense>
+    </article>
+  );
+}
+
+function Reviews({ reviews }: { reviews: Deferred<Review[]> }) {
+  const list = use(reviews);
+  return <ul>{list.map((r) => <li key={r.id}>{r.body}</li>)}</ul>;
+}
+```
+
+`Deferred<T>` is preserved in the loader data type, so passing `data.reviews`
+where `Review[]` is expected is a compile error — reading it goes through
+`use()`. Boundaries are always explicit; pracht never auto-wraps a component.
+
+`defer()` accepts a promise, or a function returning one when the work should
+not start until something reads the value. The call is memoized, so two reads
+of the same deferred value never do the work twice.
+
+#### What defers, and when
+
+Today **every render mode resolves deferred values before the response is
+written.** The benefit right now is the authoring shape and the concurrency:
+independent deferred fields resolve together rather than in series, so two
+300 ms calls cost 300 ms, not 600 ms.
+
+The reason to write `defer()` now is that it is the finished API. When the
+streaming renderer lands, `render: "ssr"` will flush the shell before deferred
+values settle and stream them in — with no change to route source. `use()`
+already accepts a settled value, a deferred one, or a bare promise for exactly
+that reason, and the same component works either way.
+
+`ssg` and `isg` will always resolve everything: those modes write files, a file
+cannot stream, and shipping fallback markup as permanent static output would be
+a correctness bug.
+
+#### Rules
+
+- **A deferred value may not redirect or set headers.** By the time it settles,
+  the response status and headers are already decided. Auth checks belong in
+  middleware or in the awaited part of the loader — which is the existing
+  pracht convention.
+- **`head()` and `headers()` see awaited data only.** Both run before the
+  render and receive the resolved loader result, so metadata cannot depend on a
+  value whose whole point is arriving late.
+- **On Preact 10, a `<Suspense>` boundary that suspends must resolve to exactly
+  one DOM element** — not `null`, not a multi-child fragment. This constraint
+  goes away with Preact 11's hydration rework. It does not bite today, because
+  nothing streams yet, but write boundaries to that shape now.
+- Pass the un-awaited call. `defer(await getReviews(id))` throws, because it
+  defeats the point silently.
+
 ### Redirecting from a loader
 
 A loader can answer with a `Response` instead of data — most often a redirect.

--- a/docs/ROUTING.md
+++ b/docs/ROUTING.md
@@ -404,8 +404,10 @@ Every other anchor attribute passes straight through, including `target`, `rel`,
 ### Prefetching
 
 Every internal link is prefetched on hover/focus by default (`"intent"`, with a
-50ms debounce). An app that wants no JS prefetching at all can compile the whole
-mechanism out with `pracht({ client: { prefetch: false } })` — see
+50ms debounce). The listener runtime loads lazily after hydration; if hover or
+focus begins while that chunk is loading, a still-hovered link is picked up
+once setup completes. An app that wants no JS prefetching at all can compile
+the whole mechanism out with `pracht({ client: { prefetch: false } })` — see
 [PERFORMANCE.md](PERFORMANCE.md#switching-off-js-prefetching). A
 per-route default can be set via the `prefetch` route meta,
 and `<Link prefetch>` overrides it per link:

--- a/examples/docs/src/routes/docs/data-loading.md
+++ b/examples/docs/src/routes/docs/data-loading.md
@@ -109,6 +109,76 @@ current user, permissions, session, or cookies. `loaderCache` does not change
 ISG `revalidate`, and it is separate from Pracht's short in-memory prefetch
 cache.
 
+### Deferred values
+
+A loader is only as fast as its slowest `await`. Wrap the slow fields in
+`defer()` so they stay out of that critical path:
+
+```ts [src/routes/product.tsx]
+import { defer } from "@pracht/core";
+import type { LoaderArgs } from "@pracht/core";
+
+export async function loader({ params }: LoaderArgs) {
+  return {
+    product: await getProduct(params.id),   // awaited
+    reviews: defer(getReviews(params.id)),  // deferred
+  };
+}
+```
+
+The marker goes on the value rather than around the whole return, so the object
+keeps its shape and the type records exactly which fields defer. A route that
+never calls `defer()` behaves exactly as it did before.
+
+Read a deferred value with `use()` inside a `<Suspense>` boundary:
+
+```tsx [src/routes/product.tsx]
+import { Suspense, use } from "@pracht/core";
+import type { Deferred } from "@pracht/core";
+
+export default function Product({ data }) {
+  return (
+    <article>
+      <h1>{data.product.name}</h1>
+      <Suspense fallback={<ReviewsSkeleton />}>
+        <Reviews reviews={data.reviews} />
+      </Suspense>
+    </article>
+  );
+}
+
+function Reviews({ reviews }: { reviews: Deferred<Review[]> }) {
+  const list = use(reviews);
+  return <ul>{list.map((r) => <li key={r.id}>{r.body}</li>)}</ul>;
+}
+```
+
+`Deferred<T>` stays in the loader data type, so passing `data.reviews` where
+`Review[]` is expected is a compile error — reading it goes through `use()`.
+Boundaries are always explicit; Pracht never wraps a component for you.
+
+`defer()` takes a promise, or a function returning one when the work should not
+start until something reads the value. It is memoized, so two reads never do
+the work twice.
+
+Today every render mode resolves deferred values before the response is
+written. The immediate win is concurrency — two independent 300 ms fields cost
+300 ms instead of 600 ms. The reason to write it now is that this is the
+finished API: when the streaming renderer lands, `render: "ssr"` will flush the
+shell first and stream these in with no change to your route source. `ssg` and
+`isg` will always resolve everything, because a static file cannot stream.
+
+Three rules:
+
+- **A deferred value cannot redirect or set headers.** By the time it settles,
+  the status and headers are already sent. Auth belongs in middleware or in the
+  awaited part of the loader.
+- **`head()` and `headers()` see awaited data only.** They run before the
+  render.
+- **A suspending `<Suspense>` boundary must resolve to exactly one DOM
+  element** on Preact 10 — not `null`, not a multi-child fragment. Preact 11
+  removes this constraint.
+
 ### Error handling
 
 Throw `PrachtHttpError` for structured error responses. Pair it with an `ErrorBoundary` export to render a fallback UI:

--- a/examples/docs/src/routes/docs/data-loading.md
+++ b/examples/docs/src/routes/docs/data-loading.md
@@ -135,9 +135,9 @@ Read a deferred value with `use()` inside a `<Suspense>` boundary:
 
 ```tsx [src/routes/product.tsx]
 import { Suspense, use } from "@pracht/core";
-import type { Deferred } from "@pracht/core";
+import type { Deferred, RouteComponentProps } from "@pracht/core";
 
-export default function Product({ data }) {
+export default function Product({ data }: RouteComponentProps<typeof loader>) {
   return (
     <article>
       <h1>{data.product.name}</h1>

--- a/examples/docs/src/routes/docs/data-loading.md
+++ b/examples/docs/src/routes/docs/data-loading.md
@@ -171,14 +171,17 @@ shell first and stream these in with no change to your route source. `ssg` and
 
 Three rules:
 
-- **A deferred value cannot redirect or set headers.** By the time it settles,
-  the status and headers are already sent. Auth belongs in middleware or in the
-  awaited part of the loader.
+- **A deferred value cannot redirect, throw `PrachtHttpError`, or set response
+  status or headers.** By the time it settles, the status and headers are
+  already sent. Auth belongs in middleware or in the awaited part of the loader.
 - **`head()` and `headers()` see awaited data only.** They run before the
   render.
 - **A suspending `<Suspense>` boundary must resolve to exactly one DOM
   element** on Preact 10 — not `null`, not a multi-child fragment. Preact 11
   removes this constraint.
+- Return `defer()` from an enumerable data property, not from a getter. Pracht
+  does not eagerly invoke loader getters to discover hidden deferred values and
+  throws instead of silently serializing an unresolved marker.
 
 ### Error handling
 

--- a/examples/docs/src/routes/docs/data-loading.md
+++ b/examples/docs/src/routes/docs/data-loading.md
@@ -119,9 +119,10 @@ import { defer } from "@pracht/core";
 import type { LoaderArgs } from "@pracht/core";
 
 export async function loader({ params }: LoaderArgs) {
+  const reviews = defer(getReviews(params.id));
   return {
-    product: await getProduct(params.id),   // awaited
-    reviews: defer(getReviews(params.id)),  // deferred
+    product: await getProduct(params.id), // overlaps with reviews
+    reviews,
   };
 }
 ```

--- a/examples/docs/src/routes/docs/prefetching.md
+++ b/examples/docs/src/routes/docs/prefetching.md
@@ -17,7 +17,8 @@ listeners that watch for user interaction with internal links. When a prefetch
 is triggered, the route's server data (the same JSON payload used during
 client-side navigation) is fetched in the background and cached. When the user
 actually clicks the link, the cached data is used immediately — no second
-network request.
+network request. If hover begins while the lazy setup chunk is still loading,
+pracht catches up when setup completes if the pointer is still over the link.
 
 Prefetched data is held in a small client-side LRU cache with a 30-second TTL. Stale entries are discarded and re-fetched on the next interaction.
 

--- a/examples/docs/src/routes/docs/reference-api.md
+++ b/examples/docs/src/routes/docs/reference-api.md
@@ -67,6 +67,16 @@ See [Agent Workflow](/docs/agent-workflow).
 
 ---
 
+## Loader Data
+
+| Export | Description |
+| --- | --- |
+| `defer(promise)` | Mark slow loader data for concurrent resolution. See [Data Loading](/docs/data-loading#deferred-values) |
+| `use(value)` | Read a `Deferred<T>`, promise, or settled value inside `<Suspense>` |
+| `Deferred<T>` | The typed marker returned by `defer()` |
+
+---
+
 ## Hooks
 
 | Export | Returns | Description |

--- a/packages/framework/src/browser.ts
+++ b/packages/framework/src/browser.ts
@@ -117,6 +117,8 @@ export { forwardRef } from "./forwardRef.ts";
 export { useIsHydrated } from "./hydration.ts";
 export { Script } from "./script.ts";
 export type { ScriptProps, ScriptStrategy } from "./script.ts";
+export { defer, use } from "./defer.ts";
+export type { Deferred } from "./defer.ts";
 export { lazy, Suspense } from "./suspense.ts";
 export { ErrorBoundary } from "./error-boundary.ts";
 export type { ErrorBoundaryComponentProps } from "./error-boundary.ts";

--- a/packages/framework/src/defer.ts
+++ b/packages/framework/src/defer.ts
@@ -177,7 +177,8 @@ function containsDeferred(value: unknown, seen = new Set<object>()): boolean {
 
 async function resolveValue(value: unknown, seen: Map<object, unknown>): Promise<unknown> {
   if (isDeferred(value)) {
-    return await (value as unknown as DeferredBox<unknown>).promise();
+    const resolved = await (value as unknown as DeferredBox<unknown>).promise();
+    return await resolveValue(resolved, seen);
   }
   if (typeof value !== "object" || value === null) return value;
 

--- a/packages/framework/src/defer.ts
+++ b/packages/framework/src/defer.ts
@@ -47,7 +47,7 @@ interface DeferredBox<T> {
 export interface Deferred<T> {
   readonly [DEFERRED]: true;
   /** @internal Phantom field; carries `T` so the type is not structurally `any`. */
-  readonly __deferred?: (value: T) => void;
+  readonly __deferred?: () => T;
 }
 
 /**
@@ -111,10 +111,15 @@ export function isDeferred(value: unknown): value is Deferred<unknown> {
  * suspends must also resolve to exactly one DOM element — not `null`, not a
  * multi-child fragment — or hydration mismatches.
  */
-export function use<T>(value: Deferred<T> | Promise<T> | T): T {
-  if (isDeferred(value)) return readSettled((value as unknown as DeferredBox<T>).promise());
-  if (isThenable(value)) return readSettled(value as Promise<T>);
-  return value as T;
+type UsedValue<T> =
+  T extends Deferred<infer TValue> ? TValue : T extends Promise<infer TValue> ? TValue : T;
+
+export function use<T>(value: T): UsedValue<T> {
+  if (isDeferred(value)) {
+    return readSettled((value as unknown as DeferredBox<UsedValue<T>>).promise()) as UsedValue<T>;
+  }
+  if (isThenable(value)) return readSettled(value as Promise<UsedValue<T>>) as UsedValue<T>;
+  return value as UsedValue<T>;
 }
 
 /**
@@ -186,7 +191,14 @@ function containsDeferred(value: unknown, seen = new Set<object>()): boolean {
 
 async function resolveValue(value: unknown, seen: Map<object, unknown>): Promise<unknown> {
   if (isDeferred(value)) {
-    const resolved = await (value as unknown as DeferredBox<unknown>).promise();
+    let resolved: unknown;
+    try {
+      resolved = await (value as unknown as DeferredBox<unknown>).promise();
+    } catch (error: unknown) {
+      if (error instanceof Response) throw deferredResponseError();
+      throw error;
+    }
+    if (resolved instanceof Response) throw deferredResponseError();
     return await resolveValue(resolved, seen);
   }
   if (typeof value !== "object" || value === null) return value;
@@ -219,4 +231,11 @@ async function resolveValue(value: unknown, seen: Map<object, unknown>): Promise
 function isPlainObject(value: object): value is Record<string, unknown> {
   const proto = Object.getPrototypeOf(value);
   return proto === Object.prototype || proto === null;
+}
+
+function deferredResponseError(): TypeError {
+  return new TypeError(
+    "A deferred loader value cannot return or throw a Response. " +
+      "Redirects, status, and headers must be decided before deferred work starts.",
+  );
 }

--- a/packages/framework/src/defer.ts
+++ b/packages/framework/src/defer.ts
@@ -1,0 +1,212 @@
+/**
+ * Deferred loader values — `defer()` marks a slow field, `use()` reads it.
+ *
+ * A loader returns its object as usual and wraps the values that should not
+ * hold up the response:
+ *
+ * ```ts
+ * export async function loader({ params }: LoaderArgs) {
+ *   return {
+ *     product: await getProduct(params.id),   // blocks
+ *     reviews: defer(getReviews(params.id)),  // does not
+ *   };
+ * }
+ * ```
+ *
+ * The marker sits on the slow value rather than wrapping the whole return, so
+ * the object keeps its shape, the type records exactly which fields defer, and
+ * a route that calls `defer()` nowhere serializes byte-identically to before.
+ *
+ * Today every path resolves deferred values before the response is written —
+ * `resolveDeferredData()` is called once, at the single loader call site in
+ * `runtime.ts`. The authoring API is the finished one: when the streaming
+ * renderer lands, `render: "ssr"` starts flushing the shell before these
+ * settle and no route source has to change. `use()` already accepts a settled
+ * value, a `Deferred`, or a bare promise for exactly that reason.
+ *
+ * Note that `ssg` and `isg` write files and therefore always resolve
+ * everything — a static file cannot stream, and shipping fallback markup as
+ * permanent output would be a correctness bug.
+ */
+
+const DEFERRED = Symbol.for("pracht.deferred");
+
+interface DeferredBox<T> {
+  readonly [DEFERRED]: true;
+  /** Lazily started so `defer(() => …)` does not fetch until something reads it. */
+  promise(): Promise<T>;
+}
+
+/**
+ * A loader value that has been marked with {@link defer}.
+ *
+ * The type parameter is preserved so passing a `Deferred<T>` where `T` is
+ * expected is a compile error — reading it goes through {@link use}.
+ */
+export interface Deferred<T> {
+  readonly [DEFERRED]: true;
+  /** @internal Phantom field; carries `T` so the type is not structurally `any`. */
+  readonly __deferred?: (value: T) => void;
+}
+
+/**
+ * Mark a loader value as deferred.
+ *
+ * Accepts a promise, or a function returning one when the work should not
+ * start until the value is read. Rejections surface where the value is read,
+ * not from the loader.
+ *
+ * A deferred value may not redirect or set headers: by the time it settles the
+ * response status and headers are already decided. Auth checks belong in
+ * middleware or in the awaited part of the loader.
+ */
+export function defer<T>(source: Promise<T> | (() => Promise<T>)): Deferred<T> {
+  if (typeof source !== "function" && !isThenable(source)) {
+    throw new TypeError(
+      "defer() expects a promise or a function returning one. " +
+        "Pass the un-awaited call — defer(getReviews(id)), not defer(await getReviews(id)).",
+    );
+  }
+
+  let started: Promise<T> | undefined;
+  const box: DeferredBox<T> = {
+    [DEFERRED]: true,
+    promise() {
+      if (!started) {
+        started = typeof source === "function" ? (async () => source())() : Promise.resolve(source);
+      }
+      return started;
+    },
+  };
+  return box as unknown as Deferred<T>;
+}
+
+/** Whether `value` was produced by {@link defer}. */
+export function isDeferred(value: unknown): value is Deferred<unknown> {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    (value as DeferredBox<unknown>)[DEFERRED] === true
+  );
+}
+
+/**
+ * Read a deferred value from inside a component.
+ *
+ * Suspends — throws the pending promise — until the value settles, so the
+ * nearest `<Suspense>` boundary shows its fallback. A value that has already
+ * settled (every path today, and `ssg`/`isg` always) is returned directly,
+ * which is what lets one component work whether or not the route streams.
+ *
+ * A boundary is required and never inferred. On Preact 10 a boundary that
+ * suspends must also resolve to exactly one DOM element — not `null`, not a
+ * multi-child fragment — or hydration mismatches.
+ */
+export function use<T>(value: Deferred<T> | Promise<T> | T): T {
+  if (isDeferred(value)) return readSettled((value as unknown as DeferredBox<T>).promise());
+  if (isThenable(value)) return readSettled(value as Promise<T>);
+  return value as T;
+}
+
+/**
+ * Resolve every {@link Deferred} in a loader result.
+ *
+ * Returns the input unchanged when it holds no deferred value, so the common
+ * case allocates nothing. Deferred values found at any depth are awaited
+ * concurrently — one slow field does not serialize behind another.
+ */
+export async function resolveDeferredData<T>(data: T): Promise<T> {
+  if (!containsDeferred(data)) return data;
+  return (await resolveValue(data, new Map())) as T;
+}
+
+type SettledState<T> =
+  | { status: "pending" }
+  | { status: "fulfilled"; value: T }
+  | { status: "rejected"; reason: unknown };
+
+const settled = new WeakMap<Promise<unknown>, SettledState<unknown>>();
+
+/**
+ * Throw-until-settled, the shape `preact-suspense` and
+ * `preact-render-to-string` both already understand.
+ */
+function readSettled<T>(promise: Promise<T>): T {
+  let state = settled.get(promise) as SettledState<T> | undefined;
+  if (!state) {
+    state = { status: "pending" };
+    settled.set(promise, state);
+    promise.then(
+      (value) => settled.set(promise, { status: "fulfilled", value }),
+      (reason) => settled.set(promise, { status: "rejected", reason }),
+    );
+  }
+  if (state.status === "fulfilled") return state.value;
+  if (state.status === "rejected") throw state.reason;
+  throw promise;
+}
+
+function isThenable(value: unknown): value is Promise<unknown> {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    typeof (value as { then?: unknown }).then === "function"
+  );
+}
+
+/**
+ * Whether `value` holds a `Deferred` anywhere.
+ *
+ * Walks the same shapes `resolveValue` rebuilds, so the two cannot disagree
+ * about what counts as traversable. Cycles are bounded by `seen`.
+ */
+function containsDeferred(value: unknown, seen = new Set<object>()): boolean {
+  if (isDeferred(value)) return true;
+  if (typeof value !== "object" || value === null) return false;
+  if (seen.has(value)) return false;
+  seen.add(value);
+
+  if (Array.isArray(value)) {
+    for (const entry of value) if (containsDeferred(entry, seen)) return true;
+    return false;
+  }
+  if (!isPlainObject(value)) return false;
+  for (const entry of Object.values(value)) if (containsDeferred(entry, seen)) return true;
+  return false;
+}
+
+async function resolveValue(value: unknown, seen: Map<object, unknown>): Promise<unknown> {
+  if (isDeferred(value)) {
+    return await (value as unknown as DeferredBox<unknown>).promise();
+  }
+  if (typeof value !== "object" || value === null) return value;
+
+  const cached = seen.get(value);
+  if (cached !== undefined) return cached;
+
+  if (Array.isArray(value)) {
+    const next: unknown[] = [];
+    seen.set(value, next);
+    const resolved = await Promise.all(value.map((entry) => resolveValue(entry, seen)));
+    next.push(...resolved);
+    return next;
+  }
+
+  // Anything that is not a plain object (Date, class instance, …) is handed
+  // back by reference. Loader data has to be JSON-serializable, so these are
+  // already the caller's problem and rebuilding them would lose their
+  // prototype.
+  if (!isPlainObject(value)) return value;
+
+  const next: Record<string, unknown> = {};
+  seen.set(value, next);
+  const entries = Object.entries(value);
+  const resolved = await Promise.all(entries.map(([, entry]) => resolveValue(entry, seen)));
+  for (let i = 0; i < entries.length; i += 1) next[entries[i][0]] = resolved[i];
+  return next;
+}
+
+function isPlainObject(value: object): value is Record<string, unknown> {
+  const proto = Object.getPrototypeOf(value);
+  return proto === Object.prototype || proto === null;
+}

--- a/packages/framework/src/defer.ts
+++ b/packages/framework/src/defer.ts
@@ -188,7 +188,14 @@ function containsDeferred(value: unknown, seen = new Set<object>()): boolean {
   seen.add(value);
 
   if (Array.isArray(value)) {
-    for (const entry of value) if (containsDeferred(entry, seen)) return true;
+    for (const [key, descriptor] of Object.entries(Object.getOwnPropertyDescriptors(value))) {
+      // Array iteration reads accessor-backed indices, which would add an
+      // observable access even when the route does not defer anything. Inspect
+      // only the data descriptors JSON serialization can consume directly.
+      if (isArrayIndexKey(key) && "value" in descriptor) {
+        if (containsDeferred(descriptor.value, seen)) return true;
+      }
+    }
     return false;
   }
   if (!isPlainObject(value)) return false;
@@ -224,9 +231,30 @@ async function resolveValue(value: unknown, seen: Map<object, unknown>): Promise
 
   if (Array.isArray(value)) {
     const next: unknown[] = [];
+    Object.setPrototypeOf(next, Object.getPrototypeOf(value));
     seen.set(value, next);
-    const resolved = await Promise.all(value.map((entry) => resolveValue(entry, seen)));
-    next.push(...resolved);
+    const descriptors = Object.getOwnPropertyDescriptors(value);
+    const entries = Reflect.ownKeys(descriptors)
+      .filter((key) => key !== "length")
+      .map((key) => [key, descriptors[key as keyof typeof descriptors]] as const);
+    const resolved = await Promise.all(
+      entries.map(([key, descriptor]) =>
+        isArrayIndexKey(key) && "value" in descriptor
+          ? resolveValue(descriptor.value, seen)
+          : undefined,
+      ),
+    );
+    for (let i = 0; i < entries.length; i += 1) {
+      const [key, descriptor] = entries[i];
+      Object.defineProperty(
+        next,
+        key,
+        isArrayIndexKey(key) && "value" in descriptor
+          ? { ...descriptor, value: resolved[i] }
+          : descriptor,
+      );
+    }
+    Object.defineProperty(next, "length", descriptors.length);
     return next;
   }
 
@@ -265,6 +293,12 @@ async function resolveValue(value: unknown, seen: Map<object, unknown>): Promise
 function isPlainObject(value: object): value is Record<string, unknown> {
   const proto = Object.getPrototypeOf(value);
   return proto === Object.prototype || proto === null;
+}
+
+function isArrayIndexKey(key: PropertyKey): key is string {
+  if (typeof key !== "string" || key === "") return false;
+  const index = Number(key);
+  return Number.isInteger(index) && index >= 0 && index < 2 ** 32 - 1 && String(index) === key;
 }
 
 function deferredResponseError(): TypeError {

--- a/packages/framework/src/defer.ts
+++ b/packages/framework/src/defer.ts
@@ -185,7 +185,14 @@ function containsDeferred(value: unknown, seen = new Set<object>()): boolean {
     return false;
   }
   if (!isPlainObject(value)) return false;
-  for (const entry of Object.values(value)) if (containsDeferred(entry, seen)) return true;
+  for (const descriptor of Object.values(Object.getOwnPropertyDescriptors(value))) {
+    // Do not invoke accessors just to look for a marker. Loader objects may
+    // expose JSON-serializable getters, and reading them here would add an
+    // observable access even when the route does not defer anything.
+    if (descriptor.enumerable && "value" in descriptor) {
+      if (containsDeferred(descriptor.value, seen)) return true;
+    }
+  }
   return false;
 }
 
@@ -222,15 +229,21 @@ async function resolveValue(value: unknown, seen: Map<object, unknown>): Promise
 
   const next = Object.create(Object.getPrototypeOf(value)) as Record<string, unknown>;
   seen.set(value, next);
-  const entries = Object.entries(value);
-  const resolved = await Promise.all(entries.map(([, entry]) => resolveValue(entry, seen)));
+  const entries = Object.entries(Object.getOwnPropertyDescriptors(value)).filter(
+    ([, descriptor]) => descriptor.enumerable,
+  );
+  const resolved = await Promise.all(
+    entries.map(([, descriptor]) =>
+      "value" in descriptor ? resolveValue(descriptor.value, seen) : undefined,
+    ),
+  );
   for (let i = 0; i < entries.length; i += 1) {
-    Object.defineProperty(next, entries[i][0], {
-      configurable: true,
-      enumerable: true,
-      value: resolved[i],
-      writable: true,
-    });
+    const [key, descriptor] = entries[i];
+    Object.defineProperty(
+      next,
+      key,
+      "value" in descriptor ? { ...descriptor, value: resolved[i] } : descriptor,
+    );
   }
   return next;
 }

--- a/packages/framework/src/defer.ts
+++ b/packages/framework/src/defer.ts
@@ -6,9 +6,10 @@
  *
  * ```ts
  * export async function loader({ params }: LoaderArgs) {
+ *   const reviews = defer(getReviews(params.id));
  *   return {
- *     product: await getProduct(params.id),   // blocks
- *     reviews: defer(getReviews(params.id)),  // does not
+ *     product: await getProduct(params.id), // overlaps with reviews
+ *     reviews,
  *   };
  * }
  * ```
@@ -69,11 +70,19 @@ export function defer<T>(source: Promise<T> | (() => Promise<T>)): Deferred<T> {
   }
 
   let started: Promise<T> | undefined;
+  if (typeof source !== "function") {
+    started = Promise.resolve(source);
+    // A loader can keep awaiting blocking data after it creates this marker.
+    // Observe eager rejections immediately so Node does not treat them as
+    // unhandled before the runtime reaches resolveDeferredData(). The original
+    // promise remains rejected and still surfaces when the value is read.
+    void started.catch(() => {});
+  }
   const box: DeferredBox<T> = {
     [DEFERRED]: true,
     promise() {
       if (!started) {
-        started = typeof source === "function" ? (async () => source())() : Promise.resolve(source);
+        started = (async () => (source as () => Promise<T>)())();
       }
       return started;
     },

--- a/packages/framework/src/defer.ts
+++ b/packages/framework/src/defer.ts
@@ -220,11 +220,18 @@ async function resolveValue(value: unknown, seen: Map<object, unknown>): Promise
   // prototype.
   if (!isPlainObject(value)) return value;
 
-  const next: Record<string, unknown> = {};
+  const next = Object.create(Object.getPrototypeOf(value)) as Record<string, unknown>;
   seen.set(value, next);
   const entries = Object.entries(value);
   const resolved = await Promise.all(entries.map(([, entry]) => resolveValue(entry, seen)));
-  for (let i = 0; i < entries.length; i += 1) next[entries[i][0]] = resolved[i];
+  for (let i = 0; i < entries.length; i += 1) {
+    Object.defineProperty(next, entries[i][0], {
+      configurable: true,
+      enumerable: true,
+      value: resolved[i],
+      writable: true,
+    });
+  }
   return next;
 }
 

--- a/packages/framework/src/defer.ts
+++ b/packages/framework/src/defer.ts
@@ -30,12 +30,16 @@
  * permanent output would be a correctness bug.
  */
 
+import { isPrachtHttpError } from "./runtime-errors.ts";
+
 const DEFERRED = Symbol.for("pracht.deferred");
 
 interface DeferredBox<T> {
   readonly [DEFERRED]: true;
   /** Lazily started so `defer(() => …)` does not fetch until something reads it. */
   promise(): Promise<T>;
+  /** Reject markers that escaped the resolver instead of silently emitting `{}`. */
+  toJSON(): never;
 }
 
 /**
@@ -57,9 +61,9 @@ export interface Deferred<T> {
  * start until the value is read. Rejections surface where the value is read,
  * not from the loader.
  *
- * A deferred value may not redirect or set headers: by the time it settles the
- * response status and headers are already decided. Auth checks belong in
- * middleware or in the awaited part of the loader.
+ * A deferred value may not redirect, throw a PrachtHttpError, or set headers:
+ * by the time it settles the response status and headers are already decided.
+ * Auth checks belong in middleware or in the awaited part of the loader.
  */
 export function defer<T>(source: Promise<T> | (() => Promise<T>)): Deferred<T> {
   if (typeof source !== "function" && !isThenable(source)) {
@@ -85,6 +89,9 @@ export function defer<T>(source: Promise<T> | (() => Promise<T>)): Deferred<T> {
         started = (async () => (source as () => Promise<T>)())();
       }
       return started;
+    },
+    toJSON() {
+      throw deferredSerializationError();
     },
   };
   return box as unknown as Deferred<T>;
@@ -202,7 +209,9 @@ async function resolveValue(value: unknown, seen: Map<object, unknown>): Promise
     try {
       resolved = await (value as unknown as DeferredBox<unknown>).promise();
     } catch (error: unknown) {
-      if (error instanceof Response) throw deferredResponseError();
+      if (error instanceof Response || isPrachtHttpError(error)) {
+        throw deferredResponseError();
+      }
       throw error;
     }
     if (resolved instanceof Response) throw deferredResponseError();
@@ -229,12 +238,15 @@ async function resolveValue(value: unknown, seen: Map<object, unknown>): Promise
 
   const next = Object.create(Object.getPrototypeOf(value)) as Record<string, unknown>;
   seen.set(value, next);
-  const entries = Object.entries(Object.getOwnPropertyDescriptors(value)).filter(
-    ([, descriptor]) => descriptor.enumerable,
+  const descriptors = Object.getOwnPropertyDescriptors(value);
+  const entries = Reflect.ownKeys(descriptors).map(
+    (key) => [key, descriptors[key as keyof typeof descriptors]] as const,
   );
   const resolved = await Promise.all(
     entries.map(([, descriptor]) =>
-      "value" in descriptor ? resolveValue(descriptor.value, seen) : undefined,
+      descriptor.enumerable && "value" in descriptor
+        ? resolveValue(descriptor.value, seen)
+        : undefined,
     ),
   );
   for (let i = 0; i < entries.length; i += 1) {
@@ -242,7 +254,9 @@ async function resolveValue(value: unknown, seen: Map<object, unknown>): Promise
     Object.defineProperty(
       next,
       key,
-      "value" in descriptor ? { ...descriptor, value: resolved[i] } : descriptor,
+      descriptor.enumerable && "value" in descriptor
+        ? { ...descriptor, value: resolved[i] }
+        : descriptor,
     );
   }
   return next;
@@ -255,7 +269,14 @@ function isPlainObject(value: object): value is Record<string, unknown> {
 
 function deferredResponseError(): TypeError {
   return new TypeError(
-    "A deferred loader value cannot return or throw a Response. " +
+    "A deferred loader value cannot return or throw a Response or throw a PrachtHttpError. " +
       "Redirects, status, and headers must be decided before deferred work starts.",
+  );
+}
+
+function deferredSerializationError(): TypeError {
+  return new TypeError(
+    "A deferred loader value reached serialization without being resolved. " +
+      "Return defer() from an enumerable data property, not from a getter.",
   );
 }

--- a/packages/framework/src/index.ts
+++ b/packages/framework/src/index.ts
@@ -171,6 +171,8 @@ export { forwardRef } from "./forwardRef.ts";
 export { useIsHydrated } from "./hydration.ts";
 export { Script } from "./script.ts";
 export type { ScriptProps, ScriptStrategy } from "./script.ts";
+export { defer, use } from "./defer.ts";
+export type { Deferred } from "./defer.ts";
 export { lazy, Suspense } from "./suspense.ts";
 export { ErrorBoundary } from "./error-boundary.ts";
 export type { ErrorBoundaryComponentProps } from "./error-boundary.ts";

--- a/packages/framework/src/prefetch.ts
+++ b/packages/framework/src/prefetch.ts
@@ -125,23 +125,31 @@ export function setupPrefetching(app: ResolvedPrachtApp, warmModules?: ModuleWar
     if (warmModules) warmModules(match);
   }
 
+  function prefetchAnchorOnIntent(anchor: HTMLAnchorElement, debounce: boolean): void {
+    const href = getInternalHref(anchor);
+    if (!href) return;
+
+    const strategy = getAnchorStrategy(anchor, href);
+    if (strategy !== "hover" && strategy !== "intent") return;
+
+    if (!debounce) {
+      prefetchHref(href);
+      return;
+    }
+
+    if (hoverTimer) clearTimeout(hoverTimer);
+    hoverTimer = setTimeout(() => {
+      prefetchHref(href);
+    }, 50);
+  }
+
   // Hover / focus prefetching (intent-based)
   document.addEventListener(
     "mouseenter",
     (e: MouseEvent) => {
       const anchor = (e.target as Element).closest?.("a") as HTMLAnchorElement | null;
       if (!anchor) return;
-
-      const href = getInternalHref(anchor);
-      if (!href) return;
-
-      const strategy = getAnchorStrategy(anchor, href);
-      if (strategy !== "hover" && strategy !== "intent") return;
-
-      if (hoverTimer) clearTimeout(hoverTimer);
-      hoverTimer = setTimeout(() => {
-        prefetchHref(href);
-      }, 50);
+      prefetchAnchorOnIntent(anchor, true);
     },
     true,
   );
@@ -164,17 +172,16 @@ export function setupPrefetching(app: ResolvedPrachtApp, warmModules?: ModuleWar
     (e: FocusEvent) => {
       const anchor = (e.target as Element).closest?.("a") as HTMLAnchorElement | null;
       if (!anchor) return;
-
-      const href = getInternalHref(anchor);
-      if (!href) return;
-
-      const strategy = getAnchorStrategy(anchor, href);
-      if (strategy !== "hover" && strategy !== "intent") return;
-
-      prefetchHref(href);
+      prefetchAnchorOnIntent(anchor, false);
     },
     true,
   );
+
+  // The prefetch runtime is loaded lazily after the router becomes ready. If
+  // hover began while that chunk was still loading, no DOM event is replayed
+  // after these listeners attach, so catch up from the current state.
+  const hoveredAnchor = document.querySelector<HTMLAnchorElement>("a:hover");
+  if (hoveredAnchor) prefetchAnchorOnIntent(hoveredAnchor, true);
 
   // Viewport-based prefetching via IntersectionObserver
   const observer =

--- a/packages/framework/src/router.ts
+++ b/packages/framework/src/router.ts
@@ -1042,9 +1042,8 @@ export async function initClientRouter(options: InitClientRouterOptions): Promis
       startShellImport(match);
     };
     registerPrefetchTarget(app, warmModules);
-    void import("./prefetch.ts").then(({ setupPrefetching }) => {
-      setupPrefetching(app, warmModules);
-    });
+    const { setupPrefetching } = await import("./prefetch.ts");
+    setupPrefetching(app, warmModules);
   }
 }
 

--- a/packages/framework/src/runtime.ts
+++ b/packages/framework/src/runtime.ts
@@ -2,6 +2,7 @@ import { h } from "preact";
 import type { FunctionComponent } from "preact";
 import { matchApiRoute, matchAppRoute, resolveApp } from "./app.ts";
 import { resolveBaseRedirectLocation, restoreBasePathInRequest, stripBase } from "./base.ts";
+import { resolveDeferredData } from "./defer.ts";
 import { collectFontHeadFragments } from "./font.ts";
 import { ROUTE_STATE_REQUEST_HEADER, SAFE_METHODS } from "./runtime-constants.ts";
 import {
@@ -880,7 +881,11 @@ export async function handlePrachtRequest<TContext>(
           return loaderResult;
         }
 
-        const data = loaderResult;
+        // Resolve any defer()ed fields before anything serializes them. One
+        // call covers every render mode and both the document and route-state
+        // paths, because this is the only place a loader is invoked. Returns
+        // the input untouched when the route defers nothing.
+        const data = await resolveDeferredData(loaderResult);
 
         if (isRouteStateRequest) {
           // Route head exports are stripped from the client bundle. Return the

--- a/packages/framework/src/runtime.ts
+++ b/packages/framework/src/runtime.ts
@@ -860,8 +860,8 @@ export async function handlePrachtRequest<TContext>(
         loaderFile = resolvedLoaderFile;
 
         let loaderResult: unknown;
+        const loaderStart = loader && timings ? performance.now() : 0;
         if (loader) {
-          const loaderStart = timings ? performance.now() : 0;
           try {
             loaderResult = await loader(routeArgs);
           } catch (error: unknown) {
@@ -871,13 +871,11 @@ export async function handlePrachtRequest<TContext>(
             if (!(error instanceof Response)) throw error;
             loaderResult = error;
           }
-          if (timings) {
-            timings.loader = performance.now() - loaderStart;
-          }
         }
 
         // Allow loaders to return a Response directly (e.g. for redirects)
         if (loaderResult instanceof Response) {
+          if (timings) timings.loader = performance.now() - loaderStart;
           return loaderResult;
         }
 
@@ -885,7 +883,12 @@ export async function handlePrachtRequest<TContext>(
         // call covers every render mode and both the document and route-state
         // paths, because this is the only place a loader is invoked. Returns
         // the input untouched when the route defers nothing.
-        const data = await resolveDeferredData(loaderResult);
+        let data: unknown;
+        try {
+          data = await resolveDeferredData(loaderResult);
+        } finally {
+          if (loader && timings) timings.loader = performance.now() - loaderStart;
+        }
 
         if (isRouteStateRequest) {
           // Route head exports are stripped from the client bundle. Return the

--- a/packages/framework/src/types.ts
+++ b/packages/framework/src/types.ts
@@ -990,6 +990,18 @@ export type LoaderData<TLoader extends LoaderLike> = TLoader extends (
   ? Awaited<TResult>
   : never;
 
+type ResolveDeferredLoaderData<T> = T extends import("./defer.ts").Deferred<infer TValue>
+  ? ResolveDeferredLoaderData<TValue>
+  : T extends readonly unknown[]
+    ? { [TKey in keyof T]: ResolveDeferredLoaderData<T[TKey]> }
+    : T extends object
+      ? { [TKey in keyof T]: ResolveDeferredLoaderData<T[TKey]> }
+      : T;
+
+type ResolvedLoaderData<TLoader extends LoaderLike> = ResolveDeferredLoaderData<
+  LoaderData<TLoader>
+>;
+
 /**
  * Extract loader data from a route module type. `pracht typegen` uses this to
  * register per-route loader data on `Register["routes"]`. When a separate
@@ -1010,14 +1022,14 @@ export interface HeadArgs<
   TLoader extends LoaderLike = undefined,
   TContext = any,
 > extends BaseRouteArgs<TContext> {
-  data: LoaderData<TLoader>;
+  data: ResolvedLoaderData<TLoader>;
 }
 
 export interface HeadersArgs<
   TLoader extends LoaderLike = undefined,
   TContext = any,
 > extends BaseRouteArgs<TContext> {
-  data: LoaderData<TLoader>;
+  data: ResolvedLoaderData<TLoader>;
 }
 
 export interface RouteComponentProps<TLoader extends LoaderLike = undefined> {

--- a/packages/framework/test/defer-runtime.test.ts
+++ b/packages/framework/test/defer-runtime.test.ts
@@ -6,6 +6,7 @@ import {
   defer,
   defineApp,
   handlePrachtRequest,
+  notFound,
   prerenderApp,
   route,
   use,
@@ -150,6 +151,29 @@ describe("defer() through the SSR document path", () => {
     expect(response.status).toBe(500);
     expect(response.headers.get("location")).toBeNull();
   });
+
+  it("does not let deferred work choose an HTTP error status", async () => {
+    const app = defineApp({
+      routes: [route("/product", "./routes/product.tsx", { render: "ssr" })],
+    });
+
+    const response = await handlePrachtRequest({
+      app,
+      registry: {
+        routeModules: {
+          "./routes/product.tsx": async () => ({
+            loader: async () => ({
+              reviews: defer(Promise.reject(notFound("late missing"))),
+            }),
+            Component: () => null,
+          }),
+        },
+      },
+      request: new Request("http://localhost/product"),
+    });
+
+    expect(response.status).toBe(500);
+  });
 });
 
 describe("defer() through the route-state path", () => {
@@ -169,6 +193,39 @@ describe("defer() through the route-state path", () => {
     expect(response.headers.get("content-type")).toContain("application/json");
     const body = (await response.json()) as { data: { reviews: Review[] } };
     expect(body.data.reviews).toEqual([{ id: 7 }]);
+  });
+
+  it("rejects a deferred marker hidden behind a getter instead of returning an empty object", async () => {
+    const reviews = defer(Promise.resolve<Review[]>([{ id: 7 }]));
+    const app = defineApp({
+      routes: [route("/product", "./routes/product.tsx", { render: "ssr" })],
+    });
+
+    const response = await handlePrachtRequest({
+      app,
+      debugErrors: true,
+      registry: {
+        routeModules: {
+          "./routes/product.tsx": async () => ({
+            loader: async () => ({
+              get reviews() {
+                return reviews;
+              },
+            }),
+            Component: () => null,
+          }),
+        },
+      },
+      request: new Request("http://localhost/product", {
+        headers: { [ROUTE_STATE_REQUEST_HEADER]: "1" },
+      }),
+    });
+
+    expect(response.status).toBe(500);
+    const body = (await response.json()) as { error: { message: string } };
+    expect(body.error.message).toContain(
+      "Return defer() from an enumerable data property, not from a getter",
+    );
   });
 });
 

--- a/packages/framework/test/defer-runtime.test.ts
+++ b/packages/framework/test/defer-runtime.test.ts
@@ -1,0 +1,157 @@
+import { h } from "preact";
+import { describe, expect, it } from "vitest";
+
+import {
+  Suspense,
+  defer,
+  defineApp,
+  handlePrachtRequest,
+  prerenderApp,
+  route,
+  use,
+} from "../src/index.ts";
+import { ROUTE_STATE_REQUEST_HEADER } from "../src/runtime-constants.ts";
+
+interface Review {
+  id: number;
+}
+
+function later<T>(value: T, ms = 5): Promise<T> {
+  return new Promise((resolve) => setTimeout(() => resolve(value), ms));
+}
+
+/** A route whose loader awaits one field and defers another. */
+function reviewsRoute(onLoad?: () => void) {
+  return async () => ({
+    loader: async () => {
+      onLoad?.();
+      return {
+        product: { name: "Widget" },
+        reviews: defer(later<Review[]>([{ id: 7 }])),
+      };
+    },
+    Component: ({ data }: { data: { product: { name: string }; reviews: Review[] } }) =>
+      h(
+        "main",
+        null,
+        h("h1", null, data.product.name),
+        h(
+          Suspense as never,
+          { fallback: h("p", null, "loading") },
+          h(ReviewList, { reviews: data.reviews }),
+        ),
+      ),
+  });
+}
+
+function ReviewList({ reviews }: { reviews: Review[] }) {
+  const list = use(reviews);
+  return h(
+    "ul",
+    null,
+    list.map((review) => h("li", { key: review.id }, `review-${review.id}`)),
+  );
+}
+
+function parseHydrationState(html: string) {
+  const match = html.match(
+    /<script id="pracht-state" type="application\/json">([\s\S]*?)<\/script>/,
+  );
+  if (!match) throw new Error("Hydration state script not found");
+  return JSON.parse(match[1]) as { data: { reviews: Review[] } };
+}
+
+describe("defer() through the SSR document path", () => {
+  it("renders the resolved value rather than the Suspense fallback", async () => {
+    const app = defineApp({
+      routes: [route("/product", "./routes/product.tsx", { render: "ssr" })],
+    });
+
+    const response = await handlePrachtRequest({
+      app,
+      registry: { routeModules: { "./routes/product.tsx": reviewsRoute() } },
+      request: new Request("http://localhost/product"),
+    });
+
+    const html = await response.text();
+    expect(response.status).toBe(200);
+    expect(html).toContain("review-7");
+    expect(html).not.toContain(">loading<");
+  });
+
+  it("serializes the resolved value into the hydration state, not a marker", async () => {
+    const app = defineApp({
+      routes: [route("/product", "./routes/product.tsx", { render: "ssr" })],
+    });
+
+    const response = await handlePrachtRequest({
+      app,
+      registry: { routeModules: { "./routes/product.tsx": reviewsRoute() } },
+      request: new Request("http://localhost/product"),
+    });
+
+    const state = parseHydrationState(await response.text());
+    expect(state.data.reviews).toEqual([{ id: 7 }]);
+  });
+
+  it("surfaces a deferred rejection as a normal route error", async () => {
+    const app = defineApp({
+      routes: [route("/product", "./routes/product.tsx", { render: "ssr" })],
+    });
+
+    const response = await handlePrachtRequest({
+      app,
+      registry: {
+        routeModules: {
+          "./routes/product.tsx": async () => ({
+            loader: async () => ({ reviews: defer(Promise.reject(new Error("upstream 500"))) }),
+            Component: () => null,
+          }),
+        },
+      },
+      request: new Request("http://localhost/product"),
+    });
+
+    // Until the response streams, a deferred rejection is still inside the
+    // pre-flush window, so it produces a real error document rather than an
+    // in-boundary error.
+    expect(response.status).toBe(500);
+  });
+});
+
+describe("defer() through the route-state path", () => {
+  it("returns resolved values so client navigation matches SSR", async () => {
+    const app = defineApp({
+      routes: [route("/product", "./routes/product.tsx", { render: "ssr" })],
+    });
+
+    const response = await handlePrachtRequest({
+      app,
+      registry: { routeModules: { "./routes/product.tsx": reviewsRoute() } },
+      request: new Request("http://localhost/product", {
+        headers: { [ROUTE_STATE_REQUEST_HEADER]: "1" },
+      }),
+    });
+
+    expect(response.headers.get("content-type")).toContain("application/json");
+    const body = (await response.json()) as { data: { reviews: Review[] } };
+    expect(body.data.reviews).toEqual([{ id: 7 }]);
+  });
+});
+
+describe("defer() under prerendering", () => {
+  it("resolves everything at build time — a static file cannot stream", async () => {
+    const app = defineApp({
+      routes: [route("/product", "./routes/product.tsx", { render: "ssg" })],
+    });
+
+    const [page] = await prerenderApp({
+      app,
+      clientEntryUrl: "/assets/client.js",
+      registry: { routeModules: { "/src/routes/product.tsx": reviewsRoute() } },
+    });
+
+    expect(page.html).toContain("review-7");
+    expect(page.html).not.toContain(">loading<");
+  });
+});

--- a/packages/framework/test/defer-runtime.test.ts
+++ b/packages/framework/test/defer-runtime.test.ts
@@ -117,6 +117,39 @@ describe("defer() through the SSR document path", () => {
     // in-boundary error.
     expect(response.status).toBe(500);
   });
+
+  it("does not turn a Response rejected by deferred work into a redirect", async () => {
+    const app = defineApp({
+      routes: [route("/product", "./routes/product.tsx", { render: "ssr" })],
+    });
+
+    const response = await handlePrachtRequest({
+      app,
+      registry: {
+        routeModules: {
+          "./routes/product.tsx": async () => ({
+            loader: async () => ({
+              reviews: defer(
+                Promise.reject(
+                  new Response(null, {
+                    status: 302,
+                    headers: {
+                      location: "/login",
+                    },
+                  }),
+                ),
+              ),
+            }),
+            Component: () => null,
+          }),
+        },
+      },
+      request: new Request("http://localhost/product"),
+    });
+
+    expect(response.status).toBe(500);
+    expect(response.headers.get("location")).toBeNull();
+  });
 });
 
 describe("defer() through the route-state path", () => {

--- a/packages/framework/test/defer.test.ts
+++ b/packages/framework/test/defer.test.ts
@@ -18,6 +18,23 @@ describe("defer()", () => {
     expect(settled).toBe(false);
   });
 
+  it("observes an eager rejection until the marker is read", async () => {
+    const error = new Error("upstream 500");
+    const unhandled: unknown[] = [];
+    const onUnhandled = (reason: unknown) => unhandled.push(reason);
+    process.on("unhandledRejection", onUnhandled);
+
+    try {
+      const marked = defer(Promise.reject(error));
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      expect(unhandled).toEqual([]);
+      await expect(resolveDeferredData({ reviews: marked })).rejects.toBe(error);
+    } finally {
+      process.off("unhandledRejection", onUnhandled);
+    }
+  });
+
   it("does not start a thunk until the value is read", async () => {
     const work = vi.fn(async () => "reviews");
     const marked = defer(work);

--- a/packages/framework/test/defer.test.ts
+++ b/packages/framework/test/defer.test.ts
@@ -77,6 +77,19 @@ describe("resolveDeferredData()", () => {
     });
   });
 
+  it("continues resolving deferred values inside a deferred result", async () => {
+    const data = {
+      section: defer(
+        deferredLater({
+          items: [defer(deferredLater("a"))],
+        }),
+      ),
+    };
+    expect(await resolveDeferredData(data)).toEqual({
+      section: { items: ["a"] },
+    });
+  });
+
   it("resolves independent fields concurrently, not in series", async () => {
     const data = {
       a: defer(deferredLater("a", 40)),

--- a/packages/framework/test/defer.test.ts
+++ b/packages/framework/test/defer.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 
-import { defer, isDeferred, resolveDeferredData, use } from "../src/defer.ts";
+import { defer, isDeferred, resolveDeferredData, type Deferred, use } from "../src/defer.ts";
 
 function deferredLater<T>(value: T, ms = 0): Promise<T> {
   return new Promise((resolve) => setTimeout(() => resolve(value), ms));
@@ -64,6 +64,19 @@ describe("defer()", () => {
     });
     await expect(resolveDeferredData({ reviews: marked })).rejects.toThrow("boom");
   });
+
+  it("keeps the marker covariant for reusable component props", () => {
+    interface Animal {
+      name: string;
+    }
+    interface Dog extends Animal {
+      bark(): void;
+    }
+
+    const dog = defer(Promise.resolve<Dog>({ name: "Rex", bark() {} }));
+    const animal: Deferred<Animal> = dog;
+    expect(animal).toBe(dog);
+  });
 });
 
 describe("resolveDeferredData()", () => {
@@ -123,6 +136,13 @@ describe("resolveDeferredData()", () => {
   it("propagates a rejection so the loader boundary sees it", async () => {
     const data = { reviews: defer(Promise.reject(new Error("upstream 500"))) };
     await expect(resolveDeferredData(data)).rejects.toThrow("upstream 500");
+  });
+
+  it("rejects a Response returned from deferred work", async () => {
+    const data = { result: defer(Promise.resolve(new Response(null, { status: 202 }))) };
+    await expect(resolveDeferredData(data)).rejects.toThrow(
+      "A deferred loader value cannot return or throw a Response",
+    );
   });
 
   it("leaves non-plain objects by reference", async () => {
@@ -198,5 +218,11 @@ describe("use()", () => {
       await thrown;
     }
     expect(use(promise)).toBe("reviews");
+  });
+
+  it("distributes its result type across optional deferred values", () => {
+    const optional = null as Deferred<string> | null;
+    const result: string | null = use(optional);
+    expect(result).toBeNull();
   });
 });

--- a/packages/framework/test/defer.test.ts
+++ b/packages/framework/test/defer.test.ts
@@ -177,6 +177,23 @@ describe("resolveDeferredData()", () => {
     expect(JSON.stringify(resolved)).toBe('{"__proto__":{"polluted":true},"reviews":"ok"}');
   });
 
+  it("does not evaluate unrelated getters while resolving deferred fields", async () => {
+    let reads = 0;
+    const data = {
+      get sequence() {
+        reads += 1;
+        return reads;
+      },
+      reviews: defer(deferredLater("ok")),
+    };
+
+    const resolved = await resolveDeferredData(data);
+
+    expect(reads).toBe(0);
+    expect(JSON.stringify(resolved)).toBe('{"sequence":1,"reviews":"ok"}');
+    expect(reads).toBe(1);
+  });
+
   it("does not recurse forever on a cyclic value", async () => {
     const cyclic: Record<string, unknown> = { reviews: defer(deferredLater("ok")) };
     cyclic.self = cyclic;

--- a/packages/framework/test/defer.test.ts
+++ b/packages/framework/test/defer.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, expectTypeOf, it, vi } from "vitest";
 
 import { defer, isDeferred, resolveDeferredData, type Deferred, use } from "../src/defer.ts";
 import type { HeadArgs, HeadersArgs, RouteComponentProps } from "../src/types.ts";
+import { PrachtHttpError } from "../src/types.ts";
 
 function deferredLater<T>(value: T, ms = 0): Promise<T> {
   return new Promise((resolve) => setTimeout(() => resolve(value), ms));
@@ -146,6 +147,15 @@ describe("resolveDeferredData()", () => {
     );
   });
 
+  it("rejects a PrachtHttpError thrown from deferred work", async () => {
+    const data = {
+      result: defer(Promise.reject(new PrachtHttpError(404, "late missing"))),
+    };
+    await expect(resolveDeferredData(data)).rejects.toThrow(
+      "A deferred loader value cannot return or throw a Response or throw a PrachtHttpError",
+    );
+  });
+
   it("leaves non-plain objects by reference", async () => {
     const when = new Date(0);
     const data = { when, reviews: defer(deferredLater([])) };
@@ -192,6 +202,35 @@ describe("resolveDeferredData()", () => {
     expect(reads).toBe(0);
     expect(JSON.stringify(resolved)).toBe('{"sequence":1,"reviews":"ok"}');
     expect(reads).toBe(1);
+  });
+
+  it("preserves non-enumerable state read by an enumerable getter", async () => {
+    const data = {
+      get publicId() {
+        return (this as { internalId?: number }).internalId;
+      },
+      reviews: defer(deferredLater("ok")),
+    };
+    Object.defineProperty(data, "internalId", { value: 42 });
+
+    const resolved = await resolveDeferredData(data);
+
+    expect(JSON.stringify(resolved)).toBe('{"publicId":42,"reviews":"ok"}');
+  });
+
+  it("rejects a deferred marker returned from a getter instead of serializing it as an object", async () => {
+    const reviews = defer(deferredLater("ok"));
+    const data = {
+      get reviews() {
+        return reviews;
+      },
+    };
+
+    const resolved = await resolveDeferredData(data);
+
+    expect(() => JSON.stringify(resolved)).toThrow(
+      "Return defer() from an enumerable data property, not from a getter",
+    );
   });
 
   it("does not recurse forever on a cyclic value", async () => {

--- a/packages/framework/test/defer.test.ts
+++ b/packages/framework/test/defer.test.ts
@@ -1,6 +1,7 @@
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, expectTypeOf, it, vi } from "vitest";
 
 import { defer, isDeferred, resolveDeferredData, type Deferred, use } from "../src/defer.ts";
+import type { HeadArgs, HeadersArgs, RouteComponentProps } from "../src/types.ts";
 
 function deferredLater<T>(value: T, ms = 0): Promise<T> {
   return new Promise((resolve) => setTimeout(() => resolve(value), ms));
@@ -155,7 +156,25 @@ describe("resolveDeferredData()", () => {
   it("handles a null prototype object", async () => {
     const bare = Object.create(null) as Record<string, unknown>;
     bare.reviews = defer(deferredLater("ok"));
-    expect(await resolveDeferredData({ bare })).toEqual({ bare: { reviews: "ok" } });
+    const resolved = await resolveDeferredData({ bare });
+    expect(resolved).toEqual({ bare: { reviews: "ok" } });
+    expect(Object.getPrototypeOf(resolved.bare)).toBeNull();
+  });
+
+  it("preserves an own __proto__ data property", async () => {
+    const data = JSON.parse('{"__proto__":{"polluted":true},"reviews":null}') as Record<
+      string,
+      unknown
+    >;
+    data.reviews = defer(deferredLater("ok"));
+
+    const resolved = await resolveDeferredData(data);
+
+    expect(Object.getPrototypeOf(resolved)).toBe(Object.prototype);
+    expect(Object.hasOwn(resolved, "__proto__")).toBe(true);
+    expect(resolved.__proto__).toEqual({ polluted: true });
+    expect("polluted" in resolved).toBe(false);
+    expect(JSON.stringify(resolved)).toBe('{"__proto__":{"polluted":true},"reviews":"ok"}');
   });
 
   it("does not recurse forever on a cyclic value", async () => {
@@ -168,6 +187,30 @@ describe("resolveDeferredData()", () => {
     expect(await resolveDeferredData(null)).toBe(null);
     expect(await resolveDeferredData(undefined)).toBe(undefined);
     expect(await resolveDeferredData("plain")).toBe("plain");
+  });
+});
+
+describe("deferred loader data types", () => {
+  async function loader() {
+    return {
+      product: { name: "Widget" },
+      reviews: defer(Promise.resolve([{ id: 1 }])),
+      summary: { score: defer(Promise.resolve(5)) },
+    };
+  }
+
+  type ResolvedData = {
+    product: { name: string };
+    reviews: { id: number }[];
+    summary: { score: number };
+  };
+
+  it("resolves deferred fields for head and headers while preserving component markers", () => {
+    expectTypeOf<HeadArgs<typeof loader>["data"]>().toEqualTypeOf<ResolvedData>();
+    expectTypeOf<HeadersArgs<typeof loader>["data"]>().toEqualTypeOf<ResolvedData>();
+    expectTypeOf<RouteComponentProps<typeof loader>["data"]["reviews"]>().toEqualTypeOf<
+      Deferred<{ id: number }[]>
+    >();
   });
 });
 

--- a/packages/framework/test/defer.test.ts
+++ b/packages/framework/test/defer.test.ts
@@ -1,0 +1,172 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { defer, isDeferred, resolveDeferredData, use } from "../src/defer.ts";
+
+function deferredLater<T>(value: T, ms = 0): Promise<T> {
+  return new Promise((resolve) => setTimeout(() => resolve(value), ms));
+}
+
+describe("defer()", () => {
+  it("marks a promise without awaiting it", () => {
+    let settled = false;
+    const promise = Promise.resolve("reviews").then((value) => {
+      settled = true;
+      return value;
+    });
+    const marked = defer(promise);
+    expect(isDeferred(marked)).toBe(true);
+    expect(settled).toBe(false);
+  });
+
+  it("does not start a thunk until the value is read", async () => {
+    const work = vi.fn(async () => "reviews");
+    const marked = defer(work);
+    expect(work).not.toHaveBeenCalled();
+
+    await resolveDeferredData({ reviews: marked });
+    expect(work).toHaveBeenCalledTimes(1);
+  });
+
+  it("starts a thunk exactly once across repeated reads", async () => {
+    const work = vi.fn(async () => "reviews");
+    const marked = defer(work);
+
+    await resolveDeferredData({ a: marked, b: marked });
+    expect(work).toHaveBeenCalledTimes(1);
+  });
+
+  it("rejects an already-awaited value with an actionable message", () => {
+    // The mistake this catches is `defer(await getReviews())`, which defeats
+    // the point silently.
+    expect(() => defer("reviews" as never)).toThrow(/Pass the un-awaited call/);
+  });
+
+  it("surfaces a synchronous throw from a thunk as a rejection", async () => {
+    const marked = defer(() => {
+      throw new Error("boom");
+    });
+    await expect(resolveDeferredData({ reviews: marked })).rejects.toThrow("boom");
+  });
+});
+
+describe("resolveDeferredData()", () => {
+  it("returns the input by reference when nothing defers", async () => {
+    const data = { product: { id: 1 }, tags: ["a", "b"] };
+    expect(await resolveDeferredData(data)).toBe(data);
+  });
+
+  it("replaces deferred fields with their settled values", async () => {
+    const data = {
+      product: { id: 1 },
+      reviews: defer(deferredLater([{ id: 7 }])),
+    };
+    expect(await resolveDeferredData(data)).toEqual({
+      product: { id: 1 },
+      reviews: [{ id: 7 }],
+    });
+  });
+
+  it("resolves nested and array-held deferred values", async () => {
+    const data = {
+      sections: [{ items: defer(deferredLater(["a"])) }],
+      meta: { nested: { deep: defer(deferredLater(42)) } },
+    };
+    expect(await resolveDeferredData(data)).toEqual({
+      sections: [{ items: ["a"] }],
+      meta: { nested: { deep: 42 } },
+    });
+  });
+
+  it("resolves independent fields concurrently, not in series", async () => {
+    const data = {
+      a: defer(deferredLater("a", 40)),
+      b: defer(deferredLater("b", 40)),
+      c: defer(deferredLater("c", 40)),
+    };
+    const start = Date.now();
+    await resolveDeferredData(data);
+    // Three 40ms fields in series would be ~120ms. Generous ceiling so this
+    // does not flake under parallel CI load; it still fails a serial resolve.
+    expect(Date.now() - start).toBeLessThan(110);
+  });
+
+  it("propagates a rejection so the loader boundary sees it", async () => {
+    const data = { reviews: defer(Promise.reject(new Error("upstream 500"))) };
+    await expect(resolveDeferredData(data)).rejects.toThrow("upstream 500");
+  });
+
+  it("leaves non-plain objects by reference", async () => {
+    const when = new Date(0);
+    const data = { when, reviews: defer(deferredLater([])) };
+    const resolved = await resolveDeferredData(data);
+    expect(resolved.when).toBe(when);
+  });
+
+  it("handles a null prototype object", async () => {
+    const bare = Object.create(null) as Record<string, unknown>;
+    bare.reviews = defer(deferredLater("ok"));
+    expect(await resolveDeferredData({ bare })).toEqual({ bare: { reviews: "ok" } });
+  });
+
+  it("does not recurse forever on a cyclic value", async () => {
+    const cyclic: Record<string, unknown> = { reviews: defer(deferredLater("ok")) };
+    cyclic.self = cyclic;
+    await expect(resolveDeferredData(cyclic)).resolves.toBeDefined();
+  });
+
+  it("passes primitives and null through untouched", async () => {
+    expect(await resolveDeferredData(null)).toBe(null);
+    expect(await resolveDeferredData(undefined)).toBe(undefined);
+    expect(await resolveDeferredData("plain")).toBe("plain");
+  });
+});
+
+describe("use()", () => {
+  it("returns an already-settled value directly", () => {
+    // This is the case on every path today, and always for ssg/isg — it is
+    // what lets one component work whether or not the route streams.
+    expect(use("reviews")).toBe("reviews");
+    expect(use(null)).toBe(null);
+  });
+
+  it("throws the pending promise so a Suspense boundary can catch it", () => {
+    const marked = defer(deferredLater("reviews", 10));
+    let thrown: unknown;
+    try {
+      use(marked);
+    } catch (error) {
+      thrown = error;
+    }
+    expect(thrown).toBeInstanceOf(Promise);
+  });
+
+  it("returns the value once the thrown promise has settled", async () => {
+    const marked = defer(deferredLater("reviews", 5));
+    try {
+      use(marked);
+    } catch (promise) {
+      await promise;
+    }
+    expect(use(marked)).toBe("reviews");
+  });
+
+  it("rethrows a rejection once settled so the nearest ErrorBoundary renders", async () => {
+    const marked = defer(Promise.reject(new Error("upstream 500")));
+    try {
+      use(marked);
+    } catch (promise) {
+      await (promise as Promise<unknown>).catch(() => {});
+    }
+    expect(() => use(marked)).toThrow("upstream 500");
+  });
+
+  it("accepts a bare promise", async () => {
+    const promise = deferredLater("reviews", 5);
+    try {
+      use(promise);
+    } catch (thrown) {
+      await thrown;
+    }
+    expect(use(promise)).toBe("reviews");
+  });
+});

--- a/packages/framework/test/defer.test.ts
+++ b/packages/framework/test/defer.test.ts
@@ -204,6 +204,67 @@ describe("resolveDeferredData()", () => {
     expect(reads).toBe(1);
   });
 
+  it("does not evaluate array index getters while looking for deferred fields", async () => {
+    let reads = 0;
+    const values: unknown[] = [];
+    Object.defineProperty(values, "0", {
+      configurable: true,
+      enumerable: true,
+      get() {
+        reads += 1;
+        return reads;
+      },
+    });
+    values.length = 1;
+    const data = { values };
+
+    const resolved = await resolveDeferredData(data);
+
+    expect(resolved).toBe(data);
+    expect(reads).toBe(0);
+    expect(JSON.stringify(resolved)).toBe('{"values":[1]}');
+    expect(reads).toBe(1);
+  });
+
+  it("preserves array index getters while resolving sibling deferred values", async () => {
+    let reads = 0;
+    const values: unknown[] = [];
+    Object.defineProperty(values, "0", {
+      configurable: true,
+      enumerable: true,
+      get() {
+        reads += 1;
+        return reads;
+      },
+    });
+    values[1] = defer(deferredLater("ok"));
+
+    const resolved = await resolveDeferredData({ values });
+
+    expect(reads).toBe(0);
+    expect(JSON.stringify(resolved)).toBe('{"values":[1,"ok"]}');
+    expect(reads).toBe(1);
+  });
+
+  it("rejects a deferred marker returned from an array getter", async () => {
+    const value = defer(deferredLater("ok"));
+    const values: unknown[] = [];
+    Object.defineProperty(values, "0", {
+      configurable: true,
+      enumerable: true,
+      get() {
+        return value;
+      },
+    });
+    values.length = 1;
+
+    const resolved = await resolveDeferredData({ values });
+
+    expect(() => JSON.stringify(resolved)).toThrow(
+      "Return defer() from an enumerable data property, not from a getter",
+    );
+  });
+
   it("preserves non-enumerable state read by an enumerable getter", async () => {
     const data = {
       get publicId() {

--- a/packages/framework/test/prefetch.test.ts
+++ b/packages/framework/test/prefetch.test.ts
@@ -125,6 +125,20 @@ describe("prefetch strategies", () => {
     expect(fetchSpy).toHaveBeenCalledTimes(1);
   });
 
+  it("catches up hover intent that began before the lazy listeners loaded", () => {
+    const anchor = addAnchor("/pricing");
+    const querySelector = vi
+      .spyOn(document, "querySelector")
+      .mockImplementation((selector) => (selector === "a:hover" ? anchor : null));
+
+    setupPrefetching(createApp());
+    vi.advanceTimersByTime(60);
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(fetchSpy.mock.calls[0][0]).toBe("/pricing");
+    querySelector.mockRestore();
+  });
+
   it('honors a per-anchor data-pracht-prefetch="none" override on hover', () => {
     const anchor = addAnchor("/pricing", { "data-pracht-prefetch": "none" });
     setupPrefetching(createApp());

--- a/packages/framework/test/runtime-timing.test.ts
+++ b/packages/framework/test/runtime-timing.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { defineApp, handlePrachtRequest, route } from "../src/index.ts";
+import { defer, defineApp, handlePrachtRequest, route } from "../src/index.ts";
 import { formatServerTimingHeader, type PrachtPhaseTimings } from "../src/runtime-timing.ts";
 
 describe("formatServerTimingHeader", () => {
@@ -82,5 +82,27 @@ describe("handlePrachtRequest timings option", () => {
     expect(timings.loader).toBeUndefined();
     expect(timings.mw).toBeTypeOf("number");
     expect(timings.render).toBeTypeOf("number");
+  });
+
+  it("includes deferred value resolution in the loader phase", async () => {
+    const timings: PrachtPhaseTimings = {};
+    const response = await handlePrachtRequest({
+      app: defineApp({ routes: [route("/", "./routes/deferred.tsx")] }),
+      registry: {
+        routeModules: {
+          "./routes/deferred.tsx": async () => ({
+            Component: () => null,
+            loader: async () => ({
+              slow: defer(new Promise((resolve) => setTimeout(() => resolve("ok"), 30))),
+            }),
+          }),
+        },
+      },
+      request: new Request("http://localhost/"),
+      timings,
+    });
+
+    expect(response.status).toBe(200);
+    expect(timings.loader).toBeGreaterThanOrEqual(20);
   });
 });

--- a/skills/audit-loaders/SKILL.md
+++ b/skills/audit-loaders/SKILL.md
@@ -65,10 +65,12 @@ flagged.
 
 Two `defer()` rules worth checking while you are in the loader:
 
-- A deferred value must not redirect or set headers — by the time it settles
-  the response is already committed. Auth belongs in middleware or the awaited
-  part of the loader.
+- A deferred value must not redirect, throw `PrachtHttpError`, or set response
+  status or headers — by the time it settles the response is already committed.
+  Auth belongs in middleware or the awaited part of the loader.
 - `defer(await …)` defeats the point and throws at runtime. Flag it.
+- `defer()` must be returned from an enumerable data property, not hidden
+  behind a getter. An unresolved marker throws during serialization.
 
 Recommend converting to `string` (ISO for dates), plain arrays, or plain objects
 before return.

--- a/skills/audit-loaders/SKILL.md
+++ b/skills/audit-loaders/SKILL.md
@@ -51,11 +51,24 @@ Flag returns that contain any of:
 | `Date`, `Map`, `Set`, `URL`  | Not preserved by `JSON.stringify`   |
 | Class instances              | Lose prototype on the client        |
 | `Function` / arrow values    | Stripped silently                   |
-| `Promise`                    | Becomes `{}`                        |
+| `Promise` (bare)             | Becomes `{}` — wrap in `defer()`    |
 | Circular refs                | Throws at serialize time            |
 | `Buffer` / typed arrays      | Becomes `{}` or numeric keys        |
 | `bigint`                     | `JSON.stringify` throws             |
 | `undefined` in arrays/object | Drops keys; arrays become `null`    |
+
+A bare promise in loader data is always a bug — it serializes to `{}`. The fix
+is `defer(promise)`, which marks the field as deferred and is read in the
+component with `use()` inside a `<Suspense>` boundary. Flag a bare promise as an
+`error` and point at `defer()`; a `defer()`ed field is correct and must not be
+flagged.
+
+Two `defer()` rules worth checking while you are in the loader:
+
+- A deferred value must not redirect or set headers — by the time it settles
+  the response is already committed. Auth belongs in middleware or the awaited
+  part of the loader.
+- `defer(await …)` defeats the point and throws at runtime. Flag it.
 
 Recommend converting to `string` (ISO for dates), plain arrays, or plain objects
 before return.


### PR DESCRIPTION
## Summary

- Adds `defer()` and `use()` — a loader marks its slow fields with `defer(promise)` instead of awaiting them inline, and components read them with `use()` inside a `<Suspense>` boundary.
- This is **phase 1 of streaming SSR**: the authoring API, with zero streaming risk. Every render mode still resolves deferred values before the response is written. See "Scope" below for what is deliberately not here.
- Relates to #191 (Streaming SSR and deferred loader data).

```ts
export async function loader({ params }: LoaderArgs) {
  return {
    product: await getProduct(params.id),   // awaited
    reviews: defer(getReviews(params.id)),  // deferred
  };
}
```

```tsx
<Suspense fallback={<ReviewsSkeleton />}>
  <Reviews reviews={data.reviews} />
</Suspense>

function Reviews({ reviews }: { reviews: Deferred<Review[]> }) {
  const list = use(reviews);
  return <ul>{list.map((r) => <li key={r.id}>{r.body}</li>)}</ul>;
}
```

### Why the marker is per-value

Two alternatives were considered and rejected. Bare promises in the returned object (`{ comments: fetchComments() }`) put nothing at the call site to say the field is special, and a promise leaking into loader data by accident would silently change flush behaviour — that is the exact class of bug `audit-loaders` exists to catch. A Remix-style `defer({...})` wrapper changes the return type of the whole loader, so every loader-shape helper has to branch, and it says *that* the loader defers without saying *what*. The per-value marker keeps the object shape, records precisely which fields defer in the type, and stays statically visible to `pracht verify`.

Worth noting TanStack recently went the other way and soft-deprecated its explicit `defer()` in favour of auto-detected bare promises. The argument for keeping it explicit here is pracht-specific: an inferred marker is invisible to `pracht verify`, and "explicit over magic" is a stated core principle.

### Implementation notes

`resolveDeferredData()` is called at the **single** loader call site in `runtime.ts`, which is why one insertion point covers every render mode plus both the document and route-state paths — prerendering routes through `handlePrachtRequest` too. It returns the input **by reference** when the route defers nothing, so the common path allocates nothing, and it resolves independent deferred fields concurrently: two 300 ms fields cost 300 ms, not 600 ms.

`use()` accepts a settled value, a `Deferred`, or a bare promise. That is what lets one component work whether or not the route streams, and it is why adopting `defer()` now costs nothing when the renderer lands.

### Scope — what is deliberately not in this PR

The streaming flush itself. It is blocked on work outside this repo, per the investigation:

- **`preact-suspense@0.3.0` cannot stream at all.** Its `Suspense.render()` returns a bare keyless Fragment, which `preact-render-to-string` unwraps, so the caught promise lands in the Suspense's own frame while `handleError` starts its boundary walk one level above it. The result is `Error: Use "renderToStringAsync" for suspenseful rendering.` The fix is one line in that package (return an array), and it needs a patch release.
- **`preact-render-to-string` swallows rejected deferred promises** in the streaming path — the fallback persists forever and the stream closes 200. Its `renderToReadableStream` `onError` is dead code; `renderToChunks` never reads it.
- **CSP.** `createInitScript()` emits an inline script with no nonce hook, which violates the starter policy `docs/CSP.md` itself publishes. That blocks default-on and needs a small upstream PR.

Streaming also does not require Preact 11 — verified working on preact 10.29.1 with `preact-render-to-string` 6.6.7 and 6.7.0, with true out-of-order flushing. Preact 11's hydration rework is what removes the one-DOM-node-per-boundary authoring constraint, so it is the trigger for making streaming the *default*, not for building it.

`ssg` and `isg` will keep resolving everything even after the renderer lands: those modes write files, a file cannot stream, and shipping fallback markup as permanent static output would be a correctness bug.

## Testing

- [x] `pnpm run verify` (build, format, lint, typecheck, test, e2e) — passes
- 24 new tests: `defer.test.ts` covers the marker, lazy/memoized thunks, concurrency, cycles, null-prototype objects, non-plain objects by reference, and rejection propagation; `defer-runtime.test.ts` drives the real renderer through `handlePrachtRequest` and `prerenderApp` to assert the SSR document, the hydration state, the route-state JSON, and the SSG output all carry resolved values rather than the fallback.

One unrelated flake surfaced during the first verify run: `packages/content/test/vite.test.ts > keeps deferred document payloads out of a webworker server entry` timed out at 5000 ms under parallel load. Its name is adjacent to this change, so it was checked rather than assumed — it passes in 49 ms in isolation and the whole file passes in 247 ms, and the second full verify run was green.

## Checklist

- [x] Docs updated if needed — `docs/DATA_LOADING.md` and the public site page `examples/docs/src/routes/docs/data-loading.md`, both covering the API, the resolve-everything-today behaviour, and the three authoring rules (no redirect or headers from a deferred value; `head()`/`headers()` see awaited data only; one DOM element per suspending boundary on Preact 10)
- [x] Skills updated if needed — `audit-loaders` had a `Promise → becomes {}` row that is now only true of *bare* promises; it now points at `defer()` and checks the two new rules
- [x] Changeset added if published packages changed — minor on `@pracht/core`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
