### PR TITLE
refactor(skills): budget the skill catalog for context

### DIFF
--- a/.changeset/skills-context-budget.md
+++ b/.changeset/skills-context-budget.md
@@ -1,0 +1,15 @@
+---
+"create-pracht": patch
+---
+
+Tighten the seeded skill catalog for context efficiency: descriptions are 25%
+smaller and the largest skill bodies 8-25% smaller.
+
+Every skill's `description` sits in the agent's system prompt for the whole
+session whether or not the skill runs, so the catalog was a ~3.5k-token
+standing tax on every scaffolded app. Descriptions are now one sentence of what
+the skill does plus its trigger phrases, and the biggest bodies (`/migrate-nextjs`,
+`/pracht-deploy`, `/pracht-debug`, `/pracht-scaffold`, `/add-db`, `/add-auth`,
+`/pre-deploy`, `/add-i18n`) drop duplicated preambles and trailing rule recaps.
+No skill loses a directive or a check. CI now enforces per-skill and
+catalog-wide budgets so the prose cannot creep back.

--- a/examples/docs/src/routes/docs/agent-skills.md
+++ b/examples/docs/src/routes/docs/agent-skills.md
@@ -25,6 +25,24 @@ The source of truth lives in the repo's [skills/ directory](https://github.com/J
 
 ---
 
+## Context Cost
+
+Installing the catalog is not free: an agent keeps every skill's `name` and `description` in its system prompt for the whole session, whether or not you invoke anything. The body of a `SKILL.md` is different — it is loaded only when you run `/<skill-name>`.
+
+Both are budgeted, and the budgets are enforced in CI:
+
+| Budget | Limit | Paid |
+| ------ | ----- | ---- |
+| One skill's `description` | 500 characters | Every session |
+| All 33 descriptions | 12,000 characters (~3k tokens) | Every session |
+| One `SKILL.md` | 20,000 bytes | Per invocation |
+
+So the whole catalog costs roughly 3k tokens of standing context, and a typical skill costs about 2k more when you actually run it. Descriptions are written as one sentence of what the skill does plus the phrases that should trigger it — the detail lives in the body, where you only pay for it on use.
+
+Installing a subset works fine if you want the bill smaller: each skill is a standalone file with no cross-file dependencies (see [Manual Install](#manual-install)).
+
+---
+
 ## Discovery Endpoint
 
 The skills are published following the [agent skills discovery RFC](https://github.com/cloudflare/agent-skills-discovery-rfc). A well-known manifest lists every skill with a canonical URL and a SHA-256 digest of its source:

--- a/skills/README.md
+++ b/skills/README.md
@@ -98,6 +98,13 @@ collide with other skill packs installed in the same app.
   without diffing first.
 - All skills end with `$ARGUMENTS` so the user can pass additional
   context at invocation time.
+- Skills are budgeted for context. A `description` is in the agent's system
+  prompt for every session whether the skill runs or not, so it is one sentence
+  of what the skill does plus the trigger phrases — nothing else — capped at 500
+  characters, with the catalog capped at 12,000. A body is loaded whole on
+  invocation and capped at 20,000 bytes: prefer tables over prose, drop
+  rationale that does not change what the agent does, and keep a trailing
+  `## Rules` section only for constraints the steps do not already state.
 - `skills/skills.test.ts` enforces these conventions in CI (frontmatter shape,
   `$ARGUMENTS`, tool policy, and that referenced CLI subcommands, MCP tools,
   and build-output paths actually exist).

--- a/skills/add-auth/SKILL.md
+++ b/skills/add-auth/SKILL.md
@@ -1,14 +1,12 @@
 ---
 name: add-auth
-version: 1.1.0
+version: 1.2.0
 description: |
-  Drop session-based auth into a pracht app following the framework's
-  recommended pattern (middleware checks the session, loaders read user info,
-  API routes mutate it). Generates session utilities, the auth middleware,
-  login/logout/signup API routes, and the matching `<Form>`-driven pages —
-  then wires the manifest with public vs. protected groups.
-  Use when asked to "add auth", "set up login", "wire authentication",
-  "add session middleware", or "I need users".
+  Wire session-based auth into a pracht app: session utilities, auth middleware,
+  login/logout/signup API routes, `<Form>` pages, and public vs. protected route
+  groups.
+  Use for "add auth", "set up login", "wire authentication", "add session
+  middleware", "I need users".
 allowed-tools:
   - Bash
   - Read
@@ -21,31 +19,29 @@ allowed-tools:
 
 # Pracht Add Auth
 
-Implements the auth pattern documented in
-`examples/docs/src/routes/docs/recipes-auth.md`. This skill stamps out the
-files; the user replaces `verifyCredentials()` with a real DB lookup.
+Stamps out the auth pattern documented in
+`examples/docs/src/routes/docs/recipes-auth.md`; the user replaces
+`verifyCredentials()` with a real DB lookup.
 
-If the pracht MCP server is registered (see docs/MCP.md), prefer its tools
-(`inspect_routes`, `inspect_api`, `inspect_build`, `doctor`, `verify`,
-`generate_*`) over shelling out. Prerequisite: `pracht inspect` needs a vite
-config with the pracht plugin registered.
+MCP: when the pracht MCP server is registered (docs/MCP.md), prefer its
+`inspect_routes`/`inspect_api`/`inspect_build`/`doctor`/`verify`/`generate_*`
+tools over shelling out. `pracht inspect` needs the pracht plugin in the vite
+config.
 
 ## Step 1: Confirm the scope
 
-Use `AskUserQuestion`:
+Use `AskUserQuestion` for:
 
-1. **What flavor?** Session cookie + email/password (default) OR magic link
-   OR OAuth (out of scope — recommend a separate skill / library).
-2. **Where do credentials live?** A DB the user already has, or no DB yet?
-   If no DB, recommend running `add-db` first.
-3. **Cookie posture for CSRF**: `SameSite=Lax` (default, recommended) vs.
-   `SameSite=Strict` vs. `SameSite=None` + token. (Cross-link `audit-csrf`.)
-
-This skill defaults to: session cookie + email/password + `SameSite=Lax`.
+1. **Flavor** — session cookie + email/password (default), magic link, or OAuth
+   (out of scope: recommend a dedicated library).
+2. **Where credentials live** — an existing DB, or none yet? If none, run
+   `/add-db` first.
+3. **Cookie posture** — `SameSite=Lax` (default, recommended), `Strict`, or
+   `None` + token. See `/audit-csrf`.
 
 ## Step 2: Session utilities
 
-`src/server/session.ts`:
+`src/server/session.ts` — HMAC-signed cookie payload:
 
 ```ts
 import { serverEnv } from "@pracht/core/env/server";
@@ -80,10 +76,10 @@ export function clearSessionCookie(): string {
 }
 
 async function getKey(usage: "sign" | "verify"): Promise<CryptoKey> {
-  // Read the secret INSIDE the function, never at module scope. On
-  // Cloudflare Workers env bindings only exist per request — a module-level
-  // `process.env.SESSION_SECRET` read (or throw) bricks the worker at import
-  // time. `serverEnv` resolves correctly per adapter (see docs/ENV.md).
+  // Read the secret INSIDE the function, never at module scope. On Cloudflare
+  // Workers env bindings only exist per request — a module-level read (or
+  // throw) bricks the worker at import time. `serverEnv` resolves correctly
+  // per adapter (docs/ENV.md).
   const secret = serverEnv.SESSION_SECRET;
   if (!secret) throw new Error("SESSION_SECRET is required");
   return crypto.subtle.importKey(
@@ -113,17 +109,17 @@ async function verify(data: string, signature: string): Promise<boolean> {
 }
 ```
 
-Notes:
 - `crypto.subtle` works in Node 18+, Cloudflare Workers, and Vercel Edge.
-- Signature verification goes through `crypto.subtle.verify`, which is a
-  constant-time comparison. Never compare signature strings with `===` — that
-  leaks timing information an attacker can use to forge signatures.
-- Drop `Secure` only if the user is on plain HTTP locally (recommend
-  conditionalizing on `NODE_ENV`).
+- Verification goes through `crypto.subtle.verify`, which compares in constant
+  time. Never compare signature strings with `===` — that leaks timing an
+  attacker can use to forge signatures.
+- Keep `HttpOnly`, `SameSite=Lax`, and `Secure` on the cookie. Drop `Secure`
+  only for plain-HTTP local dev, conditionalized on `NODE_ENV`.
 
 ## Step 3: Auth middleware
 
-`src/middleware/auth.ts`:
+`src/middleware/auth.ts` — a **Gate**: it short-circuits with a redirect rather
+than merely augmenting context (see `/audit-auth` for that distinction).
 
 ```ts
 import { redirect, type MiddlewareFn } from "@pracht/core";
@@ -141,10 +137,7 @@ export const middleware: MiddlewareFn = async ({ request, url }, next) => {
 };
 ```
 
-This is a **Gate** (short-circuits with a redirect on failure). Cross-reference
-`audit-auth` for the distinction between Gate and Augmenter.
-
-## Step 4: Login / logout API routes
+## Step 4: Auth API routes
 
 `src/api/auth/login.ts`:
 
@@ -158,23 +151,18 @@ export async function POST({ request }: ApiRouteArgs) {
   const password = String(form.get("password") ?? "");
   const requested = String(form.get("redirect") ?? "/dashboard");
 
-  // Enforce same-origin redirect (defense against open-redirect via form input).
+  // The redirect field is user input — gate it, or this is an open redirect.
   const safeRedirect = requested.startsWith("/") && !requested.startsWith("//")
     ? requested
     : "/dashboard";
 
   const user = await verifyCredentials(email, password);
   if (!user) {
-    // Redirect back to /login with an error flag — do NOT return a 401 JSON
-    // body. Pracht's <Form> only acts on 3xx responses (it follows the
-    // `location` header); a non-redirect response is silently ignored by the
-    // client, so the user would see nothing happen. The login page loader
-    // reads `?error=1` and renders the message.
+    // Redirect back with an error flag — do NOT return a 401 JSON body.
+    // Pracht's <Form> only acts on 3xx (it follows `location`); a non-redirect
+    // response is silently ignored and the user sees nothing happen.
     const back = new URLSearchParams({ error: "1", redirect: safeRedirect });
-    return new Response(null, {
-      status: 302,
-      headers: { location: `/login?${back}` },
-    });
+    return new Response(null, { status: 302, headers: { location: `/login?${back}` } });
   }
 
   const cookie = await createSessionCookie({ userId: user.id, email: user.email });
@@ -190,60 +178,26 @@ async function verifyCredentials(_email: string, _password: string) {
 }
 ```
 
-`src/api/auth/logout.ts`:
+`src/api/auth/logout.ts` — `POST` returning a 302 to `/` with
+`clearSessionCookie()` as `set-cookie`.
 
-```ts
-import type { ApiRouteArgs } from "@pracht/core";
-import { clearSessionCookie } from "../../server/session";
+`src/api/auth/signup.ts` — same shape as login: validate (`email` present,
+`password.length >= 8`), redirect to `/signup?error=1` on failure, otherwise
+hash the password, insert the user, and issue `createSessionCookie()` with a
+302 to `/dashboard`. Leave the hashing and insert as TODOs for the user.
 
-export async function POST(_args: ApiRouteArgs) {
-  return new Response(null, {
-    status: 302,
-    headers: { location: "/", "set-cookie": clearSessionCookie() },
-  });
-}
-```
+**Never ship the skeleton without real password hashing (argon2 or bcrypt).**
 
-`src/api/auth/signup.ts` (skeleton — user wires hashing + DB insert):
-
-```ts
-import type { ApiRouteArgs } from "@pracht/core";
-import { createSessionCookie } from "../../server/session";
-
-export async function POST({ request }: ApiRouteArgs) {
-  const form = await request.formData();
-  const email = String(form.get("email") ?? "").trim();
-  const password = String(form.get("password") ?? "");
-  if (!email || password.length < 8) {
-    // Same redirect-with-flag pattern as login — <Form> ignores non-3xx.
-    return new Response(null, {
-      status: 302,
-      headers: { location: "/signup?error=1" },
-    });
-  }
-  // TODO: hash password, insert user, set session.
-  const user = { id: crypto.randomUUID(), email };
-  const cookie = await createSessionCookie({ userId: user.id, email: user.email });
-  return new Response(null, {
-    status: 302,
-    headers: { location: "/dashboard", "set-cookie": cookie },
-  });
-}
-```
-
-## Step 5: Login & signup pages
+## Step 5: Login and signup pages
 
 `src/routes/login.tsx`:
 
 ```tsx
-import type { LoaderArgs, RouteComponentProps } from "@pracht/core";
-import { Form } from "@pracht/core";
+import { Form, type LoaderArgs, type RouteComponentProps } from "@pracht/core";
 
 export async function loader({ url }: LoaderArgs) {
   return {
     redirect: url.searchParams.get("redirect") ?? "/dashboard",
-    // Set by the login API route on failed credentials (see Step 4 — the
-    // API redirects back here because <Form> only acts on 3xx responses).
     error: url.searchParams.get("error") === "1",
   };
 }
@@ -272,17 +226,12 @@ Generate `signup.tsx` analogously, posting to `/api/auth/signup`.
 
 ## Step 6: Wire the manifest
 
-```ts
-import { defineApp, group, route } from "@pracht/core";
+Public routes in one group, protected routes in a group carrying the middleware:
 
+```ts
 export const app = defineApp({
-  shells: {
-    public: "./shells/public.tsx",
-    app: "./shells/app.tsx",
-  },
-  middleware: {
-    auth: "./middleware/auth.ts",
-  },
+  shells: { public: "./shells/public.tsx", app: "./shells/app.tsx" },
+  middleware: { auth: "./middleware/auth.ts" },
   routes: [
     group({ shell: "public" }, [
       route("/", "./routes/home.tsx", { render: "ssg" }),
@@ -291,56 +240,27 @@ export const app = defineApp({
     ]),
     group({ shell: "app", middleware: ["auth"] }, [
       route("/dashboard", "./routes/dashboard.tsx", { render: "ssr" }),
-      // any other protected routes…
     ]),
   ],
 });
 ```
 
-If the project already has `defineApp({...})`, merge — preserve existing
-shells/middleware/routes.
+If the project already has a `defineApp({...})`, merge into it — preserve the
+existing shells, middleware, and routes.
 
-## Step 7: Env vars
+## Step 7: Env
 
-Add to `.env.example`:
-
-```
-SESSION_SECRET=<generate with: openssl rand -base64 32>
-```
-
-Confirm `.env*` is gitignored.
+Add `SESSION_SECRET=<generate with: openssl rand -base64 32>` to
+`.env.example`, and confirm `.env*` is gitignored.
 
 ## Step 8: Verify
 
-- Step 6 added routes — run `pracht typegen` to refresh
-  `src/pracht.d.ts` / `src/pracht-routes.ts` (use
-  `pracht typegen --check` in CI).
-- `pracht dev`, navigate to `/dashboard` → redirects to
-  `/login?redirect=%2Fdashboard`.
-- After successful login, lands on `/dashboard`. After a failed login, lands
-  back on `/login?error=1` with the error message rendered.
-- Logout posts to `/api/auth/logout` and clears the cookie.
-- Run `pnpm test` and `pnpm e2e`.
-- Run `pracht verify --json` and confirm no failures.
-- Run `audit-csrf` and `audit-auth` after wiring to confirm posture.
-
-## Rules
-
-1. Always set `HttpOnly`, `SameSite=Lax`, `Secure` on the session cookie.
-2. The login form's `redirect` input is user-supplied — gate it server-side
-   (`startsWith('/')` AND `!startsWith('//')`). Otherwise this is an open
-   redirect.
-3. `verifyCredentials` is a placeholder — never ship the skeleton without
-   real password hashing (argon2 or bcrypt).
-4. Read `SESSION_SECRET` via `serverEnv` (from `@pracht/core/env/server`)
-   inside the signing/verifying functions and fail loudly there if missing.
-   Never read or validate it at module scope — on Cloudflare Workers env
-   bindings only exist per request, so a module-level throw bricks the worker
-   at import time.
-5. Failed form posts must answer with a 3xx redirect carrying an error flag —
-   `<Form>` ignores non-redirect responses, so 4xx JSON bodies are invisible
-   to the user.
-6. After wiring, recommend running `audit-auth` to confirm protected routes
-   are gated and `audit-csrf` for CSRF posture.
+- `pracht typegen` (step 6 added routes); `pracht typegen --check` in CI.
+- In `pracht dev`: `/dashboard` redirects to `/login?redirect=%2Fdashboard`; a
+  successful login lands on `/dashboard`; a failed one lands back on
+  `/login?error=1` with the message rendered; logout posts to
+  `/api/auth/logout` and clears the cookie.
+- `pnpm test`, `pnpm e2e`, and `pracht verify --json` all pass.
+- Run `/audit-auth` and `/audit-csrf` to confirm the resulting posture.
 
 $ARGUMENTS

--- a/skills/add-capabilities/SKILL.md
+++ b/skills/add-capabilities/SKILL.md
@@ -1,16 +1,13 @@
 ---
 name: add-capabilities
-version: 1.0.0
+version: 1.0.1
 description: |
-  Expose an app operation as a typed pracht capability: one contract (JSON
-  Schema input/output, effect class, named middleware, server-only `run()`)
-  projected into direct server invocation, an HTTP endpoint, a WebMCP page
-  tool, and a remote MCP tool. Wires `@pracht/capabilities`, the manifest
-  registration, `defineApp({ agents })` (Web Bot Auth, confirmation,
-  remote MCP), typed clients, `<Form capability>`, and `pracht eval` scenarios.
-  Use when asked to "add a capability", "expose this to agents", "add an MCP
-  tool", "make my app agent-callable", "add WebMCP", "serve remote MCP", or
-  "let an agent create a note".
+  Expose an app operation as a typed pracht capability — one contract projected
+  into direct server calls, an HTTP endpoint, a WebMCP page tool, and a remote MCP
+  tool — plus `defineApp({ agents })` trust config, typed clients,
+  `<Form capability>`, and `pracht eval` scenarios.
+  Use for "add a capability", "expose this to agents", "add an MCP tool", "add
+  WebMCP", "serve remote MCP", "make my app agent-callable".
 allowed-tools:
   - Bash
   - Read

--- a/skills/add-content/SKILL.md
+++ b/skills/add-content/SKILL.md
@@ -1,16 +1,12 @@
 ---
 name: add-content
-version: 1.0.0
+version: 1.0.1
 description: |
-  Wire `@pracht/content` (and the official `@pracht/markdown` compiler) into a
-  pracht app: one collection registry that owns source discovery, routes,
-  locales, compilation, static artifacts (`llms.txt`, raw source), and the
-  server-only runtime snapshot loaders and capabilities read. Covers Markdown
-  and MDX route modules, relative-image handling, route reconciliation, and the
-  Cloudflare chunking requirements.
-  Use when asked to "add a blog", "set up docs", "render markdown pages",
-  "add MDX", "content collections", "publish llms.txt from my content", or
-  "why is my markdown route 404ing".
+  Wire `@pracht/content` and `@pracht/markdown`: a collection registry owning
+  source discovery, routes, locales, compilation, and static artifacts
+  (`llms.txt`, raw source), plus Markdown/MDX route modules and snapshot loaders.
+  Use for "add a blog", "set up docs", "render markdown pages", "add MDX",
+  "content collections", "why is my markdown route 404ing".
 allowed-tools:
   - Bash
   - Read

--- a/skills/add-db/SKILL.md
+++ b/skills/add-db/SKILL.md
@@ -1,14 +1,12 @@
 ---
 name: add-db
-version: 1.1.0
+version: 1.2.0
 description: |
-  Wire Drizzle ORM into a pracht app. Asks the user which database to target
-  (Cloudflare D1, PlanetScale, Neon, Supabase, Turso, Postgres, MySQL, SQLite,
-  ...) and generates the matching driver setup, schema scaffold, migration
-  workflow, and a typed client accessible from loaders, middleware, and API
-  routes.
-  Use when asked to "add database", "set up Drizzle", "wire D1",
-  "add Postgres", "set up an ORM", or "I need a DB".
+  Wire Drizzle ORM into a pracht app: pick the target (D1, PlanetScale, Neon,
+  Supabase, Turso, Postgres, MySQL, SQLite), then generate driver setup, schema,
+  migration workflow, and a typed client for loaders, middleware, and API routes.
+  Use for "add database", "set up Drizzle", "wire D1", "add Postgres", "set up an
+  ORM", "I need a DB".
 allowed-tools:
   - Bash
   - Read
@@ -21,60 +19,47 @@ allowed-tools:
 
 # Pracht Add Database (Drizzle)
 
-Drizzle works well in pracht because it is small, type-safe, and runs in
-both Node and edge runtimes (Cloudflare Workers, Vercel Edge). This skill
-sets up the driver, schema directory, migration tooling, and a client
-factory wired to the project's adapter.
+Drizzle suits pracht because it is small, type-safe, and runs in both Node and
+edge runtimes. This skill sets up the driver, schema, migration tooling, and a
+client factory wired to the project's adapter. Never overwrite an existing
+`drizzle.config.ts`, `wrangler.toml`, or `package.json` script — diff, merge,
+and ask about collisions.
+
+MCP: when the pracht MCP server is registered (docs/MCP.md), prefer its
+`inspect_routes`/`inspect_api`/`inspect_build`/`doctor`/`verify`/`generate_*`
+tools over shelling out. `pracht inspect` needs the pracht plugin in the vite
+config; `inspect build` needs a prior `pracht build`.
 
 ## Step 1: Pick the target
 
-Use `AskUserQuestion`:
+Ask with `AskUserQuestion`, then **cross-check against the project's adapter**
+(`pracht inspect build --json`) and flag mismatches — `node-postgres` on
+Cloudflare Workers will not work.
 
-| Provider           | Driver                                   | Adapter notes                |
-| ------------------ | ---------------------------------------- | ---------------------------- |
-| Cloudflare D1      | `drizzle-orm/d1`                         | Workers binding              |
-| Cloudflare Hyperdrive (Postgres) | `drizzle-orm/postgres-js` or `node-postgres` | Workers binding |
-| PlanetScale        | `drizzle-orm/planetscale-serverless`     | Works on Node + edge         |
-| Neon (Postgres)    | `drizzle-orm/neon-serverless` or `neon-http` | Works on Node + edge     |
-| Supabase Postgres  | `drizzle-orm/postgres-js`                | Node + edge (HTTP variant)   |
-| Turso (libSQL)     | `drizzle-orm/libsql`                     | Node + edge                  |
-| Vanilla Postgres   | `drizzle-orm/node-postgres`              | Node only                    |
-| Vanilla MySQL      | `drizzle-orm/mysql2`                     | Node only                    |
-| SQLite (better-sqlite3) | `drizzle-orm/better-sqlite3`        | Node only                    |
-
-If the pracht MCP server is registered (see docs/MCP.md), prefer its tools
-(`inspect_routes`, `inspect_api`, `inspect_build`, `doctor`, `verify`,
-`generate_*`) over shelling out. Prerequisites: `pracht inspect` needs a vite
-config with the pracht plugin; `pracht inspect build` reads artifacts from a
-prior `pracht build`.
-
-Cross-check with the project's pracht adapter (`pracht inspect build --json`):
-flag mismatches (e.g., `node-postgres` on Cloudflare Workers — won't work).
-
-## Step 2: Install
+| Provider                         | Driver import                                | Extra package | Runtimes |
+| -------------------------------- | -------------------------------------------- | ------------- | -------- |
+| Cloudflare D1                    | `drizzle-orm/d1`                             | — (Workers binding) | Edge |
+| Cloudflare Hyperdrive (Postgres) | `drizzle-orm/postgres-js` or `node-postgres` | `postgres` / `pg` | Edge (binding) |
+| PlanetScale                      | `drizzle-orm/planetscale-serverless`         | `@planetscale/database` | Node + edge |
+| Neon                             | `drizzle-orm/neon-serverless` or `neon-http` | `@neondatabase/serverless` | Node + edge |
+| Supabase Postgres                | `drizzle-orm/postgres-js`                    | `postgres` | Node + edge (HTTP) |
+| Turso (libSQL)                   | `drizzle-orm/libsql`                         | `@libsql/client` | Node + edge |
+| Vanilla Postgres                 | `drizzle-orm/node-postgres`                  | `pg` + `-D @types/pg` | Node only |
+| Vanilla MySQL                    | `drizzle-orm/mysql2`                         | `mysql2` | Node only |
+| SQLite                           | `drizzle-orm/better-sqlite3`                 | `better-sqlite3` + `-D @types/better-sqlite3` | Node only |
 
 ```bash
-pnpm add drizzle-orm <driver>
+pnpm add drizzle-orm <driver-package>
 pnpm add -D drizzle-kit
 ```
 
-Specific drivers:
+## Step 2: Schema
 
-- D1: no additional package; uses the Workers binding.
-- PlanetScale: `pnpm add @planetscale/database`.
-- Neon: `pnpm add @neondatabase/serverless`.
-- Postgres / Supabase: `pnpm add postgres` (postgres-js).
-- Turso: `pnpm add @libsql/client`.
-- node-postgres: `pnpm add pg && pnpm add -D @types/pg`.
-- mysql2: `pnpm add mysql2`.
-- better-sqlite3: `pnpm add better-sqlite3 && pnpm add -D @types/better-sqlite3`.
-
-## Step 3: Schema directory
-
-`src/db/schema.ts`:
+`src/db/schema.ts` — `pgTable` from `drizzle-orm/pg-core`, `sqliteTable` from
+`drizzle-orm/sqlite-core` (D1 and SQLite), or `mysqlTable` from
+`drizzle-orm/mysql-core`:
 
 ```ts
-// Postgres example — substitute sqliteTable / mysqlTable for other dialects.
 import { pgTable, serial, text, timestamp } from "drizzle-orm/pg-core";
 
 export const users = pgTable("users", {
@@ -84,15 +69,20 @@ export const users = pgTable("users", {
 });
 ```
 
-For D1/SQLite, use `sqliteTable` from `drizzle-orm/sqlite-core`. For MySQL,
-use `mysqlTable` from `drizzle-orm/mysql-core`.
+## Step 3: Client factory
 
-## Step 4: Client factory
+Read connection strings via `serverEnv` from `@pracht/core/env/server`, never
+`process.env` — it keeps the secret out of the client bundle and resolves per
+adapter (docs/ENV.md). The shape depends on the runtime:
 
-`src/db/client.ts`:
+- **Node, persistent process** — a module-level singleton is fine, because
+  `serverEnv` works at module top level there.
+- **Edge with per-request context (Cloudflare, Vercel Edge)** — read
+  `serverEnv` or the binding *inside* a factory. Workers env bindings only
+  exist per request, so a module-level read bricks the worker at import time.
 
 ```ts
-// Example for Postgres on Node:
+// src/db/client.ts — Postgres on Node
 import { serverEnv } from "@pracht/core/env/server";
 import { drizzle } from "drizzle-orm/node-postgres";
 import { Pool } from "pg";
@@ -102,15 +92,8 @@ const pool = new Pool({ connectionString: serverEnv.DATABASE_URL });
 export const db = drizzle(pool, { schema });
 ```
 
-Read the connection string via `serverEnv` (from `@pracht/core/env/server`),
-never `process.env` — it keeps the secret out of the client bundle and
-resolves per adapter (see docs/ENV.md). The module-level singleton above is
-fine on the Node adapter, where `serverEnv` works at module top level; on
-Cloudflare/Vercel Edge, read `serverEnv` inside a factory function instead —
-Workers env bindings only exist per request.
-
-For Cloudflare D1, first register the Cloudflare context type once via the
-`Register` augmentation (the pattern the docs recommend — see
+For Cloudflare D1, register the Cloudflare context type once via the `Register`
+augmentation (the pattern in
 `examples/docs/src/routes/docs/recipes-fullstack-cloudflare.md`):
 
 ```ts
@@ -125,37 +108,26 @@ declare module "@pracht/core" {
 }
 ```
 
-Then the factory needs no per-file generics:
+The factory then needs no per-file generics:
 
 ```ts
+import type { LoaderArgs } from "@pracht/core";
 import { drizzle } from "drizzle-orm/d1";
 import * as schema from "./schema";
-import type { LoaderArgs } from "@pracht/core";
 
 export function getDb({ context }: Pick<LoaderArgs, "context">) {
   return drizzle(context.env.DB, { schema });
 }
 ```
 
-(Without the `Register` augmentation, the inline generic must describe the
-full Cloudflare context shape —
+Without that augmentation, the inline generic must describe the full context —
 `LoaderArgs<{ env: { DB: D1Database }; executionContext: ExecutionContext }>` —
-the context is `{ env, executionContext }`, not the bindings object itself.)
+because the context is `{ env, executionContext }`, not the bindings object.
 
-For PlanetScale / Neon / Turso, follow the matching driver pattern. The
-pattern is:
+## Step 4: drizzle.config.ts and scripts
 
-- **Node + persistent process**: module-level singleton.
-- **Edge + per-request context (Cloudflare/Vercel Edge)**: factory called
-  with `context` inside the loader.
-
-## Step 5: `drizzle.config.ts`
-
-If `drizzle.config.ts` already exists, diff and merge — never overwrite.
-(`process.env` is fine here: this file runs under the drizzle-kit CLI on
-Node, never inside the worker.)
-
-### Non-D1 providers (Postgres, MySQL, Turso, PlanetScale, Neon, local SQLite)
+`process.env` *is* fine in `drizzle.config.ts`: it runs under the drizzle-kit
+CLI on Node, never inside the worker.
 
 ```ts
 import { defineConfig } from "drizzle-kit";
@@ -164,74 +136,44 @@ export default defineConfig({
   schema: "./src/db/schema.ts",
   out: "./drizzle/migrations",
   dialect: "postgresql", // or "sqlite" / "mysql"
-  dbCredentials: {
-    url: process.env.DATABASE_URL!,
-  },
+  dbCredentials: { url: process.env.DATABASE_URL! },
 });
 ```
 
-### Cloudflare D1
+**D1 is the exception.** It has no TCP endpoint, so drizzle-kit can only
+*generate* migrations — applying goes through `wrangler`. Omit `dbCredentials`
+entirely (add a `driver: "d1-http"` block with Cloudflare account/database/API
+token only if you want `drizzle-kit studio`), and omit `db:push`: the
+migrations-apply flow is the only supported path. Split local from remote so
+the miniflare D1 can be iterated without touching production.
 
-D1 has no TCP endpoint, so drizzle-kit can only *generate* migrations. It
-cannot apply them — applying goes through `wrangler` (Step 6):
+| Script | Non-D1 | Cloudflare D1 |
+| ------ | ------ | ------------- |
+| `db:generate` | `drizzle-kit generate` | `drizzle-kit generate` |
+| `db:migrate` | `drizzle-kit migrate` | `wrangler d1 migrations apply <db-name> --local` / `--remote` as `db:migrate:local` / `db:migrate:remote` |
+| `db:push` | `drizzle-kit push` (local dev only — prefer migrations beyond that) | *omit* |
+| `db:studio` | `drizzle-kit studio` | `drizzle-kit studio` |
 
-```ts
-import { defineConfig } from "drizzle-kit";
+`<db-name>` is the `database_name` from `wrangler.toml`/`.jsonc`.
 
-export default defineConfig({
-  schema: "./src/db/schema.ts",
-  out: "./drizzle/migrations",
-  dialect: "sqlite",
-});
-```
+## Step 5: Bindings and env
 
-If you want `drizzle-kit studio` against D1, add a `driver: "d1-http"` block
-with Cloudflare account/database/API-token credentials (see Drizzle's D1
-docs). Otherwise omit `dbCredentials` entirely — `drizzle-kit generate`
-doesn't need them.
+- **Cloudflare D1** — merge the binding into `wrangler.toml`/`.jsonc`.
+  `migrations_dir` must match `out` in `drizzle.config.ts` or wrangler will not
+  find the SQL drizzle-kit emits:
 
-## Step 6: Scripts
+  ```toml
+  [[d1_databases]]
+  binding = "DB"
+  database_name = "my-app"
+  database_id = "<id>"
+  migrations_dir = "drizzle/migrations"
+  ```
 
-Merge these into the existing `package.json` `scripts` block — never
-overwrite scripts that already exist; diff and ask if one collides.
+- **Node / Vercel** — document `DATABASE_URL` in `.env.example`, and add
+  `.env*` to `.gitignore` if it is missing.
 
-### Non-D1 providers
-
-```json
-{
-  "scripts": {
-    "db:generate": "drizzle-kit generate",
-    "db:migrate":  "drizzle-kit migrate",
-    "db:push":     "drizzle-kit push",
-    "db:studio":   "drizzle-kit studio"
-  }
-}
-```
-
-### Cloudflare D1
-
-`drizzle-kit migrate` does not work against D1 (no TCP). Apply migrations
-via `wrangler d1 migrations apply <db-name>`, split into local vs remote so
-you can iterate safely against the miniflare D1 before touching production:
-
-```json
-{
-  "scripts": {
-    "db:generate":      "drizzle-kit generate",
-    "db:migrate:local": "wrangler d1 migrations apply <db-name> --local",
-    "db:migrate:remote": "wrangler d1 migrations apply <db-name> --remote",
-    "db:studio":        "drizzle-kit studio"
-  }
-}
-```
-
-Replace `<db-name>` with the `database_name` from `wrangler.toml`/`.jsonc`.
-Omit `db:push` for D1 — the migrations-apply flow is the only supported
-path.
-
-## Step 7: Use in a loader
-
-Demonstrate the wired-up usage:
+## Step 6: Use it in a loader
 
 ```ts
 import type { LoaderArgs } from "@pracht/core";
@@ -240,77 +182,26 @@ import { users } from "../db/schema";
 
 export async function loader(_args: LoaderArgs) {
   const rows = await db.select().from(users).limit(20);
-  return { users: rows.map(u => ({ id: u.id, email: u.email })) };
+  return { users: rows.map((u) => ({ id: u.id, email: u.email })) };
 }
 ```
 
-Note: explicit projection — never spread DB rows into loader return values
-(see `audit-secrets`).
+Project explicitly — never spread DB rows into loader return values, since
+everything returned crosses the wire (see `/audit-secrets`).
 
-## Step 8: Bindings & env vars
-
-- For Cloudflare adapters with D1: add the binding to `wrangler.toml` (or
-  `wrangler.jsonc`). If the file already exists, diff and merge the binding
-  in — never overwrite the existing config. `migrations_dir` must match the
-  `out` in `drizzle.config.ts` so wrangler finds the SQL drizzle-kit emits:
-  ```toml
-  [[d1_databases]]
-  binding = "DB"
-  database_name = "my-app"
-  database_id = "<id>"
-  migrations_dir = "drizzle/migrations"
-  ```
-- For Node/Vercel: document `DATABASE_URL` in `.env.example`. Add `.env*` to
-  `.gitignore` if missing.
-
-## Step 9: Verify
-
-Non-D1:
+## Step 7: Verify
 
 ```bash
 pnpm db:generate
-pnpm db:push   # or db:migrate after creating one
-```
-
-D1:
-
-```bash
-pnpm db:generate
-pnpm db:migrate:local   # apply to miniflare D1
-# when happy:
-pnpm db:migrate:remote  # apply to production D1
-```
-
-Then:
-
-```bash
+pnpm db:push            # non-D1; or db:migrate once a migration exists
+pnpm db:migrate:local   # D1 — then db:migrate:remote when happy
 pracht verify --json
 pnpm test
 ```
 
-Note: on a fresh project `pnpm test` is a no-op (no tests exist yet) — it
-proves nothing about the DB wiring. Suggest a loader smoke test that calls
-the Step 7 loader with a real (local) DB and asserts on the returned shape,
-or run `scaffold-tests` to set that up.
-
-## Rules
-
-1. Always confirm the adapter ↔ driver compatibility before installing.
-2. Never spread DB rows into loader return values — project explicitly.
-3. For edge runtimes, do not module-cache a connection — use a factory keyed
-   by `context.env`.
-4. In app code, read connection strings via `serverEnv` from
-   `@pracht/core/env/server`, not `process.env`; on Cloudflare, read it
-   inside functions only. (Exception: `drizzle.config.ts` runs under the
-   drizzle-kit CLI on Node, where `process.env` is fine.)
-5. Add `.env*` to `.gitignore` if a connection string is involved.
-6. Recommend a migration workflow (`db:migrate`) over `db:push` for
-   anything beyond local dev.
-7. For D1, apply migrations with `wrangler d1 migrations apply`, not
-   `drizzle-kit migrate` — D1 exposes no TCP endpoint and drizzle-kit will
-   silently fail to connect. Split into `db:migrate:local` and
-   `db:migrate:remote` so the local miniflare DB can be iterated without
-   touching production. Ensure `migrations_dir` in `wrangler.toml` matches
-   `out` in `drizzle.config.ts`.
+On a fresh project `pnpm test` is a no-op and proves nothing about the DB
+wiring. Suggest a loader smoke test that calls the Step 6 loader against a real
+local DB and asserts the returned shape, or run `/scaffold-tests` to set that
+up.
 
 $ARGUMENTS

--- a/skills/add-i18n/SKILL.md
+++ b/skills/add-i18n/SKILL.md
@@ -1,18 +1,13 @@
 ---
 name: add-i18n
-version: 2.1.0
+version: 2.2.0
 description: |
-  Wire internationalization into a pracht app with the first-party
-  `@pracht/i18n` package, following the framework's recommended pattern
-  (middleware detects locale, loaders return translations, components
-  consume via route data). Sets up the i18n instance, lazy locale
-  dictionaries with typed keys, the detection middleware (URL-prefix,
-  cookie, and `Accept-Language`), and either strategy: locale-prefixed
-  route groups with hreflang metadata, or one URL per page with a
-  cookie-backed switcher that changes no URLs.
-  Use when asked to "add i18n", "set up translations", "make my app
-  multilingual", "add locale routing", "switch language without changing
-  URLs", or "extract strings".
+  Wire `@pracht/i18n`: locale-detection middleware (URL prefix, cookie,
+  `Accept-Language`), lazy typed dictionaries, and either strategy —
+  locale-prefixed route groups with hreflang, or one URL per page with a
+  cookie-backed switcher.
+  Use for "add i18n", "set up translations", "make my app multilingual", "add
+  locale routing", "switch language without changing URLs", "extract strings".
 allowed-tools:
   - Bash
   - Read
@@ -25,74 +20,60 @@ allowed-tools:
 
 # Pracht Add i18n
 
-Pracht ships its i18n primitives as `@pracht/i18n`: locale-detection
-middleware, lazy dictionaries with keys typed from the default locale,
-`t()`/`tPlural()` (plurals via `Intl.PluralRules`), `localePath()`, and an
-`hreflang()` helper for `head()`. The full guide lives at
-`examples/docs/src/routes/docs/recipes-i18n.md`; working setups are in
-`examples/basic` — locale-prefixed (`/welcome`, `/en/welcome`,
-`/nl/welcome`) and prefix-free (`/greeting`, `src/api/locale.ts`). That page
-also keeps a hand-rolled fallback recipe if the user refuses the dependency.
+`@pracht/i18n` ships locale-detection middleware, lazy dictionaries with keys
+typed from the default locale, `t()`/`tPlural()` (plurals via
+`Intl.PluralRules`), `localePath()`, and `hreflang()` for `head()`. Full guide:
+`examples/docs/src/routes/docs/recipes-i18n.md` — which also carries a
+hand-rolled fallback recipe if the user refuses the dependency. Working setups
+live in `examples/basic`, both locale-prefixed (`/welcome`, `/en/welcome`,
+`/nl/welcome`) and prefix-free (`/greeting`, `src/api/locale.ts`).
 
-If the pracht MCP server is registered (see docs/MCP.md), prefer its tools
-(`inspect_routes`, `inspect_api`, `inspect_build`, `doctor`, `verify`,
-`generate_*`) over shelling out. Prerequisite: `pracht inspect` needs a vite
-config with the pracht plugin registered.
+MCP: when the pracht MCP server is registered (docs/MCP.md), prefer its
+`inspect_routes`/`inspect_api`/`inspect_build`/`doctor`/`verify`/`generate_*`
+tools over shelling out. `pracht inspect` needs the pracht plugin in the vite
+config.
 
 ## Step 1: Pick locales and a URL strategy
 
-Use `AskUserQuestion` once for: supported locales (default: `en` plus one or
-two more), the default locale, and the **URL strategy**:
+Use `AskUserQuestion` once for the supported locales (default `en` plus one or
+two), the default locale, and the URL strategy:
 
-- **A. Locale-prefixed URLs** (`/en/about`) — the default for public,
-  indexable content: each language is its own URL, `hreflang()` works, and
-  routes can stay `ssg`/`isg`. Adopting it changes every URL.
-- **B. One URL per page** (`/about`) — for an existing site whose URLs
-  cannot move, or an app behind a login where indexing does not matter. The
-  cookie decides the locale, switching needs no navigation, and no URL
-  changes. Cost: `Vary: Cookie, Accept-Language` makes those routes
-  per-request (`ssr`/`spa`, never `ssg`/`isg`) and a single URL cannot carry
-  hreflang alternates.
+| | **A. Locale-prefixed** (`/en/about`) | **B. One URL per page** (`/about`) |
+| --- | --- | --- |
+| Use when | Public, indexable content | URLs cannot move, or the app is behind a login |
+| Locale from | The path | The cookie — switching needs no navigation |
+| Render modes | Any, including `ssg`/`isg` | `ssr`/`spa` only (`Vary: Cookie, Accept-Language`) |
+| hreflang | Works | Impossible — one URL cannot carry alternates |
+| Cost | Changes every URL | One indexed language |
 
-Ask explicitly if the user already has a live site — never migrate an
-existing app's URLs without saying so. Both strategies can coexist in one
-app on one instance.
-
-Keep the default detection order `["path", "cookie", "header"]` in both
-cases (the path source simply never matches a prefix-free route); only
-change it when the user explicitly wants cookie-only or header-only
-detection.
-
-Install the package:
+Never migrate a live app's URLs without saying so explicitly. Both strategies
+can coexist in one app. Keep the default detection order
+`["path", "cookie", "header"]` either way — the path source simply never
+matches a prefix-free route — and change it only for an explicit cookie-only
+or header-only request.
 
 ```bash
 npm install @pracht/i18n
 ```
 
-## Step 2: The i18n instance and dictionaries
+## Step 2: Instance and dictionaries
 
 ```ts
 // src/i18n/index.ts
 import { createDictionaries, defineI18n } from "@pracht/i18n";
 
-export const i18n = defineI18n({
-  locales: ["en", "fr"],
-  defaultLocale: "en",
-});
+export const i18n = defineI18n({ locales: ["en", "fr"], defaultLocale: "en" });
 
 export type AppLocale = (typeof i18n.locales)[number];
 
 export const dictionaries = createDictionaries(
-  {
-    en: () => import("./locales/en.ts"),
-    fr: () => import("./locales/fr.ts"),
-  },
+  { en: () => import("./locales/en.ts"), fr: () => import("./locales/fr.ts") },
   { defaultLocale: "en" },
 );
 ```
 
-One dictionary module per locale — flat string keys, default export,
-`as const` so key typing works:
+One dictionary module per locale — flat string keys, default export, `as const`
+so key typing works:
 
 ```ts
 // src/i18n/locales/en.ts
@@ -103,10 +84,10 @@ export default {
 } as const;
 ```
 
-Plural keys declare one entry per `Intl.PluralRules` category the locale
-needs (`.one`, `.other`, plus `.few`/`.many` for e.g. Polish); `tPlural()`
-falls back to `.other`. Non-default locales may omit keys — `load()` merges
-the default locale underneath.
+Plural keys declare one entry per `Intl.PluralRules` category the locale needs
+(`.one`, `.other`, plus `.few`/`.many` for e.g. Polish); `tPlural()` falls back
+to `.other`. Non-default locales may omit keys — `load()` merges the default
+locale underneath.
 
 ## Step 3: Detection middleware
 
@@ -117,18 +98,18 @@ import { i18n } from "../i18n/index.ts";
 export const middleware = i18n.middleware;
 ```
 
-The middleware sets `context.locale` and persists URL-prefix choices in a
-`SameSite=Lax` cookie — but only on per-request (SSR/SPA) routes: SSG/ISG
-output is stored and replayed to every visitor, so the middleware never
-attaches `Set-Cookie` there (a baked-in cookie would fail the prerender
-build and block ISG revalidation). It also appends `Vary: Cookie` /
-`Accept-Language` when those sources were consulted. Path-resolved SSR/SPA
-responses vary on `Cookie` too, because the presence of their persistence
+It sets `context.locale`, persists URL-prefix choices in a `SameSite=Lax`
+cookie, and appends `Vary: Cookie` / `Accept-Language` for whichever sources it
+consulted. Persistence happens only on per-request (SSR/SPA) routes: SSG/ISG
+output is stored and replayed to every visitor, so a baked-in `Set-Cookie`
+would fail the prerender build and block ISG revalidation. Path-resolved
+SSR/SPA responses still vary on `Cookie`, because whether they carry that
 `Set-Cookie` depends on the incoming cookie; path-only SSG/ISG output stays
-keyed solely by URL. Type the context once via the Register pattern:
+keyed solely by URL. Cookie config stays browser-valid — `SameSite=None` always
+forces `Secure`, even if an option tries to disable it.
 
-Cookie configuration stays browser-valid: `SameSite=None` always forces
-`Secure`, even if an explicit option attempts to disable it.
+Type the context once via the Register pattern, intersecting with the app's
+existing registered context type if it has one:
 
 ```ts
 // src/env.d.ts
@@ -141,16 +122,11 @@ declare module "@pracht/core" {
 }
 ```
 
-Intersect with the existing registered context type if the app already has
-one.
+## Step 4A: Manifest — locale-prefixed URLs
 
-## Step 4: Wire the manifest
-
-### Strategy A — locale-prefixed URLs
-
-One `pathPrefix` group per locale — only registered locales produce URLs, so
-`/zz/about` 404s instead of serving duplicate default-locale content (never
-use a `/:locale` param route for this; it matches any first segment):
+One `pathPrefix` group per locale, so only registered locales produce URLs and
+`/zz/about` 404s instead of serving duplicate default-locale content. Never use
+a `/:locale` param route for this — it matches any first segment.
 
 ```ts
 import { defineApp, group, route } from "@pracht/core";
@@ -172,15 +148,10 @@ export const app = defineApp({
 });
 ```
 
-Notes:
-
-- Reusing one `localizedRoutes` array is fine with auto-generated ids; if
-  the app sets explicit `id`s, each locale's copy needs unique ids.
-- The unprefixed detector redirects using what the middleware resolved.
-  `return` the redirect — a *thrown* Response short-circuits past the
-  middleware chain, so the i18n middleware could not stamp
-  `Vary: Cookie, Accept-Language` on it (a shared cache could then replay
-  one visitor's locale redirect to everyone):
+The unprefixed detector redirects using what the middleware resolved. **`return`
+the redirect** — a *thrown* Response short-circuits past the middleware chain,
+so the i18n middleware could not stamp `Vary: Cookie, Accept-Language` on it,
+and a shared cache could replay one visitor's locale redirect to everyone:
 
 ```ts
 // src/routes/locale-redirect.tsx
@@ -196,28 +167,28 @@ export function Component() {
 }
 ```
 
-- Route matching is exact: locale prefixes are lowercase URLs; build links
-  with `i18n.localePath()` so they always come out canonical. It resolves
-  literal and encoded dot segments before prefixing, so even a path assembled
-  from user input cannot escape the locale namespace during browser URL
-  normalization.
-- If localized routes are SSG/ISG, their stored response cannot safely carry
-  a visitor-specific `Set-Cookie`. In a hydrated component shared by those
-  routes, persist the explicit prefix with
-  `useEffect(() => { i18n.setLocaleCookie(data.locale); }, [data.locale])` so the
-  SSR detector remembers it later. This is harmless on SSR pages. Without
-  JavaScript, remembering a prerendered visit requires SSR or platform edge
-  middleware before static asset serving.
+- Reusing one `localizedRoutes` array is fine with auto-generated ids; with
+  explicit `id`s, each locale's copy needs unique ones.
+- Route matching is exact and locale prefixes are lowercase — build links with
+  `i18n.localePath()` so they come out canonical. It resolves literal and
+  encoded dot segments before prefixing, so a path assembled from user input
+  cannot escape the locale namespace during browser URL normalization.
+- SSG/ISG localized routes cannot carry a visitor-specific `Set-Cookie`. In a
+  hydrated component shared by those routes, persist the prefix with
+  `useEffect(() => { i18n.setLocaleCookie(data.locale); }, [data.locale])` so
+  the SSR detector remembers it later (harmless on SSR pages). Without
+  JavaScript, remembering a prerendered visit needs SSR or platform edge
+  middleware ahead of static asset serving.
 
-### Strategy B — one URL per page
+## Step 4B: Manifest — one URL per page
 
-Nothing about the routes changes: add the middleware to the group and skip
-the prefix groups and the detector route entirely. Detection falls to the
-cookie, then `Accept-Language`; the middleware adds
-`Vary: Cookie, Accept-Language`, so keep those routes `ssr`/`spa`.
+Nothing about the routes changes: add the middleware to the group, skip the
+prefix groups and the detector route. Detection falls to the cookie, then
+`Accept-Language`, and the `Vary: Cookie, Accept-Language` header keeps those
+routes `ssr`/`spa`.
 
-Because no URL prefix ever signals an explicit choice, the *switcher* writes
-the cookie. Generate an API route (works with JavaScript disabled):
+Because no URL prefix ever signals an explicit choice, the switcher writes the
+cookie. Generate an API route so it works with JavaScript disabled:
 
 ```ts
 // src/api/locale.ts
@@ -242,8 +213,7 @@ export async function POST({ request, url }: BaseRouteArgs) {
   if (!i18n.isLocale(locale)) return new Response("Unknown locale", { status: 400 });
 
   // Parse `next` before trusting it: URL normalization can expose an origin.
-  const next = form.get("next");
-  const target = sameOriginPath(next, url, "/");
+  const target = sameOriginPath(form.get("next"), url, "/");
 
   const response = redirect(target, { request, status: 303 });
   response.headers.append("set-cookie", i18n.localeCookie(locale, { url }));
@@ -251,38 +221,40 @@ export async function POST({ request, url }: BaseRouteArgs) {
 }
 ```
 
-…and a `<Form method="post" action="/api/locale">` switcher with one
-`<button name="locale" value={locale}>` per locale plus a hidden `next`
-field carrying `useLocation().pathname + useLocation().search` so switching
-does not drop the current query. Hydrated, `<Form>` uses the framework's
-redirect handshake and re-runs the loader; without JavaScript the browser
-follows the 303 normally.
+Pair it with a `<Form method="post" action="/api/locale">` switcher: one
+`<button name="locale" value={locale}>` per locale plus a hidden `next` field
+carrying `useLocation().pathname + useLocation().search`, so switching does not
+drop the current query. Hydrated, `<Form>` uses the framework's redirect
+handshake and re-runs the loader; without JavaScript the browser follows the
+303.
 
-For an instant switch with no request at all, `i18n.setLocaleCookie(locale)`
-writes the same cookie from the browser and
-`await dictionaries.load(locale)` swaps the dictionary in place — hold the
-result in state, reset it when loader data changes, and set both
-`document.documentElement.lang` and a localized `document.title` by hand
-(`head()` already ran server-side).
-Load the dictionary before writing the cookie, and guard concurrent lazy
-loads with a monotonically increasing request id so only the latest successful
-selection commits both the cookie and component state. Catch import failures
-instead of leaving an unhandled event-handler rejection or a partially applied
-locale choice. Invalidate that request id from a `useLayoutEffect` cleanup
-keyed by loader messages so a loader-data change or unmount wins during commit;
-a passive `useEffect` cleanup leaves time for a stale import to write its cookie.
-Also increment the shared request id synchronously in the server switcher's
-`<Form onSubmit>` and before any other navigation that can replace loader data.
-Cleanup at commit cannot undo a stale cookie written while that transition was
-still in flight.
-`i18n.detectClient()` is the browser-side `detect()` if a client-only
-surface needs to resolve the locale itself.
+For an instant switch with no request, `i18n.setLocaleCookie(locale)` writes the
+same cookie from the browser and `await dictionaries.load(locale)` swaps the
+dictionary in place. That path is easy to get wrong — hold the dictionary in
+state, reset it when loader data changes, and set `document.documentElement.lang`
+and a localized `document.title` by hand (`head()` already ran server-side).
+Then:
 
-## Step 5: Use in loaders and components
+- Load the dictionary *before* writing the cookie.
+- Guard concurrent lazy loads with a monotonically increasing request id so
+  only the latest successful selection commits both cookie and state.
+- Catch import failures rather than leaving an unhandled event-handler
+  rejection or a half-applied locale.
+- Invalidate that request id from a `useLayoutEffect` cleanup keyed by loader
+  messages, so a loader-data change or unmount wins during commit; a passive
+  `useEffect` cleanup leaves time for a stale import to write its cookie.
+- Increment the shared request id synchronously in the server switcher's
+  `<Form onSubmit>` and before any other navigation that can replace loader
+  data — cleanup at commit cannot undo a stale cookie written mid-transition.
+
+`i18n.detectClient()` is the browser-side `detect()` when a client-only surface
+must resolve the locale itself.
+
+## Step 5: Loaders and components
 
 ```tsx
 import type { HeadArgs, LoaderArgs, RouteComponentProps } from "@pracht/core";
-import { t, tPlural } from "@pracht/i18n";
+import { t } from "@pracht/i18n";
 import { dictionaries, i18n } from "../i18n/index.ts";
 import { useEffect } from "preact/hooks";
 
@@ -309,88 +281,77 @@ export function Component({ data }: RouteComponentProps<typeof loader>) {
 }
 ```
 
-`messages` is a plain serializable object, so the same `t()` calls work
-after hydration and on client navigations. `hreflang()` emits one alternate
-link per locale plus `x-default` pointing at the unprefixed detector; pass
-the app's canonical origin. Relative previews remain current-origin because
-`splitLocale()` always keeps the stripped pathname root-relative, and every
-alternate preserves an input query/hash suffix. Under strategy B, omit the
-`link` entry: there is no alternate URL to point at, so emitting hreflang
-would be a lie.
+`messages` is a plain serializable object, so the same `t()` calls work after
+hydration and on client navigations. `hreflang()` emits one alternate per
+locale plus `x-default` pointing at the unprefixed detector — pass the app's
+canonical origin. Relative previews stay current-origin because `splitLocale()`
+keeps the stripped pathname root-relative, and every alternate preserves an
+input query/hash suffix. Under strategy B, omit the `link` entry entirely:
+there is no alternate URL, so emitting hreflang would be a lie.
 
-## Step 6: SEO touch-ups
+## Step 6: SEO
 
-- Set `lang` from the resolved locale in `head()` (as above).
-- Keep the detector route SSR; locale-prefixed routes may be `ssg` or
-  `isg` — every prefixed URL is a real route, so each locale prerenders,
-  and the middleware skips cookie persistence on those routes so no
-  `Set-Cookie` lands in stored output. Persist the resolved path locale after
-  hydration when the SSR detector should remember it; without JavaScript,
-  use SSR or platform edge middleware. Keep `"path"` first in the detect order
-  for prerendered routes: cookie/header detection cannot run against a stored
-  document (prerender/ISG requests carry no cookies or `Accept-Language`), and
-  a route that *depends* on those sources gets `Vary: Cookie` and is refused by
-  the ISG cache.
+- Set `lang` from the resolved locale in `head()`.
+- Keep the detector route SSR. Locale-prefixed routes may be `ssg`/`isg` —
+  every prefixed URL is a real route, and the middleware skips cookie
+  persistence there so no `Set-Cookie` lands in stored output. Keep `"path"`
+  first in the detect order for prerendered routes: cookie/header detection
+  cannot run against a stored document (prerender/ISG requests carry no cookies
+  or `Accept-Language`), and a route that *depends* on those sources gets
+  `Vary: Cookie` and is refused by the ISG cache.
 - Prerendered `head()` runs against a placeholder request origin — pass the
-  app's canonical origin to `hreflang()` on SSG/ISG routes instead of
-  `url.origin`, or the alternates bake in `http://localhost`.
-- Update the sitemap (cross-reference with `audit-seo`) to include all
-  per-locale URLs.
-- Strategy B only: one URL means one indexed language (whatever the
-  crawler's `Accept-Language` resolves to). Say this out loud to the user;
-  if it matters, that is the argument for strategy A. Still set `lang`, and
-  leave sitemap entries as the single canonical URLs they already are.
+  canonical origin to `hreflang()` on SSG/ISG routes instead of `url.origin`,
+  or the alternates bake in `http://localhost`.
+- Update the sitemap to include every per-locale URL (see `/audit-seo`).
+- Strategy B only: one URL means one indexed language, whatever the crawler's
+  `Accept-Language` resolves to. Say that out loud — if it matters, that is the
+  argument for strategy A. Still set `lang`; sitemap entries stay as-is.
 
 ## Step 7: Verify
 
-- If step 4 changed route paths (strategy A) or added the API route, run
-  `pracht typegen` to refresh the generated route types/`href()` helper. Add
-  `pracht typegen --check` to CI so stale types fail the build.
-- Boot dev: `pracht dev`.
-- Strategy A: `curl -i` the unprefixed detector with `Accept-Language: fr`
-  (expect a 302 to `/fr/...`), with a `pracht_locale` cookie (cookie beats
-  header), and with garbage (`;q=`, unknown tags — expect the default
-  locale). Visit a locale-prefixed page; confirm translated content and the
-  hreflang links in the head. On SSR, confirm `Set-Cookie` on first visit and
-  `Vary: Cookie` whether or not the request cookie already matches. On SSG/ISG,
-  confirm the stored response has neither `Set-Cookie` nor a path-only `Vary`, hydration writes
-  the locale cookie, and then the unprefixed detector returns to that locale.
-  Visit an unsupported prefix (e.g. `/zz/about`); confirm it 404s.
-- Strategy B: `curl -i` the page with `Accept-Language: fr` (expect French
-  content, `Vary: Cookie, Accept-Language`, no `Set-Cookie`) and with
-  `Cookie: pracht_locale=fr` while sending `Accept-Language: en` (cookie
-  wins). `curl -i -X POST` the switcher with `-d locale=fr` and an
-  `Origin` header matching the host (mutation API routes are
-  same-origin-checked): expect a 303 plus `Set-Cookie`. Post an unregistered
-  locale and an off-origin `next`; expect a 400 and a same-origin redirect.
-  In the browser, switch and confirm the URL never changes.
-- `pnpm test` and `pnpm e2e` still pass.
-- Run `pracht verify --json` and confirm no failures.
+Run `pracht typegen` if step 4 changed route paths or added the API route, and
+add `pracht typegen --check` to CI. Boot `pracht dev`, then:
+
+- **Strategy A.** `curl -i` the unprefixed detector with `Accept-Language: fr`
+  (302 to `/fr/...`), with a `pracht_locale` cookie (cookie beats header), and
+  with garbage (`;q=`, unknown tags → default locale). On a locale-prefixed
+  page, confirm translated content and hreflang links. On SSR, confirm
+  `Set-Cookie` on first visit and `Vary: Cookie` whether or not the request
+  cookie already matches. On SSG/ISG, confirm the stored response has neither
+  `Set-Cookie` nor a path-only `Vary`, that hydration writes the locale cookie,
+  and that the unprefixed detector then returns to that locale. `/zz/about`
+  must 404.
+- **Strategy B.** `curl -i` the page with `Accept-Language: fr` (French
+  content, `Vary: Cookie, Accept-Language`, no `Set-Cookie`), and with
+  `Cookie: pracht_locale=fr` plus `Accept-Language: en` (cookie wins).
+  `curl -i -X POST` the switcher with `-d locale=fr` and an `Origin` header
+  matching the host (mutation API routes are same-origin-checked): expect 303 +
+  `Set-Cookie`. Post an unregistered locale and an off-origin `next`: expect
+  400 and a same-origin redirect. In the browser, switch and confirm the URL
+  never changes.
+- `pnpm test`, `pnpm e2e`, and `pracht verify --json` all pass.
 
 ## Rules
 
-1. The middleware sets `context.locale`; loaders read it. Do not stash the
-   locale in module-level state — concurrent requests will collide.
-2. Only registered locales may ever reach paths, cookies, or hreflang.
-   `defineI18n`/`localePath` enforce this — never bypass them with string
-   concatenation on user input. `localePath` also resolves dot segments before
-   adding the locale prefix. Accept-Language wildcard fallbacks are resolved
-   through the registered locale list, respect explicit `q=0` exclusions, and
-   neither lookup truncation nor best-fit fallback can bypass those exclusions.
-   Directly matched longer variants win before same-language best fit, which
-   never crosses conflicting script subtags. If the defensive header-length
-   limit cuts an entry in half, discard that entry rather than parsing it with
-   an implied quality of 1.
-3. For SSG, only prerender URL combinations that exist; provide
-   `getStaticPaths` returning the locale × dynamic-param product when a
-   localized route has dynamic segments.
-4. Recommend `Intl.DateTimeFormat` and `Intl.NumberFormat` with
-   `data.locale` for formatting — no library needed.
-5. Never bundle every translation into the client: `createDictionaries`
-   loaders are per-locale lazy imports resolved in loaders; keep them that
-   way.
-6. Never move an existing app's URLs without asking. Locale prefixes are a
-   strategy, not a requirement — if the user says their URLs are fixed,
-   strategy B is the answer, not a redirect table.
+1. The middleware sets `context.locale`; loaders read it. Never stash the
+   locale in module-level state — concurrent requests collide.
+2. Only registered locales may reach paths, cookies, or hreflang.
+   `defineI18n`/`localePath` enforce that; never bypass them with string
+   concatenation on user input.
+3. `Accept-Language` handling is already conservative and must stay that way:
+   wildcard fallbacks resolve through the registered locale list, explicit
+   `q=0` exclusions hold against both lookup truncation and best-fit fallback,
+   directly matched longer variants win before same-language best fit (which
+   never crosses conflicting script subtags), and an entry cut in half by the
+   defensive header-length limit is discarded rather than parsed with an
+   implied quality of 1.
+4. For SSG with dynamic segments, `getStaticPaths` must return the locale ×
+   dynamic-param product — prerender only URL combinations that exist.
+5. Format dates and numbers with `Intl.DateTimeFormat`/`Intl.NumberFormat` and
+   `data.locale`; no library needed.
+6. Never bundle every translation into the client. `createDictionaries` loaders
+   are per-locale lazy imports resolved in loaders — keep them that way.
+7. Never move an existing app's URLs without asking. If the user says their
+   URLs are fixed, strategy B is the answer, not a redirect table.
 
 $ARGUMENTS

--- a/skills/add-images/SKILL.md
+++ b/skills/add-images/SKILL.md
@@ -1,16 +1,13 @@
 ---
 name: add-images
-version: 1.0.0
+version: 1.0.1
 description: |
-  Wire `@pracht/image` into a pracht app: the CLS-safe zero-runtime `<Image>`
-  component, the right loader for the deployment target (built-in sharp
-  endpoint, Cloudflare Image Resizing, Vercel Image Optimization, or
-  passthrough), build-time `?pracht` imports with blur placeholders, prebuilt
-  static WebP variants, and the security settings the optimization endpoint
-  needs.
-  Use when asked to "add images", "optimize images", "responsive images",
-  "set up next/image equivalent", "enable Cloudflare image resizing", "add blur
-  placeholders", or "my images cause layout shift".
+  Wire `@pracht/image`: the CLS-safe zero-runtime `<Image>`, the loader for your
+  target (sharp endpoint, Cloudflare, Vercel, passthrough), `?pracht` build-time
+  imports with blur placeholders, prebuilt WebP variants, and the optimization
+  endpoint's security settings.
+  Use for "add images", "optimize images", "responsive images", "next/image
+  equivalent", "blur placeholders", "my images cause layout shift".
 allowed-tools:
   - Bash
   - Read
@@ -30,8 +27,8 @@ zero hydration, works with `hydration: "none"`.
 
 ## Step 1: Choose the backend for the deployment target
 
-If the pracht MCP server is registered (see docs/MCP.md), prefer its tools
-(`inspect_routes`, `inspect_build`, `doctor`, `verify`) over shelling out.
+MCP: when the pracht MCP server is registered (docs/MCP.md), prefer its
+`inspect_routes`/`inspect_build`/`doctor`/`verify` tools over shelling out.
 
 ```bash
 pracht inspect build --json   # adapterTarget (requires a prior `pracht build`)

--- a/skills/add-observability/SKILL.md
+++ b/skills/add-observability/SKILL.md
@@ -1,13 +1,11 @@
 ---
 name: add-observability
-version: 1.1.0
+version: 1.1.1
 description: |
-  Wire error tracking, request tracing, and Web Vitals into a pracht app.
-  Supports Sentry or OpenTelemetry on the server side (loader/middleware
-  boundaries, API routes), and client-side Web Vitals reporting via the
-  `web-vitals` package.
-  Use when asked to "add observability", "wire Sentry", "set up tracing",
-  "add OpenTelemetry", "monitor Web Vitals", or "track errors".
+  Wire Sentry or OpenTelemetry into pracht server boundaries (loaders, middleware,
+  API routes) plus client-side Web Vitals reporting.
+  Use for "add observability", "wire Sentry", "set up tracing", "add
+  OpenTelemetry", "monitor Web Vitals", "track errors".
 allowed-tools:
   - Bash
   - Read
@@ -27,10 +25,10 @@ Three layers, each opt-in:
 3. **Web Vitals (LCP/CLS/INP/FCP/TTFB)** — client-side, posted to a beacon
    endpoint.
 
-If the pracht MCP server is registered (see docs/MCP.md), prefer its tools
-(`inspect_routes`, `inspect_api`, `inspect_build`, `doctor`, `verify`,
-`generate_*`) over shelling out. Prerequisite: `pracht inspect` needs a vite
-config with the pracht plugin registered.
+MCP: when the pracht MCP server is registered (docs/MCP.md), prefer its
+`inspect_routes`/`inspect_api`/`inspect_build`/`doctor`/`verify`/`generate_*`
+tools over shelling out. `pracht inspect` needs the pracht plugin in the vite
+config.
 
 ## Step 1: Pick the stack
 

--- a/skills/add-openapi/SKILL.md
+++ b/skills/add-openapi/SKILL.md
@@ -1,14 +1,12 @@
 ---
 name: add-openapi
-version: 1.0.0
+version: 1.0.1
 description: |
-  Wire `@pracht/openapi` into a pracht app: generate an OpenAPI 3.1 document
-  from existing `defineApi()` routes, attach the response contracts that cannot
-  be inferred with `defineOpenApi()`, serve an optional Scalar or Swagger
-  reference UI, handle deploy-base and CSP concerns, and turn warnings into a
-  CI completeness gate.
-  Use when asked to "add OpenAPI", "generate an API spec", "add Swagger",
-  "publish API docs", "add a reference UI", or "document my API routes".
+  Wire `@pracht/openapi`: generate an OpenAPI 3.1 document from `defineApi()`
+  routes, attach response contracts with `defineOpenApi()`, serve an optional
+  Scalar or Swagger UI, handle deploy-base and CSP, and gate completeness in CI.
+  Use for "add OpenAPI", "generate an API spec", "add Swagger", "publish API
+  docs", "document my API routes".
 allowed-tools:
   - Bash
   - Read
@@ -28,8 +26,8 @@ own descriptor.
 
 ## Step 1: Inventory the API first
 
-If the pracht MCP server is registered (see `docs/MCP.md`), prefer its tools
-(`inspect_api`, `inspect_routes`, `doctor`, `verify`) over shelling out.
+MCP: when the pracht MCP server is registered (docs/MCP.md), prefer its
+`inspect_api`/`inspect_routes`/`doctor`/`verify` tools over shelling out.
 
 ```bash
 pracht inspect api --json   # endpoint paths, methods, hasDefaultHandler

--- a/skills/audit-a11y/SKILL.md
+++ b/skills/audit-a11y/SKILL.md
@@ -1,13 +1,12 @@
 ---
 name: audit-a11y
-version: 1.1.0
+version: 1.1.1
 description: |
-  Per-route accessibility audit for a pracht app. Drives a headless browser
-  through every route in the manifest, runs axe-core, and reports issues
-  grouped by severity and route. Catches alt-text gaps, contrast failures,
-  missing landmarks, focus-order bugs, and form-label problems.
-  Use when asked to "audit a11y", "check accessibility", "axe my app",
-  "WCAG compliance", or "screen reader test".
+  Per-route axe-core audit of a pracht app in a headless browser: alt text,
+  contrast, landmarks, focus order, and form labels, grouped by severity and
+  route.
+  Use for "audit a11y", "check accessibility", "axe my app", "WCAG compliance",
+  "screen reader test".
 allowed-tools:
   - Bash
   - Read
@@ -61,8 +60,8 @@ project tooling.
 
 ## Step 3: Enumerate routes
 
-If the pracht MCP server is registered (see docs/MCP.md), prefer its tools
-(`inspect_routes`, `inspect_api`, `inspect_build`, `doctor`, `verify`) over
+MCP: when the pracht MCP server is registered (docs/MCP.md), prefer its
+`inspect_routes`/`inspect_api`/`inspect_build`/`doctor`/`verify` tools over
 shelling out.
 
 ```bash

--- a/skills/audit-agent-surface/SKILL.md
+++ b/skills/audit-agent-surface/SKILL.md
@@ -1,16 +1,13 @@
 ---
 name: audit-agent-surface
-version: 1.0.0
+version: 1.0.1
 description: |
-  Inventory everything in a pracht app that agents can reach — capabilities and
-  their exposure (HTTP, WebMCP, remote MCP), the `agents` trust configuration,
-  the destructive confirmation gate, `llms.txt`, Markdown negotiation, and the
-  OpenAPI document — then report where the surface is wider than intended or
-  missing a guard. Also confirms an app that wants no agent surface is actually
-  paying nothing for one.
-  Use when asked to "audit the agent surface", "what can agents do on my site",
-  "is my MCP endpoint safe", "check capability exposure", "did this PR widen
-  what agents can reach", or "make sure we ship no agent surface".
+  Inventory what agents can reach in a pracht app — capability exposure (HTTP,
+  WebMCP, remote MCP), `agents` trust config, the destructive-confirmation gate,
+  `llms.txt`, Markdown negotiation, OpenAPI — and report where the surface is
+  wider than intended, or confirm an opt-out app ships none.
+  Use for "audit the agent surface", "what can agents do on my site", "is my MCP
+  endpoint safe", "did this PR widen what agents can reach".
 allowed-tools:
   - Bash
   - Read

--- a/skills/audit-auth/SKILL.md
+++ b/skills/audit-auth/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: audit-auth
-version: 1.2.3
+version: 1.2.4
 description: |
-  Find pracht routes that look protected but aren't — missing auth middleware,
-  middleware that augments context but never gates, client-side auth checks
-  with no server enforcement, and API mutations exposed without guards.
-  Use when asked to "audit auth", "check route protection", "is my dashboard
-  protected", "find unauthenticated routes", or "review middleware coverage".
+  Find pracht routes that look protected but aren't: missing auth middleware,
+  middleware that augments context but never gates, client-only checks, and
+  unguarded API mutations.
+  Use for "audit auth", "check route protection", "find unauthenticated routes",
+  "review middleware coverage".
 allowed-tools:
   - Bash
   - Read
@@ -36,8 +36,8 @@ pracht plugin.
 pracht inspect routes --json
 ```
 
-If the pracht MCP server is registered (see `docs/MCP.md`), prefer its tools
-(`inspect_routes`, `inspect_api`, `inspect_build`, `doctor`, `verify`) over
+MCP: when the pracht MCP server is registered (docs/MCP.md), prefer its
+`inspect_routes`/`inspect_api`/`inspect_build`/`doctor`/`verify` tools over
 shelling out.
 
 Middleware is registered by name in the app manifest —

--- a/skills/audit-bundles/SKILL.md
+++ b/skills/audit-bundles/SKILL.md
@@ -1,13 +1,12 @@
 ---
 name: audit-bundles
-version: 1.2.0
+version: 1.2.1
 description: |
-  Analyze a pracht production build. Report client bundle size per route,
-  flag fat vendor chunks, find route components that ship large dependencies,
-  and suggest dynamic `import()` and prefetch strategies based on observed
-  navigation patterns.
-  Use when asked to "audit bundles", "why is my JS so big", "bundle size per
-  route", "what's in my vendor chunk", or "tune prefetching".
+  Analyze a pracht production build: client bytes per route, fat vendor chunks,
+  routes shipping large dependencies, and dynamic `import()` / prefetch
+  recommendations.
+  Use for "audit bundles", "why is my JS so big", "bundle size per route", "what's
+  in my vendor chunk", "tune prefetching".
 allowed-tools:
   - Bash
   - Read
@@ -23,11 +22,10 @@ and surfaces the worst offenders.
 
 ## Step 1: Build with analysis
 
-If the pracht MCP server is registered (see docs/MCP.md), prefer its tools
-(`inspect_routes`, `inspect_api`, `inspect_build`, `doctor`, `verify`) over
-shelling out. Prerequisites: `pracht inspect` needs a vite config with the
-pracht plugin; `pracht inspect build` reads artifacts from a prior
-`pracht build`.
+MCP: when the pracht MCP server is registered (docs/MCP.md), prefer its
+`inspect_routes`/`inspect_api`/`inspect_build`/`doctor`/`verify` tools over
+shelling out. `pracht inspect` needs the pracht plugin in the vite config.
+`inspect build` needs a prior `pracht build`.
 
 ```bash
 pracht build --analyze --json

--- a/skills/audit-csrf/SKILL.md
+++ b/skills/audit-csrf/SKILL.md
@@ -1,14 +1,13 @@
 ---
 name: audit-csrf
-version: 1.2.0
+version: 1.2.1
 description: |
-  Inventory every form submission and mutation API in the project, then verify
-  the CSRF posture. Pracht enforces same-origin on mutation API requests by
-  default (`api.requireSameOrigin`); this skill checks that the default is
-  intact and that cookie strategy, middleware, or tokens cover whatever the
-  built-in check does not.
-  Use when asked to "audit CSRF", "check CSRF protection", "are forms safe",
-  "review session security", or after enabling cross-origin form usage.
+  Check CSRF posture across every form and mutation API. Pracht enforces
+  same-origin on mutation API requests by default (`api.requireSameOrigin`); this
+  verifies the default is intact and that cookies, middleware, or tokens cover
+  what it does not.
+  Use for "audit CSRF", "check CSRF protection", "are forms safe", "review session
+  security".
 allowed-tools:
   - Bash
   - Read
@@ -71,8 +70,8 @@ Grep for `<Form ` across `src/`. For each occurrence:
 pracht inspect api --json
 ```
 
-If the pracht MCP server is registered (see `docs/MCP.md`), prefer its tools
-(`inspect_routes`, `inspect_api`, `inspect_build`, `doctor`, `verify`) over
+MCP: when the pracht MCP server is registered (docs/MCP.md), prefer its
+`inspect_routes`/`inspect_api`/`inspect_build`/`doctor`/`verify` tools over
 shelling out.
 
 For each API route, read the exported `methods`. Mutation methods: `POST`,

--- a/skills/audit-deps/SKILL.md
+++ b/skills/audit-deps/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: audit-deps
-version: 1.1.0
+version: 1.1.1
 description: |
-  Run a dependency vulnerability audit and map each finding to the pracht
-  routes, loaders, middleware, or API handlers that import the affected
-  package — so users know which surface area they need to test after upgrading.
-  Use when asked to "audit deps", "scan for CVEs", "which routes use this
-  vulnerable package", "npm audit", or "dependency security review".
+  Run a dependency vulnerability audit and map each advisory to the pracht routes,
+  loaders, middleware, and API handlers that import it — so you know what to
+  retest after upgrading.
+  Use for "audit deps", "scan for CVEs", "npm audit", "which routes use this
+  vulnerable package".
 allowed-tools:
   - Bash
   - Read
@@ -56,8 +56,8 @@ is the one the user owns.
 
 ## Step 3: Map to routes/APIs
 
-If the pracht MCP server is registered (see `docs/MCP.md`), prefer its tools
-(`inspect_routes`, `inspect_api`, `inspect_build`, `doctor`, `verify`) over
+MCP: when the pracht MCP server is registered (docs/MCP.md), prefer its
+`inspect_routes`/`inspect_api`/`inspect_build`/`doctor`/`verify` tools over
 shelling out.
 
 For each direct dependency identified in step 2:

--- a/skills/audit-headers/SKILL.md
+++ b/skills/audit-headers/SKILL.md
@@ -1,14 +1,13 @@
 ---
 name: audit-headers
-version: 1.2.0
+version: 1.2.1
 description: |
-  Audit security header coverage in a pracht app. The framework applies four
-  default security headers on every response path; this skill audits the
-  exceptions — static output served outside first-party adapters, `headers()`
-  exports that weaken the defaults, and the headers only the user can decide
-  (HSTS, CSP).
-  Use when asked to "audit security headers", "check CSP", "harden headers",
-  "set up HSTS", or "review header policy".
+  Audit security headers in a pracht app. The framework sets four defaults on
+  every response path; this covers the exceptions — static output served outside
+  first-party adapters, `headers()` exports that weaken defaults, and the choices
+  only you can make (HSTS, CSP).
+  Use for "audit security headers", "check CSP", "harden headers", "set up HSTS",
+  "review header policy".
 allowed-tools:
   - Bash
   - Read
@@ -62,8 +61,8 @@ pracht inspect routes --json
 pracht inspect api --json
 ```
 
-If the pracht MCP server is registered (see `docs/MCP.md`), prefer its tools
-(`inspect_routes`, `inspect_api`, `inspect_build`, `doctor`, `verify`) over
+MCP: when the pracht MCP server is registered (docs/MCP.md), prefer its
+`inspect_routes`/`inspect_api`/`inspect_build`/`doctor`/`verify` tools over
 shelling out.
 
 Only route modules and shells have a `headers()` export — API handlers do not

--- a/skills/audit-islands/SKILL.md
+++ b/skills/audit-islands/SKILL.md
@@ -1,14 +1,13 @@
 ---
 name: audit-islands
-version: 1.0.0
+version: 1.0.1
 description: |
-  Audit pracht islands usage: find over-hydrated routes that should use
-  `hydration: "islands"` or `"none"`, dead interactivity outside the islands
-  directory, non-serializable island props, mis-tuned client strategies, and
-  invalid render/hydration combinations.
-  Use when asked to "audit islands", "reduce hydration", "why is this island
-  not interactive", "should this page be an island", or "check partial
-  hydration".
+  Audit pracht hydration: over-hydrated routes that should be `hydration:
+  "islands"` or `"none"`, dead interactivity outside the islands directory,
+  non-serializable island props, mis-tuned `client` strategies, and invalid
+  render/hydration pairs.
+  Use for "audit islands", "reduce hydration", "why is this island not
+  interactive", "check partial hydration".
 allowed-tools:
   - Bash
   - Read
@@ -26,8 +25,8 @@ islands wired in ways that break at render time or ship dead handlers.
 
 ## Step 1: Enumerate routes and hydration modes
 
-If the pracht MCP server is registered (see docs/MCP.md), prefer its tools
-(`inspect_routes`, `inspect_api`, `inspect_build`, `doctor`, `verify`) over
+MCP: when the pracht MCP server is registered (docs/MCP.md), prefer its
+`inspect_routes`/`inspect_api`/`inspect_build`/`doctor`/`verify` tools over
 shelling out.
 
 ```bash

--- a/skills/audit-loaders/SKILL.md
+++ b/skills/audit-loaders/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: audit-loaders
-version: 1.1.0
+version: 1.1.1
 description: |
-  Audit pracht route loaders for serializability, leaked secrets,
-  unsafe loader caching, browser-only API misuse, and missing AbortSignal plumbing.
-  Use when asked to "audit loaders", "check loader data", "find serialization
-  bugs", "are my loaders safe", or "loader security review".
+  Audit pracht route loaders for serializability, leaked secrets, unsafe
+  `loaderCache`, browser-only API use, and missing `AbortSignal` plumbing.
+  Use for "audit loaders", "check loader data", "find serialization bugs", "loader
+  security review".
 allowed-tools:
   - Bash
   - Read
@@ -21,8 +21,8 @@ ends up in the browser — including secrets you never meant to expose.
 
 ## Step 1: Enumerate routes
 
-If the pracht MCP server is registered (see docs/MCP.md), prefer its tools
-(`inspect_routes`, `inspect_api`, `inspect_build`, `doctor`, `verify`) over
+MCP: when the pracht MCP server is registered (docs/MCP.md), prefer its
+`inspect_routes`/`inspect_api`/`inspect_build`/`doctor`/`verify` tools over
 shelling out.
 
 ```bash

--- a/skills/audit-redirects/SKILL.md
+++ b/skills/audit-redirects/SKILL.md
@@ -1,14 +1,13 @@
 ---
 name: audit-redirects
-version: 1.1.0
+version: 1.1.1
 description: |
-  Find open-redirect vulnerabilities in pracht loaders, middleware, and
-  navigation calls. The framework guards both ends — the client router drops
-  unsafe URL schemes, and the server `redirect()` helper rejects unsafe
-  schemes and CRLF injection — but a hand-rolled 3xx Response bypasses every
-  guard, and even a guarded redirect to an attacker-chosen origin can phish.
-  Use when asked to "audit redirects", "check for open redirects", "is my
-  ?redirect= param safe", or "review login redirect handling".
+  Find open redirects in pracht loaders, middleware, and navigation. The framework
+  rejects unsafe schemes and CRLF at both ends, but a hand-rolled 3xx Response
+  bypasses every guard, and even a guarded redirect to an attacker-chosen origin
+  can phish.
+  Use for "audit redirects", "check for open redirects", "is my ?redirect= param
+  safe", "review login redirect handling".
 allowed-tools:
   - Bash
   - Read
@@ -41,8 +40,8 @@ Bound the search first — do not grep the whole repo blind:
 pracht inspect routes --json
 ```
 
-If the pracht MCP server is registered (see `docs/MCP.md`), prefer its tools
-(`inspect_routes`, `inspect_api`, `inspect_build`, `doctor`, `verify`) over
+MCP: when the pracht MCP server is registered (docs/MCP.md), prefer its
+`inspect_routes`/`inspect_api`/`inspect_build`/`doctor`/`verify` tools over
 shelling out.
 
 The resolved graph gives you each route's `file`, `loaderFile`, and

--- a/skills/audit-secrets/SKILL.md
+++ b/skills/audit-secrets/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: audit-secrets
-version: 1.1.0
+version: 1.1.1
 description: |
-  Detect environment variables and secrets that leak from the server into
-  the client bundle via loader return values, hydration state, or accidental
-  imports of server-only modules from client code paths.
-  Use when asked to "audit secrets", "find leaked env vars", "is my API key
-  exposed", "check client bundle for secrets", or "scan for credential leaks".
+  Detect environment variables and secrets reaching the client bundle via loader
+  return values, hydration state, or server-only modules imported from client code
+  paths.
+  Use for "audit secrets", "find leaked env vars", "is my API key exposed", "scan
+  for credential leaks".
 allowed-tools:
   - Bash
   - Read

--- a/skills/audit-seo/SKILL.md
+++ b/skills/audit-seo/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: audit-seo
-version: 1.1.0
+version: 1.1.1
 description: |
-  Per-route SEO audit for a pracht app: `head()` coverage, title/description
-  presence, Open Graph and Twitter card completeness, canonical URLs, robots
-  rules, and a generated `sitemap.xml` derived from the route manifest.
-  Use when asked to "audit SEO", "check meta tags", "generate a sitemap",
-  "are my OG cards set", or "review robots.txt".
+  Per-route SEO audit: `head()` coverage, title and description presence, Open
+  Graph and Twitter cards, canonicals, robots rules, plus a `sitemap.xml`
+  generated from the route manifest.
+  Use for "audit SEO", "check meta tags", "generate a sitemap", "are my OG cards
+  set", "review robots.txt".
 allowed-tools:
   - Bash
   - Read
@@ -23,8 +23,8 @@ coverage and generates the static SEO artifacts.
 
 ## Step 1: Inventory
 
-If the pracht MCP server is registered (see docs/MCP.md), prefer its tools
-(`inspect_routes`, `inspect_api`, `inspect_build`, `doctor`, `verify`) over
+MCP: when the pracht MCP server is registered (docs/MCP.md), prefer its
+`inspect_routes`/`inspect_api`/`inspect_build`/`doctor`/`verify` tools over
 shelling out.
 
 ```bash

--- a/skills/audit-shells/SKILL.md
+++ b/skills/audit-shells/SKILL.md
@@ -1,13 +1,12 @@
 ---
 name: audit-shells
-version: 1.1.0
+version: 1.1.1
 description: |
-  Audit pracht shells for composition bugs: missing `Loading()` on SPA-using
-  shells, accidental `<html>`/`<head>`/`<body>` rendering, shells that swallow
-  children, unused shells, and redundant `ErrorBoundary` exports (shell-level
-  boundaries are valid fallbacks; routes win when both declare one).
-  Use when asked to "audit shells", "check shell composition", "find unused
-  shells", or "is my layout structured correctly".
+  Audit pracht shells: missing `Loading()` on SPA routes, `<html>`/`<head>`/
+  `<body>` rendered inside a shell, shells that never render `children`, unused
+  shells, and `ErrorBoundary` exports shadowed by every route under them.
+  Use for "audit shells", "check shell composition", "find unused shells", "is my
+  layout structured correctly".
 allowed-tools:
   - Bash
   - Read
@@ -24,8 +23,8 @@ component.
 
 ## Step 1: Enumerate
 
-If the pracht MCP server is registered (see docs/MCP.md), prefer its tools
-(`inspect_routes`, `inspect_api`, `inspect_build`, `doctor`, `verify`) over
+MCP: when the pracht MCP server is registered (docs/MCP.md), prefer its
+`inspect_routes`/`inspect_api`/`inspect_build`/`doctor`/`verify` tools over
 shelling out.
 
 ```bash

--- a/skills/configure-isg/SKILL.md
+++ b/skills/configure-isg/SKILL.md
@@ -1,14 +1,13 @@
 ---
 name: configure-isg
-version: 1.0.0
+version: 1.0.1
 description: |
-  Wire ISG (incremental static generation) revalidation correctly for the
-  project's adapter: route-level timeRevalidate/webhookRevalidate policies,
-  the authenticated /__pracht/revalidate webhook, Cloudflare Workers Caching,
-  Vercel native ISR, and cache-key pitfalls — then verify it locally.
-  Use when asked to "set up ISG", "configure revalidation", "add a
-  revalidation webhook", "my ISG page never updates", or "cache this page at
-  the edge".
+  Wire ISG revalidation for the project's adapter: route-level
+  `timeRevalidate`/`webhookRevalidate`, the authenticated `/__pracht/revalidate`
+  webhook, Cloudflare Workers Cache, Vercel ISR, and cache-key pitfalls — then
+  verify locally.
+  Use for "set up ISG", "configure revalidation", "add a revalidation webhook", "my
+  ISG page never updates", "cache this page at the edge".
 allowed-tools:
   - Bash
   - Read
@@ -30,8 +29,8 @@ webhook, and the adapter-specific cache correctly.
 
 ## Step 1: Identify adapter and candidate routes
 
-If the pracht MCP server is registered (see docs/MCP.md), prefer its tools
-(`inspect_routes`, `inspect_api`, `inspect_build`, `doctor`, `verify`) over
+MCP: when the pracht MCP server is registered (docs/MCP.md), prefer its
+`inspect_routes`/`inspect_api`/`inspect_build`/`doctor`/`verify` tools over
 shelling out.
 
 ```bash

--- a/skills/migrate-nextjs/SKILL.md
+++ b/skills/migrate-nextjs/SKILL.md
@@ -1,13 +1,12 @@
 ---
 name: migrate-nextjs
-version: 1.2.0
+version: 1.3.0
 description: |
-  Migrate a Next.js application to Pracht. Converts App Router pages, layouts,
-  middleware, API routes, data fetching, and metadata to pracht equivalents.
-  Handles React→Preact, className→class, server components→loaders, and
-  manifest wiring.
-  Use when asked to "migrate from next", "convert next.js app", "port from
-  next to pracht", "nextjs migration", or "switch from next".
+  Migrate a Next.js app to pracht: App or Pages Router pages, layouts, middleware,
+  API routes, data fetching, and metadata — plus React→Preact, `className`→`class`,
+  server components→loaders, and manifest wiring.
+  Use for "migrate from next", "convert next.js app", "port from next to pracht",
+  "nextjs migration", "switch from next".
 allowed-tools:
   - Bash
   - Read
@@ -20,136 +19,105 @@ allowed-tools:
 
 # Migrate Next.js to Pracht
 
-Systematically migrate a Next.js application (App Router or Pages Router) to pracht — a full-stack Preact framework built on Vite.
+Migrate in phases: setup → shells → routes → client components → API →
+middleware → manifest → patterns → cleanup. Read each Next.js source file
+before converting it; never infer from the filename. Prefer the simplest
+pracht equivalent, and when a Next.js feature has no equivalent, say so and
+propose an alternative instead of inventing one.
 
-## Step 0: Assess the source project
+MCP: when the pracht MCP server is registered (docs/MCP.md), use
+`generate_route`/`generate_shell`/`generate_middleware`/`generate_api` to
+scaffold and `inspect_routes`/`inspect_api`/`doctor`/`verify` to check
+progress, instead of Bash. `pracht inspect` needs the pracht plugin in the
+vite config; `inspect_build` needs a prior `pracht build`.
 
-Before touching any code, understand what you're migrating:
+## Step 0: Assess the source
 
-1. Read `next.config.js` / `next.config.mjs` / `next.config.ts` for custom config.
-2. Read `package.json` for React/Next versions and dependencies.
-3. Scan the directory structure:
-   - `app/` → App Router (Next 13+)
-   - `pages/` → Pages Router (legacy)
-   - `middleware.ts` → edge middleware
-   - `app/api/` or `pages/api/` → API routes
-4. Identify rendering patterns in use:
-   - `"use client"` directives → client components
-   - `async` page/layout components → server components with data fetching
-   - `generateStaticParams` → static generation
-   - `generateMetadata` / `metadata` export → head management
-   - Server Actions (`"use server"`) → mutations
-5. Note third-party integrations (auth, CMS, DB, analytics).
+Read `next.config.*` and `package.json` (React/Next versions, deps), then map
+the tree: `app/` (App Router), `pages/` (Pages Router), `middleware.ts`,
+`app/api/` or `pages/api/`. Note which patterns are in use — `"use client"`,
+`async` server components, `generateStaticParams`, `generateMetadata`/`metadata`,
+`"use server"` actions — and the third-party integrations (auth, CMS, DB,
+analytics). Confirm scope with the user if the app has more than ~20 routes.
 
-Ask the user to confirm the migration scope if the project is large (>20 routes).
+## Fast path: Pages Router
 
-If the pracht MCP server is registered (docs/MCP.md), use the `generate_route`/`generate_shell`/`generate_middleware`/`generate_api` MCP tools for scaffolding and `inspect_routes`/`inspect_api`/`doctor`/`verify` to check migration progress, instead of Bash. (`pracht inspect` needs the pracht plugin in the vite config; `inspect_build` needs a prior `pracht build`.)
+`pagesDir` makes a pages-router source near-drop-in — **Phase 7 is then
+automatic**:
 
-## Fast Path: Pages Router Projects
+1. `pracht({ pagesDir: "/src/pages" })` in `vite.config.ts`; copy `pages/` to
+   `src/pages/`.
+2. `_app.tsx` → pracht shell shape (`Shell` export taking `children`).
+3. `getServerSideProps`/`getStaticProps` → `loader` export.
+4. `export const RENDER_MODE = "ssg"` on static pages (`"ssr"` is the
+   default). For time-revalidated pages export `RENDER_MODE = "isg"` plus a
+   positive integer `REVALIDATE` in seconds; webhook policies require ejecting
+   to a manifest.
+5. Run the dev server, iterate, and optionally eject later with
+   `generateRoutesFile`.
 
-If the source Next.js project uses the **pages router** (`pages/` directory), pracht's `pagesDir` plugin option provides a near-drop-in migration:
-
-1. Set `pracht({ pagesDir: "/src/pages" })` in `vite.config.ts`
-2. Copy `pages/` to `src/pages/`
-3. Convert `_app.tsx` to pracht shell format (`Shell` export + `children` prop)
-4. Convert `getServerSideProps`/`getStaticProps` to `loader` exports
-5. Add `export const RENDER_MODE = "ssg"` to static pages, `"ssr"` for dynamic (default is `"ssr"`). For time-revalidated pages, export `RENDER_MODE = "isg"` and a positive integer `REVALIDATE` in seconds. Webhook policies require ejection.
-6. Run dev server, iterate on errors
-7. Optionally run `generateRoutesFile` to eject to explicit manifest
-
-For pages router projects, you can **skip manual manifest wiring entirely** (Phase 7 below).
-
-## Concept Mapping
+## Concept mapping
 
 | Next.js                         | Pracht                                                          | Notes                                                                 |
 | ------------------------------- | --------------------------------------------------------------- | --------------------------------------------------------------------- |
-| `pages/` directory              | `pagesDir` plugin option                                        | Auto-discovers routes from file system                                |
+| `pages/` directory              | `pagesDir` plugin option                                        | Auto-discovers routes from the file system                            |
 | `app/page.tsx`                  | `src/routes/*.tsx` + `route()` in manifest                      | File is a module; wiring is explicit                                  |
 | `app/layout.tsx`                | `src/shells/*.tsx` + `shells` in `defineApp`                    | Shells are named, not directory-nested                                |
-| `app/loading.tsx`               | `Loading` export on the shell                                   | Rendered as SSR placeholder for SPA routes until the client router takes over |
+| `app/loading.tsx`               | `Loading` export on the shell                                   | SSR placeholder for SPA routes until the client router takes over     |
 | `app/error.tsx`                 | `ErrorBoundary` export in route module                          | Same concept, different wiring                                        |
 | `app/not-found.tsx`             | `notFound:` in `defineApp` (or `pages/404.tsx` in pagesDir mode) | Not a route — never matches a URL, so it cannot shadow static assets  |
 | `middleware.ts`                 | `src/middleware/*.ts` + `middleware` in `defineApp`             | Named, applied per route/group                                        |
 | `app/api/*/route.ts`            | `src/api/*.ts` with `GET`/`POST` exports                        | Auto-discovered, no manifest entry                                    |
 | `generateStaticParams`          | `getStaticPaths()` export                                       | Returns `RouteParams[]` of param objects                              |
 | `generateMetadata`              | `head()` export                                                 | Returns `{ title, meta }`                                             |
-| Server Components               | `loader()` export                                               | Data fetching moves to loader; component is always a Preact component |
+| Server Components               | `loader()` export                                               | Data fetching moves to the loader; the component is a Preact component |
 | `"use server"` actions          | API routes + `<Form>` / `fetch`                                 | Mutations move to `src/api/*`; return `Response` objects              |
-| `"use client"` (few, in a mostly-server app) | `hydration: "islands"` + `src/islands/`            | Only islands ship JS; see the islands note in Phase 4                 |
-| `revalidatePath` / `res.revalidate()` | `webhookRevalidate()` + `POST /__pracht/revalidate`       | On-demand ISG regeneration; combinable with `timeRevalidate(seconds)` |
-| `useRouter()` (next/navigation) | `useNavigate()` from pracht                                     | Accepts paths or typed route targets after `pracht typegen`           |
-| `useSearchParams()`             | `useSearchParams()` from pracht                                 | Returns reactive read-only params; SSG receives the browser query after hydration, while loaders use `url.searchParams` |
-| `useParams()`                   | `useParams()` from pracht                                       | Direct equivalent; also available as `params` in loader args          |
-| `next/link` `<Link>`            | `<Link route="...">` or plain `<a>`                            | Prefer typed `<Link>` for known app routes after `pracht typegen`; plain anchors still work |
-| `next/link` `prefetch={false}`  | `<Link prefetch="none">`                                        | Pracht prefetches on hover/focus by default; also `"viewport"`, `"render"` |
-| `useLinkStatus()` / pending UI  | `useNavigation()`                                               | `{ state, location, formData }` — powers progress bars and optimistic UI |
-| `next/image`                    | `<Image>` from `@pracht/image`                                  | Responsive srcsets plus Node, Cloudflare, Vercel, or passthrough loaders |
+| `"use client"` (few, mostly-server app) | `hydration: "islands"` + `src/islands/`                 | Only islands ship JS; see Phase 4                                     |
+| `revalidatePath` / `res.revalidate()` | `webhookRevalidate()` + `POST /__pracht/revalidate`       | On-demand ISG; combinable with `timeRevalidate(seconds)`              |
+| `useRouter()` (next/navigation) | `useNavigate()`                                                 | Takes a path, or `{ route: "id" }` after `pracht typegen`             |
+| `useSearchParams()`             | `useSearchParams()`                                             | Reactive read-only params; SSG gets the browser query after hydration, loaders use `url.searchParams` |
+| `useParams()`                   | `useParams()`                                                   | Direct equivalent; also `params` in loader args                       |
+| `next/link` `<Link>`            | `<Link route="..." params={{…}}>` or plain `<a>`               | Prefer typed `<Link>` after `pracht typegen`; the router intercepts same-origin anchors |
+| `next/link` `prefetch={false}`  | `<Link prefetch="none">`                                        | Default `"intent"` (hover/focus); also `"viewport"`, `"render"`       |
+| `useLinkStatus()` / pending UI  | `useNavigation()`                                               | `{ state, location, formData }` — progress bars, optimistic UI        |
+| `next/image`                    | `<Image>` from `@pracht/image`                                  | Responsive srcsets; Node, Cloudflare, Vercel, or passthrough loaders  |
 | `next/head` or Metadata API     | `head()` export on route/shell                                  | Per-route and per-shell head merging                                  |
-| `next/script` `<Script>`        | `<Script>` from `@pracht/core`                                  | Strategies: `beforeHydration` (≈ `beforeInteractive`), `afterHydration` (≈ `afterInteractive`, default), `idle` (≈ `lazyOnload`), `visible` |
-| `className`                     | `class`                                                         | Preact uses `class` attribute                                         |
-| `React.useState` etc.           | `import { useState } from "preact/hooks"`                       | Preact hooks API is compatible                                        |
-| `React.useEffect`               | `import { useEffect } from "preact/hooks"`                      | Same API                                                              |
-| `import React from "react"`     | Remove — no import needed                                       | Pracht's Vite plugin handles JSX automatically                        |
+| `next/script` `<Script>`        | `<Script>` from `@pracht/core`                                  | `beforeHydration` (≈ `beforeInteractive`), `afterHydration` (≈ `afterInteractive`, default), `idle` (≈ `lazyOnload`), `visible` |
+| `cookies()` / `headers()`       | `request.headers` in loader/middleware/API args                 | No separate API — read the standard `Request`                         |
+| `className`                     | `class`                                                         | Preact uses the `class` attribute                                     |
+| `react` / `react-dom` imports   | `preact/hooks`, `preact/compat`                                 | Same hook APIs                                                        |
+| `import React from "react"`     | Remove                                                          | The Vite plugin handles JSX                                           |
 
-## Migration Procedure
+Scroll restoration on back/forward works out of the box. `<Link>` also takes
+`preserveScroll` (skip the scroll-to-top reset) and `viewTransition` (wrap the
+navigation in `document.startViewTransition()` where supported).
 
-### Phase 1: Project setup
+## Phase 1: Project setup
 
-1. Initialize the pracht project structure:
-   ```
-   src/
-     routes.ts          # Route manifest
-     routes/            # Route modules
-     shells/            # Layout shells
-     middleware/         # Server-side middleware
-     api/               # API routes
-   ```
-2. Create `vite.config.ts`:
+Create `src/routes.ts` (manifest), `src/routes/`, `src/shells/`,
+`src/middleware/`, `src/api/`, and a `vite.config.ts` whose `plugins` array
+contains `pracht()` from `@pracht/vite-plugin`. Then:
 
-   ```ts
-   import { defineConfig } from "vite";
-   import { pracht } from "@pracht/vite-plugin";
+- Dependencies: drop `react`/`react-dom` for `preact`; drop `next` for
+  `@pracht/core` (runtime), `@pracht/cli` (the `pracht` bin),
+  `@pracht/vite-plugin`, and a target adapter such as `@pracht/adapter-node`.
+  There is no package named `pracht`. Add `@pracht/image` if the app used
+  `next/image`, and `sharp` only for the built-in Node optimization endpoint
+  or build-time `?pracht` imports.
+- Scripts: `dev` → `pracht dev`, `build` → `pracht build`, `start` →
+  `node dist/server/server.js` (Node) or the platform deploy command; add
+  `preview` → `pracht preview`.
+- Delete `next.config.*`, `next-env.d.ts`, `.next/`.
+- In `tsconfig.json`, `"jsx": "preserve"` → `"jsx": "react-jsx"` with
+  `"jsxImportSource": "preact"`.
 
-   export default defineConfig({
-     plugins: [pracht()],
-   });
-   ```
-
-3. Update `package.json`:
-   - Replace `react`, `react-dom` → `preact`
-   - Replace `next` → `@pracht/core` (framework runtime), `@pracht/cli` (provides the `pracht` bin), `@pracht/vite-plugin`, and `@pracht/adapter-node` (or target adapter). There is no package named `pracht`.
-   - If the app imports `next/image`, add `@pracht/image`; add `sharp` only for the built-in Node optimization endpoint or build-time `?pracht` imports (static imports / blur placeholders).
-   - Update scripts: `dev` → `pracht dev`, `build` → `pracht build`, `start` → `node dist/server/server.js` (Node.js) or a platform-specific deploy command; add `preview` → `pracht preview` to serve the production build locally
-4. Remove Next.js config files: `next.config.*`, `next-env.d.ts`, `.next/`
-5. If `tsconfig.json` has `"jsx": "preserve"`, change to `"jsx": "react-jsx"` and add `"jsxImportSource": "preact"`.
-
-### Phase 2: Convert layouts → shells
-
-For each `layout.tsx`:
-
-**Next.js:**
-
-```tsx
-export default function RootLayout({ children }: { children: React.ReactNode }) {
-  return (
-    <html>
-      <body className="root">{children}</body>
-    </html>
-  );
-}
-```
-
-**Pracht:**
+## Phase 2: Layouts → shells
 
 ```tsx
 import type { ShellProps } from "@pracht/core";
 
 export function Shell({ children }: ShellProps) {
-  return (
-    <div class="root">
-      <main>{children}</main>
-    </div>
-  );
+  return <div class="root"><main>{children}</main></div>;
 }
 
 export function head() {
@@ -157,36 +125,15 @@ export function head() {
 }
 ```
 
-Key differences:
+Shells must NOT render `<html>`, `<head>`, or `<body>` — the framework owns
+the document, so move anything from `RootLayout`'s document tags into `head()`.
+Register as `defineApp({ shells: { main: "./shells/main.tsx" } })`.
 
-- Pracht shells do NOT render `<html>`, `<head>`, or `<body>` — the framework owns the HTML document.
-- Use `class` not `className`.
-- Register in `defineApp({ shells: { main: "./shells/main.tsx" } })`.
+## Phase 3: Pages → route modules
 
-### Phase 3: Convert pages → route modules
-
-For each `page.tsx`:
-
-**Next.js (Server Component with data):**
-
-```tsx
-async function getData() {
-  const res = await fetch("https://api.example.com/data");
-  return res.json();
-}
-
-export default async function Page() {
-  const data = await getData();
-  return <div className="page">{data.title}</div>;
-}
-
-export async function generateMetadata() {
-  const data = await getData();
-  return { title: data.title };
-}
-```
-
-**Pracht:**
+An `async` page that fetches and exports `generateMetadata` becomes three
+exports — the fetch moves to `loader`, the metadata to `head`, the JSX stays
+in the default export:
 
 ```tsx
 import type { LoaderArgs, RouteComponentProps } from "@pracht/core";
@@ -205,96 +152,40 @@ export default function Page({ data }: RouteComponentProps<typeof loader>) {
 }
 ```
 
-Key transforms:
+Components are never `async` — data arrives as the `data` prop.
 
-- Server-side data fetching → `loader()` export
-- `generateMetadata` → `head()` export
-- Keep `export default function Page` as the page component
-- `className` → `class`
-- No `async` components — data comes via props from loader
+## Phase 4: Client components
 
-### Phase 4: Convert client components
+Drop the `"use client"` directive (pracht has no such concept), and repoint
+imports: `react` → `preact/hooks` for hooks, `react`/`react-dom` →
+`preact/compat` for everything else. The component body is otherwise unchanged.
 
-**Next.js:**
+**Islands:** if the source is mostly server components with a handful of
+`"use client"` leaves, do not silently regress those pages to full-page
+hydration. Set `hydration: "islands"` on the route (or
+`export const HYDRATION = "islands"` in pages mode) and move the interactive
+components into `src/islands/` — the rest renders as inert HTML. See
+`docs/ISLANDS.md`.
 
-```tsx
-"use client";
-import { useState } from "react";
+## Phase 5: API routes
 
-export default function Counter() {
-  const [count, setCount] = useState(0);
-  return <button onClick={() => setCount(count + 1)}>{count}</button>;
-}
-```
-
-**Pracht:**
-
-```tsx
-import { useState } from "preact/hooks";
-
-export function Counter() {
-  const [count, setCount] = useState(0);
-  return <button onClick={() => setCount(count + 1)}>{count}</button>;
-}
-```
-
-Key transforms:
-
-- Remove `"use client"` directive — not needed in pracht
-- `import { ... } from "react"` → `import { ... } from "preact/hooks"` or `import { ... } from "preact/compat"`
-- `import { ... } from "react-dom"` → `import { ... } from "preact/compat"`
-
-**Islands note:** if the source app is mostly server components with only a handful of `"use client"` components, don't silently regress those pages to full-page hydration. Set `hydration: "islands"` on the route (or `export const HYDRATION = "islands"` in pages mode) and move the interactive components to `src/islands/` — the rest of the page renders as inert HTML and only the islands ship JavaScript. See `docs/ISLANDS.md`.
-
-### Phase 5: Convert API routes
-
-**Next.js (`app/api/users/route.ts`):**
-
-```ts
-import { NextRequest, NextResponse } from "next/server";
-
-export async function GET(request: NextRequest) {
-  const users = await getUsers();
-  return NextResponse.json(users);
-}
-```
-
-**Pracht (`src/api/users.ts`):**
+`app/api/users/route.ts` → `src/api/users.ts`, dynamic segments included
+(`app/api/users/[id]/route.ts` → `src/api/users/[id].ts`). Handlers take
+`ApiRouteArgs` and use web standards throughout:
 
 ```ts
 import type { ApiRouteArgs } from "@pracht/core";
 
 export async function GET({ request }: ApiRouteArgs) {
-  const users = await getUsers();
-  return Response.json(users);
+  return Response.json(await getUsers());
 }
 ```
 
-Key transforms:
+`NextRequest` → the standard `Request` from `ApiRouteArgs`;
+`NextResponse.json()` → `Response.json()`. No manifest wiring — API routes are
+auto-discovered.
 
-- `NextRequest` → standard `Request` (via `ApiRouteArgs`)
-- `NextResponse.json()` → `Response.json()` (Web standard)
-- Dynamic segments: `app/api/users/[id]/route.ts` → `src/api/users/[id].ts`
-- No manifest wiring needed — auto-discovered
-
-### Phase 6: Convert middleware
-
-**Next.js (`middleware.ts`):**
-
-```ts
-import { NextResponse } from "next/server";
-import type { NextRequest } from "next/server";
-
-export function middleware(request: NextRequest) {
-  const session = request.cookies.get("session");
-  if (!session) return NextResponse.redirect(new URL("/login", request.url));
-  return NextResponse.next();
-}
-
-export const config = { matcher: ["/dashboard/:path*"] };
-```
-
-**Pracht (`src/middleware/auth.ts`):**
+## Phase 6: Middleware
 
 ```ts
 import { redirect, type MiddlewareFn } from "@pracht/core";
@@ -306,44 +197,30 @@ export const middleware: MiddlewareFn = async ({ request }, next) => {
 };
 ```
 
-Then apply it in the manifest:
+`NextResponse.redirect()` → `return redirect("/path", { request })`;
+`NextResponse.next()` → `return next()`. Path matching moves out of
+`config.matcher` and into manifest assignment:
+`group({ middleware: ["auth"] }, [route("/dashboard", …)])`. Pracht middleware
+is wrap-around (Hono/Koa/Astro shape), so you can `await next()` and observe
+the response — useful for tracing.
 
-```ts
-group({ middleware: ["auth"] }, [
-  route("/dashboard", () => import("./routes/dashboard.tsx"), { render: "ssr" }),
-]);
-```
+## Phase 7: Route manifest
 
-Key transforms:
-
-- Path matching moves from `config.matcher` to manifest group/route assignment
-- `NextResponse.redirect()` → `return redirect("/path", { request })`
-- `NextResponse.next()` → `return next()`
-- Pracht middleware is **wrap-around** (Hono/Koa/Astro shape), so you can
-  also `await next()` and observe the response — useful for tracing.
-
-### Phase 7: Wire the route manifest
-
-**Note:** For pages router projects using `pagesDir`, this phase is automatic. Skip to Phase 8.
-
-Instead of hand-writing every entry, prefer `pracht generate route --path ... --render ...` (with `--shell`/`--middleware`/`--loader` as needed) per page: it creates a wired skeleton **and** updates `src/routes.ts` for you — then port the Next.js component/loader bodies into the generated files. Hand-write the manifest only for shapes the generator cannot express.
-
-Build `src/routes.ts` mapping every migrated page. Module references accept `() => import("./path")` (enables IDE navigation) or plain `"./path"` strings — both work:
+Skip this phase for `pagesDir` projects. Prefer
+`pracht generate route --path ... --render ...` (plus `--shell`/`--middleware`/
+`--loader`) per page — it creates a wired skeleton **and** updates
+`src/routes.ts` — then port the Next.js bodies into the generated files.
+Hand-write manifest entries only for shapes the generator cannot express.
 
 ```ts
 import { defineApp, group, route } from "@pracht/core";
 
 export const app = defineApp({
-  shells: {
-    main: () => import("./shells/main.tsx"),
-  },
-  middleware: {
-    auth: () => import("./middleware/auth.ts"),
-  },
+  shells: { main: () => import("./shells/main.tsx") },
+  middleware: { auth: () => import("./middleware/auth.ts") },
   routes: [
     group({ shell: "main" }, [
       route("/", () => import("./routes/home.tsx"), { render: "ssg" }),
-      route("/about", () => import("./routes/about.tsx"), { render: "ssg" }),
       route("/dashboard", () => import("./routes/dashboard.tsx"), {
         render: "ssr",
         middleware: ["auth"],
@@ -351,122 +228,63 @@ export const app = defineApp({
       route("/blog/:slug", () => import("./routes/blog-post.tsx"), { render: "isg" }),
     ]),
   ],
-  notFound: {
-    component: () => import("./routes/not-found.tsx"),
-    shell: "main",
-  },
+  notFound: { component: () => import("./routes/not-found.tsx"), shell: "main" },
 });
 ```
 
-Choose render modes based on the Next.js original:
+Module references accept `() => import("./path")` (better IDE navigation) or a
+plain `"./path"` string. Pick render modes from the Next.js original:
 
-- Static pages (no data fetching, or `generateStaticParams`) → `"ssg"`
-- Dynamic pages (`cookies()`, `headers()`, per-request data) → `"ssr"`
-- ISR pages (`revalidate` option) → `"isg"` with `timeRevalidate(seconds)`
-- On-demand ISR (`revalidatePath` / `res.revalidate()`) → add `webhookRevalidate()` (alone or as `[timeRevalidate(seconds), webhookRevalidate()]`) and trigger via `POST /__pracht/revalidate`
-- Client-only pages → `"spa"`
+| Next.js original                              | Render mode                                              |
+| --------------------------------------------- | -------------------------------------------------------- |
+| No data fetching, or `generateStaticParams`   | `"ssg"`                                                   |
+| `cookies()`, `headers()`, per-request data    | `"ssr"`                                                   |
+| `revalidate` option                           | `"isg"` + `timeRevalidate(seconds)`                       |
+| `revalidatePath` / `res.revalidate()`         | `"isg"` + `webhookRevalidate()`, triggered by `POST /__pracht/revalidate` |
+| Client-only                                   | `"spa"`                                                   |
 
-### Phase 8: Handle common patterns
+## Phase 8: Remaining patterns
 
-#### `next/link` → typed `<Link>` or plain `<a>`
+**Links and navigation.** After the manifest exists, run `pracht typegen` and
+switch known app routes to route ids: `<Link route="product" params={{ id }}>`
+and `navigate({ route: "dashboard" })`. Plain `<a href="/about">` and
+`navigate("/dashboard")` keep working for simple, external, or user-provided
+URLs.
 
-After manifest wiring is in place, run `pracht typegen` and prefer route-id based links for known app routes:
+**Images.** `<Image>` from `@pracht/image` takes the same
+`width`/`height`/`fill`/`sizes`/`quality` and priority intent — preserve them.
+Pick the loader for the deployment target:
 
-```tsx
-// Next.js
-import Link from "next/link";
-<Link href={`/products/${id}`}>Product</Link>
+| Target             | Loader                                                                          |
+| ------------------ | -------------------------------------------------------------------------------- |
+| Node               | `createImageHandler()` from `@pracht/image/node` + `sharp`; set its `localOrigin` to the same trusted value as `nodeAdapter({ canonicalOrigin })` |
+| Cloudflare Workers | `cloudflareLoader` — never bundle the Node handler, `sharp` does not run in Workers |
+| Vercel Edge        | `vercelLoader`, with Vercel's allowed image sizes aligned to the pracht breakpoints |
+| Static hosts       | `passthroughLoader`                                                              |
 
-// Pracht
-import { Link } from "@pracht/core";
-<Link route="product" params={{ id }}>Product</Link>
-```
+Static imports and blur placeholders migrate too: `import photo from
+"./photo.jpg"` → `"./photo.jpg?pracht"`, add `prachtImage()` (from
+`@pracht/image/vite`) to the Vite plugins, reference the `@pracht/image/client`
+types once in a `.d.ts`, and keep `<Image src={photo} placeholder="blur" />`
+as-is — the import supplies `width`/`height`/`blurDataURL` exactly like Next's
+static imports, though pracht's blur is CSS-only (no fade, no inline handlers).
+Where `next/image` produced files during a static export, use
+`?pracht&pracht-static`: it emits cached responsive WebP variants and bypasses
+the runtime loader while keeping plain hydration-free `<img>` markup. For
+relative images in Markdown, `defineMarkdownCollection()` from
+`@pracht/markdown` applies the same pipeline to `![alt](./photo.jpg)`. Leave
+`public/` and remote URLs unchanged, and use an absolute Vite `base` for static
+variants. See `docs/IMAGES.md`.
 
-Plain anchors still work for simple, external, or user-provided URLs because the client router intercepts same-origin `<a>` clicks:
+**Server Actions.** A `"use server"` mutation becomes an API route; the
+`revalidatePath` half becomes an authenticated webhook call:
 
-```tsx
-<a href="/about">About</a>
-```
-
-`<Link>` also accepts navigation-behavior props: `prefetch` (`"none" | "intent" | "viewport" | "render"`, default `"intent"` on hover/focus — the equivalent of `next/link`'s `prefetch` tuning), `preserveScroll` (skip the scroll-to-top reset), and `viewTransition` (wrap the navigation in `document.startViewTransition()` where supported). Scroll restoration on back/forward works out of the box, like Next.js.
-
-#### `next/image` → `@pracht/image`
-
-```tsx
-// Next.js
-import Image from "next/image";
-<Image src="/photo.jpg" width={500} height={300} alt="Photo" />
-
-// Pracht
-import { Image } from "@pracht/image";
-<Image src="/photo.jpg" width={500} height={300} alt="Photo" />
-```
-
-Choose the loader for the deployment target:
-
-- Node: mount `createImageHandler()` from `@pracht/image/node`, install
-  `sharp`, and set its `localOrigin` to the same trusted value as
-  `nodeAdapter({ canonicalOrigin })`.
-- Cloudflare Workers: configure `cloudflareLoader`; do not bundle the Node
-  handler because `sharp` does not run in Workers.
-- Vercel Edge: configure `vercelLoader` and keep Vercel's allowed image sizes
-  aligned with the Pracht breakpoints.
-- Static hosts: configure `passthroughLoader`.
-
-Preserve the original `width`, `height`, `fill`, `sizes`, `quality`, and
-priority intent. See `docs/IMAGES.md` for the endpoint and loader wiring.
-
-Static imports and blur placeholders migrate too: replace
-`import photo from "./photo.jpg"` with `import photo from "./photo.jpg?pracht"`,
-add `prachtImage()` (from `@pracht/image/vite`) to the Vite plugins, reference
-the `@pracht/image/client` types once in a `.d.ts`, and keep
-`<Image src={photo} placeholder="blur" />` as-is — the import supplies
-`width`/`height`/`blurDataURL` exactly like Next's static imports. Pracht's
-blur is CSS-only (no fade animation, no inline event handlers).
-
-For apps that relied on `next/image` producing files during a static export,
-use `?pracht&pracht-static` instead. It emits cached responsive WebP variants
-and bypasses the runtime loader while retaining plain, hydration-free `<img>`
-markup. When Markdown content contains relative images, prefer
-`defineMarkdownCollection()` from `@pracht/markdown`; it applies the same
-static pipeline to normal `![alt](./photo.jpg)` syntax. Keep root-relative
-`public/` and remote image URLs unchanged, and use an absolute Vite `base` for
-static variants.
-
-#### `useRouter` → navigation
-
-```tsx
-// Next.js
-import { useRouter } from "next/navigation";
-const router = useRouter();
-router.push("/dashboard");
-
-// Pracht
-import { useNavigate } from "@pracht/core";
-const navigate = useNavigate();
-navigate("/dashboard");
-
-// After `pracht typegen`, prefer route ids for known routes
-navigate({ route: "dashboard" });
-```
-
-#### Server Actions → API routes
-
-```tsx
-// Next.js
-"use server";
-async function createPost(formData: FormData) {
-  await db.insert({ title: formData.get("title") });
-  revalidatePath("/posts");
-}
-
-// Pracht — API route handler
+```ts
 import { withBase, type ApiRouteArgs } from "@pracht/core";
 
 export async function POST({ request }: ApiRouteArgs) {
   const form = await request.formData();
   await db.insert({ title: form.get("title") });
-  // revalidatePath("/posts") equivalent: regenerate the ISG page on demand
   await fetch(new URL(withBase("/__pracht/revalidate"), request.url), {
     method: "POST",
     headers: {
@@ -475,81 +293,39 @@ export async function POST({ request }: ApiRouteArgs) {
     },
     body: JSON.stringify({ paths: ["/posts"] }),
   });
-  return new Response(null, {
-    status: 303,
-    headers: { location: withBase("/posts") },
-  });
+  return new Response(null, { status: 303, headers: { location: withBase("/posts") } });
 }
 ```
 
-For the revalidation call to take effect, the `/posts` route must be `render: "isg"` and opt in with `revalidate: webhookRevalidate()` (or `[timeRevalidate(seconds), webhookRevalidate()]`) in the manifest — import both from `@pracht/core` — and `PRACHT_REVALIDATE_TOKEN` must be set in the runtime environment. If `/posts` is a plain SSR route, skip the revalidation call; the redirect re-renders it fresh anyway.
+That call only does something if `/posts` is `render: "isg"` and opts in with
+`revalidate: webhookRevalidate()` (or `[timeRevalidate(seconds),
+webhookRevalidate()]`, both imported from `@pracht/core`), and
+`PRACHT_REVALIDATE_TOKEN` is set in the runtime environment. If `/posts` is a
+plain SSR route, drop the call — the redirect re-renders it fresh.
 
-#### `cookies()` / `headers()` → loader args
+## Phase 9: Clean up and verify
 
-```tsx
-// Next.js
-import { cookies, headers } from "next/headers";
-const session = cookies().get("session");
-const ua = headers().get("user-agent");
+Sweep for leftovers: `"use client"`/`"use server"` directives, `next/*`
+imports, `className`, `react` imports, and `next.config.*`/`next-env.d.ts`/
+`.next/`. Run `pracht typegen` if route ids or paths changed, then `pracht dev`
+and fix errors iteratively.
 
-// Pracht — available in loader args
-export async function loader({ request }: LoaderArgs) {
-  const cookies = request.headers.get("cookie");
-  const ua = request.headers.get("user-agent");
-  return {
-    /* ... */
-  };
-}
-```
-
-### Phase 9: Clean up
-
-1. Remove all `"use client"` and `"use server"` directives.
-2. Remove all `next/*` imports (`next/link`, `next/image`, `next/navigation`, `next/headers`).
-3. Search for remaining `className` → replace with `class`.
-4. Search for remaining `react` imports → replace with `preact` equivalents.
-5. Remove `next.config.*`, `next-env.d.ts`, `.next/` directory.
-6. Run `pracht typegen` if route ids/paths changed or if you converted links/navigation to typed route ids.
-7. Run the dev server (`pracht dev`) and fix any remaining issues.
-
-## Dependency Mapping
+## Dependency mapping
 
 | Next.js package | Pracht equivalent                                                            |
 | --------------- | ---------------------------------------------------------------------------- |
-| `next`          | `@pracht/core` + `@pracht/cli` + `@pracht/vite-plugin` + `@pracht/adapter-node` (or target adapter) |
-| `next/image`    | `@pracht/image`                                         |
-| `react`         | `preact`                                                |
-| `react-dom`     | `preact`                                                |
-| `next/font/local` | `defineFont()` from `@pracht/core` — register via `head() { return { fonts: [font] } }`, use `font.className`/`font.style` in components |
+| `next`          | `@pracht/core` + `@pracht/cli` + `@pracht/vite-plugin` + a target adapter    |
+| `next/image`    | `@pracht/image`                                                              |
+| `react`, `react-dom` | `preact`                                                                |
+| `next/font/local` | `defineFont()` from `@pracht/core` — register via `head() { return { fonts: [font] } }`, use `font.className`/`font.style` |
 | `next/font/google` | Download the woff2 files into `public/fonts/` (e.g. via google-webfonts-helper), then `defineFont()` — pracht never fetches fonts at build time |
-| `@next/mdx`     | `@mdx-js/rollup` (Vite plugin)                          |
-| `next-auth`     | Direct integration in middleware/loaders                |
-| `next/og`       | `@vercel/og` or custom solution                         |
+| `@next/mdx`     | `@mdx-js/rollup` (Vite plugin)                                               |
+| `next-auth`     | Direct integration in middleware/loaders                                     |
+| `next/og`       | `@vercel/og` or a custom solution                                            |
 
-## React Library Compatibility
-
-Many React libraries work with Preact via `preact/compat`. Add aliases in `vite.config.ts` if needed:
-
-```ts
-resolve: {
-  alias: {
-    "react": "preact/compat",
-    "react-dom": "preact/compat",
-    "react/jsx-runtime": "preact/jsx-runtime",
-  }
-}
-```
-
-Note: The pracht Vite plugin sets these aliases automatically. Only add manual aliases if a dependency doesn't resolve correctly.
-
-## Rules
-
-1. Always read the Next.js source before converting — understand what each file does.
-2. Migrate in phases: setup → shells → routes → API → middleware → manifest → cleanup.
-3. Prefer the simplest pracht equivalent. Don't over-engineer the migration.
-4. Identify React libraries that need `preact/compat` aliasing and flag them.
-5. After migration, run `pracht dev` to verify. Fix errors iteratively.
-6. If a Next.js feature has no pracht equivalent, explain the gap and suggest alternatives.
-7. Use Preact idioms: `class` not `className`, no `React` import needed, `preact/hooks` for hooks.
+Most React libraries work through `preact/compat`, and the pracht Vite plugin
+already aliases `react`/`react-dom`/`react/jsx-runtime` for you. Add manual
+`resolve.alias` entries only when a dependency still fails to resolve — and
+flag those libraries to the user.
 
 $ARGUMENTS

--- a/skills/pracht-debug/SKILL.md
+++ b/skills/pracht-debug/SKILL.md
@@ -1,14 +1,12 @@
 ---
 name: pracht-debug
-version: 1.3.0
+version: 1.4.0
 description: |
-  Pracht framework-aware debugging. Systematically investigates route matching,
-  loader/API route errors, rendering issues, middleware, API routes, HMR, and build
-  problems. Uses pracht's architecture knowledge to find root causes fast.
-  Use when asked to "debug this", "fix this bug", "why is this broken",
-  "blank page", "hydration mismatch", or "404 on my route".
-  Proactively suggest when the user reports errors or unexpected behavior
-  in a pracht application.
+  Framework-aware debugging for pracht: route matching, loader and API errors,
+  rendering and hydration, middleware, HMR, and build failures — root cause first.
+  Use for "debug this", "fix this bug", "why is this broken", "blank page",
+  "hydration mismatch", "404 on my route"; suggest it when the user reports
+  unexpected pracht behavior.
 allowed-tools:
   - Bash
   - Read
@@ -21,138 +19,173 @@ allowed-tools:
 
 # Pracht Debug
 
-Framework-aware debugging for pracht applications — a full-stack Preact framework built on Vite.
+**Iron law: no fixes without root-cause investigation first.** Read the
+relevant source before diagnosing, start from the most likely cause for the
+symptom rather than a full audit, and when you find the root cause explain
+*why* it breaks. After fixing, prove the fix — run the test, check the dev
+server. Never say "this should fix it."
 
-The user will describe a symptom (error, unexpected behavior, blank page, etc.). Investigate systematically using the checklist below, stopping when you find the root cause.
+## Instruments
 
-Before deep manual inspection, prefer running `pracht verify` (add `--changed` to scope the checks to git-changed files) for a fast agent loop or `pracht doctor` when the problem could be caused by broader broken app wiring or missing files.
-When another agent/tool needs the framework's resolved graph, prefer `pracht inspect routes --json`, `pracht inspect api --json`, or `pracht inspect build --json` over reconstructing it from source files. Prerequisites: `pracht inspect` needs the pracht plugin registered in the project's vite config, and `pracht inspect build` needs a prior `pracht build`.
-If the pracht MCP server is registered (docs/MCP.md), prefer the `inspect_routes`/`inspect_api`/`doctor`/`verify` MCP tools over shelling out — same payloads, structured results.
-While the dev server is running, `GET /_pracht` serves a devtools page with the same resolved route/API graph (raw JSON at `/_pracht.json`) — useful when you have a browser or `curl` handy but no CLI access. Under a Vite deploy base, prefix both paths with that base; links from the devtools and dev-404 pages already do so. Dev SSR responses also carry a `Server-Timing` header (`mw`, `loader`, `render` durations in ms) — check it in the browser Network panel or with `curl -sI` to see which phase makes a route slow.
+Reach for these before deep manual inspection:
 
-## Iron Law
+| Tool | Use |
+| ---- | --- |
+| `pracht verify` (`--changed` to scope to git-changed files) | Fast confidence check |
+| `pracht doctor` | Broader broken wiring or missing files |
+| `pracht inspect routes\|api\|build --json` | The resolved graph — never reconstruct it from source |
+| `GET /_pracht` (JSON at `/_pracht.json`) | Same graph from a running dev server, no CLI needed |
+| `Server-Timing` on dev SSR responses | `mw` / `loader` / `render` durations in ms — which phase is slow |
 
-**NO FIXES WITHOUT ROOT CAUSE INVESTIGATION FIRST.**
+`pracht inspect` needs the pracht plugin in the vite config; `inspect build`
+needs a prior `pracht build`. Under a Vite deploy base, prefix `/_pracht` with
+that base (links from the devtools and dev-404 pages already do). When the
+pracht MCP server is registered (docs/MCP.md), prefer the
+`inspect_routes`/`inspect_api`/`doctor`/`verify` MCP tools — same payloads,
+structured results.
 
-## Debugging Checklist
+## Checklist
 
-Work through these in order, stopping when you find the root cause:
+Work in order; stop at the root cause.
 
 ### 1. Route matching
 
-- Run `pracht verify --changed` first if you want a cheap changed-file confidence check.
-- Run `pracht doctor` if the route might be missing, miswired, or pointing at a missing module across the project.
-- For machine-readable route wiring, run `pracht inspect routes --json`. With a running dev server, `curl http://localhost:5173/_pracht.json` returns the same graph.
-- Read `src/routes.ts` — is the route defined? Is the path correct?
-- Check for typos in file paths (the manifest uses relative paths like `"./routes/home.tsx"`).
-- For dynamic segments, verify bracket syntax: `route("/users/:id", ...)` in manifest, `[id].ts` in filenames.
-- Grep for the route path across the manifest and check `matchAppRoute()` logic if needed.
+- `pracht inspect routes --json` (or `curl http://localhost:5173/_pracht.json`)
+  for the resolved wiring; `pracht doctor` if a route may be missing, miswired,
+  or pointing at a missing module.
+- Is the route in `src/routes.ts` with the right path? The manifest uses
+  relative paths like `"./routes/home.tsx"` — check for typos.
+- Dynamic segments: `route("/users/:id", ...)` in the manifest, `[id].ts` in
+  filenames.
+- If needed, grep the route path across the manifest and check
+  `matchAppRoute()`.
 
-### 2. Typed route/link issues
+### 2. Typed routes and links
 
-- If `<Link route="...">`, `href("...")`, or route-object `useNavigate()` fails to typecheck, run `pracht typegen --check` to detect stale generated files.
-- Run `pracht inspect routes --json` and confirm the route id exists. If it is a fallback id, remember path changes can rename it.
-- Check generated `src/pracht.d.ts` for inferred params. `:id`, `*`, and `:path*` params are required; extra params should fail at typecheck time.
-- If runtime navigation throws `Unknown pracht route id "..."`, in dev the error includes a `Did you mean "..."?` suggestion and the list of registered route ids (production builds tree-shake this and throw the bare error) — check for a typo first, then ensure `pracht typegen` was run and the component is rendered inside the pracht route tree.
-- For unexpected URLs, reproduce with `href(routeId, options)` and compare against the route's resolved path and params.
+- A `<Link route="...">`, `href("...")`, or route-object `useNavigate()` that
+  fails to typecheck usually means stale generated files: `pracht typegen
+  --check`.
+- Confirm the route id exists in `pracht inspect routes --json`. Fallback ids
+  get renamed by path changes.
+- `src/pracht.d.ts` carries the inferred params. `:id`, `*`, and `:path*` are
+  required; extra params should fail at typecheck time.
+- Runtime `Unknown pracht route id "..."`: dev appends `Did you mean "..."?`
+  plus the registered ids (production tree-shakes that and throws bare). Check
+  the typo first, then that `pracht typegen` ran and the component renders
+  inside the pracht route tree.
+- For unexpected URLs, reproduce with `href(routeId, options)` and compare
+  against the route's resolved path and params.
 
-### 3. Loader / API route errors
+### 3. Loader / API errors
 
-- For slow pages, read the dev `Server-Timing` response header (`mw`/`loader`/`render` in ms) to see which phase dominates before reading code.
-- Read the route module's `loader` function or the matching API route handler.
-- Check that `loader` returns serializable data (no functions, no circular refs).
-- Check that API route handlers return `Response` objects and branch on `request.method` when using a default export.
-- Look for unhandled promise rejections or thrown errors.
-- Verify `LoaderArgs` destructuring matches what the framework provides: `{ request, params, context, signal, url, route }`.
+- On slow pages, read `Server-Timing` before reading code.
+- Loaders must return serializable data — no functions, no circular refs.
+- API handlers must return `Response` objects, and a default export must branch
+  on `request.method`.
+- Look for unhandled rejections or thrown errors.
+- `LoaderArgs` destructuring must match what the framework provides:
+  `{ request, params, context, signal, url, route }`.
 
-### 4. Rendering issues
+### 4. Rendering
 
-- **Blank page**: Check if the route has `render: "spa"` (no SSR content expected) vs `"ssr"`.
-- **Hydration mismatch**: In dev, pracht surfaces a fixed-position red banner at the top of the page listing each mismatched component (via Preact's `options.__m` hook). Compare server-rendered HTML vs client component output. Common causes:
-  - Date/time rendering differences
-  - Browser-only APIs used during SSR (`window`, `document`, `localStorage`)
-  - Conditional rendering based on client state
-  - Two copies of `@pracht/core` in the SSR module graph. The tell is that
-    `useLocation()` returns `/`, `useParams()` returns `{}`, and
-    `useRouteData()` returns `undefined` in the server-rendered HTML for
-    *every* page, while the hydrated client is correct — the provider and the
-    hooks hold different `createContext()` objects. The plugin prevents this by
-    keeping `@pracht/*` in `ssr.noExternal` (dev and build alike); listing a
-    `@pracht/*` package in `ssr.external` overrides that and brings the split
-    back.
-- **Missing shell**: Referencing an unregistered shell name throws at manifest resolution — `Unknown shell "..." for route "...". Did you mean "..."? Registered shells: ...` — and shows up in the dev error overlay as soon as the server loads the manifest. Verify the shell is registered in `defineApp({ shells: { ... } })` and assigned to the route/group.
-- **404 page**: Route not matched — check manifest wiring (step 1). In `pracht dev`, unmatched navigations render a dev-only 404 page listing every registered route with its render mode; compare the requested path against that table. The route table is also printed on dev-server startup and available via `pracht inspect routes`. Apps that declare `defineApp({ notFound })` render their own 404 page instead (in dev and production alike), so the route table is not shown — check `pracht inspect routes` directly. A 404 on a URL you *do* expect to work usually means the loader threw `notFound()`, not that matching failed.
+- **Blank page** — check whether the route is `render: "spa"` (no SSR content
+  expected) rather than `"ssr"`.
+- **Hydration mismatch** — dev shows a fixed red banner listing each mismatched
+  component (via Preact's `options.__m` hook). Compare server HTML against
+  client output. Usual causes: date/time differences, browser-only APIs during
+  SSR (`window`, `document`, `localStorage`), conditional rendering on client
+  state — or two copies of `@pracht/core` in the SSR module graph. The tell for
+  that last one: in the server-rendered HTML of *every* page, `useLocation()`
+  returns `/`, `useParams()` returns `{}`, and `useRouteData()` returns
+  `undefined`, while the hydrated client is correct — provider and hooks hold
+  different `createContext()` objects. The plugin prevents it by keeping
+  `@pracht/*` in `ssr.noExternal`; listing a `@pracht/*` package in
+  `ssr.external` overrides that and brings the split back.
+- **Missing shell** — an unregistered shell name throws at manifest resolution
+  (`Unknown shell "..." for route "...". Did you mean "..."? Registered shells:
+  ...`) and appears in the dev error overlay as soon as the manifest loads.
+  Check `defineApp({ shells })` and the route/group assignment.
+- **404** — usually step 1, but a 404 on a URL you *do* expect means the loader
+  threw `notFound()`, not that matching failed. In `pracht dev`, unmatched
+  navigations render a dev-only 404 listing every registered route and its
+  render mode (also printed at dev-server startup, also in `pracht inspect
+  routes`). Apps declaring `defineApp({ notFound })` render their own 404 page
+  in dev and production alike, so that table is not shown — read `pracht
+  inspect routes` directly.
 
-### 5. Middleware issues
+### 5. Middleware
 
-- Verify middleware is registered in `defineApp({ middleware: { ... } })`. An
-  unregistered name (on a route, group, or `api.middleware`) throws at manifest
-  resolution — `Unknown middleware "..." for route "...". Did you mean "..."? Registered middleware: ...`
-- Verify middleware is applied to the route/group: `middleware: ["name"]`.
-- Middleware is wrap-around: it must always return a `Response`, either by
-  calling `await next()` (to continue down the chain) or short-circuiting.
-- Common bugs:
-  - Forgetting `return next()` → `Middleware "..." did not return a Response`
-  - Calling `next()` twice → `Middleware "..." called next() multiple times`
-  - Mutating a non-object `context` → mutations don't propagate; always pass
-    an object as the request context.
-- Middleware runs server-side only, wrapping loaders and API handlers.
+- It must be registered in `defineApp({ middleware })` and applied via
+  `middleware: ["name"]` on the route or group. An unregistered name (route,
+  group, or `api.middleware`) throws at manifest resolution: `Unknown
+  middleware "..." for route "...". Did you mean "..."? Registered middleware:
+  ...`
+- Middleware is wrap-around and server-side only, wrapping loaders and API
+  handlers. It must always return a `Response`, either from `await next()` or
+  by short-circuiting. Common failures:
 
-### 6. API route issues
+| Bug | Error |
+| --- | ----- |
+| Forgetting `return next()` | `Middleware "..." did not return a Response` |
+| Calling `next()` twice | `Middleware "..." called next() multiple times` |
+| Mutating a non-object `context` | Silent — mutations don't propagate; always pass an object |
 
-- API routes live in `src/api/` and are auto-discovered (no manifest entry needed).
-- For machine-readable API inventory, run `pracht inspect api --json`.
-- File path maps to URL: `src/api/health.ts` → `/api/health`, `src/api/users/[id].ts` → `/api/users/:id`.
-- Each file exports named HTTP method handlers (`GET`, `POST`, etc.) or one default handler.
-- Missing method handler → 405 response when there is no default handler.
-- Default handlers receive the same route args and can branch on `request.method`.
-- Handlers must return `Response` objects.
+### 6. API routes
 
-### 7. Vite plugin / HMR issues
+- They live in `src/api/`, auto-discovered, no manifest entry.
+  `pracht inspect api --json` for the inventory.
+- Path maps to URL: `src/api/health.ts` → `/api/health`,
+  `src/api/users/[id].ts` → `/api/users/:id`.
+- Each file exports named method handlers (`GET`, `POST`, …) or one default
+  handler that branches on `request.method`. A missing method handler is a 405
+  when there is no default.
 
-- Check `vite.config.ts` — is `pracht()` plugin included?
-- Virtual modules: `virtual:pracht/client` (hydration), `virtual:pracht/server` (SSR), `virtual:pracht/islands-client` (islands hydration).
-- HMR: changes to `src/routes.ts` restart the dev server (`server.restart()`, not a browser-side full reload). Route, shell, and island components use Preact Fast Refresh; route/shell edits and client-reachable dependencies of inline or separately wired loaders also re-fetch active route data, with rapid saves coalesced so the newest result settles last and a failed latest refresh falls back to a reload. Adding or removing a route `loader` or route/shell `head` export reloads so the generated client hints stay current, and editing a route/shell that exports document `headers()` reloads because CSP and other response headers cannot be patched. Compiled formats receive refresh instrumentation after their companion Vite plugin runs, but Markdown, MDX, and configured additional formats reload conservatively because a transform may synthesize `headers()` from metadata; default `.tsrx` preserves state when its source is headerless. Other route/shell/middleware/API/server/islands changes invalidate the server module.
-- If HMR seems broken, check that the file is in one of the watched directories (`src/routes/`, `src/shells/`, `src/middleware/`, `src/api/`, `src/server/`, `src/islands/`).
+### 7. Vite plugin and HMR
 
-### 8. Build / deployment issues
+- Is `pracht()` in `vite.config.ts`? Virtual modules are
+  `virtual:pracht/client` (hydration), `virtual:pracht/server` (SSR),
+  `virtual:pracht/islands-client` (islands hydration).
+- HMR only watches `src/routes/`, `src/shells/`, `src/middleware/`,
+  `src/api/`, `src/server/`, `src/islands/`.
+- What each change does: editing `src/routes.ts` restarts the dev server
+  (`server.restart()`, not a browser reload). Route, shell, and island
+  components use Preact Fast Refresh; route/shell edits and client-reachable
+  loader dependencies also re-fetch active route data, with rapid saves
+  coalesced so the newest result settles last and a failed latest refresh
+  falling back to a reload. Adding or removing a route `loader` or route/shell
+  `head` export reloads so generated client hints stay current, and editing a
+  route/shell exporting document `headers()` reloads because CSP and other
+  response headers cannot be patched. Compiled formats get refresh
+  instrumentation after their companion Vite plugin runs, but Markdown, MDX,
+  and configured additional formats reload conservatively because a transform
+  may synthesize `headers()` from metadata; default `.tsrx` preserves state
+  when its source is headerless. Everything else invalidates the server module.
 
-- `pracht build` runs client + server builds, then prerenders SSG/ISG routes.
-- On serverful adapters, a failed SSG/ISG path is warned about and skipped, but
-  the build fails if every attempted prerender returns a non-200 response. Use
-  the reported underlying error to fix the shared loader/render dependency;
-  partial prerender output remains valid. Static exports fail on any bad path.
-- `pracht preview` builds and serves the production output locally (Node runs `dist/server/server.js`, Cloudflare delegates to `wrangler dev`).
-- `pracht inspect build --json` reports the resolved adapter target plus client/CSS/JS manifests from the latest build output (requires a prior `pracht build`).
-- Check `dist/client/` for client assets and `dist/server/` for server bundle.
-- ISG manifest: `dist/server/isg-manifest.json`. On Cloudflare the build also copies it to `dist/client/_pracht/isg.json` for the worker runtime to read via the assets binding.
-- Adapter mismatch: ensure `pracht({ adapter: nodeAdapter() })` or `cloudflareAdapter()` matches deployment target.
+### 8. Build and deployment
 
-## Key Files
+- `pracht build` runs the client and server builds, then prerenders SSG/ISG
+  routes. On serverful adapters a failed path is warned about and skipped, but
+  the build fails if *every* attempted prerender returns non-200 — use the
+  reported underlying error to fix the shared loader/render dependency; partial
+  output stays valid. Static exports fail on any bad path.
+- `pracht preview` builds and serves production output locally (Node runs
+  `dist/server/server.js`; Cloudflare delegates to `wrangler dev`).
+- `pracht inspect build --json` reports the resolved adapter target plus the
+  client/CSS/JS manifests from the last build.
+- Client assets land in `dist/client/`, the server bundle in `dist/server/`.
+  The ISG manifest is `dist/server/isg-manifest.json`; on Cloudflare the build
+  also copies it to `dist/client/_pracht/isg.json` for the worker to read via
+  the assets binding.
+- Confirm the adapter in `pracht({ adapter: … })` matches the deployment
+  target.
 
-| File                  | Purpose                                               |
-| --------------------- | ----------------------------------------------------- |
-| `src/routes.ts`       | App manifest — all route/shell/middleware definitions |
-| `vite.config.ts`      | Vite config with `pracht()` plugin                    |
-| `src/routes/*.tsx`    | Route modules (loader, Component)                     |
-| `src/shells/*.tsx`    | Shell layout components                               |
-| `src/middleware/*.ts` | Server-side middleware                                |
-| `src/api/*.ts`        | API route handlers                                    |
+## Framework internals
 
-## Framework Internals
-
-- `handlePrachtRequest()` dispatches: API routes → middleware → loader → render → HTML assembly
-- Route state JSON: returned when `x-pracht-route-state-request` header is present (client-side navigation)
-- Hydration state: injected as `window.__PRACHT_STATE__` in the HTML
-- Client router: `initClientRouter()` intercepts link clicks and fetches route state JSON
-
-## Rules
-
-1. Always read the relevant source files before diagnosing.
-2. Start with the most likely cause based on the symptom, not a full audit.
-3. When you find the root cause, explain _why_ it breaks and fix it.
-4. If wiring looks suspicious, run `pracht verify` first, then `pracht doctor` if you need the full-project view. If running the dev server or tests would help, do so (`pracht dev`, `pnpm test`, `pnpm e2e`).
-5. After fixing, verify the fix works (run relevant test or check dev server output).
-6. Never say "this should fix it." Verify and prove it.
+- `handlePrachtRequest()` dispatches: API routes → middleware → loader →
+  render → HTML assembly.
+- Route-state JSON is returned when the `x-pracht-route-state-request` header
+  is present (client-side navigation).
+- Hydration state is injected as `window.__PRACHT_STATE__`.
+- `initClientRouter()` intercepts link clicks and fetches that route state.
 
 $ARGUMENTS

--- a/skills/pracht-deploy/SKILL.md
+++ b/skills/pracht-deploy/SKILL.md
@@ -1,14 +1,12 @@
 ---
 name: pracht-deploy
-version: 1.2.0
+version: 1.3.0
 description: |
-  Pracht deployment guide. Walks through adapter configuration, building, and
-  deploying to Node.js, Cloudflare Workers, Netlify, Vercel, or a pure static
-  host. Handles platform config, Docker and production checklist.
-  Use when asked to "deploy", "set up deployment", "configure adapter",
-  "deploy to cloudflare", "deploy to netlify", "deploy to vercel", "static
-  export", or
-  "production build".
+  Configure a pracht adapter and deploy to Node, Cloudflare Workers, Netlify,
+  Vercel, or a pure static host: platform config, build, Docker, production
+  checklist.
+  Use for "deploy", "set up deployment", "configure adapter", "deploy to
+  cloudflare/netlify/vercel", "static export", "production build".
 allowed-tools:
   - Bash
   - Read
@@ -21,87 +19,64 @@ allowed-tools:
 
 # Pracht Deploy
 
-Guided adapter setup and deployment for pracht applications.
+Read `vite.config.ts` and `package.json` before giving any advice — never
+assume the current adapter — and ask the user for the target if their message
+does not name one. Then read only that adapter's section below. Install the
+adapter if it is missing (`pnpm add @pracht/adapter-*`), run `pracht build` to
+confirm the build succeeds, smoke-test the production runtime, and never push
+to production without explicit confirmation.
 
-## Step 1: Determine the target
+MCP: when the pracht MCP server is registered (docs/MCP.md), prefer
+`inspect_build`/`doctor`/`verify` over shelling out. `inspect_build` (like
+`pracht inspect build`) needs a prior `pracht build`; `pracht inspect` needs
+the pracht plugin in the vite config.
 
-Read `vite.config.ts` and `package.json` first — don't assume the current adapter.
-Ask the user where they want to deploy if not already clear from their message.
+| Target             | Adapter package              | Local smoke test                       |
+| ------------------ | ---------------------------- | -------------------------------------- |
+| Node.js            | `@pracht/adapter-node`       | `pracht preview`                       |
+| Cloudflare Workers | `@pracht/adapter-cloudflare` | `pracht preview` (delegates to `wrangler dev`) |
+| Netlify            | `@pracht/adapter-netlify`    | `pracht build && netlify dev`          |
+| Vercel             | `@pracht/adapter-vercel`     | `vercel build` / `vercel dev`          |
+| Static export      | `@pracht/adapter-static`     | `pracht preview`                       |
 
-If the pracht MCP server is registered (docs/MCP.md), prefer the `inspect_build`/`doctor`/`verify` MCP tools over shelling out. Note: `inspect_build` (like `pracht inspect build`) needs a prior `pracht build`, and `pracht inspect` requires the pracht plugin registered in the vite config.
-
-## Supported Adapters
-
-| Adapter            | Package                      | Status |
-| ------------------ | ---------------------------- | ------ |
-| Node.js            | `@pracht/adapter-node`       | Stable |
-| Cloudflare Workers | `@pracht/adapter-cloudflare` | Stable |
-| Netlify            | `@pracht/adapter-netlify`    | Stable |
-| Vercel             | `@pracht/adapter-vercel`     | Stable |
-| Static export      | `@pracht/adapter-static`     | Stable |
+Every adapter is wired the same way — `pracht({ adapter: <name>Adapter(…) })`
+in the `plugins` array of `vite.config.ts` — and every target builds with
+`pracht build`, which emits `dist/client/` (assets + prerendered HTML),
+`dist/server/` (server entry and build tooling),
+`dist/server/isg-manifest.json` when ISG routes exist, and
+`dist/client/.vite/manifest.json`.
 
 ---
 
-## Node.js Deployment
+## Node.js
 
-### Setup
-
-1. Ensure `@pracht/adapter-node` is installed.
-2. In `vite.config.ts`:
-   ```ts
-   import { pracht } from "@pracht/vite-plugin";
-   import { nodeAdapter } from "@pracht/adapter-node";
-   export default {
-     plugins: [
-       pracht({
-         adapter: nodeAdapter({ canonicalOrigin: "https://app.example.com" }),
-       }),
-     ],
-   };
-   ```
-
-Pin `canonicalOrigin` in production so `request.url` does not depend on the
-incoming `Host` header. `maxBodySize` is also available on `nodeAdapter()`.
-Only custom entries behind a trusted proxy that overwrites forwarded headers
-should use `createNodeRequestHandler({ trustProxy: true })`.
-If that proxy strips Vite's deploy base from the forwarded path, set
-`nodeAdapter({ basePathStripped: true })` (or the same option on a custom
-`createNodeRequestHandler`). Do not infer this from the first path segment: a
-route may legitimately begin with the same segment as the deploy base. The
-adapter restores the public base before `createContext()`, loaders, and API
-handlers receive the request.
-The proxy must also own the public bare-base redirect (`/app` to `/app/`) in
-this mode because the stripped origin cannot distinguish it from a legitimate
-base-free `/app` route.
-
-The Node adapter compresses responses by default (brotli/gzip negotiated via
-`Accept-Encoding`, streaming for dynamic bodies, an in-memory LRU for static
-assets). When the deployment sits behind a reverse proxy or CDN that already
-compresses responses, set `nodeAdapter({ compression: false })` so bodies are
-not compressed twice.
-
-### Build
-
-```bash
-pracht build
+```ts
+pracht({ adapter: nodeAdapter({ canonicalOrigin: "https://app.example.com" }) });
 ```
 
-Produces:
+Run with `node dist/server/server.js` (port 3000 by default). For production,
+put it behind a reverse proxy (nginx, Caddy) and a process manager (PM2,
+systemd) with `NODE_ENV=production`. `pracht preview` builds and runs it in one
+step (`--port <n>`, `--skip-build` to reuse a build).
 
-- `dist/client/` — static assets (JS, CSS, prerendered HTML)
-- `dist/server/server.js` — Node server entry
-- `dist/server/isg-manifest.json` — ISG revalidation config (if ISG routes exist)
-- `dist/client/.vite/manifest.json` — asset manifest for script/style injection
+- Pin `canonicalOrigin` in production so `request.url` does not depend on the
+  incoming `Host` header. `maxBodySize` is also available on `nodeAdapter()`.
+- `createNodeRequestHandler({ trustProxy: true })` is only for custom entries
+  behind a trusted proxy that overwrites forwarded headers.
+- If that proxy strips Vite's deploy base from the forwarded path, set
+  `nodeAdapter({ basePathStripped: true })` (same option on a custom
+  `createNodeRequestHandler`). Do not infer this from the first path segment —
+  a route may legitimately begin with the same segment as the deploy base. The
+  adapter restores the public base before `createContext()`, loaders, and API
+  handlers see the request, and the proxy must then own the public bare-base
+  redirect (`/app` → `/app/`), since the stripped origin cannot tell it from a
+  legitimate base-free `/app` route.
+- Responses are compressed by default (brotli/gzip negotiated via
+  `Accept-Encoding`, streaming for dynamic bodies, an in-memory LRU for static
+  assets). Behind a proxy or CDN that already compresses, set
+  `nodeAdapter({ compression: false })` to avoid doing it twice.
 
-### Run
-
-```bash
-node dist/server/server.js
-```
-
-Port 3000 by default. For a local production smoke test, `pracht preview` builds and runs the server in one step (`--port <n>`, `--skip-build` to reuse an existing build). For production: reverse proxy (nginx, Caddy), process manager (PM2, systemd), `NODE_ENV=production`.
-
-### Docker
+Docker:
 
 ```dockerfile
 FROM node:22-alpine
@@ -114,52 +89,18 @@ CMD ["node", "dist/server/server.js"]
 
 ---
 
-## Cloudflare Workers Deployment
+## Cloudflare Workers
 
-### Setup
-
-1. Ensure `@pracht/adapter-cloudflare` is installed.
-2. In `vite.config.ts`:
-   ```ts
-   import { pracht } from "@pracht/vite-plugin";
-   import { cloudflareAdapter } from "@pracht/adapter-cloudflare";
-   export default { plugins: [pracht({ adapter: cloudflareAdapter() })] };
-   ```
-
-### Build & Deploy
-
-```bash
-pracht build
-npx wrangler deploy
+```ts
+pracht({ adapter: cloudflareAdapter() });
 ```
 
-To smoke-test the built worker locally first, run `pracht preview` — it builds and then delegates to `wrangler dev`, which serves the wrangler config's `main` entry, `dist/server/worker.js`. Keep `no_bundle: true` and the JavaScript `ESModule` rule: Pracht's Vite output is already bundled and can contain lazy server chunks that Wrangler must upload separately.
-
-Wrangler owns the Worker's binding environment. Put local-only secrets such as
-`PRACHT_CONFIRMATION_SECRET` and `PRACHT_REVALIDATE_TOKEN` in a gitignored
-`.dev.vars`; prefixing the host command with those variables does not
-automatically expose them inside the Worker. Keep production values in
-`wrangler secret`.
-
-If the config contains a custom-domain route, preview can listen on localhost
-while `request.url` inside the Worker uses the custom domain. Sign that
-effective `@authority` for Web Bot Auth or temporarily disable the route. To use
-a separate local config, build first, then run:
-
 ```bash
-pracht build
-npx wrangler dev --config wrangler.local.jsonc --port 3000
+pracht build && npx wrangler deploy
 ```
-
-The local config must keep `main: "dist/server/worker.js"`, keep
-`no_bundle: true`, include the JavaScript `ESModule` rule, and omit the
-production route. `pracht preview` does not forward Wrangler's `--config`
-flag.
-
-### Wrangler Configuration
 
 ```jsonc
-// wrangler.jsonc
+// wrangler.jsonc — canonical version at examples/cloudflare/wrangler.jsonc
 {
   "name": "my-pracht-app",
   "main": "dist/server/worker.js",
@@ -174,36 +115,37 @@ flag.
 }
 ```
 
-`"no_bundle": true`, the JavaScript `ESModule` rule, `"binding": "ASSETS"`, and `"run_worker_first": true` are required. Without the first two settings, Wrangler either re-bundles Pracht's Vite output and folds lazy server chunks into the entry or omits those chunks from the upload. Without the binding, the worker's `env.ASSETS` resolves to nothing and the runtime silently falls back to `null` — headers and ISG manifests load empty, so SSG serving, ISG revalidation, and per-route headers all silently no-op. The canonical config lives at `examples/cloudflare/wrangler.jsonc`. If you rename the binding with `assetsBinding` (below), the wrangler `binding` value must match.
+`no_bundle: true`, the `ESModule` rule, `"binding": "ASSETS"`, and
+`"run_worker_first": true` are all required. Without the first two, Wrangler
+re-bundles Pracht's already-bundled Vite output — folding lazy server chunks
+into the entry or dropping them from the upload. Without the binding,
+`env.ASSETS` silently resolves to `null`: headers and ISG manifests load empty,
+so SSG serving, ISG revalidation, and per-route headers all no-op. If you
+rename the binding via `cloudflareAdapter({ assetsBinding: "STATIC" })`, the
+wrangler `binding` value must match.
 
-### Bindings (KV, D1, R2)
+**Local preview.** `pracht preview` builds, then delegates to `wrangler dev`
+against the config's `main`. Wrangler owns the binding environment: put
+local-only secrets like `PRACHT_CONFIRMATION_SECRET` and
+`PRACHT_REVALIDATE_TOKEN` in a gitignored `.dev.vars` (prefixing the host
+command with them does not expose them inside the Worker) and keep production
+values in `wrangler secret`. With a custom-domain route in the config, preview
+listens on localhost while `request.url` inside the Worker uses the custom
+domain — sign that effective `@authority` for Web Bot Auth, or temporarily
+remove the route. `pracht preview` does not forward Wrangler's `--config`, so a
+separate local config means `pracht build && npx wrangler dev --config
+wrangler.local.jsonc --port 3000`, and that config must keep
+`main: "dist/server/worker.js"`, `no_bundle: true`, and the `ESModule` rule
+while omitting the production route.
 
-```ts
-export async function loader({ context }: LoaderArgs) {
-  const value = await context.env.MY_KV.get("key");
-  return { value };
-}
-```
-
-Keep Cloudflare binding reads inside the loader, API handler, capability
-`run()`, or another request-time function. Although Workers permits top-level
-`env.MY_KV`, Pracht graph inspection intentionally fails such module-initializer
-reads because it cannot supply an authoritative binding without risking false
-graph metadata.
-
-### Custom Assets Binding
-
-```ts
-pracht({ adapter: cloudflareAdapter({ assetsBinding: "STATIC" }) });
-```
-
-### Named bindings and default-export handlers
-
-Durable Object and Workflow classes are named Worker exports. Re-export them
-from the module configured with `workerExportsFrom`. Queue consumers, Cron
-Triggers, and Email Routing are instead methods on the default export; expose
-named `queue`, `scheduled`, or `email` functions from the module configured
-with `workerHandlersFrom`:
+**Bindings.** Read them inside a loader, API handler, capability `run()`, or
+another request-time function — `context.env.MY_KV.get("key")`. Workers permits
+top-level `env` reads, but graph inspection deliberately fails them rather than
+report binding metadata it cannot authoritatively resolve. Durable Object and
+Workflow classes are named Worker exports: re-export them from
+`workerExportsFrom`. Queue consumers, Cron Triggers, and Email Routing are
+methods on the default export: expose named `queue`, `scheduled`, or `email`
+functions from `workerHandlersFrom`.
 
 ```ts
 cloudflareAdapter({
@@ -212,220 +154,187 @@ cloudflareAdapter({
 });
 ```
 
-### ISG via Workers Caching
+**ISG.** Works with no cache option: the worker-managed path serves the
+build-time snapshot, detects staleness, regenerates in the background per colo
+via the Workers Cache API, and `POST /__pracht/revalidate` forces regeneration.
+`cloudflareAdapter({ cache: true })` plus `{ "cache": { "enabled": true } }` in
+wrangler.jsonc moves that to edge-tier Workers Caching: time-revalidated pages
+then render on demand, are cached for their `revalidate` window (stale served
+instantly while the Worker re-renders), and can be purged early with
+`purgeCache()` from `@pracht/adapter-cloudflare/cache`. Webhook-only ISG routes
+keep their build-time snapshots and the worker-managed path either way.
 
-ISG works out of the box: without any cache option, the default worker-managed path serves the build-time snapshot, detects staleness, and regenerates pages in the background via the Workers Cache API — per colo — and `POST /__pracht/revalidate` triggers on-demand regeneration. Enabling `cache: true` moves ISG from that per-colo worker-managed path to edge-tier Workers Caching, on both sides:
-
-```ts
-pracht({ adapter: cloudflareAdapter({ cache: true }) });
-```
-
-```jsonc
-// wrangler.jsonc
-{ "cache": { "enabled": true } }
-```
-
-Before enabling it, audit ISG URLs for unbounded query strings. Workers Caching
+Audit ISG URLs for unbounded query strings before enabling it — Workers Caching
 keys the exact path and query string, including parameter order and trailing
-slashes; use a bounded query allowlist/canonical redirect or an uncached gateway
-with a pathname-only `cf.cacheKey`, and normalize `Accept` there for routes that
-export markdown or declare `markdown: true` for middleware-owned negotiation.
-See `docs/ADAPTERS.md#cache-key-cardinality`.
-
-Time-revalidated ISG pages then render on demand, are cached at the edge for
-their `revalidate` window (stale pages served instantly while the Worker
-re-renders in the background), and can be purged early with `purgeCache()` from
-`@pracht/adapter-cloudflare/cache`. Webhook-only ISG routes keep their
-build-time snapshots and the worker-managed path either way.
+slashes. Use a bounded query allowlist or canonical redirect, or an uncached
+gateway with a pathname-only `cf.cacheKey`, and normalize `Accept` there for
+routes that export markdown or declare `markdown: true`. See
+`docs/ADAPTERS.md#cache-key-cardinality`.
 
 ---
 
-## Netlify Deployment
+## Netlify
 
-### Setup
+```ts
+pracht({ adapter: netlifyAdapter() });
+```
 
-1. Ensure `@pracht/adapter-netlify` and `netlify-cli` are installed.
-2. In `vite.config.ts`:
-   ```ts
-   import { pracht } from "@pracht/vite-plugin";
-   import { netlifyAdapter } from "@pracht/adapter-netlify";
-   export default { plugins: [pracht({ adapter: netlifyAdapter() })] };
-   ```
-3. Add `netlify.toml`:
-   ```toml
-   [build]
-     command = "pnpm build"
-     publish = "dist/client"
+```toml
+# netlify.toml
+[build]
+  command = "pnpm build"
+  publish = "dist/client"
 
-   [functions]
-     directory = "netlify/functions"
-   ```
-
-### Build, Preview, and Deploy
+[functions]
+  directory = "netlify/functions"
+```
 
 ```bash
 npx pracht build && npx netlify dev
 npx netlify deploy --build --prod
 ```
 
-The build emits `netlify/functions/pracht.mjs`. Page requests go through that
-function so Markdown negotiation and route-state requests remain correct;
-hashed assets bypass it and stay outside the function bundle at the origin
-root. With a Vite deploy base, the function instead bundles and serves the
-base-free asset and `/_pracht` trees so `/app/...` requests remain inside the
-mount. Custom `excludedPath` entries still bypass their literal origin-root
-URLs, but matching files remain bundled for base-prefixed requests. The
-generated config enumerates only client files the function can serve and roots
-applicable exclusions at the function file so Netlify's tracer cannot re-add
-bypassed trees. Netlify durable caching
-implements time-based ISG and per-path cache tags implement authenticated
-webhook revalidation. A trailing-slash ISG document request permanently
-redirects to the canonical slashless URL before rendering, and webhook
-revalidation normalizes either spelling before purging the cache tag.
-Only `Cache-Control`, `CDN-Cache-Control`, and `Netlify-CDN-Cache-Control`
-override the adapter's cache defaults; provider-specific headers for another
-CDN do not. Set a cache window to `0` to disable stale serving or freshness.
-`Netlify-Vary` owns route-state variants, while the standard `Vary: Accept`
-header owns Markdown negotiation. Cacheable negotiated SSG representations use
-the same `Netlify-Vary` instructions as their prerendered HTML. Shared ISG
-renders strip visitor-specific request data and Netlify context metadata before
-loaders or context factories run.
+`pracht preview` exits with guidance here — it cannot emulate Netlify's
+Functions and CDN. Build the generated function first, then use `netlify dev`.
+Set `PRACHT_REVALIDATE_TOKEN` in Netlify when webhook revalidation is enabled.
 
-`pracht preview` exits with guidance because it cannot emulate Netlify's
-Functions and CDN behavior. Build the generated function before using
-`netlify dev` for the platform-shaped local runtime. Configure
-`PRACHT_REVALIDATE_TOKEN` in Netlify when webhook revalidation is enabled.
+The build emits `netlify/functions/pracht.mjs`. Page requests go through it so
+Markdown negotiation and route-state requests stay correct; hashed assets
+bypass it and stay outside the function bundle at the origin root. With a Vite
+deploy base, the function instead bundles and serves the base-free asset and
+`/_pracht` trees so `/app/...` requests stay inside the mount; custom
+`excludedPath` entries still bypass their literal origin-root URLs, but their
+files remain bundled for base-prefixed requests. The generated config
+enumerates only client files the function can serve and roots exclusions at the
+function file, so Netlify's tracer cannot re-add bypassed trees.
+
+Caching: Netlify durable caching implements time-based ISG and per-path cache
+tags implement authenticated webhook revalidation. A trailing-slash ISG
+document request permanently redirects to the canonical slashless URL before
+rendering, and webhook revalidation normalizes either spelling before purging
+the tag. Only `Cache-Control`, `CDN-Cache-Control`, and
+`Netlify-CDN-Cache-Control` override the adapter's cache defaults —
+provider-specific headers for another CDN do not; a window of `0` disables
+stale serving or freshness. `Netlify-Vary` owns route-state variants while
+standard `Vary: Accept` owns Markdown negotiation, and cacheable negotiated SSG
+representations reuse their prerendered HTML's `Netlify-Vary` instructions.
+Shared ISG renders strip visitor-specific request data and Netlify context
+metadata before loaders or context factories run.
 
 ---
 
-## Vercel Deployment
+## Vercel
 
-### Setup
-
-1. Ensure `@pracht/adapter-vercel` is installed.
-2. In `vite.config.ts`:
-   ```ts
-   import { pracht } from "@pracht/vite-plugin";
-   import { vercelAdapter } from "@pracht/adapter-vercel";
-   export default { plugins: [pracht({ adapter: vercelAdapter() })] };
-   ```
-
-### Build & Deploy
-
-```bash
-pracht build
-npx vercel deploy --prebuilt
+```ts
+pracht({ adapter: vercelAdapter() });
 ```
 
-Produces: `.vercel/output/config.json`, `.vercel/output/static/`, `.vercel/output/functions/render.func/server.js`
+```bash
+pracht build && npx vercel deploy --prebuilt
+```
 
-There is no faithful local Vercel production runtime, so `pracht preview`
-exits with guidance. Use `vercel build` or `vercel dev`. Set
+Emits `.vercel/output/config.json`, `.vercel/output/static/`, and
+`.vercel/output/functions/render.func/server.js`.
+
+There is no faithful local Vercel production runtime, so `pracht preview` exits
+with guidance — use `vercel build` or `vercel dev`. Set
 `PRACHT_REVALIDATE_TOKEN` at build time when using webhook revalidation; its
 Vercel bypass token is embedded in `.prerender-config.json`. Rename the main
-Edge Function with `vercelAdapter({ functionName })` if its default `render`
-name would collide with an ISG route. Custom entries must export the
-`nodeListener` created by `createVercelNodeListener(handle)` for Node ISR
-functions.
+Edge Function with `vercelAdapter({ functionName })` if the default `render`
+would collide with an ISG route. Custom entries must export the `nodeListener`
+created by `createVercelNodeListener(handle)` for Node ISR functions.
 
 ---
 
-## Static Export Deployment
+## Static export
 
-For apps where every route is `render: "ssg"` (or loaderless, full-hydration
-`"spa"`), with no
-request middleware, API routes, or HTTP/MCP/WebMCP-exposed capabilities. SSG
-loaders run only at build time and must produce HTML plus valid JSON route
-state; dynamic SSG routes must export `getStaticPaths()`. Anything else fails the build with an error naming the
-offenders — that is the signal to pick a serverful adapter instead. Only
-manifest-registered capabilities participate; every registered capability
-module must load successfully so exposure validation can fail closed. The
-`notFound` page must use full hydration (the default), because the shared
-`404.html` needs the client router to adopt the visitor's actual URL. Sub-path
-deploys (GitHub Pages *project* sites, S3 key prefixes) set Vite `base` to that
-path; CDN and document-relative bases (`""` / `"./"`) are build errors,
-because they split assets from the deploy root or resolve them beneath nested
-page directories. Under a base,
-internal navigation must go through `<Link route>` / `href()` — a hand-written
-`<a href="/about">` still means the origin root.
-Pracht's preview and first-party serverful adapters redirect the bare base
-(`/app`) to its trailing-slash form (`/app/`) before serving the root document;
-custom adapters receive the same behavior through `handlePrachtRequest()`.
-Framework-owned browser URLs from the default image loader and OpenAPI
-companion artifacts pick up the same base automatically.
-
-### Setup
-
-1. Ensure `@pracht/adapter-static` is installed.
-2. In `vite.config.ts`:
-   ```ts
-   import { pracht } from "@pracht/vite-plugin";
-   import { staticAdapter } from "@pracht/adapter-static";
-   export default { plugins: [pracht({ adapter: staticAdapter() })] };
-   // With dynamic SPA routes, add { fallback: "200.html" } and configure the
-   // host to rewrite unmatched URLs to it. If the route or shell exports
-   // head(), also set generic fallbackHead metadata shared by every rewrite.
-   ```
-
-### Build & Deploy
+```ts
+pracht({ adapter: staticAdapter() });
+// Dynamic SPA routes: staticAdapter({ fallback: "200.html" }) plus a host
+// rewrite for unmatched URLs. If the route or shell exports head(), also set
+// generic fallbackHead metadata shared by every rewrite.
+```
 
 ```bash
 pracht build      # dist/client/ is the whole deployment
 pracht preview    # local static file server over dist/client/
 ```
 
-Upload `dist/client/` to any static host (GitHub Pages, S3, nginx, Netlify).
-`dist/server/` is build tooling only — never deploy it. The host must serve
-`<dir>/index.html` for clean URLs and should use `404.html` as its error
-document. A static `notFound` page must use full hydration so that shared
-document can adopt the visitor's real URL. Client navigation fetches collision-safe
-bounded opaque `.json` files under `_pracht/state/` for full-hydration SSG
-routes whose loader or route/shell `head()` metadata participates in navigation;
-equivalent raw-Unicode and percent-encoded URL segment spellings resolve to the
-same state file. Explicitly loaderless and headless routes fetch no Pracht
-state; loaderless routes with head metadata fetch static state for font-head
-fragments but still use browser-side requests to an external API for live
-data. Files under `public/_pracht/state/` may not occupy a generated
-route-state path; the build rejects the collision instead of overwriting the
-public file. Files copied from `public/` or emitted by Vite also may not occupy
-the generated `404.html` or configured fallback path, including a case- or
-Unicode-normalization-equivalent spelling; the build rejects the portable
-collision instead of overwriting existing output. Generic `fallbackHead` fonts
-remain registered while the fallback commits a loaderless dynamic SPA route.
-See docs/ADAPTERS.md § Static Adapter for host header
-configuration and limitations (markdown negotiation, base paths). Pages are
-written to the percent-decoded output path, matching how static hosts resolve
-requests; `pracht preview` decodes request segments the same way. The SPA fallback only client-renders matched SPA routes; dynamic
-SSG paths omitted by `getStaticPaths()` render the app's not-found page with
-the build-time loader data or handled error state carried over from `404.html`.
-The host rewrite that serves the fallback answers unknown URLs with status 200 (soft 404), and an app
-with no `notFound` page and no unshadowed client-routable SPA catch-all renders them blank — the build
-warns about that shape. A dynamic SPA route, its shell, or the not-found page
-with `head()` requires an explicit `fallbackHead`, because the shared static
-document cannot evaluate URL-specific server metadata. Prerendered pages must
-map to distinct portable filesystem paths; duplicate/case-folded or
-Unicode-normalization-equivalent outputs, Windows-invalid or overlong filename
-components, and file/directory conflicts such as `/` with `/index.html` fail
-before any page is written. Fallback names likewise reject Windows reserved
-device names and the portable 255-byte/code-unit component limit.
+Upload `dist/client/` to any static host. `dist/server/` is build tooling —
+never deploy it. The host must serve `<dir>/index.html` for clean URLs and
+should use `404.html` as its error document. See `docs/ADAPTERS.md` § Static
+Adapter for host header configuration and the markdown-negotiation and
+base-path limitations.
+
+**Eligibility.** Every route must be `render: "ssg"` (or a loaderless,
+full-hydration `"spa"`), with no request middleware, API routes, or
+HTTP/MCP/WebMCP-exposed capabilities. Anything else fails the build with an
+error naming the offenders — that is the signal to pick a serverful adapter.
+SSG loaders run only at build time and must produce HTML plus valid JSON route
+state; dynamic SSG routes must export `getStaticPaths()`. Only
+manifest-registered capabilities participate, and every registered capability
+module must load successfully so exposure validation fails closed. The
+`notFound` page must use full hydration (the default) because the shared
+`404.html` needs the client router to adopt the visitor's actual URL.
+
+**Deploy base.** Sub-path deploys (GitHub Pages *project* sites, S3 key
+prefixes) set Vite `base` to that path. CDN and document-relative bases (`""`,
+`"./"`) are build errors — they split assets from the deploy root or resolve
+them beneath nested page directories. Under a base, internal navigation must go
+through `<Link route>` / `href()`; a hand-written `<a href="/about">` still
+means the origin root. Preview and the first-party serverful adapters redirect
+the bare base (`/app` → `/app/`) before serving the root document, and custom
+adapters get the same behavior via `handlePrachtRequest()`. Framework-owned
+browser URLs from the default image loader and the OpenAPI companion artifacts
+pick up the base automatically.
+
+**Route state.** Client navigation fetches collision-safe bounded opaque
+`.json` files under `_pracht/state/`, for full-hydration SSG routes whose
+loader or route/shell `head()` metadata participates in navigation. Equivalent
+raw-Unicode and percent-encoded URL segment spellings resolve to the same state
+file. Explicitly loaderless and headless routes fetch no state; loaderless
+routes with head metadata fetch static state for font-head fragments but still
+hit an external API from the browser for live data.
+
+**Build-time collision guards** (all fail the build rather than overwrite):
+
+- A file under `public/_pracht/state/` occupying a generated route-state path.
+- A `public/` or Vite-emitted file occupying the generated `404.html` or the
+  configured fallback path, including case- or Unicode-normalization-equivalent
+  spellings.
+- Prerendered pages that do not map to distinct portable filesystem paths:
+  duplicate, case-folded, or Unicode-normalization-equivalent outputs;
+  Windows-invalid or overlong filename components; file/directory conflicts
+  such as `/` against `/index.html`. Fallback names additionally reject Windows
+  reserved device names and the portable 255-byte/code-unit component limit.
+
+Pages are written to the percent-decoded output path, matching how static hosts
+resolve requests; `pracht preview` decodes request segments the same way.
+
+**SPA fallback.** It only client-renders matched SPA routes. Dynamic SSG paths
+omitted by `getStaticPaths()` render the app's not-found page with the
+build-time loader data or handled error state carried over from `404.html`. The
+host rewrite answers unknown URLs with status 200 (a soft 404), and an app with
+no `notFound` page and no unshadowed client-routable SPA catch-all renders them
+blank — the build warns about that shape. A dynamic SPA route, its shell, or
+the not-found page exporting `head()` requires an explicit `fallbackHead`,
+because the shared static document cannot evaluate URL-specific server
+metadata; generic `fallbackHead` fonts stay registered while the fallback
+commits a loaderless dynamic SPA route.
 
 ---
 
-## Deployment Checklist
+## Pre-flight checklist
 
-1. **Build**: Run `pracht build` and verify `dist/` output.
-2. **Environment variables**: Ensure secrets/config needed by loaders are available at runtime.
-3. **Static assets**: Verify `dist/client/` contains prerendered HTML for SSG routes (and ISG routes — except time-revalidated ISG routes on Cloudflare with Workers Caching enabled, which render on demand; webhook-only ISG routes keep their build-time snapshots).
-4. **ISG routes**: Confirm the ISG manifest (`dist/server/isg-manifest.json`; on Cloudflare also `dist/client/_pracht/isg.json`) exists if using incremental static generation.
-5. **API routes**: Test API endpoints work in the production runtime. For Node.js, run `pracht preview` (or `node dist/server/server.js`).
-6. **Middleware**: Verify auth/redirect middleware behaves correctly in production.
-
-## Rules
-
-1. Read `vite.config.ts` and `package.json` before giving advice.
-2. Run `pracht build` to verify the build succeeds before deploying.
-3. Smoke-test the production runtime before pushing to production. For Node.js and Cloudflare, run `pracht preview`; for Netlify, run `pracht build && netlify dev`.
-4. If the user needs an adapter that isn't installed, help them add it (`pnpm add @pracht/adapter-*`).
-5. Don't push to production without the user's explicit confirmation.
+1. `pracht build` succeeds and `dist/` looks right.
+2. Every secret and config value the loaders need is present in the target
+   runtime.
+3. `dist/client/` holds prerendered HTML for SSG routes — and for ISG routes,
+   except time-revalidated ones on Cloudflare with Workers Caching enabled,
+   which render on demand. Webhook-only ISG routes keep build-time snapshots.
+4. The ISG manifest exists if ISG is in use: `dist/server/isg-manifest.json`,
+   plus `dist/client/_pracht/isg.json` on Cloudflare.
+5. API endpoints answer correctly in the production runtime.
+6. Auth and redirect middleware behave correctly in production.
 
 $ARGUMENTS

--- a/skills/pracht-scaffold/SKILL.md
+++ b/skills/pracht-scaffold/SKILL.md
@@ -1,13 +1,12 @@
 ---
 name: pracht-scaffold
-version: 1.1.0
+version: 1.2.0
 description: |
-  Pracht code scaffolding. Prefer the framework-native CLI generators
-  (`pracht generate route|shell|middleware|api`) and only fall back to manual
-  edits when the CLI flags cannot express the requested shape. Knows pracht
-  conventions (Preact idioms, render modes, route manifest).
-  Use when asked to "scaffold", "generate a route", "create a new page",
-  "add middleware", "add an API route", or "create a shell".
+  Scaffold pracht code with the native generators (`pracht generate
+  route|shell|middleware|api`), falling back to manual edits only when the CLI
+  flags cannot express the requested shape.
+  Use for "scaffold", "generate a route", "create a new page", "add middleware",
+  "add an API route", "create a shell".
 allowed-tools:
   - Bash
   - Read
@@ -20,11 +19,12 @@ allowed-tools:
 
 # Pracht Scaffold
 
-Generate pracht framework modules with correct types, exports, and manifest wiring.
+Parse what the user wants to create and generate it with the CLI. Ask when
+something is ambiguous (render mode, shell assignment). Keep generated code
+minimal — only the exports they actually need — and finish by summarizing what
+was created and how it was wired.
 
-## First Choice
-
-Use the CLI first:
+## Always try the CLI first
 
 ```bash
 pracht generate route --path /dashboard --render ssr
@@ -33,169 +33,146 @@ pracht generate middleware --name auth
 pracht generate api --path /health --methods GET,POST
 ```
 
-`pracht generate route` supports the full flag matrix below — do not fall back to manual edits for shapes it already covers:
+If the CLI can express the request, do not reimplement the scaffold by hand.
+`pracht generate route` covers this flag matrix:
 
-| Flag               | Meaning                                                                              |
-| ------------------ | ------------------------------------------------------------------------------------ |
-| `--path` (required) | Route path, e.g. `/dashboard` or `/blog/:slug`                                       |
-| `--render`         | Render mode: `ssr` (default), `spa`, `ssg`, or `isg`                                 |
-| `--shell`          | Registered shell name (manifest apps only)                                           |
-| `--middleware`     | Registered middleware names, comma-separated (manifest apps only)                    |
-| `--loader`         | Include a `loader` export                                                            |
-| `--error-boundary` | Include an `ErrorBoundary` export                                                    |
-| `--static-paths`   | Include `getStaticPaths` (added automatically for dynamic `ssg`/`isg` paths)         |
-| `--title`          | Page title used in the `head()` export                                               |
-| `--revalidate`     | ISG revalidation window in seconds (`isg` only, default 3600)                        |
-| `--json`           | Machine-readable output                                                              |
+| Flag                | Meaning                                                                      |
+| ------------------- | ---------------------------------------------------------------------------- |
+| `--path` (required) | Route path, e.g. `/dashboard` or `/blog/:slug`                               |
+| `--render`          | `ssr` (default), `spa`, `ssg`, or `isg`                                      |
+| `--shell`           | Registered shell name (manifest apps only)                                   |
+| `--middleware`      | Registered middleware names, comma-separated (manifest apps only)            |
+| `--loader`          | Include a `loader` export                                                    |
+| `--error-boundary`  | Include an `ErrorBoundary` export                                            |
+| `--static-paths`    | Include `getStaticPaths` (automatic for dynamic `ssg`/`isg` paths)           |
+| `--title`           | Page title for the `head()` export                                           |
+| `--revalidate`      | ISG window in seconds (`isg` only, default 3600)                             |
+| `--json`            | Machine-readable output                                                      |
 
-`generate shell` and `generate middleware` take `--name`; `generate api` takes `--path` and `--methods` (comma-separated). All subcommands accept `--json`.
+`generate shell` and `generate middleware` take `--name`; `generate api` takes
+`--path` and `--methods`. All subcommands accept `--json` — use it when another
+agent or tool consumes the output. When the pracht MCP server is registered
+(docs/MCP.md), call the `generate_route`/`generate_shell`/`generate_middleware`/
+`generate_api` MCP tools instead of Bash: same behavior, structured results.
 
-- `--shell`/`--middleware` names must already be registered in the app manifest — the CLI errors otherwise. Generate the shell/middleware first, then the route that references it.
-- If the pracht MCP server is registered (docs/MCP.md), call the `generate_route`/`generate_shell`/`generate_middleware`/`generate_api` MCP tools instead of Bash — same behavior, structured results.
-- Add `--json` when another agent/tool needs machine-readable output.
-- `generate route` also emits a Playwright smoke test in `e2e/` when the app has a Playwright setup (`playwright.config.*` or an `e2e/` directory). Pass `--no-test` to skip it, `--test` to force it. The test imports `@playwright/test`; if that dependency is absent, follow the generator's install note before typechecking. Keep the generated test — it is the output-level proof the route works.
-- Use `pracht inspect routes --json` or `pracht inspect api --json` to confirm current wiring before manual edits when the existing graph matters. `pracht inspect` requires the pracht plugin registered in the project's vite config.
-- If the app has typed routes (`src/pracht-routes.ts` / `.d.ts`) or the user asks for typed links, run `pracht typegen` after adding or renaming routes.
-- If the app commits `.pracht/app-graph.json`, run `pracht plan --write` after changing routes and include the refreshed snapshot — `pracht verify` fails when it is stale.
-- If `src/routes.ts` declares `constraints:`, respect them (e.g. put new `/app/**` routes behind the required middleware). Never delete or weaken a constraint to make `pracht verify` pass — that is a policy change the user must approve.
-- If the CLI can express the request, do not reimplement the scaffold by hand.
-- Only edit files manually when the CLI cannot cover the requested shape.
+- `--shell`/`--middleware` names must already be registered or the CLI errors.
+  Generate the shell or middleware first, then the route referencing it.
+- `generate route` also emits a Playwright smoke test in `e2e/` when the app
+  has a Playwright setup (`playwright.config.*` or an `e2e/` directory);
+  `--no-test` skips it, `--test` forces it. The test imports
+  `@playwright/test` — if that dependency is missing, follow the generator's
+  install note before typechecking. Keep the test: it is the output-level proof
+  the route works.
+- **The generators wire the manifest themselves.** `generate route` inserts the
+  `route(...)` call into `src/routes.ts` (adding `route`/`timeRevalidate`
+  imports as needed) and `generate shell`/`generate middleware` upsert their
+  registry entries. Do not re-edit the manifest after a successful run.
 
-The user will describe what they want to create. Parse their request and generate the appropriate module(s). Always ask if anything is ambiguous (e.g. render mode, shell assignment).
+## Project conventions
 
-## What You Can Scaffold
+| Kind       | Directory         | Key exports                                                                      |
+| ---------- | ----------------- | -------------------------------------------------------------------------------- |
+| Route      | `src/routes/`     | `loader`, `head`, `Component`, `ErrorBoundary`, `getStaticPaths`                 |
+| Shell      | `src/shells/`     | `Shell`, `head`                                                                  |
+| Middleware | `src/middleware/` | `middleware`                                                                     |
+| API route  | `src/api/`        | Named method handlers (`GET`, `POST`, `PUT`, `PATCH`, `DELETE`) or one default dispatcher |
 
-| Kind       | Directory         | Key exports                                                          | Example                        |
-| ---------- | ----------------- | -------------------------------------------------------------------- | ------------------------------ |
-| Route      | `src/routes/`     | `loader`, `head`, `Component`, `ErrorBoundary`, `getStaticPaths`     | `src/routes/blog.tsx`          |
-| Shell      | `src/shells/`     | `Shell`, `head`                                                      | `src/shells/marketing.tsx`     |
-| Middleware | `src/middleware/` | `middleware`                                                         | `src/middleware/rate-limit.ts` |
-| API route  | `src/api/`        | Named HTTP method handlers (`GET`, `POST`, `PUT`, `PATCH`, `DELETE`) or one default method dispatcher           | `src/api/users/[id].ts`        |
+Render modes: `"ssr"` (default), `"ssg"` (static at build), `"isg"`
+(incremental static, `revalidate: timeRevalidate(seconds)` — import
+`timeRevalidate` from `@pracht/core`), `"spa"` (client-only). Use Preact
+idioms: `class` not `className`, functional components, `import type` for
+type-only imports.
 
-## Templates (manual fallback)
+Before and after scaffolding:
 
-Use these only when the CLI cannot express the requested shape.
+- Read `pracht inspect routes --json` / `pracht inspect api --json` to confirm
+  current wiring when the existing graph matters. `pracht inspect` needs the
+  pracht plugin in the vite config.
+- If `src/routes.ts` declares `constraints:`, respect them — e.g. put new
+  `/app/**` routes behind the required middleware. Never delete or weaken a
+  constraint to make `pracht verify` pass; that is a policy change only the
+  user can approve.
+- Run `pracht typegen` after adding or renaming routes in a typed-routes app
+  (`src/pracht-routes.ts` / `.d.ts`), and include the generated files.
+- Run `pracht plan --write` if the app commits `.pracht/app-graph.json` —
+  `pracht verify` fails on a stale snapshot.
+- Finish with `pracht verify`.
 
-### Route
+## Manual fallback
+
+Only for shapes the CLI cannot express. Read the existing `src/routes.ts` first
+to pick up current shells, middleware, and structure.
+
+**Route** — `head()` plus `Component`; add `loader` only when the route needs
+server data (the CLI omits it unless `--loader` is passed), `ErrorBoundary`
+only if requested, and `getStaticPaths` only for SSG/ISG routes with dynamic
+segments:
 
 ```tsx
+import type { LoaderArgs, RouteComponentProps } from "@pracht/core";
+
+export async function loader(_args: LoaderArgs) {
+  return {/* loader data */};
+}
+
 export function head() {
   return { title: "Page Title" };
 }
 
-export function Component() {
+export function Component({ data }: RouteComponentProps<typeof loader>) {
   return <section>{/* route UI */}</section>;
 }
 ```
 
-- Include a `loader` only when the route needs server data (matches the CLI, which omits it unless `--loader` is passed):
+**Shell** — `Shell({ children }: ShellProps)` rendering `{children}`, plus an
+optional `head()`. Never render `<html>`, `<head>`, or `<body>`.
 
-  ```tsx
-  import type { LoaderArgs, RouteComponentProps } from "@pracht/core";
-
-  export async function loader(_args: LoaderArgs) {
-    return {
-      /* loader data */
-    };
-  }
-
-  export function Component({ data }: RouteComponentProps<typeof loader>) {
-    return <section>{/* route UI */}</section>;
-  }
-  ```
-
-- Include `ErrorBoundary` only if requested.
-- Include `getStaticPaths` only for SSG/ISG routes with dynamic segments.
-- Use `RouteComponentProps<typeof loader>` for typed `data` prop.
-
-### Shell
-
-```tsx
-import type { ShellProps } from "@pracht/core";
-
-export function Shell({ children }: ShellProps) {
-  return (
-    <div class="shell-name">
-      <nav>{/* navigation */}</nav>
-      <main>{children}</main>
-    </div>
-  );
-}
-
-export function head() {
-  return { title: "Shell Title" };
-}
-```
-
-### Middleware
-
-Middleware wraps the rest of the request via `next()`:
+**Middleware** — wrap-around via `next()`:
 
 ```ts
 import { redirect, type MiddlewareFn } from "@pracht/core";
 
 export const middleware: MiddlewareFn = async ({ context, request }, next) => {
-  // Mutate context, validate auth, etc.
-  // - Call `return next()` to continue
-  // - Return `redirect("/path", { request })` to short-circuit with a redirect
-  // - Return any `Response` to short-circuit
-  // - Wrap `await next()` in try/catch/finally for tracing/logging
+  // `return next()` continues; returning any Response short-circuits, e.g.
+  // `redirect("/path", { request })`. Wrap `await next()` in try/catch/finally
+  // for tracing.
   return next();
 };
 ```
 
-### API Route
+**API route** — one export per method the user needs (or a default export only
+when they want to branch on `request.method` manually), parsing bodies with
+`request.json()` / `request.formData()` and always returning a `Response`:
 
 ```ts
 import type { ApiRouteArgs } from "@pracht/core";
 
 export function GET({ params, url }: ApiRouteArgs) {
-  return Response.json({
-    /* response data */
-  });
+  return Response.json({/* response data */});
 }
 ```
 
-- Only include the HTTP methods the user needs.
-- Use a default export only when the user wants to branch on `request.method` manually.
-- Use `request.json()`, `request.formData()`, etc. for body parsing.
-- Always return `Response` objects (typically `Response.json()`).
-- Dynamic segments use bracket syntax in filenames: `[id].ts`, `[...slug].ts`.
-- For live server→client updates, use Server-Sent Events:
-  `createEventStream(request, { keepAlive: 15 })` from `@pracht/core/server`
-  returns `{ response, send, close }` — return `response`, push with
-  `send({ data, event?, id? })`, and stop producing when `send()` returns
-  `false` (client disconnected). Consume in components with
-  `useEventSource(url, { json: true })` from `@pracht/core`. Works on all
-  adapters. For WebSockets use `isUpgradeRequest(request)` plus the
-  per-adapter recipes in `docs/ADAPTERS.md` (Cloudflare: API route + Durable
-  Object; Node: `nodeAdapter({ configureServerFrom })`; Vercel: unsupported —
-  use SSE).
+Dynamic segments use bracket filenames: `[id].ts`, `[...slug].ts`. API routes
+are auto-discovered — no manifest entry.
 
-## Wiring Into the Manifest (manual fallback only)
+For live server→client updates, use Server-Sent Events:
+`createEventStream(request, { keepAlive: 15 })` from `@pracht/core/server`
+returns `{ response, send, close }` — return `response`, push with
+`send({ data, event?, id? })`, and stop producing when `send()` returns `false`
+(client disconnected). Consume with `useEventSource(url, { json: true })` from
+`@pracht/core`. Works on every adapter. For WebSockets use
+`isUpgradeRequest(request)` plus the per-adapter recipes in `docs/ADAPTERS.md`
+(Cloudflare: API route + Durable Object; Node:
+`nodeAdapter({ configureServerFrom })`; Vercel: unsupported — use SSE).
 
-The CLI generators wire the manifest themselves: `pracht generate route` inserts the `route(...)` call into `src/routes.ts` (adding `route`/`timeRevalidate` imports as needed), and `generate shell`/`generate middleware` upsert their registry entries. **Do not re-edit the manifest after a successful `pracht generate` run.**
+**Manifest wiring**, only for hand-created files:
 
-Only when you created module files by hand, update `src/routes.ts` to register the new module:
+- Route — a `route("/path", () => import("./routes/file.tsx"), { id: "name",
+  render: "ssr" })` call in the right group or at the top level.
+- Shell — `shellName: () => import("./shells/file.tsx")` in the `shells` record.
+- Middleware — `mwName: () => import("./middleware/file.ts")` in the
+  `middleware` record.
 
-- **Routes**: Add a `route("/path", () => import("./routes/filename.tsx"), { id: "name", render: "ssr" })` call inside the appropriate group or at the top level. Plain strings like `"./routes/filename.tsx"` also work.
-- **Shells**: Add to the `shells` record: `shellName: () => import("./shells/filename.tsx")` (or `"./shells/filename.tsx"`).
-- **Middleware**: Add to the `middleware` record: `mwName: () => import("./middleware/filename.ts")` (or `"./middleware/filename.ts"`).
-- **API routes**: No manifest change needed — auto-discovered from `src/api/` by the Vite plugin.
-
-Available render modes: `"ssr"` (default), `"ssg"` (static at build), `"isg"` (incremental static with `revalidate: timeRevalidate(seconds)`), `"spa"` (client-only).
-
-Import `timeRevalidate` from `"@pracht/core"` when using ISG.
-
-## Rules
-
-1. Prefer `pracht generate ...` over manual edits.
-2. Read the project's existing `src/routes.ts` to determine current shells, middleware, and route structure before adding when the CLI cannot finish the job on its own.
-3. Place files in the conventional directories (`src/routes/`, `src/shells/`, `src/middleware/`, `src/api/`).
-4. Keep generated code minimal — only include exports the user actually needs.
-5. Use Preact idioms: `class` not `className`, functional components, `import type` for type-only imports.
-6. When route ids/paths change in a typed-routes app, run `pracht typegen` and include the generated route files.
-7. Finish with `pracht verify` (and `pracht plan --write` when the app commits an app-graph snapshot).
-8. After scaffolding, summarize what was created and how it was wired.
+Plain `"./routes/file.tsx"` strings work in place of the import functions.
 
 $ARGUMENTS

--- a/skills/pracht-test-api/SKILL.md
+++ b/skills/pracht-test-api/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: pracht-test-api
-version: 1.2.0
+version: 1.2.1
 description: |
-  Auto-generate Vitest request/response tests for every handler in `src/api/`.
-  Each test instantiates a `Request`, calls the exported HTTP method handler
-  directly, and asserts on the returned `Response` — no server boot required.
-  Use when asked to "test my API routes", "scaffold API tests", "generate
-  tests for src/api", or "add tests for this endpoint".
+  Generate Vitest request/response tests for every handler in `src/api/`: build a
+  `Request`, call the exported method handler directly, assert on the returned
+  `Response` — no server boot.
+  Use for "test my API routes", "scaffold API tests", "generate tests for
+  src/api", "add tests for this endpoint".
 allowed-tools:
   - Bash
   - Read
@@ -31,10 +31,10 @@ prompt the user to). This skill does not handle Vitest setup.
 
 ## Step 2: Enumerate API handlers
 
-If the pracht MCP server is registered (see docs/MCP.md), prefer its tools
-(`inspect_routes`, `inspect_api`, `inspect_build`, `doctor`, `verify`,
-`generate_*`) over shelling out. Prerequisite: `pracht inspect` needs a vite
-config with the pracht plugin registered.
+MCP: when the pracht MCP server is registered (docs/MCP.md), prefer its
+`inspect_routes`/`inspect_api`/`inspect_build`/`doctor`/`verify`/`generate_*`
+tools over shelling out. `pracht inspect` needs the pracht plugin in the vite
+config.
 
 ```bash
 pracht inspect api --json

--- a/skills/pre-deploy/SKILL.md
+++ b/skills/pre-deploy/SKILL.md
@@ -1,16 +1,14 @@
 ---
 name: pre-deploy
-version: 1.3.0
+version: 1.4.0
 description: |
-  Adapter-aware pre-deployment checklist for pracht apps targeting Node,
-  Cloudflare Workers, Vercel, or a pure static export. Catches the issues that
-  only surface in the production runtime: missing env vars, Node-only APIs in
-  edge bundles, ISG manifest absence, oversized edge bundles, missing
-  wrangler/vercel config, and static hosts missing clean-URL, 404, or security
-  header configuration.
-  Use when asked to "pre-deploy check", "ready to ship?", "deployment
-  checklist", "is my build production-safe", or before running `wrangler
-  deploy` / `vercel deploy`.
+  Adapter-aware pre-deployment checklist (Node, Cloudflare Workers, Vercel, static)
+  for the failures that only surface in production: missing env vars, Node-only
+  APIs in edge bundles, absent ISG manifest, oversized bundles, missing
+  wrangler/vercel config, and static hosts without clean URLs, 404, or security
+  headers.
+  Use for "pre-deploy check", "ready to ship?", "deployment checklist", "is my
+  build production-safe", before `wrangler deploy` or `vercel deploy`.
 allowed-tools:
   - Bash
   - Read
@@ -20,239 +18,206 @@ allowed-tools:
 
 # Pracht Pre-Deploy
 
-Run this before every production deploy. Each adapter has a different runtime
-contract; this skill enforces the contract that matches your build.
+Run before every production deploy. Each adapter has a different runtime
+contract; enforce the one that matches the build. Never deploy on the user's
+behalf — end at the verdict.
 
-## Step 1: Detect the adapter
-
-If the pracht MCP server is registered (see docs/MCP.md), prefer its tools
-(`inspect_routes`, `inspect_api`, `inspect_build`, `doctor`, `verify`) over
+MCP: when the pracht MCP server is registered (docs/MCP.md), prefer its
+`inspect_routes`/`inspect_api`/`inspect_build`/`doctor`/`verify` tools over
 shelling out.
 
-Read `vite.config.ts` and look for `nodeAdapter()`, `cloudflareAdapter()`,
-`vercelAdapter()`, or `staticAdapter()`. Confirm with:
+## Step 1: Build, then detect the adapter
 
-```bash
-pracht inspect build --json
-```
-
-The `adapterTarget` field is authoritative. Prerequisites: `pracht inspect`
-needs a vite config with the pracht plugin, and `inspect build` reads
-artifacts from a prior build — if `pracht build` has not been run recently,
-run it first:
+Always build first — never lint a stale `dist/`.
 
 ```bash
 pracht build
+pracht inspect build --json
 ```
 
-## Step 2: Run framework-wide checks
+`adapterTarget` is authoritative; `vite.config.ts` (`nodeAdapter()`,
+`cloudflareAdapter()`, `vercelAdapter()`, `staticAdapter()`) is the
+cross-check. Never assume the adapter.
+
+## Step 2: Framework-wide checks
 
 ```bash
 pracht doctor --json
 pracht verify --json
+pracht typegen --check   # only if src/pracht-routes.ts or src/pracht.d.ts exists
 ```
 
-If the app uses generated typed routes (`src/pracht-routes.ts` or
-`src/pracht.d.ts` exists), also run:
-
-```bash
-pracht typegen --check
-```
-
-These catch app-graph wiring problems independent of the adapter — including
+These catch app-graph wiring problems independent of the adapter, including
 `defineApp({ constraints })` violations and a stale `.pracht/app-graph.json`
-snapshot (fix the latter with `pracht plan --write`, then re-review the plan
-output). Resolve all `status: "error"` entries before continuing.
+snapshot (fix that with `pracht plan --write`, then re-review the plan output).
+Resolve every `status: "error"` before continuing — **if `pracht doctor`
+reports errors, stop here**; the remaining checks will be noisy false
+positives. Stale generated typed-route files block deployment; if the app does
+not use them yet, note that `typegen --check` is optional.
 
-When the deploy corresponds to a PR, `pracht report --base origin/main` produces
-a markdown summary (graph diff + verify + budgets) worth attaching to it.
+For a PR deploy, `pracht report --base origin/main` produces a markdown summary
+(graph diff + verify + budgets) worth attaching.
 
-## Step 3: Adapter-specific checklist
+## Step 3: Adapter checklist
 
 ### Node (`@pracht/adapter-node`)
 
-- `dist/server/server.js` exists.
-- `dist/client/.vite/manifest.json` exists.
-- `dist/server/isg-manifest.json` exists if any route has `render: "isg"`.
-- Smoke test: `pracht preview --skip-build` (or `node dist/server/server.js`) boots and `curl localhost:3000` returns 200.
-- Required env vars (grep `process.env.*` across `src/`) are set in the
-  deployment environment. List them for the user.
-- If the app mounts `createImageHandler()` from `@pracht/image/node`, confirm
-  `sharp` is installed and `localOrigin` is the same trusted public origin as
-  `nodeAdapter({ canonicalOrigin })`. A relative image endpoint without both
-  values is an error in every environment; loopback-looking request origins
-  are intentionally not trusted.
-- Reverse-proxy / TLS termination configured (out of scope for this skill —
-  flag for confirmation).
-- If the proxy strips Vite's deploy base, confirm
-  `nodeAdapter({ basePathStripped: true })`; application code should still
-  observe the public base in `request.url`, and the proxy must own the public
-  bare-base redirect (`/app` to `/app/`).
+- `dist/server/server.js`, `dist/client/.vite/manifest.json`, and — if any
+  route is `render: "isg"` — `dist/server/isg-manifest.json` all exist.
+- `pracht preview --skip-build` (or `node dist/server/server.js`) boots and
+  `curl localhost:3000` returns 200.
+- Every env var the app reads (grep `process.env.*` across `src/`) is set in
+  the deployment environment. List them for the user.
+- If the app mounts `createImageHandler()` from `@pracht/image/node`, `sharp`
+  is installed and `localOrigin` is the same trusted public origin as
+  `nodeAdapter({ canonicalOrigin })`. A relative image endpoint without both is
+  an error in every environment; loopback-looking request origins are
+  intentionally not trusted.
+- Reverse proxy / TLS termination configured — out of scope here, flag for
+  confirmation.
+- If the proxy strips Vite's deploy base, `nodeAdapter({ basePathStripped:
+  true })` is set; application code should still observe the public base in
+  `request.url`, and the proxy must own the bare-base redirect (`/app` →
+  `/app/`).
 
 ### Cloudflare Workers (`@pracht/adapter-cloudflare`)
 
-- `wrangler.toml` (or `wrangler.jsonc`) present at repo root.
-- `main` points to `dist/server/worker.js` — the thin deploy wrapper that
-  re-exports only the default handler and Cloudflare entrypoint classes.
-  Pointing `main` at `dist/server/server.js` is an **error**: workerd
-  validates every named export of the deploy entry and rejects the build
-  metadata (`buildTarget`, manifests, `resolvedApp`, ...) that `server.js`
-  exports for the prerender pass.
-- `no_bundle` is `true`, with an `ESModule` rule whose globs include
-  `"**/*.js"`. Pracht's Vite output is already bundled and may contain lazy
-  server chunks; these settings make Wrangler upload the chunks as separate
-  modules instead of folding them into the entry file.
-- `assets.directory` points to `dist/client`.
-- `compatibility_date` is set, and is a date the installed workerd supports.
-  It must not be *newer* than the runtime: workerd refuses to start with
-  "This Worker requires compatibility date X, but the newest date supported
-  by this server binary is Y". Never set it to today's date — that is by
-  construction at or beyond the newest released workerd.
-- Bindings declared in wrangler config for every `context.env.*` access in
-  loaders, middleware, and API routes (grep, then cross-check).
-- **No Node-only APIs in the server bundle.** Grep the server files for:
-  `fs`, `path` (Node form), `process.cwd`, `Buffer`, `__dirname`,
-  `__filename`, `crypto.createHash` (use `crypto.subtle` instead),
-  `child_process`, `cluster`, `worker_threads`. Two nuances before flagging:
-  - Consult `compatibility_flags` in the wrangler config first — with
-    `nodejs_compat`, `Buffer` and several `node:` modules are legal in
-    workerd. Only flag APIs the active flags don't cover.
-  - Dev already runs inside workerd via `@cloudflare/vite-plugin`, so most
-    incompatibilities surface in dev; this check is the backstop for code
-    paths dev never hit.
-- An API route importing `@pracht/image/node` is an error on Workers because
-  its optimizer requires `sharp`. Require `cloudflareLoader` (or
-  `passthroughLoader`) instead.
-- ISG: worker-managed ISG via the per-colo Workers Cache API works out of the
-  box. If time-revalidated routes should use the edge-tier Workers Caching
-  upgrade instead, confirm both sides — `cloudflareAdapter({ cache: true })`
-  in vite config and `"cache": { "enabled": true }` in wrangler config.
-- When Workers Caching is enabled, flag ISG routes reachable through unbounded
-  query strings. Require a bounded allowlist/canonical redirect or an uncached
-  gateway with a normalized `cf.cacheKey`; also check that markdown-capable
-  routes normalize `Accept` at the gateway when variant fan-out matters.
-- Bundle size: measure what actually deploys — `dist/server/worker.js` plus
-  its `dist/server/server.js` import and lazy chunks (`no_bundle: true` plus
-  the JavaScript `ESModule` rule uploads the pre-built module graph;
-  `worker.js` alone is a few lines).
-  Workers limit is ~1 MB
-  compressed for free tier, ~10 MB on paid. Warn at 80% of the active limit.
+- `wrangler.toml`/`wrangler.jsonc` present at repo root, `assets.directory`
+  pointing at `dist/client`, and bindings declared for every `context.env.*`
+  access in loaders, middleware, and API routes (grep, then cross-check).
+- `main` points at `dist/server/worker.js` — the thin deploy wrapper
+  re-exporting only the default handler and Cloudflare entrypoint classes.
+  Pointing it at `dist/server/server.js` is an **error**: workerd validates
+  every named export of the deploy entry and rejects the build metadata
+  (`buildTarget`, manifests, `resolvedApp`, …) that `server.js` exports for the
+  prerender pass.
+- `no_bundle: true` plus an `ESModule` rule whose globs include `"**/*.js"`.
+  Pracht's Vite output is already bundled and may contain lazy server chunks;
+  these settings make Wrangler upload them as separate modules instead of
+  folding them into the entry.
+- `compatibility_date` is set and is a date the installed workerd supports. It
+  must not be *newer* than the runtime, or workerd refuses to start ("This
+  Worker requires compatibility date X, but the newest date supported by this
+  server binary is Y"). Never set it to today's date — that is by construction
+  at or beyond the newest released workerd.
+- **No Node-only APIs in the server bundle.** Grep the server files for `fs`,
+  `path` (Node form), `process.cwd`, `Buffer`, `__dirname`, `__filename`,
+  `crypto.createHash` (use `crypto.subtle`), `child_process`, `cluster`,
+  `worker_threads`. Check `compatibility_flags` first — with `nodejs_compat`,
+  `Buffer` and several `node:` modules are legal — and only flag what the
+  active flags do not cover. Dev already runs inside workerd via
+  `@cloudflare/vite-plugin`, so this is the backstop for code paths dev never
+  hits.
+- An API route importing `@pracht/image/node` is an error on Workers (its
+  optimizer needs `sharp`). Require `cloudflareLoader` or `passthroughLoader`.
+- ISG works out of the box via the per-colo Workers Cache API. If
+  time-revalidated routes should use the edge-tier Workers Caching upgrade,
+  confirm *both* sides: `cloudflareAdapter({ cache: true })` and
+  `"cache": { "enabled": true }` in wrangler config. With it enabled, flag ISG
+  routes reachable through unbounded query strings — require a bounded
+  allowlist or canonical redirect, or an uncached gateway with a normalized
+  `cf.cacheKey` — and check that markdown-capable routes normalize `Accept` at
+  the gateway when variant fan-out matters.
+- Bundle size: measure what actually deploys — `dist/server/worker.js` plus its
+  `dist/server/server.js` import and lazy chunks (`worker.js` alone is a few
+  lines; `no_bundle` uploads the pre-built module graph). The Workers limit is
+  ~1 MB compressed on free, ~10 MB on paid. Warn at 80% of the active limit.
 
 ### Vercel (`@pracht/adapter-vercel`)
 
-- `.vercel/output/config.json` exists post-build.
+- `.vercel/output/config.json` exists with `version: 3`, and
+  `.vercel/output/static/` is populated.
 - The render function exists at
   `.vercel/output/functions/<functionName>.func/server.js`. The name defaults
-  to `render` but is configurable via `vercelAdapter({ functionName })` —
-  read the configured name from `vite.config.ts` instead of hardcoding
-  `render.func`.
-- `.vercel/output/static/` populated.
-- Required env vars are configured in the Vercel project (cannot verify from
-  CLI without `vercel env pull` — run that and diff against `process.env.*`
-  references).
-- Edge runtime constraints: the render function's `.vc-config.json` is
-  **always** written with `runtime: "edge"`, so run the same Node-only API
-  check as Cloudflare **unconditionally** for Vercel builds. Do not skip it
-  based on a runtime probe — ISG routes run the same bundle on Node, but any
-  Node-only API still breaks the edge function.
-- ISG functions: every `<route>.prerender-config.json` must sit next to a
-  **Serverless** `<route>.func` (`.vc-config.json` with `launcherType:
-  "Nodejs"`). Vercel rejects a prerender config paired with an edge function:
+  to `render` but is configurable via `vercelAdapter({ functionName })` — read
+  it from `vite.config.ts` rather than hardcoding `render.func`.
+- Env vars are configured in the Vercel project. This cannot be verified from
+  the CLI alone: run `vercel env pull` and diff against `process.env.*` uses.
+- **Run the Cloudflare Node-only API check unconditionally.** The render
+  function's `.vc-config.json` is always written with `runtime: "edge"`. Do not
+  skip it based on a runtime probe — ISG routes run the same bundle on Node,
+  but a Node-only API still breaks the edge function.
+- Every `<route>.prerender-config.json` sits next to a **Serverless**
+  `<route>.func` (`.vc-config.json` with `launcherType: "Nodejs"`). Vercel
+  rejects a prerender config paired with an edge function:
   `Unexpected function type "EdgeFunction" at path "<route>"`.
-- Region configuration: `vercelAdapter({ regions: "all" })` is valid for the
-  Edge render function, but generated Node ISG function configs must omit
-  `regions` so the project's default Serverless region applies. Node configs
-  may only contain arrays of concrete region identifiers.
-- An API route importing `@pracht/image/node` is an error for the Vercel Edge
+- `vercelAdapter({ regions: "all" })` is valid for the Edge render function,
+  but generated Node ISG function configs must omit `regions` so the project
+  default applies; Node configs may only contain arrays of concrete region
+  identifiers.
+- An API route importing `@pracht/image/node` is an error for the Edge
   function. Require `vercelLoader` (with aligned allowed sizes) or
-  `passthroughLoader` instead.
-- Build Output API v3 sanity: `config.json` has `version: 3`.
+  `passthroughLoader`.
 
 ### Static export (`@pracht/adapter-static`)
 
-`adapterTarget` is `"static"`. There is no server to get wrong, so the
-checklist is about what the *host* must do and what the build cannot enforce.
+There is no server to get wrong, so this checklist is about what the *host*
+must do and what the build cannot enforce.
 
 - `dist/client/` exists and is the deploy root. `dist/server/` is build tooling
-  only — it must not be uploaded (it contains the prerender bundle).
-- The build itself is the gate: it fails closed on `ssr`/`isg` routes, SPA
-  loaders, non-full SPA hydration, API routes, route/not-found middleware,
+  and must not be uploaded — it contains the prerender bundle.
+- The build is the gate: it fails closed on `ssr`/`isg` routes, SPA loaders,
+  non-full SPA hydration, API routes, route/not-found middleware,
   network-exposed capabilities, and any Vite `base` that is not `/` or a
-  root-absolute path (CDN and document-relative bases are rejected). If
-  `pracht build` succeeded, those contracts already hold — do not re-derive
-  them by hand. Report a failing build verbatim; the message names the routes.
-- Host must serve `index.html` for directory URLs (clean URLs). Confirm the
-  host's setting: S3 website endpoints need an index document, nginx needs
-  `try_files $uri $uri/index.html`, GitHub Pages and Netlify do it by default.
-- Host must map `404.html` as the error document, otherwise unknown URLs get
-  the host's generic error page instead of the app's `notFound` route. Verify
-  `dist/client/404.html` exists; if it does not, the app declares no `notFound`
-  page — flag it as a `warn`.
+  root-absolute path. If `pracht build` succeeded, those contracts already hold
+  — do not re-derive them by hand. Report a failing build verbatim; the message
+  names the routes.
+- The host serves `index.html` for directory URLs. Confirm the actual setting:
+  S3 website endpoints need an index document, nginx needs
+  `try_files $uri $uri/index.html`; GitHub Pages and Netlify do it by default.
+- The host maps `404.html` as its error document, or unknown URLs get the
+  host's generic error page instead of the app's `notFound` route. Verify
+  `dist/client/404.html` exists — if it does not, the app declares no
+  `notFound` page: `warn`.
 - **Security headers are not applied.** Every other adapter sets the four
   default security headers at request time; a static host has no request
-  runtime. `dist/server/headers-manifest.json` records the headers each route
-  *would* have carried — mirror the ones you need in the host's own header
-  config (`_headers` on Netlify, CloudFront response header policies, nginx
-  `add_header`). This is an `error` for any app handling user input, and
-  `warn` otherwise. HSTS and CSP are host-side decisions either way.
+  runtime. `dist/server/headers-manifest.json` records what each route *would*
+  have carried — mirror the ones you need into the host's own header config
+  (`_headers` on Netlify, CloudFront response header policies, nginx
+  `add_header`). `error` for any app handling user input, `warn` otherwise.
+  HSTS and CSP are host-side decisions either way.
 - If `staticAdapter({ fallback })` is configured, the host needs a rewrite of
-  unmatched URLs to that file, and the rewrite must not shadow real files.
-  Note that it makes unknown URLs answer `200` (soft 404s). Without the
-  rewrite the fallback file is inert — deep links into dynamic `render: "spa"`
-  routes will 404.
-- Smoke test the real output, not the dev server:
-  `pracht preview --skip-build` serves `dist/client/` the way a dumb host
-  would. Check `/`, one dynamic SSG path, one deep link into a SPA route, and
-  one unknown URL.
-- Routes exporting `markdown` rely on server-side `Accept` negotiation, which
-  a static host cannot do — agents asking for `text/markdown` get HTML. The
-  build prints a note when this applies; publish `.md` files under `public/`
-  if a raw-markdown corpus matters.
-- Deploying to a sub-path (GitHub Pages *project* site, S3 key prefix) needs
-  Vite `base` set to that path (`base: "/my-project/"`). Check it matches the
-  deploy path exactly — a mismatch 404s every asset. Then check the app has no
-  hand-written root-absolute internal links (`<a href="/about">`): those are
-  not base-prefixed and will leave the deploy. `grep -rn 'href="/' src/` and
-  confirm each hit is external, an asset under `public/`, or a `<Link route>`.
-  Framework-owned URLs from `@pracht/image`'s `defaultLoader` and the OpenAPI
-  companion UI/document already carry the base; do not flag their base-free
-  route declarations. Custom image loaders and OpenAPI provider asset URLs
-  still need to match the intended host.
-  CDN bases (`https://cdn…`) and document-relative bases (`""` / `"./"`) are
-  build errors, not sub-path deploys.
+  unmatched URLs to that file that does not shadow real files. It makes unknown
+  URLs answer `200` (soft 404s), and without it the fallback file is inert —
+  deep links into dynamic `render: "spa"` routes will 404.
+- Smoke test the real output, not the dev server: `pracht preview --skip-build`
+  serves `dist/client/` the way a dumb host would. Check `/`, one dynamic SSG
+  path, one deep link into a SPA route, and one unknown URL.
+- Routes exporting `markdown` rely on server-side `Accept` negotiation, which a
+  static host cannot do — agents asking for `text/markdown` get HTML. The build
+  prints a note; publish `.md` files under `public/` if a raw-markdown corpus
+  matters.
+- Sub-path deploys (GitHub Pages *project* site, S3 key prefix) need Vite
+  `base` set to that path (`base: "/my-project/"`), matching the deploy path
+  exactly — a mismatch 404s every asset. Then confirm no hand-written
+  root-absolute internal links: `grep -rn 'href="/' src/` and check each hit is
+  external, an asset under `public/`, or a `<Link route>`. Framework-owned URLs
+  from `@pracht/image`'s `defaultLoader` and the OpenAPI companion
+  UI/document already carry the base — do not flag their base-free route
+  declarations — but custom image loaders and OpenAPI provider asset URLs still
+  need to match the intended host. CDN bases (`https://cdn…`) and
+  document-relative bases (`""` / `"./"`) are build errors, not sub-path
+  deploys.
 
-## Step 4: Cross-cutting checks
+## Step 4: Cross-cutting
 
-- Run `audit-secrets` to confirm no `process.env.*` or `context.env.*` values
-  flow into loader return values.
-- Run `audit-headers` to confirm `applyDefaultSecurityHeaders` is in use on
-  user-facing responses (or that `headers()` exports cover the same ground).
-  On a static export this check moves entirely to the host's header config —
-  see the static section above.
-- Confirm `git status` is clean (deploying uncommitted work is a footgun).
+- `/audit-secrets` — no `process.env.*` or `context.env.*` value flows into a
+  loader return value.
+- `/audit-headers` — `applyDefaultSecurityHeaders` is in use on user-facing
+  responses, or `headers()` exports cover the same ground. On a static export
+  this moves entirely to the host config; see above.
+- `git status` is clean. Deploying uncommitted work is a footgun.
 
 ## Step 5: Report
 
-Produce a checklist grouped by `Framework`, `Adapter`, `Cross-cutting`. Tag
-each item with a primary severity — `error` (blocks deploy), `warn` (deploy
-proceeds but risky), `info` — and keep pass/fail as the secondary per-item
-status. End with a one-line verdict: `READY` / `BLOCKED (N errors)` /
-`READY WITH WARNINGS (N warnings)`.
+A checklist grouped by `Framework`, `Adapter`, `Cross-cutting`. Tag each item
+with a primary severity — `error` (blocks deploy), `warn` (proceeds but risky),
+`info` — keeping pass/fail as the secondary per-item status. End with one line:
+`READY` / `BLOCKED (N errors)` / `READY WITH WARNINGS (N warnings)`.
 
-## Rules
-
-1. Always run `pracht build` first. Do not lint a stale `dist/`.
-2. Detect the adapter — never assume.
-3. For Cloudflare/Vercel-edge, the Node-only API check is non-negotiable; an
-   API not covered by the active compatibility flags will crash the worker on
-   a code path that may never hit in dev.
-4. For a static export, never report `READY` without naming the host settings
-   the deploy depends on (clean URLs, `404.html`, security headers, and the
-   fallback rewrite if configured). The build cannot verify any of them, so an
-   unqualified `READY` is the one way this skill can mislead.
-5. If the app does not use generated typed route files yet, note that `pracht typegen --check` is optional; if it does, stale generated files block deployment.
-6. Do not deploy on the user's behalf. End the skill at the verdict.
-7. If `pracht doctor` reports errors, do not run any other checks until those
-   are resolved — they will produce noisy false positives.
+For a static export, never report `READY` without naming the host settings the
+deploy depends on — clean URLs, `404.html`, security headers, and the fallback
+rewrite if configured. The build cannot verify any of them, so an unqualified
+`READY` is the one way this skill can mislead.
 
 $ARGUMENTS

--- a/skills/scaffold-e2e/SKILL.md
+++ b/skills/scaffold-e2e/SKILL.md
@@ -1,14 +1,13 @@
 ---
 name: scaffold-e2e
-version: 1.1.0
+version: 1.1.1
 description: |
-  Scaffold Playwright end-to-end tests for a pracht app: install Playwright,
-  generate `playwright.config.ts` that boots `pracht dev` (or the production
-  build via `pracht preview`), and emit a smoke test for every route in the
-  manifest that asserts 200, head/title, no console errors, and basic
-  navigation.
-  Use when asked to "scaffold E2E", "set up Playwright", "add browser tests",
-  or "create smoke tests for my routes".
+  Set up Playwright for a pracht app: install it, generate a
+  `playwright.config.ts` that boots `pracht dev` (or the build via `pracht
+  preview`), and emit a smoke test per manifest route asserting 200, head/title,
+  no console errors, and navigation.
+  Use for "scaffold E2E", "set up Playwright", "add browser tests", "create smoke
+  tests for my routes".
 allowed-tools:
   - Bash
   - Read
@@ -82,10 +81,10 @@ If `playwright.config.ts` already exists, merge — do not clobber.
 
 ## Step 4: Generate per-route smoke tests
 
-If the pracht MCP server is registered (see docs/MCP.md), prefer its tools
-(`inspect_routes`, `inspect_api`, `inspect_build`, `doctor`, `verify`,
-`generate_*`) over shelling out. Prerequisite: `pracht inspect` needs a vite
-config with the pracht plugin registered.
+MCP: when the pracht MCP server is registered (docs/MCP.md), prefer its
+`inspect_routes`/`inspect_api`/`inspect_build`/`doctor`/`verify`/`generate_*`
+tools over shelling out. `pracht inspect` needs the pracht plugin in the vite
+config.
 
 ```bash
 pracht inspect routes --json

--- a/skills/scaffold-tests/SKILL.md
+++ b/skills/scaffold-tests/SKILL.md
@@ -1,14 +1,12 @@
 ---
 name: scaffold-tests
-version: 1.2.0
+version: 1.2.1
 description: |
-  Scaffold Vitest unit/integration tests for pracht routes, loaders, and
-  middleware. Asks the user once whether to use vitest browser mode with
-  `vitest-browser-preact` (real DOM, real events) or classic JSDOM-based
-  tests with `@testing-library/preact`. Wires `vitest.config.ts`, builds
-  `LoaderArgs` with `@pracht/test`, and emits ready-to-run files.
-  Use when asked to "scaffold tests", "set up Vitest", "add unit tests",
-  "test this loader", or "test this route".
+  Set up Vitest for pracht routes, loaders, and middleware — browser mode with
+  `vitest-browser-preact` or JSDOM with `@testing-library/preact` — wiring
+  `vitest.config.ts`, `LoaderArgs` via `@pracht/test`, and runnable test files.
+  Use for "scaffold tests", "set up Vitest", "add unit tests", "test this loader",
+  "test this route".
 allowed-tools:
   - Bash
   - Read
@@ -134,10 +132,10 @@ If `vitest.config.ts` already exists, merge — never clobber.
 
 ## Step 4: Generate the tests
 
-If the pracht MCP server is registered (see docs/MCP.md), prefer its tools
-(`inspect_routes`, `inspect_api`, `inspect_build`, `doctor`, `verify`,
-`generate_*`) over shelling out. Prerequisite: `pracht inspect` needs a vite
-config with the pracht plugin registered.
+MCP: when the pracht MCP server is registered (docs/MCP.md), prefer its
+`inspect_routes`/`inspect_api`/`inspect_build`/`doctor`/`verify`/`generate_*`
+tools over shelling out. `pracht inspect` needs the pracht plugin in the vite
+config.
 
 This skill covers **loaders, middleware, and components**. For API handlers
 (`src/api/**`), delegate to `/pracht-test-api` — it owns handler enumeration and

--- a/skills/skills.test.ts
+++ b/skills/skills.test.ts
@@ -449,3 +449,42 @@ describe("audit-* tool policy", () => {
     }
   });
 });
+
+// ---------------------------------------------------------------------------
+// Context budgets
+// ---------------------------------------------------------------------------
+
+// Every skill's `description` sits in the agent's system prompt for the whole
+// session, invoked or not, so the catalog total is a per-session tax on every
+// user who installs the pack. The body is paid once per invocation. Both are
+// ratchets set just above the current worst case: they exist to make a
+// regression an explicit decision (raise the number in the same commit) rather
+// than a silent drift back toward prose.
+const MAX_DESCRIPTION_CHARS = 500;
+const MAX_DESCRIPTION_TOTAL_CHARS = 12_000;
+const MAX_SKILL_BYTES = 20_000;
+
+describe("context budgets", () => {
+  it.each(skills)("$name keeps its description under the always-on budget", (skill) => {
+    const { description } = parsed(skill);
+    expect(
+      description.length,
+      `skills/${skill.name}/SKILL.md description is ${description.length} chars; the budget is ${MAX_DESCRIPTION_CHARS}. Descriptions are always in context — keep one sentence of what it does plus the trigger phrases, and move the detail into the body.`,
+    ).toBeLessThanOrEqual(MAX_DESCRIPTION_CHARS);
+  });
+
+  it("keeps the whole catalog's descriptions under the always-on budget", () => {
+    const total = skills.reduce((sum, skill) => sum + parsed(skill).description.length, 0);
+    expect(
+      total,
+      `the ${skills.length} skill descriptions total ${total} chars; the budget is ${MAX_DESCRIPTION_TOTAL_CHARS}. Every one of them is in context for every session.`,
+    ).toBeLessThanOrEqual(MAX_DESCRIPTION_TOTAL_CHARS);
+  });
+
+  it.each(skills)("$name keeps its body under the per-invocation budget", (skill) => {
+    expect(
+      skill.raw.length,
+      `skills/${skill.name}/SKILL.md is ${skill.raw.length} bytes; the budget is ${MAX_SKILL_BYTES}. A skill is loaded whole on invocation — prefer tables over prose, drop rationale that does not change what the agent does, and keep a trailing "Rules" section only for constraints the steps do not already state.`,
+    ).toBeLessThanOrEqual(MAX_SKILL_BYTES);
+  });
+});

--- a/skills/tune-render-mode/SKILL.md
+++ b/skills/tune-render-mode/SKILL.md
@@ -1,12 +1,11 @@
 ---
 name: tune-render-mode
-version: 1.1.0
+version: 1.1.1
 description: |
-  Recommend the right pracht render mode (ssg, isg, ssr, spa) for each route
-  based on what its loader actually does. Most apps pick a mode once and never
-  revisit; this skill surfaces routes that are mis-tuned.
-  Use when asked to "tune render modes", "make my site faster", "should this
-  route be SSG", "audit render modes", or "review SSG/ISG/SSR choices".
+  Recommend the right render mode (ssg, isg, ssr, spa) per route from what each
+  loader actually does, then apply the change after confirmation.
+  Use for "tune render modes", "should this route be SSG", "audit render modes",
+  "review SSG/ISG/SSR choices", "make my site faster".
 allowed-tools:
   - Bash
   - Read
@@ -61,8 +60,8 @@ For each route:
 
 ## Step 1: Enumerate
 
-If the pracht MCP server is registered (see docs/MCP.md), prefer its tools
-(`inspect_routes`, `inspect_api`, `inspect_build`, `doctor`, `verify`) over
+MCP: when the pracht MCP server is registered (docs/MCP.md), prefer its
+`inspect_routes`/`inspect_api`/`inspect_build`/`doctor`/`verify` tools over
 shelling out.
 
 ```bash

--- a/skills/typed-routes/SKILL.md
+++ b/skills/typed-routes/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: typed-routes
-version: 1.1.0
+version: 1.1.1
 description: |
-  Add or maintain pracht typed routes, typed links, route-object navigation,
-  and generated href helpers. Use when asked to "add typed routes", "fix typed
-  links", "replace hard-coded hrefs", "run typegen", or make navigation route-id
-  based instead of string based.
+  Add or maintain pracht typed routes: run typegen, adopt route-id based links and
+  navigation, and replace hard-coded hrefs with generated helpers.
+  Use for "add typed routes", "fix typed links", "replace hard-coded hrefs", "run
+  typegen".
 allowed-tools:
   - Bash
   - Read
@@ -24,10 +24,10 @@ Use this workflow to keep route ids, params, links, and navigation type-safe.
 
 The resolved app graph is the source of truth — not a manual glob of `src/`.
 
-If the pracht MCP server is registered (see docs/MCP.md), prefer its tools
-(`inspect_routes`, `inspect_api`, `inspect_build`, `doctor`, `verify`,
-`generate_*`) over shelling out. Prerequisite: `pracht inspect` needs a vite
-config with the pracht plugin registered.
+MCP: when the pracht MCP server is registered (docs/MCP.md), prefer its
+`inspect_routes`/`inspect_api`/`inspect_build`/`doctor`/`verify`/`generate_*`
+tools over shelling out. `pracht inspect` needs the pracht plugin in the vite
+config.
 
 ```bash
 pracht inspect routes --json

--- a/skills/upgrade-pracht/SKILL.md
+++ b/skills/upgrade-pracht/SKILL.md
@@ -1,14 +1,13 @@
 ---
 name: upgrade-pracht
-version: 1.0.1
+version: 1.0.2
 description: |
-  Upgrade the @pracht/* packages in an app safely: inventory installed
-  versions, read the changelogs between installed and target, map breaking
-  changes to actual usage in the codebase, apply the upgrade, and walk the
-  verification ladder (doctor, typegen, verify, build, tests).
-  Use when asked to "upgrade pracht", "update @pracht packages", "bump the
-  framework", "what changed in the new pracht version", or "is this pracht
-  upgrade safe".
+  Upgrade the `@pracht/*` packages safely: inventory installed versions, read the
+  changelogs between installed and target, map breaking changes to real usage,
+  apply, then walk the verification ladder (doctor, typegen, verify, build,
+  tests).
+  Use for "upgrade pracht", "update @pracht packages", "bump the framework", "what
+  changed in the new pracht version", "is this upgrade safe".
 allowed-tools:
   - Bash
   - Read


### PR DESCRIPTION
## Summary

- Two different budgets were unmanaged in `skills/`. A skill's `description` sits in the agent's system prompt for the **whole session** whether or not the skill is ever invoked — 33 of them was a ~3.5k-token standing tax on every app that seeds the catalog. A `SKILL.md` body is loaded **whole on invocation**, so a user deploying to Cloudflare was also paying for the Node, Netlify, Vercel, and static sections of `/pracht-deploy`.
- Descriptions: **14,379 → 10,781 chars (-25%, ~900 tokens off every session)**. Each is now one sentence of what the skill does plus its trigger phrases; the detail moved into the body, where it is only paid for on use. Every trigger phrase was preserved — the retrieval signal is what makes the description worth its cost.
- Bodies: **307,227 → 281,567 bytes (-8% overall)**, weighted toward the ones that cost the most per invocation: `/migrate-nextjs` -23%, `/pracht-debug` -25%, `/add-db` -25%, `/add-auth` -23%, `/pracht-scaffold` -20%, `/pracht-deploy` -18%, `/pre-deploy` -13%, `/add-i18n` -9%. The savings come from collapsing the 4-line MCP/prerequisite preamble that repeated in 29 skills, deleting trailing `## Rules` sections that restated their own steps, and converting branch-per-target prose into tables. **No directive, check, constraint, or code template was dropped** — the diff is compression, not scope reduction.
- `skills.test.ts` now enforces the budgets (500 chars per description, 12,000 across the catalog, 20,000 bytes per body) with failure messages that explain what to cut. The numbers are ratchets set just above the current worst case, so a regression has to be an explicit decision in the same commit rather than silent drift back toward prose.
- Skills stay single-file. Progressive disclosure via a `references/` directory would have cut more, but it would break all three distribution paths at once — the agent-skills discovery manifest carries one `url` per skill, `sync-skills.js` and `create-pracht` copy only `SKILL.md`, and the docs site promises a one-`curl` install. Noted as a possible follow-up if the budgets ever bind.

No issue linked.

## Testing

- [x] `pnpm run verify` (build, format, lint, typecheck, test, e2e) — passed, 90.9s
- The drift guard grew from 229 to 296 assertions; all pass. It already verified that every referenced CLI subcommand, flag, MCP tool name, build-output path, and cross-skill `/reference` is real, which is what makes a rewrite of this size safe to land.

## Checklist

- [x] Docs updated if needed — `skills/README.md` gains the budget convention; the public [Agent Skills](https://pracht.resynapse.dev/docs/agent-skills) page gains a **Context Cost** section, since what the catalog costs a reader's context window is exactly the kind of thing they should be able to look up before installing it.
- [x] Skills updated if needed — this PR is the skills change.
- [x] Changeset added if published packages changed — `create-pracht` seeds the catalog, so `patch`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)