### PR TITLE
Normalize content-length for null-body responses

### DIFF
--- a/.changeset/calm-bodies.md
+++ b/.changeset/calm-bodies.md
@@ -1,0 +1,10 @@
+---
+"@pracht/adapter-cloudflare": patch
+"@pracht/adapter-netlify": patch
+"@pracht/adapter-node": patch
+"@pracht/adapter-vercel": patch
+"@pracht/core": patch
+"@pracht/vite-plugin": patch
+---
+
+Normalize null-body responses across development and production adapters so an explicit nonzero `Content-Length` cannot leave clients waiting for bytes.

--- a/docs/ADAPTERS.md
+++ b/docs/ADAPTERS.md
@@ -1461,6 +1461,28 @@ segments to the same filesystem spelling used by static-export page output.
 
 ---
 
+## Null-body response framing
+
+`normalizeResponseHeaders()` from `@pracht/core/server` removes
+`Content-Length` whenever a Fetch `Response` has a null body. The core response
+decorators, `pracht dev`, and the first-party production response writers all
+apply this policy, so an explicit nonzero length cannot survive on HEAD, 204,
+205, or 304 responses that carry no representation bytes. Node may emit its own
+`Content-Length: 0` for a 205 after normalization; it never forwards the
+application's nonzero value.
+
+The check follows `Response.body`, not the request method alone. A HEAD
+response that still carries the corresponding GET representation in its Fetch
+`Response` keeps valid representation metadata such as a computed compressed
+`Content-Length`; the HTTP transport suppresses those bytes. Protocol-switch
+responses are returned untouched so Cloudflare's nonstandard `webSocket`
+handle is preserved.
+
+Custom adapter response writers should call `normalizeResponseHeaders()` at
+their final Web-to-platform boundary as well. This covers adapter-owned
+responses in addition to the responses already normalized by
+`handlePrachtRequest()`.
+
 ## Default `Cache-Control`
 
 Every adapter stamps `Cache-Control: private, no-cache` on `GET`/`HEAD`

--- a/examples/docs/src/routes/docs/adapters.md
+++ b/examples/docs/src/routes/docs/adapters.md
@@ -636,6 +636,30 @@ To serve a static export under a sub-path, see [Sub-Path Deploys](/docs/deployme
 
 ---
 
+## Null-body responses
+
+Pracht removes `Content-Length` from any application Fetch `Response` whose
+body is actually null before it reaches the development or production
+transport. This keeps explicit nonzero lengths from leaking onto bodyless HEAD,
+204, 205, and 304 responses; Node may replace the removed value with its own
+`Content-Length: 0` for a 205. A HEAD response that still carries the GET
+representation keeps its valid length metadata while the transport suppresses
+the bytes.
+
+If you write a custom response transport, apply the same policy at its final
+boundary:
+
+```ts
+import { normalizeResponseHeaders } from "@pracht/core/server";
+
+const response = normalizeResponseHeaders(
+  await handlePrachtRequest({ app, registry, request }),
+);
+```
+
+Protocol-switch responses are returned untouched so runtime-specific handles,
+such as Cloudflare's `webSocket`, remain attached.
+
 ## Context Factory
 
 Adapters inject platform-specific values into loaders and API routes via a context factory. With generated entries, point the adapter at a module that exports `createContext`:

--- a/packages/adapter-cloudflare/test/runtime.test.ts
+++ b/packages/adapter-cloudflare/test/runtime.test.ts
@@ -236,6 +236,42 @@ describe("createCloudflareFetchHandler under a deploy base", () => {
   });
 });
 
+describe("null-body response headers", () => {
+  it.each([
+    ["HEAD", 200],
+    ["GET", 204],
+    ["GET", 205],
+    ["GET", 304],
+  ])("strips content-length from a null-body %s %s response", async (method, status) => {
+    const respond = () =>
+      new Response(null, {
+        status,
+        headers: { "content-length": "42", "x-test": "kept" },
+      });
+    const handler = createCloudflareFetchHandler({
+      apiRoutes: resolveApiRoutes(["/src/api/empty.ts"]),
+      app: defineApp({ routes: [] }),
+      registry: {
+        apiModules: {
+          "/src/api/empty.ts": async () => ({ GET: respond, HEAD: respond }),
+        },
+      },
+    });
+    const { executionContext } = createExecutionContext();
+
+    const response = await handler(
+      new Request("https://example.com/api/empty", { method }),
+      { ASSETS: create404Assets() },
+      executionContext,
+    );
+
+    expect(response.status).toBe(status);
+    expect(response.headers.get("content-length")).toBeNull();
+    expect(response.headers.get("x-test")).toBe("kept");
+    expect(response.body).toBeNull();
+  });
+});
+
 describe("createCloudflareFetchHandler ISG", () => {
   it("serves OAuth metadata before a colliding asset", async () => {
     const fetchAsset = vi.fn(async () => new Response("stale metadata"));

--- a/packages/adapter-netlify/test/index.test.ts
+++ b/packages/adapter-netlify/test/index.test.ts
@@ -1199,3 +1199,34 @@ describe("resolveNetlifyStaticDir", () => {
     await expect(resolveNetlifyStaticDir([missing, present])).resolves.toBe(present);
   });
 });
+
+describe("null-body response headers", () => {
+  it.each([
+    ["HEAD", 200],
+    ["GET", 204],
+    ["GET", 205],
+    ["GET", 304],
+  ])("strips content-length from a null-body %s %s response", async (method, status) => {
+    const respond = () =>
+      new Response(null, {
+        status,
+        headers: { "content-length": "42", "x-test": "kept" },
+      });
+    const handler = createNetlifyHandler({
+      apiRoutes: resolveApiRoutes(["/src/api/empty.ts"]),
+      app: defineApp({ routes: [] }),
+      registry: {
+        apiModules: {
+          "/src/api/empty.ts": async () => ({ GET: respond, HEAD: respond }),
+        },
+      },
+    });
+
+    const response = await handler(new Request("https://example.com/api/empty", { method }), {});
+
+    expect(response.status).toBe(status);
+    expect(response.headers.get("content-length")).toBeNull();
+    expect(response.headers.get("x-test")).toBe("kept");
+    expect(response.body).toBeNull();
+  });
+});

--- a/packages/adapter-node/src/node-request.ts
+++ b/packages/adapter-node/src/node-request.ts
@@ -1,5 +1,6 @@
 import type { IncomingMessage, ServerResponse } from "node:http";
 import { Readable } from "node:stream";
+import { normalizeResponseHeaders } from "@pracht/core/server";
 
 import {
   COMPRESSION_MIN_SIZE,
@@ -250,6 +251,7 @@ export async function writeWebResponse(
   response: Response,
   compression?: CompressionState,
 ): Promise<void> {
+  response = normalizeResponseHeaders(response);
   res.statusCode = response.status;
   res.statusMessage = response.statusText;
 

--- a/packages/adapter-node/test/index.test.ts
+++ b/packages/adapter-node/test/index.test.ts
@@ -1248,4 +1248,38 @@ describe("default cache-control (shared with the Cloudflare and Vercel adapters)
     expect(response.status).toBe(200);
     expect(response.headers.has("cache-control")).toBe(false);
   });
+
+  it.each([
+    ["HEAD", 200],
+    ["GET", 204],
+    ["GET", 205],
+    ["GET", 304],
+  ])("strips content-length from a null-body %s %s response", async (method, status) => {
+    const respond = () =>
+      new Response(null, {
+        status,
+        headers: { "content-length": "42", "x-test": "kept" },
+      });
+    const response = await serve(
+      {
+        apiRoutes: resolveApiRoutes(["/src/api/empty.ts"]),
+        app: defineApp({ routes: [] }),
+        canonicalOrigin: "https://app.test",
+        registry: {
+          apiModules: {
+            "/src/api/empty.ts": async () => ({ GET: respond, HEAD: respond }),
+          },
+        },
+      },
+      "/api/empty",
+      { method },
+    );
+
+    expect(response.status).toBe(status);
+    // Node adds its own explicit zero length for 205; the application-provided
+    // non-zero framing must never survive.
+    expect([null, "0"]).toContain(response.headers.get("content-length"));
+    expect(response.headers.get("x-test")).toBe("kept");
+    expect(await response.text()).toBe("");
+  });
 });

--- a/packages/adapter-vercel/src/index.ts
+++ b/packages/adapter-vercel/src/index.ts
@@ -9,6 +9,7 @@ import {
   jsonResponse,
   classifyRevalidationSkip,
   matchAppRoute,
+  normalizeResponseHeaders,
   preventHeuristicCaching,
   type ModuleRegistry,
   PRACHT_REVALIDATE_ENDPOINT,
@@ -252,6 +253,7 @@ function prepareVercelISGResponse(request: Request, response: Response): Respons
 }
 
 async function writeNodeResponse(res: VercelNodeResponse, response: Response): Promise<void> {
+  response = normalizeResponseHeaders(response);
   res.statusCode = response.status;
   if (response.statusText) res.statusMessage = response.statusText;
 

--- a/packages/adapter-vercel/test/index.test.ts
+++ b/packages/adapter-vercel/test/index.test.ts
@@ -52,6 +52,37 @@ describe("createVercelEdgeHandler under a deploy base", () => {
   });
 });
 
+describe("createVercelEdgeHandler null-body response headers", () => {
+  it.each([
+    ["HEAD", 200],
+    ["GET", 204],
+    ["GET", 205],
+    ["GET", 304],
+  ])("strips content-length from a null-body %s %s response", async (method, status) => {
+    const respond = () =>
+      new Response(null, {
+        status,
+        headers: { "content-length": "42", "x-test": "kept" },
+      });
+    const handler = createVercelEdgeHandler({
+      apiRoutes: resolveApiRoutes(["/src/api/empty.ts"]),
+      app: defineApp({ routes: [] }),
+      registry: {
+        apiModules: {
+          "/src/api/empty.ts": async () => ({ GET: respond, HEAD: respond }),
+        },
+      },
+    });
+
+    const response = await handler(new Request("https://example.com/api/empty", { method }), {});
+
+    expect(response.status).toBe(status);
+    expect(response.headers.get("content-length")).toBeNull();
+    expect(response.headers.get("x-test")).toBe("kept");
+    expect(response.body).toBeNull();
+  });
+});
+
 describe("createVercelNodeListener", () => {
   it("provides waitUntil and drains registered work", async () => {
     let releaseTask: (() => void) | undefined;
@@ -186,6 +217,26 @@ describe("createVercelNodeListener", () => {
     expect(consoleWarn).toHaveBeenCalledWith(expect.stringContaining("uncacheable"));
 
     consoleWarn.mockRestore();
+  });
+
+  it.each([
+    ["HEAD", 200],
+    ["GET", 204],
+    ["GET", 205],
+    ["GET", 304],
+  ])("strips content-length from a null-body %s %s response", async (method, status) => {
+    const { body, headers } = await invokeListener(
+      () =>
+        new Response(null, {
+          status,
+          headers: { "content-length": "42", "x-test": "kept" },
+        }),
+      { headers: { host: "example.com" }, method, url: "/pricing" },
+    );
+
+    expect(headers["content-length"]).toBeUndefined();
+    expect(headers["x-test"]).toBe("kept");
+    expect(body).toBe("");
   });
 });
 

--- a/packages/framework/src/index.ts
+++ b/packages/framework/src/index.ts
@@ -200,6 +200,7 @@ export {
   formatServerTimingHeader,
   Link,
   handlePrachtRequest,
+  normalizeResponseHeaders,
   readHydrationState,
   startApp,
   useBlocker,

--- a/packages/framework/src/runtime-headers.ts
+++ b/packages/framework/src/runtime-headers.ts
@@ -113,6 +113,45 @@ export function isProtocolSwitchResponse(response: Response): boolean {
 }
 
 /**
+ * Remove representation framing from a response that has no representation.
+ *
+ * Fetch permits callers to pair a null body with an explicit
+ * `Content-Length`, including for 204, 205, and 304 responses. Forwarding a
+ * non-zero value to an HTTP transport can leave a client waiting for bytes
+ * that will never arrive (205 is especially easy for generic HTTP parsers to
+ * frame from the header). Keep this at the shared response boundary so dev and
+ * every production adapter make the same choice.
+ *
+ * A HEAD response whose `Response` still carries the corresponding GET body is
+ * intentionally left alone. Its Content-Length is representation metadata,
+ * and the HTTP transport suppresses the body. Only an actually null Fetch body
+ * is normalized here.
+ */
+export function normalizeResponseHeaders(response: Response): Response {
+  if (
+    isProtocolSwitchResponse(response) ||
+    response.body !== null ||
+    !response.headers.has("content-length")
+  ) {
+    return response;
+  }
+
+  try {
+    response.headers.delete("content-length");
+    return response;
+  } catch {
+    // Responses returned by fetch() can carry an immutable header guard.
+    const headers = new Headers(response.headers);
+    headers.delete("content-length");
+    return new Response(null, {
+      status: response.status,
+      statusText: response.statusText,
+      headers,
+    });
+  }
+}
+
+/**
  * Headers that already express a CDN caching policy. Any of them means the
  * author has decided; pracht adds nothing.
  */
@@ -142,29 +181,30 @@ const CDN_CACHE_CONTROL_HEADERS = [
  * route-state JSON, static assets, and user `headers()` exports or middleware.
  */
 export function preventHeuristicCaching(request: Request, response: Response): Response {
-  if (request.method !== "GET" && request.method !== "HEAD") return response;
+  const normalized = normalizeResponseHeaders(response);
+  if (request.method !== "GET" && request.method !== "HEAD") return normalized;
   // A WebSocket handshake carries no cacheable body, and the fallback branch
   // below would destroy it: reconstructing the response drops the `webSocket`
   // handle and the constructor rejects status 101 outright.
-  if (isProtocolSwitchResponse(response)) return response;
+  if (isProtocolSwitchResponse(normalized)) return normalized;
   // Any CDN-targeted policy counts as "the author decided". Honouring only
   // Cloudflare's proprietary header would stamp `private, no-cache` on a
   // response whose author deliberately set the vendor-neutral
   // `CDN-Cache-Control` (RFC 9213) and left `Cache-Control` off on purpose.
   for (const header of CDN_CACHE_CONTROL_HEADERS) {
-    if (response.headers.has(header)) return response;
+    if (normalized.headers.has(header)) return normalized;
   }
 
   try {
-    response.headers.set("cache-control", "private, no-cache");
-    return response;
+    normalized.headers.set("cache-control", "private, no-cache");
+    return normalized;
   } catch {
     // Immutable headers (e.g. a response passed through from `fetch`).
-    const headers = new Headers(response.headers);
+    const headers = new Headers(normalized.headers);
     headers.set("cache-control", "private, no-cache");
-    return new Response(response.body, {
-      status: response.status,
-      statusText: response.statusText,
+    return new Response(normalized.body, {
+      status: normalized.status,
+      statusText: normalized.statusText,
       headers,
     });
   }
@@ -175,11 +215,13 @@ export function withDefaultSecurityHeaders(response: Response): Response {
 
   const headers = new Headers(response.headers);
   applySecurityAndRouteHeaders(headers);
-  return new Response(response.body, {
-    status: response.status,
-    statusText: response.statusText,
-    headers,
-  });
+  return normalizeResponseHeaders(
+    new Response(response.body, {
+      status: response.status,
+      statusText: response.statusText,
+      headers,
+    }),
+  );
 }
 
 /**
@@ -228,11 +270,13 @@ export function withRouteResponseHeaders(
 
   const headers = new Headers(response.headers);
   applySecurityAndRouteHeaders(headers, options);
-  return new Response(response.body, {
-    status: response.status,
-    statusText: response.statusText,
-    headers,
-  });
+  return normalizeResponseHeaders(
+    new Response(response.body, {
+      status: response.status,
+      statusText: response.statusText,
+      headers,
+    }),
+  );
 }
 
 function getRouteStateCacheControl(loaderCache: LoaderCache | undefined): string {

--- a/packages/framework/src/runtime.ts
+++ b/packages/framework/src/runtime.ts
@@ -1,6 +1,10 @@
 import { matchAppRoute } from "./app.ts";
 import { SAFE_METHODS } from "./runtime-constants.ts";
-import { withDefaultSecurityHeaders, withRouteResponseHeaders } from "./runtime-headers.ts";
+import {
+  normalizeResponseHeaders,
+  withDefaultSecurityHeaders,
+  withRouteResponseHeaders,
+} from "./runtime-headers.ts";
 import {
   createNotFoundMatch,
   renderPage,
@@ -31,6 +35,12 @@ export type { HandlePrachtRequestOptions };
  *   4. The page router.
  */
 export async function handlePrachtRequest<TContext>(
+  options: HandlePrachtRequestOptions<TContext>,
+): Promise<Response> {
+  return normalizeResponseHeaders(await handlePrachtRequestPipeline(options));
+}
+
+async function handlePrachtRequestPipeline<TContext>(
   options: HandlePrachtRequestOptions<TContext>,
 ): Promise<Response> {
   const prepared = await createRequestContext(options);
@@ -94,6 +104,7 @@ export {
 export {
   applyDefaultSecurityHeaders,
   isProtocolSwitchResponse,
+  normalizeResponseHeaders,
   preventHeuristicCaching,
 } from "./runtime-headers.ts";
 export { formatServerTimingHeader, type PrachtPhaseTimings } from "./runtime-timing.ts";

--- a/packages/framework/src/server.ts
+++ b/packages/framework/src/server.ts
@@ -55,6 +55,7 @@ export {
   formatServerTimingHeader,
   handlePrachtRequest,
   isProtocolSwitchResponse,
+  normalizeResponseHeaders,
   preventHeuristicCaching,
   PrachtRuntimeProvider,
 } from "./runtime.ts";

--- a/packages/framework/test/security.test.ts
+++ b/packages/framework/test/security.test.ts
@@ -4,6 +4,7 @@ import {
   buildPathFromSegments,
   defineApp,
   handlePrachtRequest,
+  normalizeResponseHeaders,
   redirect,
   resolveApiRoutes,
   resolveApp,
@@ -12,6 +13,31 @@ import {
 import { applyHeaders, assertSafeHeaderValue } from "../src/runtime-headers.ts";
 import { buildRedirectResponse } from "../src/runtime-middleware.ts";
 import { shouldExposeServerErrors } from "../src/runtime-errors.ts";
+
+describe("normalizeResponseHeaders", () => {
+  it.each([
+    ["HEAD", 200],
+    ["204", 204],
+    ["205", 205],
+    ["304", 304],
+  ])("removes content-length from a null-body %s response", (_label, status) => {
+    const response = normalizeResponseHeaders(
+      new Response(null, { status, headers: { "content-length": "42", "x-test": "kept" } }),
+    );
+
+    expect(response.headers.get("content-length")).toBeNull();
+    expect(response.headers.get("x-test")).toBe("kept");
+    expect(response.body).toBeNull();
+  });
+
+  it("preserves representation metadata when the Response carries a body", () => {
+    const response = normalizeResponseHeaders(
+      new Response("representation", { headers: { "content-length": "14" } }),
+    );
+
+    expect(response.headers.get("content-length")).toBe("14");
+  });
+});
 
 describe("buildRedirectResponse", () => {
   const baseUrl = "http://localhost/page";

--- a/packages/vite-plugin/src/plugin-dev-ssr.ts
+++ b/packages/vite-plugin/src/plugin-dev-ssr.ts
@@ -11,7 +11,11 @@ import type {
   ResolvedRoute,
   RouteErrorContext,
 } from "@pracht/core";
-import { applyDefaultSecurityHeaders, resolveRegistryModule } from "@pracht/core";
+import {
+  applyDefaultSecurityHeaders,
+  normalizeResponseHeaders,
+  resolveRegistryModule,
+} from "@pracht/core";
 import type { AgentTrafficBuffer } from "./agent-traffic.ts";
 import { createAgentTrafficBuffer } from "./agent-traffic.ts";
 import {
@@ -237,39 +241,41 @@ export function createDevSSRMiddleware(
       // otherwise fall through to the plain-text fallback.
       let capturedRouteError = false;
       let routeErrorContext: RouteErrorContext | undefined;
-      const response = await framework.handlePrachtRequest({
-        app: serverMod.resolvedApp,
-        registry: serverMod.registry,
-        request: webRequest,
-        debugErrors: true,
-        onRouteError: (error: unknown, _requestPath: string, context?: RouteErrorContext) => {
-          capturedRouteError = true;
-          routeError = error;
-          routeErrorContext = context;
-          reportedError = error;
-          hasReportedError = true;
-          logDevRequestError(server, {
-            context,
-            error,
-            path: requestUrl.pathname,
-          });
-        },
-        onApiError: (error: unknown, _requestPath: string, context?: RouteErrorContext) => {
-          reportedError = error;
-          hasReportedError = true;
-          logDevRequestError(server, {
-            context,
-            error,
-            path: requestUrl.pathname,
-          });
-        },
-        clientEntryUrl: withDevBase(CLIENT_BROWSER_PATH),
-        islandsEntryUrl: withDevBase(ISLANDS_CLIENT_BROWSER_PATH),
-        islandsBootstrapRequired: serverMod.islandsBootstrapRequired === true,
-        apiRoutes: serverMod.apiRoutes,
-        timings,
-        onCapabilityAudit: agentTraffic.record,
-      });
+      const response = normalizeResponseHeaders(
+        await framework.handlePrachtRequest({
+          app: serverMod.resolvedApp,
+          registry: serverMod.registry,
+          request: webRequest,
+          debugErrors: true,
+          onRouteError: (error: unknown, _requestPath: string, context?: RouteErrorContext) => {
+            capturedRouteError = true;
+            routeError = error;
+            routeErrorContext = context;
+            reportedError = error;
+            hasReportedError = true;
+            logDevRequestError(server, {
+              context,
+              error,
+              path: requestUrl.pathname,
+            });
+          },
+          onApiError: (error: unknown, _requestPath: string, context?: RouteErrorContext) => {
+            reportedError = error;
+            hasReportedError = true;
+            logDevRequestError(server, {
+              context,
+              error,
+              path: requestUrl.pathname,
+            });
+          },
+          clientEntryUrl: withDevBase(CLIENT_BROWSER_PATH),
+          islandsEntryUrl: withDevBase(ISLANDS_CLIENT_BROWSER_PATH),
+          islandsBootstrapRequired: serverMod.islandsBootstrapRequired === true,
+          apiRoutes: serverMod.apiRoutes,
+          timings,
+          onCapabilityAudit: agentTraffic.record,
+        }),
+      );
 
       // A 404 from the runtime normally falls through to Vite (which has
       // already had its shot at static files, since this middleware is

--- a/packages/vite-plugin/test/dev-response.test.ts
+++ b/packages/vite-plugin/test/dev-response.test.ts
@@ -54,6 +54,7 @@ async function request(
   options: {
     apiResponse?: () => Response;
     loaderCookies?: string[];
+    method?: string;
     url?: string;
   } = {},
 ) {
@@ -66,6 +67,9 @@ async function request(
           GET: () =>
             options.apiResponse?.() ??
             new Response("ok", { headers: { "content-type": "text/plain" } }),
+          HEAD: () =>
+            options.apiResponse?.() ??
+            new Response(null, { headers: { "content-type": "text/plain" } }),
         }),
       },
       routeModules: {
@@ -101,7 +105,7 @@ async function request(
   const response = createResponse();
   const req = {
     headers: { accept: "*/*", host: "localhost" },
-    method: "GET",
+    method: options.method ?? "GET",
     url: options.url ?? "/api/download",
   } as unknown as IncomingMessage;
 
@@ -142,6 +146,24 @@ describe("writeDevResponseHeaders", () => {
 });
 
 describe("dev SSR response body", () => {
+  it.each([
+    ["HEAD", 200],
+    ["GET", 204],
+    ["GET", 205],
+    ["GET", 304],
+  ])("strips content-length from a null-body %s %s response", async (method, status) => {
+    const response = await request({
+      apiResponse: () =>
+        new Response(null, { status, headers: { "content-length": "42", "x-test": "kept" } }),
+      method,
+    });
+
+    expect(response.res.statusCode).toBe(status);
+    expect(response.headers["content-length"]).toBeUndefined();
+    expect(response.headers["x-test"]).toBe("kept");
+    expect(response.bytes.length).toBe(0);
+  });
+
   it("forwards a binary API body byte for byte", async () => {
     const response = await request({
       apiResponse: () =>


### PR DESCRIPTION
Closes #363. This adds a shared response-header policy that strips Content-Length from actual null-body responses while preserving body-backed HEAD metadata and protocol-switch identity. The policy is covered across core, development, Node, Cloudflare, Netlify, and both Vercel response paths for HEAD, 204, 205, and 304 responses. Internal and public adapter documentation and patch changesets are included, and pnpm run verify --check passes.