### PR TITLE
Fail builds with empty prerender output

### DIFF
--- a/.changeset/fail-empty-prerender.md
+++ b/.changeset/fail-empty-prerender.md
@@ -1,0 +1,7 @@
+---
+"@pracht/core": patch
+---
+
+Fail builds when every attempted SSG/ISG page returns a non-200 response instead of shipping empty prerender output.
+
+Serverful builds still warn and skip individual failures when at least one page prerenders successfully; static exports remain fail-fast.

--- a/docs/RENDERING_MODES.md
+++ b/docs/RENDERING_MODES.md
@@ -72,6 +72,13 @@ with `/index.html` or `/guide` with `/guide/index.html`.
 
 Prerendering runs concurrently (default: 10 parallel renders). Tune it with `pracht({ prerenderConcurrency })` in your Vite config when CI needs more or less parallelism.
 
+With a serverful adapter, an individual SSG/ISG path that returns a non-200
+response is warned about and skipped because the runtime server can still
+answer it. If every attempted SSG/ISG render fails, however, `pracht build`
+exits non-zero instead of producing empty prerender output. A partially
+successful prerender remains valid. Static exports fail on the first failed
+path because they have no runtime fallback.
+
 ---
 
 ## SSR — Server-Side Rendering

--- a/examples/docs/src/routes/docs/rendering.md
+++ b/examples/docs/src/routes/docs/rendering.md
@@ -50,6 +50,12 @@ export function Component({ data }) {
 
 The build calls `getStaticPaths()` to enumerate params, constructs full paths from the route pattern, then runs the loader and renderer for each. Prerendering runs concurrently (default: 10 parallel renders), configurable with `pracht({ prerenderConcurrency })`.
 
+With a serverful adapter, a path that returns a non-200 response during SSG/ISG
+is warned about and skipped because the runtime server can still answer it. If
+every attempted prerender fails, `pracht build` exits non-zero rather than
+produce empty prerender output. Partial output is still allowed. A static
+export fails on the first bad path because it has no runtime fallback.
+
 ---
 
 ## SSR — Server-Side Rendering

--- a/packages/framework/src/prerender.ts
+++ b/packages/framework/src/prerender.ts
@@ -77,6 +77,8 @@ export async function prerenderApp(
   const results: PrerenderResult[] = [];
   const isgManifest: Record<string, ISGManifestEntry> = {};
   const generatedAt = Date.now();
+  let failedPrerenders = 0;
+  let firstPrerenderError: unknown;
 
   // Collect all work items first, then render in parallel batches
   const work: {
@@ -155,6 +157,10 @@ export async function prerenderApp(
           console.warn(
             `  Warning: ${item.render.toUpperCase()} route "${item.pathname}" returned status ${response.status}, skipping.`,
           );
+          failedPrerenders++;
+          if (firstPrerenderError === undefined && renderError !== undefined) {
+            firstPrerenderError = renderError;
+          }
           return null;
         }
 
@@ -256,6 +262,16 @@ export async function prerenderApp(
         };
       }
     }
+  }
+
+  if (work.length > 0 && failedPrerenders === work.length) {
+    const noun = failedPrerenders === 1 ? "render" : "renders";
+    throw new Error(
+      `No SSG/ISG pages were prerendered: all ${failedPrerenders} attempted ${noun} returned a non-200 response. ` +
+        "Refusing to finish a build with empty prerender output. Fix the build-time loader or render failures, or move request-dependent routes to SSR." +
+        describeRenderError(firstPrerenderError),
+      firstPrerenderError === undefined ? undefined : { cause: firstPrerenderError },
+    );
   }
 
   if (options.withISGManifest) {

--- a/packages/framework/test/static-export.test.ts
+++ b/packages/framework/test/static-export.test.ts
@@ -177,6 +177,68 @@ describe("prerenderApp staticExport", () => {
     expect(pages.every((page) => page.routeState === undefined)).toBe(true);
   });
 
+  it("fails a serverful build instead of producing empty prerender output", async () => {
+    const renderError = new Error("docs transform stub is unavailable");
+    const app = defineApp({
+      routes: [
+        route("/docs", "./routes/docs.tsx", { render: "ssg", hasLoader: true }),
+        route("/account", "./routes/account.tsx", { render: "ssr" }),
+      ],
+    });
+    const brokenRegistry = {
+      routeModules: {
+        "/src/routes/docs.tsx": async () => ({
+          Component: () => h("main", null, "docs"),
+          loader: () => {
+            throw renderError;
+          },
+        }),
+      },
+    };
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+
+    try {
+      await expect(prerenderApp({ app, registry: brokenRegistry })).rejects.toMatchObject({
+        cause: renderError,
+        message: expect.stringMatching(
+          /No SSG\/ISG pages were prerendered: all 1 attempted render returned a non-200 response.*empty prerender output/s,
+        ),
+      });
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  it("keeps successful output when only some serverful prerenders fail", async () => {
+    const app = defineApp({
+      routes: [
+        route("/working", "./routes/working.tsx", { render: "ssg" }),
+        route("/broken", "./routes/broken.tsx", { render: "ssg", hasLoader: true }),
+      ],
+    });
+    const partialRegistry = {
+      routeModules: {
+        "/src/routes/working.tsx": async () => ({
+          Component: () => h("main", null, "working"),
+        }),
+        "/src/routes/broken.tsx": async () => ({
+          Component: () => h("main", null, "broken"),
+          loader: () => {
+            throw new Error("optional page data unavailable");
+          },
+        }),
+      },
+    };
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+
+    try {
+      const pages = await prerenderApp({ app, registry: partialRegistry });
+      expect(pages.map((page) => page.path)).toEqual(["/working"]);
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
   it("fails a static export when a build-time loader redirects", async () => {
     const app = defineApp({
       routes: [route("/old", "./routes/redirect.tsx", { render: "ssg", hasLoader: true })],

--- a/skills/pracht-debug/SKILL.md
+++ b/skills/pracht-debug/SKILL.md
@@ -118,6 +118,10 @@ Work through these in order, stopping when you find the root cause:
 ### 8. Build / deployment issues
 
 - `pracht build` runs client + server builds, then prerenders SSG/ISG routes.
+- On serverful adapters, a failed SSG/ISG path is warned about and skipped, but
+  the build fails if every attempted prerender returns a non-200 response. Use
+  the reported underlying error to fix the shared loader/render dependency;
+  partial prerender output remains valid. Static exports fail on any bad path.
 - `pracht preview` builds and serves the production output locally (Node runs `dist/server/server.js`, Cloudflare delegates to `wrangler dev`).
 - `pracht inspect build --json` reports the resolved adapter target plus client/CSS/JS manifests from the latest build output (requires a prior `pracht build`).
 - Check `dist/client/` for client assets and `dist/server/` for server bundle.


### PR DESCRIPTION
## Summary

- Fail serverful builds when every attempted SSG/ISG prerender returns a non-200 response, while preserving partial-success behavior and underlying error details.
- Add regression coverage, internal and public rendering documentation, debug-skill guidance, and a patch changeset for `@pracht/core`.
- Relevant issue: N/A.

## Testing

- [x] `pnpm run verify` (build, format, lint, typecheck, test, e2e)

## Checklist

- [x] Docs updated if needed
- [x] Skills updated if needed
- [x] Changeset added if published packages changed
