### PR TITLE
feat(bench): reproducible harness for the framework's own cost

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,3 +115,37 @@ jobs:
 
       - name: E2E tests
         run: pnpm e2e
+
+  bundle-size:
+    name: Bundle Size
+    needs: install
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
+        with:
+          version: 11.0.0
+
+      - name: Install Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Restore build output
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: packages/*/dist
+          key: build-${{ github.sha }}
+
+      # Bytes only: chunk sizes are deterministic, so they can gate a PR.
+      # The harness also measures build and dev timings, which are not run
+      # here — a shared CI runner cannot produce a number worth failing on.
+      - name: Check client bytes against baseline
+        run: pnpm bench:check

--- a/bench/README.md
+++ b/bench/README.md
@@ -1,0 +1,72 @@
+# bench
+
+Measures what pracht costs an application, so the numbers on the docs site come
+from a command anyone can re-run instead of from memory.
+
+```bash
+pnpm bench              # bytes + timings, printed as a table
+pnpm bench:check        # bytes only, fails when they drift (what CI runs)
+node bench/run.mjs --json
+node bench/run.mjs --bytes-only --update   # re-record bench/baseline.json
+```
+
+## Two kinds of number
+
+**Bytes are deterministic.** The same commit on the same package versions emits
+byte-identical chunks. They are recorded in `baseline.json`, and
+`pnpm bench:check` fails the build when they move — an accidental import that
+pulls a new module into the client entry shows up as a failing PR rather than as
+a surprise six months later.
+
+**Timings are not.** They move with machine load, and this repo is routinely
+built on a laptop running several workspaces at once. The harness measures them,
+reports the median of N samples with the observed spread, and discards the first
+sample — but nothing in CI fails on a timing, because a shared runner cannot
+produce a number worth failing on.
+
+## The fixtures
+
+`fixtures/ladder` is one app with three routes that render *identical markup* and
+share one `Counter` component. The only variable across them is the hydration
+mode, so the difference between two rows is framework runtime rather than
+application code.
+
+| Route      | Hydration  |
+| ---------- | ---------- |
+| `/none`    | `none`     |
+| `/islands` | `islands`  |
+| `/full`    | `full`     |
+
+It is built twice: once as-is, and once with `PRACHT_BENCH_PREFETCH=off`, which
+sets `pracht({ client: { prefetch: false } })`. Every other input is identical,
+so the delta is the prefetch runtime and nothing else.
+
+`fixtures/compat` is the same full-hydration page with `preact/compat` in the
+client graph. It is a separate app on purpose: `preact/compat` lands in the
+shared vendor chunk, so measuring it inside the ladder build would inflate every
+other rung.
+
+## What `+ lazy` counts
+
+`pracht build --analyze` reports the chunks a route loads *to hydrate*. The
+client router then `import()`s part of its own runtime — today, the prefetch
+runtime — so those bytes reach the browser on a full-hydration route without
+appearing in any route total.
+
+The harness finds them by subtraction: every emitted client chunk the route
+report attributes to nothing. They are added only to full-hydration rows,
+because the islands bootstrap imports neither the router nor the prefetch
+runtime, and `hydration: "none"` ships no JavaScript at all.
+
+This is why the two prefetch rows differ by ~1.4 KB gzip in the `+ lazy` column
+but only ~0.3 KB in the reported column. The published ladder quotes the cold
+number.
+
+## When the baseline moves
+
+A failing `pnpm bench:check` is a question, not a verdict: did this PR mean to
+change what every app downloads? If yes, run
+`node bench/run.mjs --bytes-only --update`, commit the new `baseline.json`, and
+update the published table in
+`examples/docs/src/routes/docs/performance.md` so the site and the harness never
+disagree.

--- a/bench/baseline.json
+++ b/bench/baseline.json
@@ -1,0 +1,45 @@
+{
+  "note": "Byte sizes are deterministic for a given commit. Regenerate with `node bench/run.mjs --update`.",
+  "rungs": [
+    {
+      "rung": "hydration: none",
+      "hydration": "none",
+      "bytes": 0,
+      "gzipBytes": 0,
+      "lazyGzipBytes": 0,
+      "coldGzipBytes": 0
+    },
+    {
+      "rung": "hydration: islands",
+      "hydration": "islands",
+      "bytes": 17723,
+      "gzipBytes": 7776,
+      "lazyGzipBytes": 0,
+      "coldGzipBytes": 7776
+    },
+    {
+      "rung": "hydration: full",
+      "hydration": "full",
+      "bytes": 41416,
+      "gzipBytes": 15790,
+      "lazyGzipBytes": 1126,
+      "coldGzipBytes": 16916
+    },
+    {
+      "rung": "hydration: full, prefetch off",
+      "hydration": "full",
+      "bytes": 40507,
+      "gzipBytes": 15446,
+      "lazyGzipBytes": 0,
+      "coldGzipBytes": 15446
+    },
+    {
+      "rung": "hydration: full + preact/compat",
+      "hydration": "full",
+      "bytes": 46069,
+      "gzipBytes": 17239,
+      "lazyGzipBytes": 1128,
+      "coldGzipBytes": 18367
+    }
+  ]
+}

--- a/bench/fixtures/compat/package.json
+++ b/bench/fixtures/compat/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@pracht/bench-compat",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "dependencies": {
+    "@pracht/adapter-node": "workspace:*",
+    "@pracht/core": "workspace:*"
+  },
+  "devDependencies": {
+    "@pracht/cli": "workspace:*",
+    "@pracht/vite-plugin": "workspace:*",
+    "preact": "^10.26.9",
+    "preact-render-to-string": "^6.5.13",
+    "vite": "^8.0.0"
+  }
+}

--- a/bench/fixtures/compat/src/routes.ts
+++ b/bench/fixtures/compat/src/routes.ts
@@ -1,0 +1,15 @@
+import { defineApp, group, route } from "@pracht/core";
+
+// Deliberately a separate app from the ladder fixture: `preact/compat` lands in
+// the shared vendor chunk, so measuring it in the same build would inflate
+// every other rung.
+export const app = defineApp({
+  shells: {
+    site: () => import("./shells/site.tsx"),
+  },
+  routes: [
+    group({ shell: "site" }, [
+      route("/full", () => import("./routes/full-page.tsx"), { id: "full", render: "ssg" }),
+    ]),
+  ],
+});

--- a/bench/fixtures/compat/src/routes/full-page.tsx
+++ b/bench/fixtures/compat/src/routes/full-page.tsx
@@ -1,0 +1,17 @@
+import { useState } from "preact/compat";
+
+// Rung 4: the same full-hydration page as the ladder fixture, with the React
+// compatibility layer in the client graph. The delta against the ladder's
+// `/full` route is what `preact/compat` costs.
+export function Component() {
+  const [count, setCount] = useState(0);
+  return (
+    <section>
+      <h1>Bundle ladder</h1>
+      <p>Every rung renders this paragraph.</p>
+      <button type="button" onClick={() => setCount((value) => value + 1)}>
+        Count: {count}
+      </button>
+    </section>
+  );
+}

--- a/bench/fixtures/compat/src/shells/site.tsx
+++ b/bench/fixtures/compat/src/shells/site.tsx
@@ -1,0 +1,16 @@
+import type { ShellProps } from "@pracht/core";
+
+export function Shell({ children }: ShellProps) {
+  return (
+    <div>
+      <header>
+        <strong>ladder</strong>
+      </header>
+      <main>{children}</main>
+    </div>
+  );
+}
+
+export function head() {
+  return { title: "pracht bundle ladder" };
+}

--- a/bench/fixtures/compat/vite.config.ts
+++ b/bench/fixtures/compat/vite.config.ts
@@ -1,0 +1,19 @@
+import { defineConfig } from "vite";
+import { nodeAdapter } from "@pracht/adapter-node";
+import { pracht } from "@pracht/vite-plugin";
+
+export default defineConfig({
+  // The alias a real migration adds so React-authored dependencies resolve.
+  // The fixture's own component imports `preact/compat` directly, which is
+  // what the alias resolves to — the measured bytes are the same either way,
+  // and this way the fixture typechecks without React's type packages.
+  resolve: {
+    alias: {
+      "react-dom/test-utils": "preact/test-utils",
+      "react-dom": "preact/compat",
+      "react/jsx-runtime": "preact/jsx-runtime",
+      react: "preact/compat",
+    },
+  },
+  plugins: [pracht({ adapter: nodeAdapter() })],
+});

--- a/bench/fixtures/ladder/package.json
+++ b/bench/fixtures/ladder/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@pracht/bench-ladder",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "dependencies": {
+    "@pracht/adapter-node": "workspace:*",
+    "@pracht/core": "workspace:*"
+  },
+  "devDependencies": {
+    "@pracht/cli": "workspace:*",
+    "@pracht/vite-plugin": "workspace:*",
+    "preact": "^10.26.9",
+    "preact-render-to-string": "^6.5.13",
+    "vite": "^8.0.0"
+  }
+}

--- a/bench/fixtures/ladder/src/counter.tsx
+++ b/bench/fixtures/ladder/src/counter.tsx
@@ -1,0 +1,17 @@
+import { useState } from "preact/hooks";
+
+/**
+ * The one interactive component in the fixture.
+ *
+ * Every rung renders the same markup, so this file is shared between the
+ * island route and the full-hydration route: the measured delta between them
+ * is framework runtime, not application code.
+ */
+export function Counter({ start = 0 }: { start?: number }) {
+  const [count, setCount] = useState(start);
+  return (
+    <button type="button" onClick={() => setCount((value) => value + 1)}>
+      Count: {count}
+    </button>
+  );
+}

--- a/bench/fixtures/ladder/src/islands/counter.tsx
+++ b/bench/fixtures/ladder/src/islands/counter.tsx
@@ -1,0 +1,7 @@
+import type { IslandProps } from "@pracht/core";
+
+import { Counter } from "../counter.tsx";
+
+export default function CounterIsland({ start = 0 }: { start?: number } & IslandProps) {
+  return <Counter start={start} />;
+}

--- a/bench/fixtures/ladder/src/routes.ts
+++ b/bench/fixtures/ladder/src/routes.ts
@@ -1,0 +1,28 @@
+import { defineApp, group, route } from "@pracht/core";
+
+// Three routes, one shell, one interactive component, identical markup. The
+// only variable across them is the hydration mode, so `pracht build --json`
+// reports the framework's cost per rung rather than the app's.
+export const app = defineApp({
+  shells: {
+    site: () => import("./shells/site.tsx"),
+  },
+  routes: [
+    group({ shell: "site" }, [
+      route("/none", () => import("./routes/static-page.tsx"), {
+        id: "none",
+        render: "ssg",
+        hydration: "none",
+      }),
+      route("/islands", () => import("./routes/islands-page.tsx"), {
+        id: "islands",
+        render: "ssg",
+        hydration: "islands",
+      }),
+      route("/full", () => import("./routes/full-page.tsx"), {
+        id: "full",
+        render: "ssg",
+      }),
+    ]),
+  ],
+});

--- a/bench/fixtures/ladder/src/routes/full-page.tsx
+++ b/bench/fixtures/ladder/src/routes/full-page.tsx
@@ -1,0 +1,13 @@
+import { Counter } from "../counter.tsx";
+
+// Rung 3: hydration "full" (the default). The whole page hydrates and the
+// client router takes over navigation.
+export function Component() {
+  return (
+    <section>
+      <h1>Bundle ladder</h1>
+      <p>Every rung renders this paragraph.</p>
+      <Counter start={0} />
+    </section>
+  );
+}

--- a/bench/fixtures/ladder/src/routes/islands-page.tsx
+++ b/bench/fixtures/ladder/src/routes/islands-page.tsx
@@ -1,0 +1,13 @@
+import CounterIsland from "../islands/counter.tsx";
+
+// Rung 2: hydration "islands". Only the island chunk and the islands bootstrap
+// reach the browser; the router runtime never loads.
+export function Component() {
+  return (
+    <section>
+      <h1>Bundle ladder</h1>
+      <p>Every rung renders this paragraph.</p>
+      <CounterIsland start={0} />
+    </section>
+  );
+}

--- a/bench/fixtures/ladder/src/routes/static-page.tsx
+++ b/bench/fixtures/ladder/src/routes/static-page.tsx
@@ -1,0 +1,10 @@
+// Rung 1: hydration "none". Same prose as the other rungs, minus the button
+// that would need a runtime to work.
+export function Component() {
+  return (
+    <section>
+      <h1>Bundle ladder</h1>
+      <p>Every rung renders this paragraph.</p>
+    </section>
+  );
+}

--- a/bench/fixtures/ladder/src/shells/site.tsx
+++ b/bench/fixtures/ladder/src/shells/site.tsx
@@ -1,0 +1,16 @@
+import type { ShellProps } from "@pracht/core";
+
+export function Shell({ children }: ShellProps) {
+  return (
+    <div>
+      <header>
+        <strong>ladder</strong>
+      </header>
+      <main>{children}</main>
+    </div>
+  );
+}
+
+export function head() {
+  return { title: "pracht bundle ladder" };
+}

--- a/bench/fixtures/ladder/vite.config.ts
+++ b/bench/fixtures/ladder/vite.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from "vite";
+import { nodeAdapter } from "@pracht/adapter-node";
+import { pracht } from "@pracht/vite-plugin";
+
+// PRACHT_BENCH_PREFETCH=off measures the `client.prefetch` compile-out rung.
+// Every other input is identical between the two builds, so the delta is the
+// prefetch runtime and nothing else.
+const prefetch = process.env.PRACHT_BENCH_PREFETCH !== "off";
+
+export default defineConfig({
+  plugins: [pracht({ adapter: nodeAdapter(), client: { prefetch } })],
+});

--- a/bench/run.mjs
+++ b/bench/run.mjs
@@ -1,0 +1,361 @@
+#!/usr/bin/env node
+/**
+ * The pracht benchmark harness.
+ *
+ * Two kinds of number come out of here and they are treated differently:
+ *
+ * - **Bytes** are deterministic. The same commit on the same package versions
+ *   emits byte-identical chunks, so they are recorded in `baseline.json` and
+ *   `--check` fails when they drift. This is the part CI gates on.
+ * - **Timings** are not. They move with machine load, and this repo is
+ *   routinely built on a laptop running several workspaces at once. They are
+ *   measured, reported with their spread, and never gated.
+ *
+ * Usage:
+ *   node bench/run.mjs                 measure everything, print a table
+ *   node bench/run.mjs --bytes-only    skip timings (deterministic, fast)
+ *   node bench/run.mjs --check         fail when bytes drift from baseline.json
+ *   node bench/run.mjs --update        rewrite baseline.json from this run
+ *   node bench/run.mjs --json          emit the raw results
+ *   node bench/run.mjs --iterations=5  timing samples per metric (default 3)
+ */
+import { spawn } from "node:child_process";
+import { createServer } from "node:net";
+import { mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { gzipSync } from "node:zlib";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const benchDir = dirname(fileURLToPath(import.meta.url));
+const rootDir = resolve(benchDir, "..");
+const cliBin = join(rootDir, "packages/cli/bin/pracht.js");
+const baselinePath = join(benchDir, "baseline.json");
+
+/**
+ * One build per row. `env` is the only thing that varies between two builds of
+ * the same fixture, which is what makes a rung-to-rung delta attributable.
+ */
+const BUILDS = [
+  { id: "ladder", fixture: "ladder", env: {} },
+  { id: "ladder-no-prefetch", fixture: "ladder", env: { PRACHT_BENCH_PREFETCH: "off" } },
+  { id: "compat", fixture: "compat", env: {} },
+];
+
+/** Rows of the published ladder, in the order a reader climbs them. */
+const LADDER = [
+  { rung: "hydration: none", build: "ladder", route: "/none" },
+  { rung: "hydration: islands", build: "ladder", route: "/islands" },
+  { rung: "hydration: full", build: "ladder", route: "/full" },
+  { rung: "hydration: full, prefetch off", build: "ladder-no-prefetch", route: "/full" },
+  { rung: "hydration: full + preact/compat", build: "compat", route: "/full" },
+];
+
+const args = process.argv.slice(2);
+const flag = (name) => args.includes(`--${name}`);
+const option = (name, fallback) => {
+  const match = args.find((arg) => arg.startsWith(`--${name}=`));
+  return match ? match.slice(name.length + 3) : fallback;
+};
+
+const bytesOnly = flag("bytes-only");
+const iterations = Number.parseInt(option("iterations", "3"), 10);
+
+function fixtureDir(fixture) {
+  return join(benchDir, "fixtures", fixture);
+}
+
+function runCli(fixture, cliArgs, env = {}) {
+  return new Promise((settle, fail) => {
+    const child = spawn(process.execPath, [cliBin, ...cliArgs], {
+      cwd: fixtureDir(fixture),
+      env: { ...process.env, ...env, NO_COLOR: "1" },
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    let stdout = "";
+    let stderr = "";
+    child.stdout.on("data", (chunk) => (stdout += chunk));
+    child.stderr.on("data", (chunk) => (stderr += chunk));
+    child.on("error", fail);
+    child.on("close", (code) => {
+      if (code !== 0) {
+        fail(new Error(`pracht ${cliArgs.join(" ")} in ${fixture} exited ${code}\n${stderr}`));
+        return;
+      }
+      settle(stdout);
+    });
+  });
+}
+
+/** `--json` prints the report after the build log, so find where the JSON starts. */
+function parseReport(stdout) {
+  const start = stdout.indexOf("{");
+  if (start === -1) throw new Error("no JSON report in build output");
+  return JSON.parse(stdout.slice(start));
+}
+
+/**
+ * Chunks the build emitted that the route report attributes to nothing.
+ *
+ * `pracht build --analyze` reports the chunks a route loads to hydrate. The
+ * router additionally `import()`s some of its own runtime after hydration —
+ * today that is the prefetch runtime — so those bytes reach the browser on a
+ * hydrating route without appearing in any route total. Measuring them keeps
+ * the published ladder from quietly understating a cold load.
+ */
+function collectUnattributed(fixture, report) {
+  const attributed = new Set(report.shared.chunks.map((chunk) => chunk.url));
+  for (const route of report.routes) {
+    for (const chunk of route.chunks) attributed.add(chunk.url);
+  }
+
+  const assetsDir = join(fixtureDir(fixture), "dist/client/assets");
+  const chunks = [];
+  for (const name of readdirSync(assetsDir).sort()) {
+    if (!name.endsWith(".js")) continue;
+    if (attributed.has(`/assets/${name}`)) continue;
+    const source = readFileSync(join(assetsDir, name));
+    chunks.push({
+      // Content hashes change with every source edit; the stem is the stable
+      // identity a baseline can be compared against.
+      name: name.replace(/-[A-Za-z0-9_-]{8}\.js$/, ".js"),
+      bytes: source.byteLength,
+      // Same defaults as the CLI's own report, so the two are comparable.
+      gzipBytes: gzipSync(source).byteLength,
+    });
+  }
+  return chunks;
+}
+
+async function freePort() {
+  return await new Promise((settle, fail) => {
+    const server = createServer();
+    server.on("error", fail);
+    // No host: the probe has to reserve the port on every family, because the
+    // dev server binds localhost, which resolves to ::1 on macOS.
+    server.listen(0, () => {
+      const { port } = server.address();
+      server.close(() => settle(port));
+    });
+  });
+}
+
+/**
+ * Time from spawning `pracht dev` to the first fully-read HTML response.
+ *
+ * Cold: a fresh Vite cache directory per sample, so the number includes
+ * dependency optimization and first-request compilation rather than measuring
+ * a warm cache left behind by the previous sample.
+ */
+async function measureDevFirstRender(fixture, route) {
+  const port = await freePort();
+  const cacheDir = mkdtempSync(join(tmpdir(), "pracht-bench-"));
+  const started = performance.now();
+  const child = spawn(
+    process.execPath,
+    [cliBin, "dev", "--port", String(port), "--cache-dir", cacheDir],
+    {
+      cwd: fixtureDir(fixture),
+      env: {
+        ...process.env,
+        NO_COLOR: "1",
+        PORT: String(port),
+        NODE_OPTIONS: [process.env.NODE_OPTIONS, "--experimental-strip-types"]
+          .filter(Boolean)
+          .join(" "),
+      },
+      stdio: "ignore",
+    },
+  );
+
+  try {
+    const deadline = Date.now() + 120_000;
+    for (;;) {
+      if (Date.now() > deadline) throw new Error(`dev server for ${fixture} never answered`);
+      try {
+        const response = await fetch(`http://localhost:${port}${route}`);
+        if (response.ok) {
+          await response.text();
+          return performance.now() - started;
+        }
+      } catch {
+        // Not listening yet.
+      }
+      await new Promise((settle) => setTimeout(settle, 25));
+    }
+  } finally {
+    child.kill("SIGTERM");
+    await new Promise((settle) => child.on("close", settle));
+    rmSync(cacheDir, { force: true, recursive: true });
+  }
+}
+
+function median(values) {
+  const sorted = [...values].sort((left, right) => left - right);
+  const middle = Math.floor(sorted.length / 2);
+  return sorted.length % 2 === 0 ? (sorted[middle - 1] + sorted[middle]) / 2 : sorted[middle];
+}
+
+/**
+ * Discards the first sample. The first build of a fixture populates Vite's
+ * dependency cache and the OS page cache; including it would measure the
+ * machine's cold state rather than the framework.
+ */
+async function sample(label, iterationCount, measure) {
+  const samples = [];
+  for (let index = 0; index <= iterationCount; index += 1) {
+    const value = await measure();
+    if (index > 0) samples.push(value);
+    process.stderr.write(`  ${label} ${index}/${iterationCount}\r`);
+  }
+  process.stderr.write(`${" ".repeat(40)}\r`);
+  return {
+    medianMs: Math.round(median(samples)),
+    minMs: Math.round(Math.min(...samples)),
+    maxMs: Math.round(Math.max(...samples)),
+    samples: samples.map((value) => Math.round(value)),
+  };
+}
+
+function formatBytes(bytes) {
+  if (bytes === 0) return "0";
+  if (bytes < 1024) return `${bytes} B`;
+  return `${(bytes / 1024).toFixed(1)} KB`;
+}
+
+async function main() {
+  const reports = {};
+  const unattributed = {};
+
+  for (const build of BUILDS) {
+    process.stderr.write(`building ${build.id}…\n`);
+    const stdout = await runCli(build.fixture, ["build", "--json"], build.env);
+    reports[build.id] = parseReport(stdout);
+    unattributed[build.id] = collectUnattributed(build.fixture, reports[build.id]);
+  }
+
+  const rungs = LADDER.map((entry) => {
+    const report = reports[entry.build];
+    const route = report.routes.find((candidate) => candidate.path === entry.route);
+    if (!route) throw new Error(`${entry.build} has no route ${entry.route}`);
+    // The lazily-imported runtime hangs off the client router, and only a
+    // full-hydration route loads that. `hydration: "none"` ships nothing, and
+    // the islands bootstrap deliberately imports neither the router nor the
+    // prefetch runtime, so neither carries these bytes.
+    const lazy = (route.hydration ?? "full") === "full" ? unattributed[entry.build] : [];
+    const lazyGzipBytes = lazy.reduce((total, chunk) => total + chunk.gzipBytes, 0);
+    return {
+      rung: entry.rung,
+      build: entry.build,
+      route: entry.route,
+      hydration: route.hydration ?? "full",
+      bytes: route.totalBytes,
+      gzipBytes: route.totalGzipBytes,
+      lazyGzipBytes,
+      lazyChunks: lazy.map((chunk) => chunk.name),
+      coldGzipBytes: route.totalGzipBytes + lazyGzipBytes,
+    };
+  });
+
+  const results = { rungs, timings: null };
+
+  if (!bytesOnly) {
+    process.stderr.write("timing production build…\n");
+    const buildTime = await sample("build", iterations, async () => {
+      const started = performance.now();
+      await runCli("ladder", ["build"]);
+      return performance.now() - started;
+    });
+    process.stderr.write("timing dev first render…\n");
+    const devFirstRender = await sample("dev", iterations, () =>
+      measureDevFirstRender("ladder", "/full"),
+    );
+    results.timings = { iterations, buildTime, devFirstRender };
+  }
+
+  if (flag("json")) {
+    console.log(JSON.stringify(results, null, 2));
+  } else {
+    const width = Math.max(...rungs.map((rung) => rung.rung.length));
+    console.log("");
+    console.log(
+      `${"Rung".padEnd(width)}  ${"Gzip".padStart(9)}  ${"Raw".padStart(9)}  ${"+ lazy".padStart(9)}`,
+    );
+    for (const rung of rungs) {
+      console.log(
+        `${rung.rung.padEnd(width)}  ${formatBytes(rung.gzipBytes).padStart(9)}  ${formatBytes(
+          rung.bytes,
+        ).padStart(9)}  ${formatBytes(rung.coldGzipBytes).padStart(9)}`,
+      );
+    }
+    if (results.timings) {
+      const { buildTime, devFirstRender } = results.timings;
+      console.log("");
+      console.log(`Timings (median of ${iterations}, first sample discarded)`);
+      console.log(
+        `  production build      ${buildTime.medianMs} ms  (${buildTime.minMs}–${buildTime.maxMs})`,
+      );
+      console.log(
+        `  dev first render      ${devFirstRender.medianMs} ms  (${devFirstRender.minMs}–${devFirstRender.maxMs})`,
+      );
+      console.log("  Timings are machine-dependent and are never gated in CI.");
+    }
+    console.log("");
+  }
+
+  if (flag("update")) {
+    const baseline = {
+      note: "Byte sizes are deterministic for a given commit. Regenerate with `node bench/run.mjs --update`.",
+      rungs: rungs.map(({ rung, hydration, bytes, gzipBytes, lazyGzipBytes, coldGzipBytes }) => ({
+        rung,
+        hydration,
+        bytes,
+        gzipBytes,
+        lazyGzipBytes,
+        coldGzipBytes,
+      })),
+    };
+    writeFileSync(baselinePath, `${JSON.stringify(baseline, null, 2)}\n`);
+    console.log(`Wrote ${baselinePath}`);
+  }
+
+  if (flag("check")) {
+    const baseline = JSON.parse(readFileSync(baselinePath, "utf8"));
+    const drift = [];
+    for (const rung of rungs) {
+      const expected = baseline.rungs.find((candidate) => candidate.rung === rung.rung);
+      if (!expected) {
+        drift.push(`${rung.rung}: not in baseline`);
+        continue;
+      }
+      for (const key of ["bytes", "gzipBytes", "lazyGzipBytes", "coldGzipBytes"]) {
+        if (expected[key] !== rung[key]) {
+          drift.push(
+            `${rung.rung}: ${key} ${expected[key]} → ${rung[key]} (${
+              rung[key] > expected[key] ? "+" : ""
+            }${rung[key] - expected[key]})`,
+          );
+        }
+      }
+    }
+    for (const expected of baseline.rungs) {
+      if (!rungs.some((rung) => rung.rung === expected.rung)) {
+        drift.push(`${expected.rung}: in baseline but not measured`);
+      }
+    }
+    if (drift.length > 0) {
+      console.error("\nClient bytes drifted from bench/baseline.json:\n");
+      for (const line of drift) console.error(`  ${line}`);
+      console.error(
+        "\nIf the change is intended, run `node bench/run.mjs --bytes-only --update` and" +
+          " include the new baseline in the commit — and update the published numbers in" +
+          " examples/docs/src/routes/docs/performance.md.\n",
+      );
+      process.exitCode = 1;
+      return;
+    }
+    console.log("Client bytes match bench/baseline.json.");
+  }
+}
+
+await main();

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -250,3 +250,34 @@ When a route blows its budget, the usual levers, in order of impact:
    shell; a heavy dependency imported in a shell taxes every page.
 4. **Audit the vendor chunk** — see the `audit-bundles` skill for a guided
    deep-dive into fan-in, heavy dependencies, and prefetch tuning.
+
+## The benchmark harness
+
+`--analyze` answers "what does *my app* ship". `bench/` answers "what does
+*pracht* cost", so the framework's own numbers are reproducible rather than
+remembered:
+
+```bash
+pnpm bench              # bytes + timings, printed as a table
+pnpm bench:check        # bytes only, fails when they drift (what CI runs)
+```
+
+The harness builds a fixture whose three routes render identical markup and
+share one interactive component, varying nothing but the hydration mode. A
+delta between two rows is therefore framework runtime, not application code.
+
+Bytes are deterministic, so they are recorded in `bench/baseline.json` and the
+`bundle-size` CI job fails when they move — an accidental import that pulls a
+new module into the client entry surfaces as a failing PR. Timings are not
+deterministic, so the harness reports their median and spread and nothing in CI
+gates on them.
+
+One thing the harness measures that `--analyze` cannot: chunks the router
+`import()`s *after* hydration. The prefetch runtime is one, so a full-hydration
+route fetches roughly 1.1 KB gzip that no route total mentions. The harness
+attributes it by subtraction and reports it in a `+ lazy` column, which is why
+`client: { prefetch: false }` is worth about 1.4 KB on a cold load rather than
+the ~0.3 KB the route report implies.
+
+See [bench/README.md](../bench/README.md) for the fixture layout and what to do
+when the baseline moves.

--- a/package.json
+++ b/package.json
@@ -19,6 +19,8 @@
     "version": "changeset version",
     "release": "node ./scripts/build.mjs --force && changeset publish",
     "e2e": "playwright test",
+    "bench": "node ./bench/run.mjs",
+    "bench:check": "node ./bench/run.mjs --bytes-only --check",
     "dev:example": "cd examples/cloudflare && node ../../packages/cli/bin/pracht.js dev",
     "build:example": "cd examples/cloudflare && node ../../packages/cli/bin/pracht.js build"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -51,6 +51,56 @@ importers:
         specifier: ^3.2.4
         version: 3.2.4(@types/node@22.19.17)(jsdom@29.0.2)(lightningcss@1.32.0)(yaml@2.9.0)
 
+  bench/fixtures/compat:
+    dependencies:
+      '@pracht/adapter-node':
+        specifier: workspace:*
+        version: link:../../../packages/adapter-node
+      '@pracht/core':
+        specifier: workspace:*
+        version: link:../../../packages/framework
+    devDependencies:
+      '@pracht/cli':
+        specifier: workspace:*
+        version: link:../../../packages/cli
+      '@pracht/vite-plugin':
+        specifier: workspace:*
+        version: link:../../../packages/vite-plugin
+      preact:
+        specifier: ^10.26.9
+        version: 10.29.1
+      preact-render-to-string:
+        specifier: ^6.5.13
+        version: 6.6.7(preact@10.29.1)
+      vite:
+        specifier: ^8.0.0
+        version: 8.0.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@22.19.17)(esbuild@0.27.3)(yaml@2.9.0)
+
+  bench/fixtures/ladder:
+    dependencies:
+      '@pracht/adapter-node':
+        specifier: workspace:*
+        version: link:../../../packages/adapter-node
+      '@pracht/core':
+        specifier: workspace:*
+        version: link:../../../packages/framework
+    devDependencies:
+      '@pracht/cli':
+        specifier: workspace:*
+        version: link:../../../packages/cli
+      '@pracht/vite-plugin':
+        specifier: workspace:*
+        version: link:../../../packages/vite-plugin
+      preact:
+        specifier: ^10.26.9
+        version: 10.29.1
+      preact-render-to-string:
+        specifier: ^6.5.13
+        version: 6.6.7(preact@10.29.1)
+      vite:
+        specifier: ^8.0.0
+        version: 8.0.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@22.19.17)(esbuild@0.27.3)(yaml@2.9.0)
+
   examples/basic:
     dependencies:
       '@pracht/adapter-cloudflare':

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,6 +1,7 @@
 packages:
   - packages/*
   - examples/*
+  - bench/fixtures/*
 
 minimumReleaseAge: 10080
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -56,6 +56,8 @@
     "packages/cli/test/fixtures/cloudflare-runtime-import"
   ],
   "include": [
+    "bench/**/*.ts",
+    "bench/**/*.tsx",
     "packages/**/*.ts",
     "packages/**/*.tsx",
     "packages/vite-plugin/virtual.d.ts",


### PR DESCRIPTION
## Summary

`pracht build --analyze` tells an *app* what it ships. Nothing told us what *pracht* costs, so the numbers we quote about the framework came from memory and drifted silently between audits. This adds `bench/`.

```
Rung                                  Gzip        Raw     + lazy
hydration: none                          0          0          0
hydration: islands                  7.6 KB    17.3 KB     7.6 KB
hydration: full                    15.4 KB    40.4 KB    16.5 KB
hydration: full, prefetch off      15.1 KB    39.6 KB    15.1 KB
hydration: full + preact/compat    16.8 KB    45.0 KB    17.9 KB
```

**Methodology.** `fixtures/ladder` is one app whose three routes render identical markup and share one `Counter` component; the only variable is the hydration mode, so a delta between rows is framework runtime rather than application code. It is built twice, the second time with `client: { prefetch: false }` and every other input unchanged. `fixtures/compat` is a separate app because `preact/compat` lands in the shared vendor chunk and would inflate every other rung if measured in the same build.

**Bytes are gated, timings are not.** Chunk sizes are deterministic for a given commit, so they live in `bench/baseline.json` and a new `bundle-size` CI job fails when they move — an accidental import that pulls a new module into the client entry becomes a failing PR instead of a surprise. Timings move with machine load, so the harness reports median-of-N with the observed spread, discards the first sample, and nothing in CI fails on them.

**One thing this measures that `--analyze` cannot.** The client router `import()`s part of its own runtime after hydration. The prefetch runtime is ~1.1 KB gzip that appears in no route total. The harness finds these by subtraction and reports them in a `+ lazy` column, attributed only to full-hydration routes — the islands bootstrap imports neither the router nor prefetch. That is why turning prefetch off is worth ~1.4 KB on a cold load rather than the ~0.3 KB the route report implies. Fixing `--analyze` to account for lazily-imported runtime chunks is a reasonable follow-up; this PR only stops the published numbers from being wrong about it.

```bash
pnpm bench          # bytes + timings
pnpm bench:check    # bytes only, fails on drift (what CI runs)
```

## Testing

- [x] `pnpm run verify` (build, format, lint, typecheck, test, e2e) — passed in 85.7s
- [x] `pnpm bench` end to end; `--check` verified against both a matching and a deliberately mutated baseline (exit 1 with a per-rung diff)

## Checklist

- [x] Docs updated if needed — `bench/README.md` and a new section in `docs/PERFORMANCE.md`. No public-site page: this is contributor tooling. The site-facing numbers land in the stacked docs PR.
- [ ] Skills updated if needed — N/A
- [ ] Concise, user-facing changeset added if published packages changed — N/A, no published package changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)