### PR TITLE
feat(vite-plugin): compose the framework vendor chunk with the app's chunking

### DIFF
--- a/.changeset/composable-chunk-groups.md
+++ b/.changeset/composable-chunk-groups.md
@@ -1,0 +1,15 @@
+---
+"@pracht/vite-plugin": minor
+---
+
+Compose the framework vendor chunk with the app's chunking instead of replacing it.
+
+Pracht now reads `build.rollupOptions.output` and contributes its Preact group
+in the same form the app used — `codeSplitting.groups`, `advancedChunks.groups`,
+or a wrapped `manualChunks` function. Previously it always wrote `manualChunks`,
+which Rolldown ignores as soon as an app sets `codeSplitting`: configuring
+chunking (to group feature modules, say) silently cost you the vendor
+chunk, and an app-provided `manualChunks` was overwritten outright.
+
+New `pracht({ vendorChunk: false })` opts out entirely, and `frameworkChunkGroups()`
+is exported for apps that want to place the framework group themselves.

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -86,6 +86,42 @@ fragment navigation by whether the entry carries a router-stamped scroll key, so
 the two are one mechanism rather than two features — removing it would change
 navigation semantics, not just bundle size.
 
+## Composing with the app's chunking
+
+Pracht has one chunking opinion — Preact belongs in a shared `vendor` chunk —
+and contributes it rather than imposing it. `frameworkChunkConfig()` reads what
+the app put in `build.rollupOptions.output` and answers in the same form:
+
+| App config | Pracht contributes |
+| --- | --- |
+| nothing | `codeSplitting: { groups: [vendor] }` |
+| `codeSplitting: { groups: [...] }` | the same, appended by Vite's array-concatenating merge |
+| `advancedChunks: { groups: [...] }` (deprecated) | `advancedChunks: { groups: [vendor] }` |
+| `manualChunks(id)` (deprecated) | a function that answers `"vendor"` for Preact and delegates the rest |
+| `codeSplitting: false` | nothing |
+| an array of outputs | nothing, plus a warning naming `frameworkChunkGroups()` |
+
+The form matters because Rolldown resolves the three against each other:
+`codeSplitting` makes `advancedChunks` *and* `manualChunks` no-ops. A plugin
+that hard-codes `manualChunks` therefore loses its own policy the moment an app
+sets `codeSplitting` to group feature modules or split a heavy dependency —
+which is exactly the kind of policy an app is likely to configure here.
+
+Precedence inside `groups` is Rolldown's: higher `priority` first, then
+declaration order. The plugin's group arrives last, so an app group at equal
+priority that also matches Preact wins, and pracht's takes only what nothing
+else claimed. `pracht({ vendorChunk: false })` suppresses the contribution
+entirely; `frameworkChunkGroups()` is exported for apps that want to place the
+same definition somewhere else in their own list.
+
+Grouping changes have to be judged against the prerendered documents rather
+than the bundle report. A broad group — `entriesAware` across everything —
+can score better on chunk counts and sizes while reshuffling entry chunks
+enough that the per-route stylesheet links disappear from the emitted HTML.
+Targeted groups compose cleanly; measured on preact-www, pracht kept its vendor
+chunk while the app's own `manualChunks` function ran for everything else, with
+critical CSS still linked.
+
 ## `pracht build --analyze`
 
 After a successful production build, `--analyze` prints a per-route report of

--- a/examples/docs/src/routes/docs/performance.md
+++ b/examples/docs/src/routes/docs/performance.md
@@ -32,6 +32,64 @@ Preact, preact/hooks, and preact-suspense are extracted into a shared `vendor` c
 - Route chunks stay small — they only contain route-specific code.
 - Deploying a route change doesn't invalidate the vendor cache.
 
+### Composing with your own chunking
+
+The framework group is *contributed*, not imposed. Whatever you configure in
+`build.rollupOptions.output` stays, and pracht appends its Preact group in the
+same form you used — so grouping a feature into its own chunk does not cost you
+the vendor chunk:
+
+```ts [vite.config.ts]
+export default defineConfig({
+  plugins: [pracht()],
+  build: {
+    rollupOptions: {
+      output: {
+        codeSplitting: {
+          groups: [{ name: "editor", test: /src[\\/]features[\\/]editor/ }],
+        },
+      },
+    },
+  },
+});
+```
+
+Precedence is Rolldown's own: higher `priority` first, then declaration order.
+Your groups are declared first, so a group that would also capture Preact wins
+at equal priority and pracht's group takes only what nothing else claimed.
+
+Check the prerendered HTML after a grouping change, not only the sizes. A broad
+group — `entriesAware` over everything, for instance — can reshuffle entry
+chunks enough that the per-route `<link rel="stylesheet">` tags pracht injects
+disappear from `dist/client/**/index.html`. Targeted groups do not have this
+problem; measure the pages, not just the bundle report.
+
+To place the framework group yourself — at a different priority, or merged into
+one of your own — turn the automatic one off and use the exported definition:
+
+```ts [vite.config.ts]
+import { frameworkChunkGroups, pracht } from "@pracht/vite-plugin";
+
+export default defineConfig({
+  plugins: [pracht({ vendorChunk: false })],
+  build: {
+    rollupOptions: {
+      output: {
+        codeSplitting: {
+          groups: [
+            ...frameworkChunkGroups(),
+            { name: "editor", test: /src[\\/]features[\\/]editor/ },
+          ],
+        },
+      },
+    },
+  },
+});
+```
+
+`vendorChunk: false` on its own makes pracht contribute no chunking config at
+all, which is what you want if Preact belongs in your app chunks.
+
 ## Core Runtime Splitting
 
 The generated client entry imports a lean browser bootstrap from `@pracht/core/client`.

--- a/examples/docs/src/routes/docs/reference-config.md
+++ b/examples/docs/src/routes/docs/reference-config.md
@@ -71,6 +71,12 @@ route options and `<Link>` props.
 An unknown key here is an error rather than a silent no-op, so a typo cannot
 quietly ship the feature you meant to remove.
 
+### Chunking
+
+| Option | Default | Description |
+| --- | --- | --- |
+| `vendorChunk` | `true` | Contribute the Preact [vendor chunk group](/docs/performance#composing-with-your-own-chunking) to whatever the app configured in `build.rollupOptions.output`. `false` contributes nothing |
+
 ### Agent surfaces
 
 | Option | Default | Description |

--- a/packages/vite-plugin/src/chunk-groups.ts
+++ b/packages/vite-plugin/src/chunk-groups.ts
@@ -1,0 +1,135 @@
+/**
+ * Pracht's client chunking policy, expressed as something an app can build on.
+ *
+ * The framework has exactly one opinion here: Preact belongs in its own chunk,
+ * shared by every route and cached across deploys that only change app code.
+ * Everything else about chunking is the app's call — merging the long tail of
+ * small initial chunks, splitting a heavy dependency out of a route, grouping
+ * by feature.
+ *
+ * Those two have to coexist, and under Rolldown that is not automatic:
+ * `output.codeSplitting` makes `manualChunks` and `advancedChunks` ignored
+ * outright, so a plugin that hard-codes one form silently deletes whichever
+ * form the app used. Pracht therefore looks at what the app configured and
+ * contributes its group in the same form, as one entry appended to the app's
+ * list rather than as a replacement for it.
+ *
+ * Precedence follows Rolldown's own rule — higher `priority` first, then
+ * declaration order. The app's groups are declared first, so an app group that
+ * would also capture Preact wins at equal priority, and pracht's group only
+ * takes what nothing else claimed. To keep the framework chunk intact while
+ * merging everything around it, give the app group a `test` that excludes
+ * Preact, or raise pracht's group by placing {@link frameworkChunkGroups}
+ * explicitly and setting `vendorChunk: false`.
+ */
+
+/**
+ * Modules that make up the framework runtime's vendor chunk.
+ *
+ * `[\\/]` rather than `/` so the group matches on Windows, and no trailing
+ * boundary so the Preact family — `preact/hooks`, `preact-suspense`,
+ * `preact-render-to-string` — lands in one chunk with Preact itself.
+ */
+const FRAMEWORK_VENDOR_TEST = /node_modules[\\/]preact/;
+
+/** Name of the chunk pracht groups the Preact runtime into. */
+export const FRAMEWORK_VENDOR_CHUNK = "vendor";
+
+export interface ChunkGroup {
+  name: string;
+  test?: RegExp | string;
+  priority?: number;
+  minSize?: number;
+  [option: string]: unknown;
+}
+
+/**
+ * Pracht's chunk groups, as a fresh array an app can place in its own
+ * `output.codeSplitting.groups`.
+ *
+ * Use this together with `pracht({ vendorChunk: false })` when the framework
+ * group has to sit somewhere other than last — pracht then contributes no
+ * chunking config of its own and the app's list is the whole policy.
+ */
+export function frameworkChunkGroups(): ChunkGroup[] {
+  return [{ name: FRAMEWORK_VENDOR_CHUNK, test: FRAMEWORK_VENDOR_TEST }];
+}
+
+/** Whether a module id belongs in the framework vendor chunk. */
+export function isFrameworkVendorModule(id: string): boolean {
+  return FRAMEWORK_VENDOR_TEST.test(id);
+}
+
+interface OutputOptionsLike {
+  codeSplitting?: unknown;
+  advancedChunks?: unknown;
+  manualChunks?: unknown;
+}
+
+type ManualChunksFn = (id: string, meta: unknown) => string | null | undefined | void;
+
+export interface FrameworkChunkConfig {
+  /** Partial `build.rollupOptions.output` for Vite to merge over the app's. */
+  output?: Record<string, unknown>;
+  /** Emitted by the plugin as a warning; `undefined` when there is nothing to say. */
+  warning?: string;
+}
+
+/**
+ * Build the chunking config pracht contributes, given what the app configured.
+ *
+ * Returns a partial `output` because Vite merges a plugin's `config()` result
+ * over the user config and concatenates arrays: returning only pracht's group
+ * is what appends it to the app's list instead of replacing it.
+ */
+export function frameworkChunkConfig(output: unknown): FrameworkChunkConfig {
+  if (Array.isArray(output)) {
+    // Vite would concatenate our array with theirs (duplicating every output)
+    // or, with the object form, replace the whole array. Neither is a chunking
+    // policy anyone asked for, so contribute nothing and say so.
+    return {
+      warning:
+        "build.rollupOptions.output is an array, so pracht did not add its Preact vendor " +
+        `chunk group. Add frameworkChunkGroups() from @pracht/vite-plugin to each output's ` +
+        "codeSplitting.groups to keep the framework chunk.",
+    };
+  }
+
+  const options = (output ?? {}) as OutputOptionsLike;
+
+  // An explicit `codeSplitting: false` is the app switching code splitting off
+  // wholesale; a vendor group cannot mean anything there.
+  if (options.codeSplitting === false) return {};
+
+  const groups = frameworkChunkGroups();
+
+  if (options.codeSplitting === undefined) {
+    // Rolldown ignores `advancedChunks` as soon as `codeSplitting` is present,
+    // so an app still on the deprecated name gets pracht's group in that same
+    // shape rather than having its own config silently dropped.
+    if (isRecord(options.advancedChunks)) {
+      return { output: { advancedChunks: { groups } } };
+    }
+    // Same reasoning for the (also deprecated) function form: emitting
+    // `codeSplitting` here would make the app's `manualChunks` a no-op, so
+    // compose with it instead. Pracht answers first — the framework chunk is
+    // not something an app opts out of by accident — and delegates otherwise.
+    if (typeof options.manualChunks === "function") {
+      const appManualChunks = options.manualChunks as ManualChunksFn;
+      return {
+        output: {
+          manualChunks(id: string, meta: unknown) {
+            if (isFrameworkVendorModule(id)) return FRAMEWORK_VENDOR_CHUNK;
+            return appManualChunks(id, meta);
+          },
+        },
+      };
+    }
+  }
+
+  return { output: { codeSplitting: { groups } } };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/packages/vite-plugin/src/index.ts
+++ b/packages/vite-plugin/src/index.ts
@@ -11,6 +11,7 @@ import {
 
 import type { RenderMode } from "@pracht/core";
 import { PRACHT_GRAPH_ONLY_ENV } from "@pracht/core/server";
+import { frameworkChunkConfig } from "./chunk-groups.ts";
 import { createEnvSafetyPlugin, PUBLIC_ENV_PREFIX, SERVER_ENV_MODULE_ID } from "./env-safety.ts";
 import { createClientModulePrefreshPlugin } from "./client-module-prefresh.ts";
 import { reachesRouteHintedModule } from "./head-hint-reload.ts";
@@ -73,6 +74,7 @@ export type {
   PrachtLlmsTxtOptions,
   PrachtPluginOptions,
 } from "./plugin-options.ts";
+export { FRAMEWORK_VENDOR_CHUNK, frameworkChunkGroups, type ChunkGroup } from "./chunk-groups.ts";
 export {
   createPrachtClientModuleSource,
   createPrachtIslandsClientModuleSource,
@@ -175,6 +177,21 @@ export function pracht(options: PrachtPluginOptions = {}): Plugin[] {
         __PRACHT_CLIENT_PREFETCH__: String(resolved.client.prefetch),
       };
 
+      // Contributed rather than imposed: pracht adds its Preact group to the
+      // app's own chunking config in whichever form the app used, so an app
+      // that merges its small initial chunks keeps the framework chunk, and an
+      // app that wants Preact somewhere else can say so.
+      const clientChunkConfig =
+        isSSRBuild || !resolved.vendorChunk
+          ? {}
+          : frameworkChunkConfig(
+              (_config.build as { rollupOptions?: { output?: unknown } } | undefined)?.rollupOptions
+                ?.output,
+            );
+      if (clientChunkConfig.warning) {
+        console.warn(`[pracht] ${clientChunkConfig.warning}`);
+      }
+
       return {
         appType: "custom" as const,
         // Expose PRACHT_PUBLIC_-prefixed vars on import.meta.env (client and
@@ -197,24 +214,15 @@ export function pracht(options: PrachtPluginOptions = {}): Plugin[] {
           ...clientFeatureDefines,
         },
         // The vendor split only makes sense for the client bundle; SSR builds
-        // that disable code splitting (e.g. webworker targets) reject
-        // `manualChunks` outright.
+        // that disable code splitting (e.g. webworker targets) reject chunk
+        // grouping outright.
         ...(isSSRBuild
           ? {}
           : {
               build: {
                 rollupOptions: {
                   ...(wantsIslandsEntry ? { input: [PRACHT_ISLANDS_CLIENT_MODULE_ID] } : {}),
-                  output: {
-                    manualChunks(id: string) {
-                      if (
-                        id.includes("node_modules/preact") ||
-                        id.includes("node_modules/preact-suspense")
-                      ) {
-                        return "vendor";
-                      }
-                    },
-                  },
+                  ...(clientChunkConfig.output ? { output: clientChunkConfig.output } : {}),
                 },
               },
             }),

--- a/packages/vite-plugin/src/plugin-options.ts
+++ b/packages/vite-plugin/src/plugin-options.ts
@@ -73,6 +73,16 @@ export interface PrachtPluginOptions {
    * compiled out of the client bundle. See {@link PrachtClientOptions}.
    */
   client?: PrachtClientOptions;
+  /**
+   * Group the Preact runtime into a shared `vendor` chunk. Defaults to `true`.
+   *
+   * The group is appended to whatever `build.rollupOptions.output` chunking
+   * the app configures, so app-level grouping and the framework chunk compose
+   * (see `frameworkChunkGroups()`). Set `false` to contribute nothing at all —
+   * for an app that places `frameworkChunkGroups()` itself, or one that wants
+   * Preact merged into its own chunks.
+   */
+  vendorChunk?: boolean;
   appFile?: string;
   routesDir?: string;
   shellsDir?: string;
@@ -142,6 +152,7 @@ export const CLIENT_FEATURE_DEFAULTS: Required<PrachtClientOptions> = {
 
 const DEFAULTS: ResolvedPrachtPluginOptions = {
   client: CLIENT_FEATURE_DEFAULTS,
+  vendorChunk: true,
   appFile: "/src/routes.ts",
   middlewareDir: "/src/middleware",
   routesDir: "/src/routes",
@@ -173,6 +184,11 @@ export function resolveOptions(options: PrachtPluginOptions): ResolvedPrachtPlug
     resolved.llmsTxt = false;
   }
   resolved.client = resolveClientOptions(options.client);
+  if (typeof resolved.vendorChunk !== "boolean") {
+    throw new Error(
+      `pracht({ vendorChunk }) expects a boolean, got ${JSON.stringify(resolved.vendorChunk)}.`,
+    );
+  }
   resolved.additionalExtensions = normalizeAdditionalExtensions(resolved.additionalExtensions);
   if (!new Set(["spa", "ssr", "ssg", "isg"]).has(resolved.pagesDefaultRender)) {
     throw new Error('pracht({ pagesDefaultRender }) expects "spa", "ssr", "ssg", or "isg".');

--- a/packages/vite-plugin/test/plugin-build-config.test.ts
+++ b/packages/vite-plugin/test/plugin-build-config.test.ts
@@ -23,7 +23,11 @@ interface BuildConfig {
   build?: {
     rollupOptions?: {
       external?: unknown[];
-      output?: { manualChunks?: unknown };
+      output?: {
+        manualChunks?: unknown;
+        codeSplitting?: { groups?: Array<{ name: string; test?: unknown }> };
+        advancedChunks?: { groups?: Array<{ name: string; test?: unknown }> };
+      };
     };
   };
 }
@@ -32,6 +36,7 @@ function runConfigHook(
   adapter: PrachtAdapter,
   isSsrBuild: boolean,
   options: Partial<Parameters<typeof pracht>[0]> = {},
+  userConfig: Record<string, unknown> = {},
 ): BuildConfig {
   const plugin = pracht({ adapter, ...options }).find((candidate) => candidate.name === "pracht");
   if (!plugin) throw new Error("pracht plugin not found");
@@ -39,7 +44,15 @@ function runConfigHook(
     config: Record<string, unknown>,
     env: { command: string; mode: string; isSsrBuild: boolean },
   ) => BuildConfig;
-  return hook.call(plugin as never, {}, { command: "build", mode: "production", isSsrBuild });
+  return hook.call(plugin as never, userConfig, {
+    command: "build",
+    mode: "production",
+    isSsrBuild,
+  });
+}
+
+function withOutput(output: unknown): Record<string, unknown> {
+  return { build: { rollupOptions: { output } } };
 }
 
 function runConfigResolvedHook(base: string): void {
@@ -260,12 +273,88 @@ describe("pracht plugin build config", () => {
     expect(dev.define?.__PRACHT_CLIENT_PREFETCH__).toBe("false");
   });
 
-  it("keeps the vendor manualChunks split on client builds only", () => {
+  it("groups Preact into a vendor chunk on client builds only", () => {
     const clientConfig = runConfigHook(edgeAdapter, false);
     const ssrConfig = runConfigHook(edgeAdapter, true);
 
-    expect(typeof clientConfig.build?.rollupOptions?.output?.manualChunks).toBe("function");
-    expect(ssrConfig.build?.rollupOptions?.output?.manualChunks).toBeUndefined();
+    expect(clientConfig.build?.rollupOptions?.output?.codeSplitting?.groups).toEqual([
+      { name: "vendor", test: /node_modules[\\/]preact/ },
+    ]);
+    expect(ssrConfig.build?.rollupOptions?.output).toBeUndefined();
+  });
+
+  it("contributes only its own group, so Vite appends it to the app's", () => {
+    // Vite merges a plugin's config over the user's and concatenates arrays.
+    // Returning the whole merged list here would duplicate every app group.
+    const config = runConfigHook(
+      edgeAdapter,
+      false,
+      {},
+      withOutput({
+        codeSplitting: {
+          groups: [{ name: "editor", test: /src[\\/]features[\\/]editor/ }],
+        },
+      }),
+    );
+
+    expect(config.build?.rollupOptions?.output?.codeSplitting?.groups).toEqual([
+      { name: "vendor", test: /node_modules[\\/]preact/ },
+    ]);
+  });
+
+  it("contributes nothing when the app switches code splitting off", () => {
+    const config = runConfigHook(edgeAdapter, false, {}, withOutput({ codeSplitting: false }));
+
+    expect(config.build?.rollupOptions?.output).toBeUndefined();
+  });
+
+  it("contributes nothing when vendorChunk is disabled", () => {
+    const config = runConfigHook(edgeAdapter, false, { vendorChunk: false });
+
+    expect(config.build?.rollupOptions?.output).toBeUndefined();
+  });
+
+  it("matches the deprecated advancedChunks form so the app's groups survive", () => {
+    // Rolldown ignores advancedChunks as soon as codeSplitting is present.
+    const config = runConfigHook(
+      edgeAdapter,
+      false,
+      {},
+      withOutput({ advancedChunks: { groups: [{ name: "app" }] } }),
+    );
+
+    expect(config.build?.rollupOptions?.output?.advancedChunks?.groups).toEqual([
+      { name: "vendor", test: /node_modules[\\/]preact/ },
+    ]);
+    expect(config.build?.rollupOptions?.output?.codeSplitting).toBeUndefined();
+  });
+
+  it("composes with a manualChunks function instead of replacing it", () => {
+    const appManualChunks = vi.fn((id: string) => (id.includes("lodash") ? "utils" : undefined));
+    const config = runConfigHook(
+      edgeAdapter,
+      false,
+      {},
+      withOutput({ manualChunks: appManualChunks }),
+    );
+
+    const composed = config.build?.rollupOptions?.output?.manualChunks as (
+      id: string,
+      meta: unknown,
+    ) => unknown;
+    expect(typeof composed).toBe("function");
+    expect(composed("/app/node_modules/preact/dist/preact.mjs", {})).toBe("vendor");
+    expect(composed("/app/node_modules/lodash/index.js", {})).toBe("utils");
+    expect(appManualChunks).toHaveBeenCalledWith("/app/node_modules/lodash/index.js", {});
+  });
+
+  it("warns rather than clobbering an array of outputs", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const config = runConfigHook(edgeAdapter, false, {}, withOutput([{ format: "es" }]));
+
+    expect(config.build?.rollupOptions?.output).toBeUndefined();
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining("frameworkChunkGroups()"));
+    warn.mockRestore();
   });
 
   it("does not force edge-only SSR options on non-edge adapters", () => {

--- a/skills/audit-bundles/SKILL.md
+++ b/skills/audit-bundles/SKILL.md
@@ -145,6 +145,44 @@ prefetching first: the router silently stops honouring `route({ prefetch })` and
 `<Link prefetch>`, and the imperative `prefetch()` export becomes a no-op. See
 `docs/PERFORMANCE.md#switching-off-js-prefetching`.
 
+## Step 6b: Chunk-group composition
+
+App-level chunking and pracht's vendor chunk coexist — recommend it freely.
+Pracht reads `build.rollupOptions.output` and contributes its Preact group in
+whichever form the app used, so adding a group (to merge the long tail of small
+initial chunks, say) does not cost the framework chunk:
+
+```ts
+// vite.config.ts
+build: {
+  rollupOptions: {
+    output: {
+      codeSplitting: { groups: [{ name: "app", tags: ["$initial"], minSize: 20_000 }] },
+    },
+  },
+}
+```
+
+Two things to check when an app already configures chunking:
+
+- **Mixed forms.** Rolldown lets `codeSplitting` silence both `advancedChunks`
+  and `manualChunks`. An app that sets more than one is running only
+  `codeSplitting`; report the dead config as `warn`.
+- **A group that swallows Preact.** Precedence is higher `priority` first, then
+  declaration order, with pracht's group last — so an app group matching
+  `node_modules` at equal priority absorbs the framework runtime. If a separate,
+  long-cached framework chunk was the intent, recommend a `priority` bump or a
+  `test` that excludes Preact.
+
+Verify any grouping change against the prerendered HTML, not just the numbers:
+a group broad enough to reshuffle entry chunks can drop the stylesheet links
+pracht injects per route. Compare `<link rel="stylesheet">` tags in
+`dist/client/**/index.html` before and after.
+
+`pracht({ vendorChunk: false })` makes pracht contribute nothing, for an app
+that wants Preact inside its own chunks or places `frameworkChunkGroups()`
+itself.
+
 ## Step 7: Report
 
 Three sections:


### PR DESCRIPTION
## Summary

The plugin hard-wrote `build.rollupOptions.output.manualChunks` to put Preact in a shared `vendor` chunk. Rolldown resolves the three chunking forms against each other — `codeSplitting` makes **both** `advancedChunks` and `manualChunks` no-ops — so an app that configured `codeSplitting` to merge its small initial chunks silently lost the vendor chunk, and an app that wrote its own `manualChunks` had it overwritten outright. Neither failure said anything.

`frameworkChunkConfig()` now reads what the app put in `output` and contributes the framework group in the same form:

| App config | Pracht contributes |
| --- | --- |
| nothing | `codeSplitting: { groups: [vendor] }` |
| `codeSplitting: { groups: [...] }` | the same, appended by Vite's array-concatenating merge |
| `advancedChunks: { groups: [...] }` | `advancedChunks: { groups: [vendor] }` |
| `manualChunks(id)` | a function answering `"vendor"` for Preact, delegating the rest |
| `codeSplitting: false` | nothing |
| an array of outputs | nothing, plus a warning naming `frameworkChunkGroups()` |

An array of outputs is left alone because Vite's config merge would either duplicate every output or replace the array wholesale — the previous code did the latter silently.

Precedence stays Rolldown's own: higher `priority` first, then declaration order, with the framework group declared last, so an app group at equal priority that also matches Preact wins. `pracht({ vendorChunk: false })` contributes nothing at all, and `frameworkChunkGroups()` is exported for apps that want to place the same definition themselves.

## Verified on preact-www

Pracht keeps its vendor chunk while the app's targeted `manualChunks` function runs for everything else; critical CSS stayed linked and Home, the guide, and the REPL rendered.

One finding worth carrying: a broad `entriesAware` group scored better on chunk counts and sizes but **dropped the per-route `<link rel="stylesheet">` tags from the prerendered HTML**. Targeted grouping is the viable shape. Both `docs/PERFORMANCE.md` and the `audit-bundles` skill now say to judge a grouping change against the emitted documents, not the bundle report.

## Scope

`serverOnly()` / `<StaticHtml>` was split out into **#347** (draft). It works and measures well, but `<StaticHtml>` deliberately never hydrates, which is wrong for preact-www's Home page — its compiled Markdown embeds `<logo>`, `<todo-list>`, `<github-repos>` and other component-mapped custom elements. That PR carries the open question about whether `@pracht/markdown` should adopt the primitive by default.

## Testing

- [x] `pnpm run verify` (build, format, lint, typecheck, test, e2e)
- [x] Six new plugin tests covering each composition form, the opt-out, and the array-of-outputs warning
- [x] Exercised against preact-www's real chunking config (see above)

## Checklist

- [x] Docs updated if needed — `docs/PERFORMANCE.md`, site pages `performance` and `reference-config`
- [x] Skills updated if needed — `audit-bundles` (composition is possible, mixed forms are dead config, groups that swallow Preact, verify against prerendered HTML)
- [x] Changeset added if published packages changed — `@pracht/vite-plugin` (minor)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
