### PR TITLE
Publish virtual.d.ts so npm installs can type virtual:pracht/* imports

### DIFF
--- a/.changeset/virtual-types-published.md
+++ b/.changeset/virtual-types-published.md
@@ -1,0 +1,6 @@
+---
+"@pracht/vite-plugin": patch
+"create-pracht": patch
+---
+
+Publish `virtual.d.ts` and expose it as `@pracht/vite-plugin/virtual`, so apps installed from npm can typecheck `virtual:pracht/*` imports; new scaffolds include it in `compilerOptions.types` automatically.

--- a/examples/docs/src/routes/docs/capabilities.md
+++ b/examples/docs/src/routes/docs/capabilities.md
@@ -118,6 +118,12 @@ const same = await capabilities.notes.create({ title });
 
 Both take the same path (one endpoint table, one settled event, one revalidation rule); `capabilities` is a nested view of the same call, and private capabilities are absent from it entirely. Reach for the nested form when typing a name by hand — its members are real property accesses, so a typo gets `Did you mean 'search'?` where a string literal argument gets no suggestion.
 
+TypeScript resolves the `virtual:pracht/*` module declarations from `@pracht/vite-plugin/virtual`. New scaffolds include it in `compilerOptions.types`; an app created before that adds it next to `vite/client`:
+
+```json [tsconfig.json]
+{ "compilerOptions": { "types": ["vite/client", "@pracht/vite-plugin/virtual"] } }
+```
+
 For calls driven by interaction — a button, a search box, a picker — `useCapability()` owns the pending/error/result state:
 
 ```tsx [src/routes/notes.tsx]

--- a/packages/start/src/index.js
+++ b/packages/start/src/index.js
@@ -1094,7 +1094,7 @@ function createBaseTSConfig(_adapter) {
       skipLibCheck: true,
       strict: true,
       target: "ES2022",
-      types: ["vite/client"],
+      types: ["vite/client", "@pracht/vite-plugin/virtual"],
       verbatimModuleSyntax: true,
     },
   };

--- a/packages/start/test/index.test.js
+++ b/packages/start/test/index.test.js
@@ -165,7 +165,8 @@ describe("create-pracht", () => {
               "strict": true,
               "target": "ES2022",
               "types": [
-                  "vite/client"
+                  "vite/client",
+                  "@pracht/vite-plugin/virtual"
               ],
               "verbatimModuleSyntax": true
           }
@@ -246,7 +247,8 @@ describe("create-pracht", () => {
               "strict": true,
               "target": "ES2022",
               "types": [
-                  "vite/client"
+                  "vite/client",
+                  "@pracht/vite-plugin/virtual"
               ],
               "verbatimModuleSyntax": true
           }
@@ -477,7 +479,8 @@ describe("create-pracht", () => {
               "strict": true,
               "target": "ES2022",
               "types": [
-                  "vite/client"
+                  "vite/client",
+                  "@pracht/vite-plugin/virtual"
               ],
               "verbatimModuleSyntax": true
           }

--- a/packages/vite-plugin/package.json
+++ b/packages/vite-plugin/package.json
@@ -25,7 +25,8 @@
     "directory": "packages/vite-plugin"
   },
   "files": [
-    "dist"
+    "dist",
+    "virtual.d.ts"
   ],
   "type": "module",
   "exports": {
@@ -36,6 +37,9 @@
     "./pages-router": {
       "types": "./dist/pages-router.d.mts",
       "default": "./dist/pages-router.mjs"
+    },
+    "./virtual": {
+      "types": "./virtual.d.ts"
     }
   },
   "publishConfig": {

--- a/skills/add-capabilities/SKILL.md
+++ b/skills/add-capabilities/SKILL.md
@@ -314,6 +314,8 @@ import { capabilities, useCapability } from "virtual:pracht/capabilities";
 const result = await capabilities.notes.search({ query: "roadmap" });
 ```
 
+Unresolvable in TS? Add `"@pracht/vite-plugin/virtual"` to tsconfig `types`.
+
 ```tsx
 // One contract for the human form and the agent tool.
 <Form capability="notes.create" onCapabilityResult={(result) => { /* … */ }}>


### PR DESCRIPTION
## Summary

- `@pracht/vite-plugin` publishes only `dist/`, so `virtual.d.ts` never reaches npm consumers and any app installed from the registry fails to typecheck `import … from "virtual:pracht/capabilities"`. Workspace-linked examples resolve the file relatively, which is why no example ever caught it (found while scaffolding a real app from the registry for the WebMCP Challenge).
- Ship `virtual.d.ts` in `files` and expose it as `@pracht/vite-plugin/virtual` (same pattern as `@pracht/content/virtual`).
- `create-pracht` now emits `"types": ["vite/client", "@pracht/vite-plugin/virtual"]` in scaffolded tsconfigs.
- Docs: capabilities page documents the one-line tsconfig addition for existing apps; `add-capabilities` skill gets the same pointer (kept within the skill context budget).

## Testing

- [x] `pnpm run verify` (build, format, lint, typecheck, test, e2e)

## Checklist

- [x] Docs updated if needed
- [x] Skills updated if needed
- [x] Concise, user-facing changeset added if published packages changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)