### PR TITLE
feat(cli): add `pracht upgrade`, backed by per-package deprecation manifests

### DIFF
--- a/.changeset/core-deprecations-manifest.md
+++ b/.changeset/core-deprecations-manifest.md
@@ -1,0 +1,5 @@
+---
+"@pracht/core": patch
+---
+
+Publish a `deprecations.json` manifest and codemods so `pracht upgrade` can find and rewrite removed APIs in an app.

--- a/.changeset/pracht-upgrade-command.md
+++ b/.changeset/pracht-upgrade-command.md
@@ -1,0 +1,5 @@
+---
+"@pracht/cli": minor
+---
+
+Add `pracht upgrade`, which reports `@pracht/*` APIs the app still uses that the installed versions have deprecated or removed, and applies the codemods those packages publish. Findings come from a `deprecations.json` shipped by each package rather than from the CLI, so `--check` gates CI and `--json` gives agents a stable id, severity, replacement, and call sites per migration.

--- a/VISION_MVP.md
+++ b/VISION_MVP.md
@@ -213,6 +213,11 @@ Each adapter:
   app has an e2e setup.
 - **Authoring guide**: `pracht llms [--write]` and the MCP `get_docs` tool expose
   the framework's conventions to any coding agent.
+- **Upgrades**: every `@pracht/*` package publishes a `deprecations.json` in its
+  tarball describing the APIs it renamed or removed, how to detect them in
+  source, and an optional codemod. `pracht upgrade` reads the installed
+  manifests, reports real call sites, applies codemods with `--fix`, and gates
+  CI with `--check`. See [docs/UPGRADES.md](docs/UPGRADES.md).
 
 See [docs/AGENT_WORKFLOW.md](docs/AGENT_WORKFLOW.md).
 
@@ -289,7 +294,7 @@ pracht/
     adapter-cloudflare/  # Cloudflare Workers adapter
     adapter-netlify/     # Netlify Functions v2 adapter
     adapter-vercel/      # Vercel Edge adapter
-    cli/              # Dev/build/generate/inspect/verify/plan/report/doctor commands
+    cli/              # Dev/build/generate/inspect/verify/plan/report/upgrade/doctor commands
     content/          # Server-only content registry + generated artifacts
     markdown/         # Official Markdown route modules + local image imports
     image/            # Responsive <Image> component + runtime/static optimization

--- a/docs/UPGRADES.md
+++ b/docs/UPGRADES.md
@@ -1,0 +1,112 @@
+# Upgrades and deprecations
+
+Contributor reference for the deprecation mechanism behind `pracht upgrade`.
+The user-facing page is
+[examples/docs/src/routes/docs/upgrading.md](../examples/docs/src/routes/docs/upgrading.md)
+(published at <https://pracht.resynapse.dev/docs/upgrading>).
+
+## Why the manifests live in the packages
+
+Before this existed, the upgrade path was `skills/upgrade-pracht/SKILL.md`:
+prose telling a human or an agent to fetch a dozen `CHANGELOG.md` files from
+GitHub, read every section between installed and target, and grep the app for
+whatever the entries happened to name. That has three problems. The changelogs
+are not published in most tarballs (only `@pracht/cli` ships one), so the
+instructions had to hard-code raw GitHub URLs and a package→directory table
+that drifts. The mapping from a prose entry to an actual API is re-derived by
+whoever is reading. And the skill is versioned separately from the packages it
+describes, so it is wrong the moment a package moves.
+
+A `deprecations.json` in the tarball inverts all three: it ships and versions
+with the package that owns it, it names the API precisely enough to locate in
+source, and any package in the `@pracht/*` scope — including third-party ones —
+is read by the same reader.
+
+## Layout
+
+| Path | Role |
+| ---- | ---- |
+| `packages/cli/src/deprecations.ts` | Manifest schema, validation, package inventory, source scan, codemod runner, formatter |
+| `packages/cli/src/commands/upgrade.ts` | `pracht upgrade` — flags, exit codes, JSON shape |
+| `packages/framework/deprecations.json` | `@pracht/core`'s records |
+| `packages/framework/codemods/` | `@pracht/core`'s codemods |
+
+## Adding a record
+
+When a change removes or renames a public API, add a record in the same PR as
+the change, alongside the changeset.
+
+1. Add an entry to the owning package's `deprecations.json`. If the package has
+   none, create one, add `deprecations.json` (and `codemods` if applicable) to
+   `files`, and add `"pracht": { "deprecations": "./deprecations.json" }` to its
+   `package.json`.
+2. Give it an `id` of `<package-short>.<slug>`. Ids are permanent: reports, CI
+   output, and review comments cite them.
+3. Set `since` to the version that deprecated the API and `removedIn` to the
+   version that removes it. While a removal is unscheduled, omit `removedIn`.
+4. Write a `detect.pattern` specific enough that it cannot match unrelated app
+   code. Comments and string literals are masked before matching, so a mention
+   in a comment does not count as usage; set `detect.matchStrings` when the API
+   genuinely lives in a string (a config value, a package.json field).
+5. Ship a codemod when the migration is mechanical.
+
+### Severity is derived, not declared
+
+A record is reported as `error` only when the installed version is at or past
+its `removedIn` — the app is calling something that no longer exists. Everything
+else is `warn`. This is what lets `pracht upgrade --check` be a safe CI gate: a
+deprecation announced today cannot turn a green build red, only a missed
+migration can.
+
+Records whose `since` is newer than the installed version are skipped entirely,
+so a downgrade does not produce noise about a future version's deprecations.
+
+### Codemod contract
+
+A codemod is a plain ES module with a default export:
+
+```js
+export default {
+  id: "core.use-revalidate-route",
+  transform(source, { path }) {
+    return rewritten; // or null when there is nothing to change
+  },
+};
+```
+
+Text in, text out, so publishing one adds no dependency to the tarball. It runs
+once per file the record's detector matched. `resolveCodemodPath` refuses any
+path that resolves outside the publishing package, so a manifest cannot point
+the runner at an arbitrary file on disk.
+
+## Scanning
+
+`buildUpgradeReport(root)`:
+
+1. Reads the app's `package.json` for `@pracht/*` dependencies, then walks up
+   from the app root collecting `node_modules/@pracht/*` so hoisted transitive
+   packages are included too.
+2. Resolves each package by walking parent `node_modules` directories rather
+   than through `require.resolve` — most packages do not export
+   `./package.json`, which would make resolution fail for the majority.
+3. Loads and validates each manifest. A malformed manifest or record is a
+   warning and a skip, never a failure: a bad record in one dependency must not
+   hide the good records in another.
+4. Walks the app tree once (skipping `node_modules`, `dist`, and the adapter
+   output directories) and runs every applicable detector against each file.
+
+Because resolution walks upward, tests must use fixtures **outside** the repo —
+a fixture under `packages/` resolves the workspace's own packages. Both test
+files create their apps in the OS temp directory for this reason.
+
+## What is deliberately not built
+
+- **Target-version manifests.** The report reads installed packages only, so it
+  answers "did I miss a migration" rather than "what will break if I upgrade".
+  Previewing needs registry fetches; the loader is structured so a second
+  manifest source can be added without touching the scan or the report.
+- **Running the package manager.** `pracht upgrade` prints the command for the
+  detected lockfile and stops. Installing is not something a report command
+  should do behind your back.
+- **Wiring into `pracht verify`.** A deprecation is not a broken build, and
+  `verify` is a gate. `pracht upgrade --check` is the opt-in gate instead.

--- a/examples/docs/src/routes.ts
+++ b/examples/docs/src/routes.ts
@@ -85,6 +85,10 @@ export const app = defineApp({
         id: "cli",
         render: "ssg",
       }),
+      route("/docs/upgrading", () => import("./routes/docs/upgrading.md"), {
+        id: "upgrading",
+        render: "ssg",
+      }),
       route("/docs/deployment", () => import("./routes/docs/deployment.md"), {
         id: "deployment",
         render: "ssg",

--- a/examples/docs/src/routes/docs/cli.md
+++ b/examples/docs/src/routes/docs/cli.md
@@ -6,8 +6,8 @@ prev:
   href: /docs/env
   title: Environment Variables
 next:
-  href: /docs/deployment
-  title: Deployment
+  href: /docs/upgrading
+  title: Upgrading
 ---
 
 ## create-pracht
@@ -177,6 +177,27 @@ The doctor command checks:
 - App manifest or pages-router directory wiring
 - Referenced shell, middleware, and route modules
 - Package-level CLI and adapter dependencies
+
+---
+
+## pracht upgrade
+
+Report `@pracht/*` APIs your app still uses that the installed versions have
+deprecated or removed, and apply the codemods those packages publish.
+
+```sh
+pracht upgrade                  # report findings and the upgrade command
+pracht upgrade --json           # structured report for agents and scripts
+pracht upgrade --check          # exit 1 when a removed API is still used
+pracht upgrade --check --strict # also fail on not-yet-removed deprecations
+pracht upgrade --fix            # apply published codemods, then re-report
+```
+
+Findings come from the `deprecations.json` each package ships in its tarball,
+not from this CLI, so they stay accurate for whatever versions are installed —
+including third-party packages in the `@pracht/*` scope. The command never
+installs anything; it prints the command for your package manager and leaves
+running it to you. See [Upgrading](/docs/upgrading).
 
 ---
 

--- a/examples/docs/src/routes/docs/deployment.md
+++ b/examples/docs/src/routes/docs/deployment.md
@@ -3,8 +3,8 @@ title: Deployment
 lead: pracht apps deploy anywhere via platform adapters. Each adapter handles request conversion, asset serving, and the runtime's supported ISG revalidation strategy.
 breadcrumb: Deployment
 prev:
-  href: /docs/cli
-  title: CLI
+  href: /docs/upgrading
+  title: Upgrading
 next:
   href: /docs/adapters
   title: Adapters Reference

--- a/examples/docs/src/routes/docs/upgrading.md
+++ b/examples/docs/src/routes/docs/upgrading.md
@@ -1,0 +1,194 @@
+---
+title: Upgrading
+lead: Every @pracht/* package ships a machine-readable deprecations manifest. `pracht upgrade` reads the manifests of what you have installed, finds the call sites in your app, and applies published codemods.
+breadcrumb: Upgrading
+prev:
+  href: /docs/cli
+  title: CLI
+next:
+  href: /docs/deployment
+  title: Deployment
+---
+
+## The problem with changelog-driven upgrades
+
+pracht packages are versioned independently and pin each other exactly, so an upgrade means moving the whole family at once and then working out which of the entries across a dozen changelogs actually touch your code. That reading is manual, easy to skip, and stale the moment a package moves.
+
+`pracht upgrade` replaces the reading with data. Each package publishes a `deprecations.json` describing every API it renamed, changed, or removed — the versions each change spans, how to find it in source, and optionally a codemod that rewrites it. The CLI reads those manifests from the packages installed in your app, scans your source, and reports real call sites.
+
+---
+
+## Run it
+
+```bash
+pracht upgrade
+```
+
+```
+Installed pracht packages
+  @pracht/cli          1.12.0  (package.json: ^1.12.0)
+  @pracht/core         0.16.0  (package.json: ^0.16.0)
+  @pracht/vite-plugin  0.11.1  (package.json: ^0.11.1)
+
+1 removed API and 0 deprecations in use.
+
+REMOVED  core.use-revalidate-route — useRevalidateRoute() was replaced by useRevalidate()
+  Removed in @pracht/core 0.2.7 (installed: 0.16.0).
+  Replacement: useRevalidate()
+  useRevalidateRoute was an alias for useRevalidate with the same signature and return value, so the change is a rename.
+  https://pracht.resynapse.dev/docs/data-loading#userevalidate
+    src/routes/dashboard.tsx:1  import { useRevalidateRoute } from "@pracht/core";
+    src/routes/dashboard.tsx:4  const revalidate = useRevalidateRoute();
+  Codemod available — run `pracht upgrade --fix`.
+
+Move the family forward together (pracht packages pin each other exactly):
+  pnpm up @pracht/cli@latest @pracht/core@latest @pracht/vite-plugin@latest
+```
+
+The command never installs anything. It prints the command for your package manager (detected from the lockfile) and leaves running it to you.
+
+### Severities
+
+| Label | Meaning |
+| ----- | ------- |
+| `REMOVED` | The installed version no longer has this API. The code is broken now. |
+| `DEPRECATED` | Still present in the installed version, with removal scheduled or announced. |
+
+Only `REMOVED` findings make `pracht upgrade --check` fail, so a deprecation that has not landed yet never breaks a build that was green.
+
+### Options
+
+```bash
+pracht upgrade --json      # structured report for agents and scripts
+pracht upgrade --check     # exit 1 when a removed API is still used (CI gate)
+pracht upgrade --check --strict   # also fail on not-yet-removed deprecations
+pracht upgrade --fix       # apply the published codemods, then re-report
+```
+
+`--fix` rewrites files in place and re-scans, so the report you see afterwards reflects the migrated source. Codemods are textual — review the diff and run your tests.
+
+### In CI
+
+```yaml
+- run: pnpm pracht upgrade --check
+```
+
+This catches the case where an upgrade landed but one call site was missed, which otherwise shows up as a runtime error on a route nobody opened during review.
+
+---
+
+## For agents
+
+`pracht upgrade --json` is the intended entry point for a coding agent asked to upgrade the framework:
+
+```json
+{
+  "ok": false,
+  "packageManager": "pnpm",
+  "upgradeCommand": "pnpm up @pracht/core@latest",
+  "packages": [{ "name": "@pracht/core", "declared": "^0.16.0", "version": "0.16.0", "deprecations": 1 }],
+  "findings": [
+    {
+      "id": "core.use-revalidate-route",
+      "package": "@pracht/core",
+      "title": "useRevalidateRoute() was replaced by useRevalidate()",
+      "severity": "error",
+      "since": "0.0.1",
+      "removedIn": "0.2.7",
+      "installedVersion": "0.16.0",
+      "replacement": "useRevalidate()",
+      "docs": "https://pracht.resynapse.dev/docs/data-loading#userevalidate",
+      "codemod": true,
+      "occurrences": [{ "file": "src/routes/dashboard.tsx", "line": 4, "text": "const revalidate = useRevalidateRoute();" }]
+    }
+  ],
+  "warnings": []
+}
+```
+
+Every finding carries a stable `id`, so an agent (or a review comment) can name a migration precisely instead of quoting a changelog paragraph. The [upgrade-pracht skill](/docs/agent-skills) drives this command.
+
+---
+
+## What the report covers
+
+The manifests come from the packages **installed in your app**, so the report answers "am I still using something these versions changed or removed?" — the check to run after an upgrade, and the one worth gating CI on.
+
+It does not yet fetch manifests for versions you have not installed, so it cannot preview what a future release will break before you install it. Read the changelogs for that.
+
+---
+
+## Publishing deprecations from your own package
+
+The manifest format is not private to first-party packages. Any package in the `@pracht/*` scope that an app depends on is read the same way, so an integration can ship its own migrations.
+
+Add a `deprecations.json` at the package root, list it in `files`, and point `package.json` at it:
+
+```json
+{
+  "files": ["dist", "deprecations.json", "codemods"],
+  "pracht": { "deprecations": "./deprecations.json" }
+}
+```
+
+```json
+{
+  "version": 1,
+  "package": "@pracht/core",
+  "deprecations": [
+    {
+      "id": "core.use-revalidate-route",
+      "title": "useRevalidateRoute() was replaced by useRevalidate()",
+      "since": "0.0.1",
+      "removedIn": "0.2.7",
+      "replacement": "useRevalidate()",
+      "detail": "The alias had the same signature and return value, so the change is a rename.",
+      "docs": "https://pracht.resynapse.dev/docs/data-loading#userevalidate",
+      "detect": {
+        "include": ["src/**/*.{ts,tsx,js,jsx,mts,mjs}"],
+        "pattern": "\\buseRevalidateRoute\\b"
+      },
+      "codemod": "./codemods/use-revalidate-route.js"
+    }
+  ]
+}
+```
+
+| Field | Meaning |
+| ----- | ------- |
+| `id` | Stable identifier, `<package-short>.<slug>`. Never reused or renamed. |
+| `since` | Version that deprecated the API. Records the installed version predates are skipped. |
+| `removedIn` | Version that removed it. Omit while removal is unscheduled. |
+| `detect.include` | Globs relative to the app root (`**`, `*`, `?`, `{a,b}`). |
+| `detect.pattern` | Regular expression source. Comments and string literals are masked out before matching unless `detect.matchStrings` is `true`. |
+| `codemod` | Path, relative to the package root, of a codemod module. Paths that escape the package are ignored. |
+
+A record with no `detect` is only reported once the API is actually removed, since there is no way to point at a call site.
+
+### Codemods
+
+A codemod is a plain ES module with a default export, so publishing one costs no extra dependencies:
+
+```js [codemods/use-revalidate-route.js]
+export default {
+  id: "core.use-revalidate-route",
+  transform(source, { path }) {
+    if (!source.includes("useRevalidateRoute")) return null;
+    return source.replace(/\buseRevalidateRoute\b/g, "useRevalidate");
+  },
+};
+```
+
+Return the rewritten source, or `null` when there is nothing to change in that file. `transform` is called once per file that the record's detector matched.
+
+---
+
+## Manual steps that remain
+
+Some things a manifest cannot express, and that still belong in the changelog:
+
+- **Peer ranges.** After a major bump, re-check `vite`, `preact`, `preact-render-to-string`, and `wrangler` ranges.
+- **One resolved copy of the runtime.** pracht packages depend on their siblings at exact versions, so a partial upgrade can install two copies of `@pracht/core` and split the runtime. Confirm with `pnpm why @pracht/core`.
+- **Behavioural changes with no API surface.** A changed default cannot be grepped for.
+
+After any upgrade, walk the ladder: `pracht upgrade --check`, `pracht doctor`, `pracht typegen --check`, `pracht verify`, then your build and tests.

--- a/examples/docs/src/shells/docs.tsx
+++ b/examples/docs/src/shells/docs.tsx
@@ -71,6 +71,7 @@ const NAV = [
     label: "Guides",
     links: [
       { href: "/docs/cli", Icon: IconTerminal2, title: "CLI" },
+      { href: "/docs/upgrading", Icon: IconRefresh, title: "Upgrading" },
       { href: "/docs/deployment", Icon: IconCloud, title: "Deployment" },
     ],
   },

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -211,6 +211,23 @@ pracht doctor
 pracht doctor --json
 ```
 
+### `pracht upgrade`
+
+Report `@pracht/*` APIs the app still uses that the installed versions have
+deprecated or removed, from the `deprecations.json` each package publishes, and
+apply the codemods those packages ship.
+
+```bash
+pracht upgrade
+pracht upgrade --json             # structured report for agents
+pracht upgrade --check            # exit 1 when a removed API is still used
+pracht upgrade --check --strict   # also fail on not-yet-removed deprecations
+pracht upgrade --fix              # apply published codemods, then re-report
+```
+
+The command never installs anything; it prints the upgrade command for the
+detected package manager.
+
 ### `pracht mcp`
 
 Start a Model Context Protocol server on stdio that exposes inspect, doctor,

--- a/packages/cli/src/commands/upgrade.ts
+++ b/packages/cli/src/commands/upgrade.ts
@@ -1,0 +1,95 @@
+import { defineCommand } from "citty";
+
+import {
+  applyCodemods,
+  buildUpgradeReport,
+  formatUpgradeReport,
+  type UpgradeReport,
+} from "../deprecations.js";
+import { handleCliError } from "../utils.js";
+
+function serializeReport(report: UpgradeReport, extra: Record<string, unknown> = {}): string {
+  return JSON.stringify(
+    {
+      ok: report.ok,
+      packageManager: report.packageManager,
+      upgradeCommand: report.upgradeCommand,
+      packages: report.packages.map((entry) => ({
+        name: entry.name,
+        declared: entry.declared,
+        version: entry.version,
+        deprecations: entry.manifest?.deprecations.length ?? 0,
+      })),
+      findings: report.findings.map((finding) => ({
+        ...finding,
+        // The absolute codemod path is an implementation detail of this
+        // machine; consumers only need to know whether one exists.
+        codemod: finding.codemod !== null,
+      })),
+      warnings: report.warnings,
+      ...extra,
+    },
+    null,
+    2,
+  );
+}
+
+export default defineCommand({
+  meta: {
+    name: "upgrade",
+    description: "Report deprecated and removed pracht APIs still in use, and migrate them",
+  },
+  args: {
+    check: {
+      type: "boolean",
+      description: "Exit non-zero when a removed API is still used (for CI)",
+    },
+    strict: {
+      type: "boolean",
+      description: "With --check, also fail on deprecations that are not yet removed",
+    },
+    fix: {
+      type: "boolean",
+      description: "Apply published codemods for the reported deprecations",
+    },
+    json: {
+      type: "boolean",
+      description: "Output as JSON",
+    },
+  },
+  async run({ args }) {
+    const json = args.json === true;
+    try {
+      const report = buildUpgradeReport(process.cwd());
+
+      if (args.fix) {
+        const result = await applyCodemods(report);
+        // Re-scan so the printed report reflects the rewritten source rather
+        // than the state that motivated the run.
+        const after = buildUpgradeReport(process.cwd());
+        if (json) {
+          console.log(serializeReport(after, { fixed: result }));
+        } else {
+          for (const file of result.changedFiles) console.log(`updated  ${file}`);
+          for (const skip of result.skipped) console.log(`skipped  ${skip.id} — ${skip.reason}`);
+          if (result.changedFiles.length > 0) console.log("");
+          console.log(formatUpgradeReport(after));
+          console.log("\nReview the changes and run your tests — codemods are textual.");
+        }
+        if (shouldFail(after, args)) process.exitCode = 1;
+        return;
+      }
+
+      console.log(json ? serializeReport(report) : formatUpgradeReport(report));
+      if (shouldFail(report, args)) process.exitCode = 1;
+    } catch (error) {
+      handleCliError(error, { json });
+    }
+  },
+});
+
+function shouldFail(report: UpgradeReport, args: { check?: boolean; strict?: boolean }): boolean {
+  if (!args.check) return false;
+  if (args.strict) return report.findings.length > 0;
+  return !report.ok;
+}

--- a/packages/cli/src/deprecations.ts
+++ b/packages/cli/src/deprecations.ts
@@ -1,0 +1,859 @@
+// Machine-readable deprecations.
+//
+// Every published `@pracht/*` package may ship a `deprecations.json` alongside
+// its `dist/`, pointed at by the `pracht.deprecations` field in its
+// `package.json`. Each record describes one renamed, changed, or removed API:
+// the versions it spans, how to find it in app source, and (optionally) a
+// codemod that rewrites it.
+//
+// The upgrade path then stops being prose a human or an agent has to
+// re-derive from CHANGELOG diffs. `pracht upgrade` reads the manifests of the
+// packages that are actually installed, greps the app for the APIs they name,
+// and reports real call sites — which is also why the manifests live in the
+// npm tarball rather than in this CLI: a package's deprecations ship and
+// version with the package that owns them, including third-party ones.
+import { existsSync, readdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
+import { dirname, isAbsolute, join, resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+import { maskCommentsAndStrings } from "@pracht/capabilities/static";
+
+import { displayPath } from "./project.js";
+
+export const DEPRECATION_MANIFEST_VERSION = 1;
+
+/** Manifest path relative to the owning package root when the field is absent. */
+const DEFAULT_MANIFEST_FILE = "deprecations.json";
+
+/** Where a record looks for usage when it does not narrow `include` itself. */
+const DEFAULT_INCLUDE = [
+  "src/**/*.{ts,tsx,js,jsx,mts,mjs,cts,cjs}",
+  "*.config.{ts,tsx,js,jsx,mts,mjs,cts,cjs}",
+];
+
+const IGNORED_DIRECTORIES = new Set([
+  ".git",
+  ".netlify",
+  ".output",
+  ".pracht",
+  ".turbo",
+  ".vercel",
+  ".vite",
+  ".wrangler",
+  "build",
+  "coverage",
+  "dist",
+  "node_modules",
+]);
+
+/** Skip anything implausible as hand-written source; keeps a bad glob cheap. */
+const MAX_SCANNED_FILE_BYTES = 1_000_000;
+
+export interface DeprecationDetector {
+  /** Glob patterns, relative to the app root, POSIX separators. */
+  include: string[];
+  /** Regular expression source matched against each file. */
+  pattern: string;
+  /** Extra regex flags; `g` is always applied. */
+  flags?: string;
+  /**
+   * Match inside string and comment tokens too. Off by default so a mention in
+   * a comment, or the name of an unrelated route, is not reported as usage.
+   */
+  matchStrings?: boolean;
+}
+
+export interface DeprecationRecord {
+  /** Stable identifier, `<package-short>.<slug>`. Cited by reports and CI. */
+  id: string;
+  title: string;
+  /** Version of the owning package that deprecated the API. */
+  since: string;
+  /** Version that removed it. Absent means removal is not scheduled yet. */
+  removedIn?: string;
+  replacement?: string;
+  detail?: string;
+  docs?: string;
+  detect?: DeprecationDetector;
+  /** Path, relative to the owning package root, of a codemod module. */
+  codemod?: string;
+}
+
+export interface DeprecationManifest {
+  version: number;
+  package: string;
+  deprecations: DeprecationRecord[];
+}
+
+/**
+ * A codemod is a plain text transform so any package can ship one without
+ * pulling an AST toolchain into its tarball. Returning `null` means "nothing
+ * to change here", which is not an error — detection is per file, and a
+ * pattern can match a line a rename does not apply to.
+ */
+export interface DeprecationCodemod {
+  id?: string;
+  transform(source: string, context: { path: string }): string | null;
+}
+
+export interface InstalledPackage {
+  name: string;
+  /** Range declared in the app's `package.json`, if it is a direct dependency. */
+  declared: string | null;
+  /** Resolved version on disk, or `null` when the package is not installed. */
+  version: string | null;
+  directory: string | null;
+  manifest: DeprecationManifest | null;
+}
+
+export type DeprecationSeverity = "error" | "warn";
+
+export interface DeprecationOccurrence {
+  file: string;
+  line: number;
+  text: string;
+}
+
+export interface DeprecationFinding {
+  id: string;
+  package: string;
+  title: string;
+  severity: DeprecationSeverity;
+  since: string;
+  removedIn: string | null;
+  installedVersion: string | null;
+  replacement: string | null;
+  detail: string | null;
+  docs: string | null;
+  /** Absolute path of the codemod module, when the owning package ships one. */
+  codemod: string | null;
+  occurrences: DeprecationOccurrence[];
+}
+
+export interface UpgradeReport {
+  root: string;
+  packageManager: "pnpm" | "npm" | "yarn" | "bun";
+  /** Suggested command to move the whole family forward; never run for you. */
+  upgradeCommand: string | null;
+  packages: InstalledPackage[];
+  findings: DeprecationFinding[];
+  /** Non-fatal problems: unreadable or malformed manifests, bad globs. */
+  warnings: string[];
+  /** True when nothing is using an API that the installed versions removed. */
+  ok: boolean;
+}
+
+export interface CodemodResult {
+  changedFiles: string[];
+  appliedIds: string[];
+  /** Findings that have no codemod, or whose codemod failed to load. */
+  skipped: { id: string; reason: string }[];
+}
+
+// ---------------------------------------------------------------------------
+// Versions
+// ---------------------------------------------------------------------------
+
+interface ParsedVersion {
+  major: number;
+  minor: number;
+  patch: number;
+  prerelease: string | null;
+}
+
+export function parseVersion(value: string): ParsedVersion | null {
+  const match = /^(\d+)\.(\d+)\.(\d+)(?:-([0-9A-Za-z.-]+))?(?:\+[0-9A-Za-z.-]+)?$/.exec(
+    value.trim(),
+  );
+  if (!match) return null;
+  return {
+    major: Number(match[1]),
+    minor: Number(match[2]),
+    patch: Number(match[3]),
+    prerelease: match[4] ?? null,
+  };
+}
+
+/**
+ * `null` when either side is not a plain semver version — callers treat an
+ * incomparable pair as "unknown" rather than guessing an ordering.
+ */
+export function compareVersions(a: string, b: string): number | null {
+  const left = parseVersion(a);
+  const right = parseVersion(b);
+  if (!left || !right) return null;
+  if (left.major !== right.major) return left.major - right.major;
+  if (left.minor !== right.minor) return left.minor - right.minor;
+  if (left.patch !== right.patch) return left.patch - right.patch;
+  if (left.prerelease === right.prerelease) return 0;
+  // A prerelease sorts before its release: 1.0.0-rc.1 < 1.0.0.
+  if (left.prerelease === null) return 1;
+  if (right.prerelease === null) return -1;
+  return left.prerelease < right.prerelease ? -1 : 1;
+}
+
+// ---------------------------------------------------------------------------
+// Globs
+// ---------------------------------------------------------------------------
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+/** Supports `**`, `*`, `?`, and `{a,b}` against POSIX-separated paths. */
+export function globToRegExp(glob: string): RegExp {
+  let source = "";
+  for (let index = 0; index < glob.length; index += 1) {
+    const char = glob[index];
+    if (char === "*") {
+      if (glob[index + 1] === "*") {
+        index += 1;
+        if (glob[index + 1] === "/") {
+          index += 1;
+          // `a/**/b` has to match `a/b` too, so the separator is part of the
+          // repeated group rather than a literal between them.
+          source += "(?:[^/]*/)*";
+        } else {
+          source += ".*";
+        }
+      } else {
+        source += "[^/]*";
+      }
+      continue;
+    }
+    if (char === "?") {
+      source += "[^/]";
+      continue;
+    }
+    if (char === "{") {
+      const end = glob.indexOf("}", index);
+      if (end === -1) {
+        source += "\\{";
+        continue;
+      }
+      const alternatives = glob
+        .slice(index + 1, end)
+        .split(",")
+        .map((entry) => escapeRegExp(entry));
+      source += `(?:${alternatives.join("|")})`;
+      index = end;
+      continue;
+    }
+    source += escapeRegExp(char);
+  }
+  return new RegExp(`^${source}$`);
+}
+
+// ---------------------------------------------------------------------------
+// Manifests
+// ---------------------------------------------------------------------------
+
+function readJsonFile(filePath: string): unknown {
+  return JSON.parse(readFileSync(filePath, "utf-8"));
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function optionalString(value: unknown): string | undefined {
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+/**
+ * Validates a manifest that came from another package's tarball. Anything
+ * malformed is reported and dropped: a bad record in a dependency must not
+ * stop the command from reporting the good ones.
+ */
+export function parseDeprecationManifest(
+  value: unknown,
+  packageName: string,
+  warnings: string[],
+): DeprecationManifest | null {
+  if (!isRecord(value)) {
+    warnings.push(`${packageName}: deprecations manifest is not an object.`);
+    return null;
+  }
+  if (value.version !== DEPRECATION_MANIFEST_VERSION) {
+    warnings.push(
+      `${packageName}: deprecations manifest version ${String(value.version)} is not supported ` +
+        `(this CLI understands version ${DEPRECATION_MANIFEST_VERSION}).`,
+    );
+    return null;
+  }
+  if (!Array.isArray(value.deprecations)) {
+    warnings.push(`${packageName}: deprecations manifest has no "deprecations" array.`);
+    return null;
+  }
+
+  const records: DeprecationRecord[] = [];
+  for (const entry of value.deprecations) {
+    if (!isRecord(entry)) {
+      warnings.push(`${packageName}: skipped a deprecation entry that is not an object.`);
+      continue;
+    }
+    const id = optionalString(entry.id);
+    const title = optionalString(entry.title);
+    const since = optionalString(entry.since);
+    if (!id || !title || !since) {
+      warnings.push(
+        `${packageName}: skipped a deprecation entry missing "id", "title", or "since".`,
+      );
+      continue;
+    }
+
+    let detect: DeprecationDetector | undefined;
+    if (entry.detect !== undefined) {
+      if (!isRecord(entry.detect) || typeof entry.detect.pattern !== "string") {
+        warnings.push(`${packageName}: ${id} has a "detect" without a string "pattern".`);
+        continue;
+      }
+      const include = Array.isArray(entry.detect.include)
+        ? entry.detect.include.filter((glob): glob is string => typeof glob === "string")
+        : DEFAULT_INCLUDE;
+      try {
+        // Compiled eagerly so a bad pattern is a manifest warning rather than
+        // a crash halfway through the scan.
+        new RegExp(entry.detect.pattern, entry.detect.flags ? String(entry.detect.flags) : "");
+      } catch (error) {
+        warnings.push(
+          `${packageName}: ${id} has an invalid "detect.pattern" (${(error as Error).message}).`,
+        );
+        continue;
+      }
+      detect = {
+        include: include.length > 0 ? include : DEFAULT_INCLUDE,
+        pattern: entry.detect.pattern,
+        ...(typeof entry.detect.flags === "string" ? { flags: entry.detect.flags } : {}),
+        ...(entry.detect.matchStrings === true ? { matchStrings: true } : {}),
+      };
+    }
+
+    records.push({
+      id,
+      title,
+      since,
+      ...(optionalString(entry.removedIn) ? { removedIn: optionalString(entry.removedIn)! } : {}),
+      ...(optionalString(entry.replacement)
+        ? { replacement: optionalString(entry.replacement)! }
+        : {}),
+      ...(optionalString(entry.detail) ? { detail: optionalString(entry.detail)! } : {}),
+      ...(optionalString(entry.docs) ? { docs: optionalString(entry.docs)! } : {}),
+      ...(detect ? { detect } : {}),
+      ...(optionalString(entry.codemod) ? { codemod: optionalString(entry.codemod)! } : {}),
+    });
+  }
+
+  return { version: DEPRECATION_MANIFEST_VERSION, package: packageName, deprecations: records };
+}
+
+function loadManifestForPackage(
+  packageDirectory: string,
+  packageJson: Record<string, unknown>,
+  packageName: string,
+  warnings: string[],
+): DeprecationManifest | null {
+  const pracht = isRecord(packageJson.pracht) ? packageJson.pracht : null;
+  const declared = pracht ? optionalString(pracht.deprecations) : undefined;
+  // An undeclared but conventionally named file still counts: it keeps the
+  // field optional for first-party packages without making the contract
+  // implicit for third-party ones, which should declare it.
+  const manifestPath = resolve(packageDirectory, declared ?? DEFAULT_MANIFEST_FILE);
+  if (!existsSync(manifestPath)) {
+    if (declared) {
+      warnings.push(`${packageName}: pracht.deprecations points at a missing file (${declared}).`);
+    }
+    return null;
+  }
+  try {
+    return parseDeprecationManifest(readJsonFile(manifestPath), packageName, warnings);
+  } catch (error) {
+    warnings.push(
+      `${packageName}: could not read deprecations manifest (${(error as Error).message}).`,
+    );
+    return null;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Installed package inventory
+// ---------------------------------------------------------------------------
+
+function readPackageJson(filePath: string): Record<string, unknown> | null {
+  try {
+    const parsed = readJsonFile(filePath);
+    return isRecord(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Walks up from the app root looking for `node_modules/<name>`. Resolving
+ * through `require` would be stricter but fails on packages that do not export
+ * `./package.json`, which is most of them.
+ */
+function findInstalledPackage(root: string, name: string): string | null {
+  let directory = resolve(root);
+  for (;;) {
+    const candidate = join(directory, "node_modules", ...name.split("/"));
+    if (existsSync(join(candidate, "package.json"))) return candidate;
+    const parent = dirname(directory);
+    if (parent === directory) return null;
+    directory = parent;
+  }
+}
+
+function collectPrachtDependencyNames(appPackageJson: Record<string, unknown> | null): Set<string> {
+  const names = new Set<string>();
+  if (!appPackageJson) return names;
+  for (const field of ["dependencies", "devDependencies", "peerDependencies"]) {
+    const section = appPackageJson[field];
+    if (!isRecord(section)) continue;
+    for (const name of Object.keys(section)) {
+      if (name.startsWith("@pracht/")) names.add(name);
+    }
+  }
+  return names;
+}
+
+/** Hoisted transitive pracht packages carry deprecations that affect app code too. */
+function collectInstalledPrachtNames(root: string): Set<string> {
+  const names = new Set<string>();
+  let directory = resolve(root);
+  for (;;) {
+    const scope = join(directory, "node_modules", "@pracht");
+    if (existsSync(scope)) {
+      try {
+        for (const entry of listDirectories(scope)) names.add(`@pracht/${entry}`);
+      } catch {
+        // An unreadable node_modules is the package manager's problem, not ours.
+      }
+    }
+    const parent = dirname(directory);
+    if (parent === directory) return names;
+    directory = parent;
+  }
+}
+
+function listDirectories(directory: string): string[] {
+  // pnpm links workspace and store packages in, so a scope entry is as likely
+  // to be a symlink as a real directory.
+  return readdirSync(directory, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory() || entry.isSymbolicLink())
+    .map((entry) => entry.name);
+}
+
+export function readInstalledPackages(root: string, warnings: string[]): InstalledPackage[] {
+  const appPackageJson = readPackageJson(resolve(root, "package.json"));
+  const declaredRanges = new Map<string, string>();
+  for (const field of ["dependencies", "devDependencies", "peerDependencies"]) {
+    const section = appPackageJson?.[field];
+    if (!isRecord(section)) continue;
+    for (const [name, range] of Object.entries(section)) {
+      if (name.startsWith("@pracht/") && typeof range === "string" && !declaredRanges.has(name)) {
+        declaredRanges.set(name, range);
+      }
+    }
+  }
+
+  const names = new Set<string>([
+    ...collectPrachtDependencyNames(appPackageJson),
+    ...collectInstalledPrachtNames(root),
+  ]);
+
+  const packages: InstalledPackage[] = [];
+  for (const name of [...names].sort()) {
+    const directory = findInstalledPackage(root, name);
+    const packageJson = directory ? readPackageJson(join(directory, "package.json")) : null;
+    const version = typeof packageJson?.version === "string" ? packageJson.version : null;
+    packages.push({
+      name,
+      declared: declaredRanges.get(name) ?? null,
+      version,
+      directory,
+      manifest:
+        directory && packageJson
+          ? loadManifestForPackage(directory, packageJson, name, warnings)
+          : null,
+    });
+  }
+  return packages;
+}
+
+// ---------------------------------------------------------------------------
+// Scanning
+// ---------------------------------------------------------------------------
+
+interface CompiledDetector {
+  record: DeprecationRecord;
+  owner: InstalledPackage;
+  includes: RegExp[];
+  pattern: RegExp;
+  matchStrings: boolean;
+}
+
+/**
+ * A record only applies when the installed version actually contains it. The
+ * `error` severity is reserved for APIs the installed version has already
+ * removed — code calling those is broken right now, not merely dated.
+ */
+function severityFor(
+  record: DeprecationRecord,
+  installedVersion: string | null,
+): {
+  applies: boolean;
+  severity: DeprecationSeverity;
+} {
+  if (!installedVersion) return { applies: true, severity: "warn" };
+  const sinceOrder = compareVersions(installedVersion, record.since);
+  if (sinceOrder !== null && sinceOrder < 0) return { applies: false, severity: "warn" };
+  if (!record.removedIn) return { applies: true, severity: "warn" };
+  const removedOrder = compareVersions(installedVersion, record.removedIn);
+  if (removedOrder === null) return { applies: true, severity: "warn" };
+  return { applies: true, severity: removedOrder >= 0 ? "error" : "warn" };
+}
+
+function collectScannableFiles(root: string): string[] {
+  const files: string[] = [];
+  const walk = (directory: string): void => {
+    let entries: { name: string; isDirectory(): boolean }[];
+    try {
+      entries = readdirSync(directory, { withFileTypes: true });
+    } catch {
+      return;
+    }
+    for (const entry of entries) {
+      const fullPath = join(directory, entry.name);
+      if (entry.isDirectory()) {
+        if (IGNORED_DIRECTORIES.has(entry.name)) continue;
+        walk(fullPath);
+        continue;
+      }
+      files.push(fullPath);
+    }
+  };
+  walk(resolve(root));
+  return files;
+}
+
+function scanFile(
+  root: string,
+  filePath: string,
+  detectors: CompiledDetector[],
+  results: Map<string, DeprecationOccurrence[]>,
+): void {
+  let source: string;
+  try {
+    if (statSync(filePath).size > MAX_SCANNED_FILE_BYTES) return;
+    source = readFileSync(filePath, "utf-8");
+  } catch {
+    return;
+  }
+
+  const relativePath = displayPath(root, filePath);
+  let masked: string | null = null;
+  const lineStarts = buildLineStarts(source);
+
+  for (const detector of detectors) {
+    if (!detector.includes.some((include) => include.test(relativePath))) continue;
+    // Masking preserves offsets, so line numbers stay correct either way.
+    const haystack = detector.matchStrings ? source : (masked ??= maskCommentsAndStrings(source));
+    detector.pattern.lastIndex = 0;
+    let match: RegExpExecArray | null;
+    while ((match = detector.pattern.exec(haystack)) !== null) {
+      const line = lineNumberAt(lineStarts, match.index);
+      const occurrences = results.get(detector.record.id) ?? [];
+      occurrences.push({
+        file: relativePath,
+        line,
+        text: sourceLine(source, lineStarts, line),
+      });
+      results.set(detector.record.id, occurrences);
+      // A zero-width pattern would otherwise spin here forever.
+      if (match[0].length === 0) detector.pattern.lastIndex += 1;
+    }
+  }
+}
+
+function buildLineStarts(source: string): number[] {
+  const starts = [0];
+  for (let index = 0; index < source.length; index += 1) {
+    if (source[index] === "\n") starts.push(index + 1);
+  }
+  return starts;
+}
+
+function lineNumberAt(lineStarts: number[], offset: number): number {
+  let low = 0;
+  let high = lineStarts.length - 1;
+  while (low < high) {
+    const middle = Math.ceil((low + high) / 2);
+    if (lineStarts[middle] <= offset) low = middle;
+    else high = middle - 1;
+  }
+  return low + 1;
+}
+
+function sourceLine(source: string, lineStarts: number[], line: number): string {
+  const start = lineStarts[line - 1] ?? 0;
+  const end = lineStarts[line] ?? source.length + 1;
+  return source.slice(start, end - 1).trim();
+}
+
+// ---------------------------------------------------------------------------
+// Report
+// ---------------------------------------------------------------------------
+
+function detectPackageManager(root: string): UpgradeReport["packageManager"] {
+  if (existsSync(resolve(root, "pnpm-lock.yaml"))) return "pnpm";
+  if (existsSync(resolve(root, "yarn.lock"))) return "yarn";
+  if (existsSync(resolve(root, "bun.lock")) || existsSync(resolve(root, "bun.lockb"))) return "bun";
+  return "npm";
+}
+
+function upgradeCommandFor(
+  packageManager: UpgradeReport["packageManager"],
+  packages: InstalledPackage[],
+): string | null {
+  // Only direct dependencies: telling someone to install a hoisted transitive
+  // package would add a dependency they never had.
+  const names = packages.filter((entry) => entry.declared !== null).map((entry) => entry.name);
+  if (names.length === 0) return null;
+  const specs = names.map((name) => `${name}@latest`).join(" ");
+  switch (packageManager) {
+    case "pnpm":
+      return `pnpm up ${specs}`;
+    case "yarn":
+      return `yarn up ${specs}`;
+    case "bun":
+      return `bun update ${names.join(" ")}`;
+    default:
+      return `npm install ${specs}`;
+  }
+}
+
+export function buildUpgradeReport(root: string): UpgradeReport {
+  const warnings: string[] = [];
+  const packages = readInstalledPackages(root, warnings);
+
+  const detectors: CompiledDetector[] = [];
+  const applicable: {
+    record: DeprecationRecord;
+    owner: InstalledPackage;
+    severity: DeprecationSeverity;
+  }[] = [];
+  const seenIds = new Set<string>();
+
+  for (const owner of packages) {
+    for (const record of owner.manifest?.deprecations ?? []) {
+      const { applies, severity } = severityFor(record, owner.version);
+      if (!applies) continue;
+      if (seenIds.has(record.id)) {
+        warnings.push(`${owner.name}: duplicate deprecation id "${record.id}" was ignored.`);
+        continue;
+      }
+      seenIds.add(record.id);
+      applicable.push({ record, owner, severity });
+      if (!record.detect) continue;
+      detectors.push({
+        record,
+        owner,
+        includes: record.detect.include.map((glob) => globToRegExp(glob)),
+        pattern: new RegExp(
+          record.detect.pattern,
+          record.detect.flags?.includes("g")
+            ? record.detect.flags
+            : `${record.detect.flags ?? ""}g`,
+        ),
+        matchStrings: record.detect.matchStrings === true,
+      });
+    }
+  }
+
+  const occurrencesById = new Map<string, DeprecationOccurrence[]>();
+  if (detectors.length > 0) {
+    for (const filePath of collectScannableFiles(root)) {
+      scanFile(root, filePath, detectors, occurrencesById);
+    }
+  }
+
+  const findings: DeprecationFinding[] = [];
+  for (const { record, owner, severity } of applicable) {
+    const occurrences = occurrencesById.get(record.id) ?? [];
+    // A record with no detector cannot be located in source, so it is only
+    // worth reporting when a human has to act on it regardless — which is
+    // exactly the already-removed case.
+    if (occurrences.length === 0 && (record.detect || severity !== "error")) continue;
+    findings.push({
+      id: record.id,
+      package: owner.name,
+      title: record.title,
+      severity,
+      since: record.since,
+      removedIn: record.removedIn ?? null,
+      installedVersion: owner.version,
+      replacement: record.replacement ?? null,
+      detail: record.detail ?? null,
+      docs: record.docs ?? null,
+      codemod:
+        record.codemod && owner.directory
+          ? resolveCodemodPath(owner.directory, record.codemod)
+          : null,
+      occurrences,
+    });
+  }
+
+  findings.sort((a, b) => {
+    if (a.severity !== b.severity) return a.severity === "error" ? -1 : 1;
+    return a.id < b.id ? -1 : a.id > b.id ? 1 : 0;
+  });
+
+  const packageManager = detectPackageManager(root);
+  return {
+    root,
+    packageManager,
+    upgradeCommand: upgradeCommandFor(packageManager, packages),
+    packages,
+    findings,
+    warnings,
+    ok: findings.every((finding) => finding.severity !== "error"),
+  };
+}
+
+/** Keeps a manifest from pointing a codemod outside the package that ships it. */
+function resolveCodemodPath(packageDirectory: string, codemod: string): string | null {
+  if (isAbsolute(codemod)) return null;
+  const resolved = resolve(packageDirectory, codemod);
+  const base = resolve(packageDirectory);
+  if (resolved !== base && !resolved.startsWith(`${base}/`)) return null;
+  return existsSync(resolved) ? resolved : null;
+}
+
+// ---------------------------------------------------------------------------
+// Codemods
+// ---------------------------------------------------------------------------
+
+export async function applyCodemods(report: UpgradeReport): Promise<CodemodResult> {
+  const changedFiles = new Set<string>();
+  const appliedIds: string[] = [];
+  const skipped: { id: string; reason: string }[] = [];
+
+  for (const finding of report.findings) {
+    if (finding.occurrences.length === 0) continue;
+    if (!finding.codemod) {
+      skipped.push({ id: finding.id, reason: "no codemod is published for this deprecation" });
+      continue;
+    }
+
+    let codemod: DeprecationCodemod;
+    try {
+      const loaded = (await import(pathToFileURL(finding.codemod).href)) as {
+        default?: DeprecationCodemod;
+      };
+      if (!loaded.default || typeof loaded.default.transform !== "function") {
+        throw new Error("module has no default export with a transform() function");
+      }
+      codemod = loaded.default;
+    } catch (error) {
+      skipped.push({
+        id: finding.id,
+        reason: `codemod failed to load (${(error as Error).message})`,
+      });
+      continue;
+    }
+
+    let applied = false;
+    for (const file of new Set(finding.occurrences.map((entry) => entry.file))) {
+      const fullPath = resolve(report.root, file);
+      let source: string;
+      try {
+        source = readFileSync(fullPath, "utf-8");
+      } catch {
+        continue;
+      }
+      let next: string | null;
+      try {
+        next = codemod.transform(source, { path: fullPath });
+      } catch (error) {
+        skipped.push({
+          id: finding.id,
+          reason: `codemod threw on ${file} (${(error as Error).message})`,
+        });
+        next = null;
+      }
+      if (next === null || next === source) continue;
+      writeFileSync(fullPath, next);
+      changedFiles.add(file);
+      applied = true;
+    }
+    if (applied) appliedIds.push(finding.id);
+  }
+
+  return { changedFiles: [...changedFiles].sort(), appliedIds, skipped };
+}
+
+// ---------------------------------------------------------------------------
+// Formatting
+// ---------------------------------------------------------------------------
+
+export function formatUpgradeReport(report: UpgradeReport): string {
+  const lines: string[] = [];
+
+  lines.push("Installed pracht packages");
+  if (report.packages.length === 0) {
+    lines.push("  none found — is this a pracht app with dependencies installed?");
+  }
+  const width = Math.max(0, ...report.packages.map((entry) => entry.name.length));
+  for (const entry of report.packages) {
+    const version = entry.version ?? "not installed";
+    const declared = entry.declared ? `  (package.json: ${entry.declared})` : "  (transitive)";
+    lines.push(`  ${entry.name.padEnd(width)}  ${version}${declared}`);
+  }
+
+  const errors = report.findings.filter((finding) => finding.severity === "error");
+  const warns = report.findings.filter((finding) => finding.severity === "warn");
+
+  lines.push("");
+  if (report.findings.length === 0) {
+    lines.push("No deprecated or removed APIs are in use.");
+  } else {
+    lines.push(
+      `${errors.length} removed ${errors.length === 1 ? "API" : "APIs"} and ` +
+        `${warns.length} ${warns.length === 1 ? "deprecation" : "deprecations"} in use.`,
+    );
+  }
+
+  for (const finding of report.findings) {
+    lines.push("");
+    const label = finding.severity === "error" ? "REMOVED" : "DEPRECATED";
+    lines.push(`${label}  ${finding.id} — ${finding.title}`);
+    const version = finding.installedVersion ? ` (installed: ${finding.installedVersion})` : "";
+    lines.push(
+      finding.removedIn
+        ? `  ${finding.severity === "error" ? "Removed" : "Removal scheduled"} in ${
+            finding.package
+          } ${finding.removedIn}${version}.`
+        : `  Deprecated since ${finding.package} ${finding.since}${version}.`,
+    );
+    if (finding.replacement) lines.push(`  Replacement: ${finding.replacement}`);
+    if (finding.detail) lines.push(`  ${finding.detail}`);
+    if (finding.docs) lines.push(`  ${finding.docs}`);
+    for (const occurrence of finding.occurrences) {
+      lines.push(`    ${occurrence.file}:${occurrence.line}  ${occurrence.text}`);
+    }
+    if (finding.codemod) lines.push("  Codemod available — run `pracht upgrade --fix`.");
+  }
+
+  for (const warning of report.warnings) {
+    lines.push("");
+    lines.push(`WARN  ${warning}`);
+  }
+
+  if (report.upgradeCommand) {
+    lines.push("");
+    lines.push("Move the family forward together (pracht packages pin each other exactly):");
+    lines.push(`  ${report.upgradeCommand}`);
+  }
+
+  return lines.join("\n");
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -26,6 +26,7 @@ const main = defineCommand({
     preview: () => import("./commands/preview.js").then((m) => m.default),
     report: () => import("./commands/report.js").then((m) => m.default),
     typegen: () => import("./commands/typegen.js").then((m) => m.default),
+    upgrade: () => import("./commands/upgrade.js").then((m) => m.default),
     verify: () => import("./commands/verify.js").then((m) => m.default),
   },
 });

--- a/packages/cli/test/cli-upgrade.test.js
+++ b/packages/cli/test/cli-upgrade.test.js
@@ -1,0 +1,130 @@
+import { cpSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { repoRoot, runCli, runCliStatus } from "./helpers/cli-fixtures.js";
+import { removeTempDir } from "./helpers/remove-temp-dir.ts";
+
+const tempDirs = [];
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) removeTempDir(dir);
+});
+
+const frameworkDir = resolve(repoRoot, "packages/framework");
+const frameworkVersion = JSON.parse(
+  readFileSync(join(frameworkDir, "package.json"), "utf-8"),
+).version;
+
+/**
+ * Installs the *published* `@pracht/core` deprecations artifacts — the real
+ * manifest and the real codemod — into a fixture's node_modules, so this
+ * exercises what ships rather than a synthetic stand-in.
+ *
+ * The fixture lives in the OS temp dir on purpose: the CLI walks parent
+ * directories for `node_modules/@pracht/*` the way Node resolution does, and a
+ * fixture under packages/ would resolve the workspace's own packages instead.
+ */
+function createApp(files) {
+  const root = mkdtempSync(join(tmpdir(), "pracht-cli-upgrade-"));
+  tempDirs.push(root);
+
+  const corePath = join(root, "node_modules/@pracht/core");
+  mkdirSync(corePath, { recursive: true });
+  writeFileSync(
+    join(corePath, "package.json"),
+    JSON.stringify({
+      name: "@pracht/core",
+      version: frameworkVersion,
+      pracht: { deprecations: "./deprecations.json" },
+    }),
+  );
+  cpSync(join(frameworkDir, "deprecations.json"), join(corePath, "deprecations.json"));
+  cpSync(join(frameworkDir, "codemods"), join(corePath, "codemods"), { recursive: true });
+
+  writeFileSync(
+    join(root, "package.json"),
+    JSON.stringify({
+      name: "fixture-app",
+      dependencies: { "@pracht/core": `^${frameworkVersion}` },
+    }),
+  );
+  for (const [relativePath, contents] of Object.entries(files)) {
+    const filePath = join(root, relativePath);
+    mkdirSync(dirname(filePath), { recursive: true });
+    writeFileSync(filePath, contents, "utf-8");
+  }
+  return root;
+}
+
+describe("pracht upgrade", () => {
+  it("reports a removed API with its call sites and fails --check", () => {
+    const appDir = createApp({
+      "src/routes/dashboard.tsx": [
+        'import { useRevalidateRoute } from "@pracht/core";',
+        "",
+        "export default function Dashboard() {",
+        "  const revalidate = useRevalidateRoute();",
+        "  return <button onClick={revalidate}>Refresh</button>;",
+        "}",
+      ].join("\n"),
+    });
+
+    const report = JSON.parse(runCli(["upgrade", "--json"], { cwd: appDir }).stdout);
+    expect(report.ok).toBe(false);
+    expect(report.findings).toHaveLength(1);
+    expect(report.findings[0]).toMatchObject({
+      id: "core.use-revalidate-route",
+      package: "@pracht/core",
+      severity: "error",
+      removedIn: "0.2.7",
+      codemod: true,
+    });
+    expect(report.findings[0].occurrences.map((entry) => entry.line)).toEqual([1, 4]);
+
+    const text = runCli(["upgrade"], { cwd: appDir }).stdout;
+    expect(text).toContain("REMOVED  core.use-revalidate-route");
+    expect(text).toContain("src/routes/dashboard.tsx:4");
+    expect(text).toContain("pracht upgrade --fix");
+
+    // The plain report is advisory; only --check turns it into a gate.
+    expect(runCliStatus(["upgrade"], { cwd: appDir }).status).toBe(0);
+    expect(runCliStatus(["upgrade", "--check"], { cwd: appDir }).status).toBe(1);
+  }, 60_000);
+
+  it("applies the published codemod and leaves the app clean", () => {
+    const appDir = createApp({
+      "src/app.tsx":
+        'import { useRevalidate, useRevalidateRoute } from "@pracht/core";\n' +
+        "export const refresh = useRevalidateRoute;\n" +
+        "export const other = useRevalidate;\n",
+    });
+
+    const output = runCli(["upgrade", "--fix"], { cwd: appDir }).stdout;
+    expect(output).toContain("updated  src/app.tsx");
+    expect(output).toContain("No deprecated or removed APIs are in use.");
+
+    // The rename must not leave a duplicate specifier behind in a file that
+    // already imported the replacement.
+    expect(readFileSync(join(appDir, "src/app.tsx"), "utf-8")).toBe(
+      'import { useRevalidate } from "@pracht/core";\n' +
+        "export const refresh = useRevalidate;\n" +
+        "export const other = useRevalidate;\n",
+    );
+    expect(runCliStatus(["upgrade", "--check"], { cwd: appDir }).status).toBe(0);
+  }, 60_000);
+
+  it("says nothing is in use for an app on current APIs", () => {
+    const appDir = createApp({
+      "src/app.tsx":
+        'import { useRevalidate } from "@pracht/core";\nexport const r = useRevalidate;',
+    });
+
+    const output = runCli(["upgrade"], { cwd: appDir }).stdout;
+    expect(output).toContain("No deprecated or removed APIs are in use.");
+    expect(output).toContain(`@pracht/core  ${frameworkVersion}`);
+    expect(output).toContain("npm install @pracht/core@latest");
+  }, 60_000);
+});

--- a/packages/cli/test/deprecations.test.ts
+++ b/packages/cli/test/deprecations.test.ts
@@ -1,0 +1,289 @@
+import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  applyCodemods,
+  buildUpgradeReport,
+  compareVersions,
+  globToRegExp,
+  parseDeprecationManifest,
+  type DeprecationRecord,
+} from "../src/deprecations.js";
+import { removeTempDir } from "./helpers/remove-temp-dir.ts";
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) removeTempDir(dir);
+});
+
+// Deliberately outside the repo: the report walks parent directories for
+// `node_modules/@pracht/*` exactly as Node resolution does, so a fixture under
+// packages/ would pick up the workspace's own packages.
+function createApp(files: Record<string, string>): string {
+  const root = mkdtempSync(join(tmpdir(), "pracht-deprecations-"));
+  tempDirs.push(root);
+  for (const [relativePath, contents] of Object.entries(files)) {
+    const filePath = join(root, relativePath);
+    mkdirSync(dirname(filePath), { recursive: true });
+    writeFileSync(filePath, contents, "utf-8");
+  }
+  return root;
+}
+
+function installedCore(version: string, deprecations: DeprecationRecord[]): Record<string, string> {
+  return {
+    "package.json": JSON.stringify({
+      name: "fixture-app",
+      dependencies: { "@pracht/core": `^${version}` },
+    }),
+    "node_modules/@pracht/core/package.json": JSON.stringify({
+      name: "@pracht/core",
+      version,
+      pracht: { deprecations: "./deprecations.json" },
+    }),
+    "node_modules/@pracht/core/deprecations.json": JSON.stringify({
+      version: 1,
+      package: "@pracht/core",
+      deprecations,
+    }),
+  };
+}
+
+const RENAME_RECORD: DeprecationRecord = {
+  id: "core.use-revalidate-route",
+  title: "useRevalidateRoute() was replaced by useRevalidate()",
+  since: "0.0.1",
+  removedIn: "0.2.7",
+  replacement: "useRevalidate()",
+  detect: { include: ["src/**/*.{ts,tsx}"], pattern: "\\buseRevalidateRoute\\b" },
+};
+
+describe("compareVersions", () => {
+  it("orders releases and sorts a prerelease before its release", () => {
+    expect(compareVersions("0.16.0", "0.2.7")).toBeGreaterThan(0);
+    expect(compareVersions("0.2.7", "0.16.0")).toBeLessThan(0);
+    expect(compareVersions("1.0.0", "1.0.0")).toBe(0);
+    expect(compareVersions("1.0.0-rc.1", "1.0.0")).toBeLessThan(0);
+    expect(compareVersions("1.0.0", "1.0.0-rc.1")).toBeGreaterThan(0);
+  });
+
+  it("returns null rather than guessing when a side is not plain semver", () => {
+    expect(compareVersions("workspace:*", "1.0.0")).toBeNull();
+    expect(compareVersions("1.0.0", "next")).toBeNull();
+  });
+});
+
+describe("globToRegExp", () => {
+  it("matches nested paths, brace alternatives, and root-level config files", () => {
+    const source = globToRegExp("src/**/*.{ts,tsx}");
+    expect(source.test("src/app.ts")).toBe(true);
+    expect(source.test("src/routes/nested/page.tsx")).toBe(true);
+    expect(source.test("src/app.js")).toBe(false);
+    expect(source.test("other/app.ts")).toBe(false);
+
+    const config = globToRegExp("*.config.{ts,js}");
+    expect(config.test("vite.config.ts")).toBe(true);
+    // A single `*` must not cross a separator, or every glob leaks into
+    // subdirectories the record never named.
+    expect(config.test("nested/vite.config.ts")).toBe(false);
+  });
+});
+
+describe("parseDeprecationManifest", () => {
+  it("keeps valid records and reports the ones it drops", () => {
+    const warnings: string[] = [];
+    const manifest = parseDeprecationManifest(
+      {
+        version: 1,
+        deprecations: [
+          RENAME_RECORD,
+          { id: "core.no-title", since: "1.0.0" },
+          { id: "core.bad-pattern", title: "x", since: "1.0.0", detect: { pattern: "([" } },
+          "not an object",
+        ],
+      },
+      "@pracht/core",
+      warnings,
+    );
+
+    expect(manifest?.deprecations.map((record) => record.id)).toEqual([
+      "core.use-revalidate-route",
+    ]);
+    expect(warnings).toHaveLength(3);
+    expect(warnings.join("\n")).toContain("core.bad-pattern");
+  });
+
+  it("refuses a manifest written against a future schema version", () => {
+    const warnings: string[] = [];
+    expect(
+      parseDeprecationManifest({ version: 2, deprecations: [] }, "@pracht/core", warnings),
+    ).toBeNull();
+    expect(warnings[0]).toContain("is not supported");
+  });
+});
+
+describe("buildUpgradeReport", () => {
+  it("reports a removed API as an error with its call sites", () => {
+    const root = createApp({
+      ...installedCore("0.16.0", [RENAME_RECORD]),
+      "src/routes/dashboard.tsx": [
+        'import { useRevalidateRoute } from "@pracht/core";',
+        "",
+        "export default function Dashboard() {",
+        "  const revalidate = useRevalidateRoute();",
+        "  return <button onClick={revalidate}>Refresh</button>;",
+        "}",
+      ].join("\n"),
+    });
+
+    const report = buildUpgradeReport(root);
+    expect(report.ok).toBe(false);
+    expect(report.findings).toHaveLength(1);
+
+    const [finding] = report.findings;
+    expect(finding.id).toBe("core.use-revalidate-route");
+    // Installed 0.16.0 is past the 0.2.7 removal, so this code is broken now
+    // rather than merely dated — that distinction is the whole severity axis.
+    expect(finding.severity).toBe("error");
+    expect(finding.installedVersion).toBe("0.16.0");
+    expect(finding.occurrences).toEqual([
+      {
+        file: "src/routes/dashboard.tsx",
+        line: 1,
+        text: 'import { useRevalidateRoute } from "@pracht/core";',
+      },
+      {
+        file: "src/routes/dashboard.tsx",
+        line: 4,
+        text: "const revalidate = useRevalidateRoute();",
+      },
+    ]);
+  });
+
+  it("downgrades to a warning when the removal is still ahead of the installed version", () => {
+    const root = createApp({
+      ...installedCore("0.16.0", [{ ...RENAME_RECORD, removedIn: "0.20.0" }]),
+      "src/app.ts": "export const revalidate = useRevalidateRoute;",
+    });
+
+    const report = buildUpgradeReport(root);
+    expect(report.findings[0].severity).toBe("warn");
+    // A scheduled removal is not a broken build, so `--check` stays green.
+    expect(report.ok).toBe(true);
+  });
+
+  it("ignores mentions inside comments and strings", () => {
+    const root = createApp({
+      ...installedCore("0.16.0", [RENAME_RECORD]),
+      "src/app.ts": [
+        "// TODO: we used to call useRevalidateRoute here",
+        'export const note = "useRevalidateRoute was removed";',
+      ].join("\n"),
+    });
+
+    expect(buildUpgradeReport(root).findings).toEqual([]);
+  });
+
+  it("skips records the installed version predates, and files outside the record's globs", () => {
+    const root = createApp({
+      ...installedCore("0.16.0", [
+        { ...RENAME_RECORD, id: "core.future", since: "0.20.0", removedIn: "0.21.0" },
+      ]),
+      "src/app.ts": "useRevalidateRoute();",
+      "scripts/legacy.ts": "useRevalidateRoute();",
+    });
+    expect(buildUpgradeReport(root).findings).toEqual([]);
+
+    const scoped = createApp({
+      ...installedCore("0.16.0", [RENAME_RECORD]),
+      "scripts/legacy.ts": "useRevalidateRoute();",
+    });
+    expect(buildUpgradeReport(scoped).findings).toEqual([]);
+  });
+
+  it("suggests the upgrade command for the app's package manager", () => {
+    const npmApp = createApp(installedCore("0.16.0", []));
+    expect(buildUpgradeReport(npmApp).packageManager).toBe("npm");
+    expect(buildUpgradeReport(npmApp).upgradeCommand).toBe("npm install @pracht/core@latest");
+
+    const pnpmApp = createApp({
+      ...installedCore("0.16.0", []),
+      "pnpm-lock.yaml": "lockfileVersion: 9.0\n",
+    });
+    expect(buildUpgradeReport(pnpmApp).upgradeCommand).toBe("pnpm up @pracht/core@latest");
+  });
+
+  it("surfaces a malformed dependency manifest as a warning instead of failing", () => {
+    const root = createApp({
+      "package.json": JSON.stringify({ dependencies: { "@pracht/core": "^0.16.0" } }),
+      "node_modules/@pracht/core/package.json": JSON.stringify({
+        name: "@pracht/core",
+        version: "0.16.0",
+        pracht: { deprecations: "./deprecations.json" },
+      }),
+      "node_modules/@pracht/core/deprecations.json": "{ not json",
+    });
+
+    const report = buildUpgradeReport(root);
+    expect(report.findings).toEqual([]);
+    expect(report.warnings.join("\n")).toContain("could not read deprecations manifest");
+  });
+});
+
+describe("applyCodemods", () => {
+  it("rewrites detected call sites and leaves a clean report behind", async () => {
+    const root = createApp({
+      ...installedCore("0.16.0", [
+        { ...RENAME_RECORD, codemod: "./codemods/use-revalidate-route.js" },
+      ]),
+      "node_modules/@pracht/core/codemods/use-revalidate-route.js": [
+        "export default {",
+        '  id: "core.use-revalidate-route",',
+        "  transform(source) {",
+        '    if (!source.includes("useRevalidateRoute")) return null;',
+        '    return source.replace(/\\buseRevalidateRoute\\b/g, "useRevalidate");',
+        "  },",
+        "};",
+      ].join("\n"),
+      "src/app.ts": 'import { useRevalidateRoute } from "@pracht/core";\nuseRevalidateRoute();',
+    });
+
+    const result = await applyCodemods(buildUpgradeReport(root));
+    expect(result.appliedIds).toEqual(["core.use-revalidate-route"]);
+    expect(result.changedFiles).toEqual(["src/app.ts"]);
+    expect(readFileSync(join(root, "src/app.ts"), "utf-8")).toBe(
+      'import { useRevalidate } from "@pracht/core";\nuseRevalidate();',
+    );
+    expect(buildUpgradeReport(root).findings).toEqual([]);
+  });
+
+  it("reports findings that have no published codemod rather than silently passing", async () => {
+    const root = createApp({
+      ...installedCore("0.16.0", [RENAME_RECORD]),
+      "src/app.ts": "useRevalidateRoute();",
+    });
+
+    const result = await applyCodemods(buildUpgradeReport(root));
+    expect(result.changedFiles).toEqual([]);
+    expect(result.skipped).toEqual([
+      { id: "core.use-revalidate-route", reason: "no codemod is published for this deprecation" },
+    ]);
+  });
+
+  it("refuses a codemod path that escapes the package that published it", async () => {
+    const root = createApp({
+      ...installedCore("0.16.0", [{ ...RENAME_RECORD, codemod: "../../../evil.js" }]),
+      "src/app.ts": "useRevalidateRoute();",
+      "evil.js": "export default { transform: () => { throw new Error('pwned'); } };",
+    });
+
+    const report = buildUpgradeReport(root);
+    expect(report.findings[0].codemod).toBeNull();
+    const result = await applyCodemods(report);
+    expect(result.changedFiles).toEqual([]);
+  });
+});

--- a/packages/framework/codemods/use-revalidate-route.js
+++ b/packages/framework/codemods/use-revalidate-route.js
@@ -1,0 +1,25 @@
+// Codemod for `core.use-revalidate-route`.
+//
+// `useRevalidateRoute` was an alias for `useRevalidate` with the same
+// signature, so the migration is a rename. The only wrinkle is a file that
+// already imports both, where the rename would leave a duplicate specifier.
+//
+// The default export implements the codemod contract read by
+// `pracht upgrade --fix`: `transform(source, { path })` returns the rewritten
+// source, or `null` when there is nothing to change.
+
+export default {
+  id: "core.use-revalidate-route",
+  transform(source) {
+    if (!source.includes("useRevalidateRoute")) return null;
+    const renamed = source.replace(/\buseRevalidateRoute\b/g, "useRevalidate");
+    return renamed.replace(/import\s*\{([^}]*)\}/g, (statement, specifiers) => {
+      const names = specifiers
+        .split(",")
+        .map((entry) => entry.trim())
+        .filter((entry) => entry.length > 0);
+      const unique = [...new Set(names)];
+      return unique.length === names.length ? statement : `import { ${unique.join(", ")} }`;
+    });
+  },
+};

--- a/packages/framework/deprecations.json
+++ b/packages/framework/deprecations.json
@@ -1,0 +1,20 @@
+{
+  "version": 1,
+  "package": "@pracht/core",
+  "deprecations": [
+    {
+      "id": "core.use-revalidate-route",
+      "title": "useRevalidateRoute() was replaced by useRevalidate()",
+      "since": "0.0.1",
+      "removedIn": "0.2.7",
+      "replacement": "useRevalidate()",
+      "detail": "useRevalidateRoute was an alias for useRevalidate with the same signature and return value, so the change is a rename.",
+      "docs": "https://pracht.resynapse.dev/docs/data-loading#userevalidate",
+      "detect": {
+        "include": ["src/**/*.{ts,tsx,js,jsx,mts,mjs}"],
+        "pattern": "\\buseRevalidateRoute\\b"
+      },
+      "codemod": "./codemods/use-revalidate-route.js"
+    }
+  ]
+}

--- a/packages/framework/package.json
+++ b/packages/framework/package.json
@@ -25,11 +25,16 @@
     "directory": "packages/framework"
   },
   "files": [
+    "codemods",
+    "deprecations.json",
     "dist"
   ],
   "sideEffects": [
     "./dist/prerender.mjs"
   ],
+  "pracht": {
+    "deprecations": "./deprecations.json"
+  },
   "type": "module",
   "exports": {
     ".": {

--- a/skills/upgrade-pracht/SKILL.md
+++ b/skills/upgrade-pracht/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: upgrade-pracht
-version: 1.0.2
+version: 1.1.0
 description: |
   Upgrade the `@pracht/*` packages safely: inventory installed versions, read the
   changelogs between installed and target, map breaking changes to real usage,
@@ -22,19 +22,31 @@ allowed-tools:
 Upgrade `@pracht/*` dependencies with the changelog read *before* the install,
 not after the build breaks.
 
-## Step 1: Inventory
+## Step 1: Inventory and machine-readable deprecations
 
-List every installed pracht package and its resolved version:
+Start with the CLI — it inventories the installed family *and* reports every
+deprecated or removed API the app still uses, from the `deprecations.json`
+each package publishes in its tarball:
 
 ```bash
-pnpm list --depth 1 --json | grep -A2 '@pracht/'   # or read package.json + lockfile
+pracht upgrade --json
 ```
 
-The family: `@pracht/core`, `@pracht/cli`, `@pracht/vite-plugin`,
-`@pracht/adapter-node`, `@pracht/adapter-cloudflare`, `@pracht/adapter-vercel`,
-`@pracht/preact-ssr-precompile`, `@pracht/content`, `@pracht/markdown`,
-`@pracht/image`. Get the latest published versions with
-`npm view <pkg> version`.
+The payload gives you `packages[]` (name, declared range, installed version)
+and `findings[]`, each with a stable `id`, a `severity` (`error` = the
+installed version already removed it, `warn` = deprecated), a `replacement`,
+the exact `occurrences` in app source, and whether a `codemod` is published.
+Use those findings as the spine of the plan; they are precise where a
+changelog paragraph is not.
+
+If the command is unavailable (very old `@pracht/cli`), fall back to
+`pnpm list --depth 1 --json | grep -A2 '@pracht/'`. The family: `@pracht/core`,
+`@pracht/cli`, `@pracht/vite-plugin`, `@pracht/adapter-node`,
+`@pracht/adapter-cloudflare`, `@pracht/adapter-netlify`,
+`@pracht/adapter-vercel`, `@pracht/adapter-static`,
+`@pracht/preact-ssr-precompile`, `@pracht/capabilities`, `@pracht/content`,
+`@pracht/markdown`, `@pracht/image`, `@pracht/i18n`, `@pracht/openapi`. Get the
+latest published versions with `npm view <pkg> version`.
 
 ## Step 2: Understand the versioning model
 
@@ -58,7 +70,12 @@ After any upgrade, confirm a single core resolution:
 pnpm why @pracht/core   # exactly one version may appear
 ```
 
-## Step 3: Read the changelogs between installed and target
+## Step 3: Read the changelogs for what the manifests cannot express
+
+`pracht upgrade` reads the manifests of the packages that are **installed**, so
+it catches migrations you have already missed but cannot preview a version you
+have not installed yet. It also cannot express changed defaults, peer ranges,
+or behavioural changes with no API surface. The changelogs still cover those.
 
 Only `@pracht/cli` ships `CHANGELOG.md` in its npm tarball
 (`node_modules/@pracht/cli/CHANGELOG.md`); the other packages publish `dist/`
@@ -108,14 +125,23 @@ required: confirm the target versions and which migrations to apply. Then:
 pnpm up '@pracht/core@<v>' '@pracht/cli@<v>' '@pracht/vite-plugin@<v>' <adapters...>
 ```
 
-Upgrade every installed `@pracht/*` package in the same command. Apply the
-agreed code migrations with minimal diffs, one changelog entry at a time.
+Upgrade every installed `@pracht/*` package in the same command. Then let the
+published codemods do the mechanical part before touching anything by hand:
+
+```bash
+pracht upgrade          # re-read findings against the new versions
+pracht upgrade --fix    # apply published codemods, then re-report
+```
+
+Review the codemod diff — the transforms are textual. Apply the remaining
+migrations with minimal diffs, one changelog entry at a time.
 
 ## Step 6: Verification ladder
 
 Run in order; stop and fix at the first failure:
 
 ```bash
+pracht upgrade --check        # no removed API left in use
 pracht doctor --json          # wiring still valid
 pracht typegen --check        # generated route types up to date?
 pracht typegen                # regenerate if --check failed or routes changed
@@ -124,8 +150,9 @@ pracht build                  # full production build (budgets included)
 pnpm test                     # the app's own suite
 ```
 
-`pracht doctor`, `verify`, and `typegen --check` exit non-zero on failure, so
-they gate CI cleanly.
+`pracht upgrade --check`, `doctor`, `verify`, and `typegen --check` exit
+non-zero on failure, so they gate CI cleanly. Add `pracht upgrade --check` to
+the app's CI to catch the call site a future upgrade misses.
 
 ## Step 7: Rollback note
 
@@ -145,7 +172,8 @@ roll the whole family back together.
 
 1. Never mix `@pracht/*` versions from different release waves — upgrade and
    roll back the family as a unit, and verify with `pnpm why @pracht/core`.
-2. Read changelogs before installing, not after something breaks.
+2. Read `pracht upgrade --json` first and changelogs second — both before
+   installing, not after something breaks.
 3. Never apply a breaking-change migration without explicit user confirmation
    via `AskUserQuestion`.
 4. Treat 0.x minor bumps as potentially breaking.


### PR DESCRIPTION
## Summary

Ember's most underrated achievement is that a 2015 app upgrades to today, because deprecations are *data* — cited by id, carried in the framework, and paired with codemods. pracht had the opposite: `skills/upgrade-pracht/SKILL.md` told a human or agent to fetch a dozen `CHANGELOG.md` files from raw GitHub URLs (most packages don't ship one in the tarball), read every section between installed and target, and grep the app for whatever the prose happened to name. That mapping was manual, easy to skip, and versioned separately from the packages it described.

**Every `@pracht/*` package can now publish a `deprecations.json` in its tarball.** One record per renamed or removed API: the versions it spans, a detector for locating it in app source, and an optional codemod. `pracht upgrade` reads the manifests of the packages *actually installed*, scans the app, and reports real call sites.

```
REMOVED  core.use-revalidate-route — useRevalidateRoute() was replaced by useRevalidate()
  Removed in @pracht/core 0.2.7 (installed: 0.16.0).
  Replacement: useRevalidate()
    src/routes/dashboard.tsx:1  import { useRevalidateRoute } from "@pracht/core";
    src/routes/dashboard.tsx:4  const revalidate = useRevalidateRoute();
  Codemod available — run `pracht upgrade --fix`.
```

### What's here

- **`packages/cli/src/deprecations.ts`** — manifest schema and validation, installed-package inventory, source scan, codemod runner, report formatter.
- **`packages/cli/src/commands/upgrade.ts`** — `--json` (agent entry point, stable `id` per migration), `--check` (CI gate), `--strict`, `--fix` (apply codemods, then re-report).
- **Severity is derived, not declared.** A finding is `error` only when the installed version is at or past the record's `removedIn` — the code is broken *now*. Everything else is `warn`. That's what makes `--check` safe to gate CI on: a deprecation announced today cannot redden a green build, only a missed migration can.
- **Seeded with real data** — `@pracht/core`'s manifest carries the `useRevalidateRoute` → `useRevalidate` rename removed in 0.2.7 (#115), with a working codemod.
- **Third-party packages are first-class.** Any package in the `@pracht/*` scope is read by the same reader; the format is documented for external authors.

### Deliberately not built

- **Target-version manifests.** The report reads installed packages, so it answers "did I miss a migration", not "what will break if I upgrade" — that needs registry fetches. The loader is structured so a second manifest source drops in without touching the scan.
- **Running the package manager.** It prints the command for the detected lockfile and stops.
- **Wiring into `pracht verify`.** A deprecation isn't a broken build; `--check` is the opt-in gate.

Follow-up worth considering: a runtime `deprecate()` in `@pracht/core` that emits dev warnings citing the same record ids.

## Testing

- [x] `pnpm run verify` (build, format, lint, typecheck, test, e2e) — passed in 101.9s
- 17 new tests: `packages/cli/test/deprecations.test.ts` (unit — version compare, globs, manifest validation, severity derivation, comment/string masking, codemod path escape) and `packages/cli/test/cli-upgrade.test.js` (spawns the real binary against a fixture with the *published* `@pracht/core` manifest and codemod installed).
- Fixtures live in the OS temp dir on purpose: resolution walks parent `node_modules` like Node does, so a fixture under `packages/` would resolve the workspace's own packages.

## Checklist

- [x] Docs updated if needed — new public page [`/docs/upgrading`](examples/docs/src/routes/docs/upgrading.md) (routed + nav + prev/next chain), `pracht upgrade` section on the CLI page and in the CLI README, internal `docs/UPGRADES.md`, VISION_MVP entry
- [x] Skills updated if needed — `upgrade-pracht` now drives `pracht upgrade --json` / `--fix` / `--check`, keeping changelog reading for what a manifest cannot express (peer ranges, changed defaults, duplicate-core)
- [x] Concise, user-facing changeset added if published packages changed — `@pracht/cli` minor, `@pracht/core` patch

🤖 Generated with [Claude Code](https://claude.com/claude-code)