### PR TITLE
docs: correct hydration-mode and adapter claims on the site

### DIFF
--- a/examples/docs/src/routes/docs/cli.md
+++ b/examples/docs/src/routes/docs/cli.md
@@ -30,7 +30,7 @@ pnpm create pracht my-app --adapter=vercel --template=tailwind --yes
 
 Options:
 
-- `--adapter=node|cf|vercel` — choose Node.js, Cloudflare Workers, or Vercel output.
+- `--adapter=node|cf|netlify|vercel|static` — choose Node.js, Cloudflare Workers, Netlify, Vercel, or pure static output.
 - `--router=manifest|pages` — choose explicit `src/routes.ts` routing or file-system `src/pages/` routing.
 - `--template=minimal|tailwind`, `--tailwind`, `--no-tailwind` — control Tailwind setup.
 - `--agent-tools`, `--no-agent-tools` — seed or skip the pracht Claude Code skills, `.mcp.json`, and `AGENTS.md`/`CLAUDE.md`.

--- a/examples/docs/src/routes/docs/getting-started.md
+++ b/examples/docs/src/routes/docs/getting-started.md
@@ -25,7 +25,7 @@ yarn create pracht my-app
 bunx create-pracht my-app
 ```
 
-The CLI will ask you to choose an adapter (Node.js, Cloudflare Workers, or Vercel), whether to use the explicit manifest router or the file-system pages router, whether to add Tailwind CSS, and whether to seed the agent tooling. Adapters can be changed later in `vite.config.ts`. Moving from pages routing to manifest routing is an explicit ejection step because named shells, route middleware, capabilities, constraints, and runtime agent configuration live in the manifest; see [Pages Router](/docs/routing#pages-router-auto-discovery).
+The CLI will ask you to choose an adapter (Node.js, Cloudflare Workers, Netlify, Vercel, or a pure static export), whether to use the explicit manifest router or the file-system pages router, whether to add Tailwind CSS, and whether to seed the agent tooling. Adapters can be changed later in `vite.config.ts`. Moving from pages routing to manifest routing is an explicit ejection step because named shells, route middleware, capabilities, constraints, and runtime agent configuration live in the manifest; see [Pages Router](/docs/routing#pages-router-auto-discovery).
 
 For reproducible setup in CI, demos, or agents, pass the same choices as flags:
 

--- a/examples/docs/src/routes/docs/why-pracht.md
+++ b/examples/docs/src/routes/docs/why-pracht.md
@@ -41,9 +41,21 @@ The manifest tells you exactly which file handles which path, what shell wraps i
 
 Other frameworks typically default to one mode globally (SSR in Next.js, SSG in Astro) and make you opt out per page. Pracht treats the render mode as a first-class route config — `"ssg"`, `"ssr"`, `"isg"`, or `"spa"` — so the decision is always visible and intentional.
 
+### Per-route hydration modes
+
+Hydration is a separate axis from rendering. Every route also declares `hydration` — `"full"` (the default), `"islands"`, or `"none"` — so a route can be server-rendered every request and still ship almost no JavaScript:
+
+```ts
+route("/", "./routes/home.tsx", { render: "ssg", hydration: "none" }),
+route("/pricing", "./routes/pricing.tsx", { render: "isg", hydration: "islands" }),
+route("/dashboard", "./routes/dashboard.tsx", { render: "ssr" }),
+```
+
+With `"islands"`, only components in `src/islands/` hydrate, each as its own code-split chunk loaded by a small bootstrap, with per-usage `client` strategies (`load`, `idle`, `visible`). With `"none"`, the route ships no framework JavaScript at all. See [Islands](/docs/islands).
+
 ### Multi-adapter deployment
 
-One codebase deploys to Node.js, Cloudflare Workers, or Vercel with a one-line adapter swap. Adapters handle platform-specific concerns (static file serving, request conversion, edge bindings, and Node ISG cache invalidation) so your application code stays portable.
+One codebase deploys to Node.js, Cloudflare Workers, Netlify, Vercel, or a pure static host with a one-line adapter swap. Adapters handle platform-specific concerns (static file serving, request conversion, edge bindings, and per-platform ISG invalidation) so your application code stays portable.
 
 ---
 
@@ -63,7 +75,7 @@ Remix pioneered loader/action patterns for data loading. Pracht adopts a similar
 
 ### Astro
 
-Astro excels at content sites with its island architecture and zero-JS-by-default approach. Pracht is for apps that need interactive Preact components on every page — the framework is built around full hydration, not islands. If your site is mostly static content with a few interactive widgets, Astro is likely better.
+Astro is built for content sites: islands and zero JavaScript by default, with UI frameworks as an integration. Pracht supports the same shapes through `hydration: "islands"` and `hydration: "none"`, but treats them as one axis of a route's configuration rather than the default posture — the client router, full hydration, and per-route render modes are all first-class. If your site is almost entirely content and you want a framework whose defaults enforce that, Astro fits well. If you have a mix of static pages and app-like pages that should share one codebase, shells, middleware, and deploy, pracht lets each route pick its own point on both axes.
 
 ### SvelteKit
 
@@ -71,7 +83,7 @@ SvelteKit has great DX and small bundles thanks to Svelte's compiler approach. I
 
 ### Fresh (Deno)
 
-Fresh is a Preact framework for Deno with island-based hydration. Pracht runs on Node.js, Cloudflare Workers, and Vercel, uses full hydration, and supports ISG. If you're on Deno and want islands, Fresh is great. If you want broader deployment targets and per-route rendering, pracht fits better.
+Fresh is a Preact framework for Deno built around island hydration. Pracht's islands mode is directly inspired by it, but pracht runs on Node.js, Cloudflare Workers, Netlify, Vercel, and static hosts, and adds SSG/ISG/SPA render modes alongside SSR. If you're on Deno, Fresh is the natural choice. If you want broader deployment targets and per-route control over both rendering and hydration, pracht fits better.
 
 ---
 
@@ -79,5 +91,6 @@ Fresh is a Preact framework for Deno with island-based hydration. Pracht runs on
 
 - You want Preact's small footprint for a full-stack app
 - Different pages in your app need different rendering strategies
+- Different pages need different amounts of client JavaScript, from full hydration down to none
 - You value seeing route → file → render mode in one place
 - You want to deploy the same codebase to multiple platforms


### PR DESCRIPTION
## Summary

- The public [Why Pracht?](https://pracht.resynapse.dev/docs/why-pracht) page told readers the framework "is built around full hydration, not islands" and recommended Astro instead for island-shaped sites — but `hydration: "full" | "islands" | "none"` has shipped and is documented on [/docs/islands](https://pracht.resynapse.dev/docs/islands). The page was arguing against a feature we have.
- Adds a **Per-route hydration modes** section so the second axis appears in "Core differences" alongside per-route render modes.
- Rewrites the Astro and Fresh comparisons to describe the real tradeoff (defaults and posture) instead of a missing feature.
- Same-class drift fixed while in there: `why-pracht.md` listed three adapters (five ship), `cli.md` documented `--adapter=node|cf|vercel` (actual: `node|cf|netlify|vercel|static`, per `packages/start/src/index.js:1896`), and `getting-started.md` listed three adapters in the `create-pracht` prompt.

No published package changed, so no changeset.

## Testing

- [x] `pnpm run verify` (build, format, lint, typecheck, test, e2e) — passed in 86.6s

## Checklist

- [x] Docs updated if needed — this PR is the docs update
- [ ] Skills updated if needed — N/A, no skill references these claims
- [ ] Concise, user-facing changeset added if published packages changed — N/A, docs site only

🤖 Generated with [Claude Code](https://claude.com/claude-code)