### PR TITLE
fix(dev): log API route failures

### DIFF
--- a/.changeset/log-api-route-errors.md
+++ b/.changeset/log-api-route-errors.md
@@ -1,0 +1,7 @@
+---
+"@pracht/core": patch
+"@pracht/capabilities": patch
+"@pracht/vite-plugin": patch
+---
+
+Log API handler and middleware failures in the dev terminal with phase and source-file attribution.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -398,16 +398,20 @@ difference here only shows up after deploy.
   bytes, so a PDF, an image, or a `Uint8Array` from an API route is
   byte-identical in dev and production. `text/event-stream` keeps its own
   earlier branch: it must stream and never buffer.
-- A loader, middleware, or render failure is logged once to
+- A page loader, page middleware, render, API handler, or API middleware failure is logged once to
   `server.config.logger`, with phase, route id, request path, and message —
-  plus `file:line:column` when the error blames a module of the user's
+  plus the matched route/loader/middleware source file, or `file:line:column`
+  when the error blames a module of the user's
   (`describeAnnotatedUserModule()`), which is how a route file that will not
   compile gets named: it fails while the virtual server module is evaluated, so
   there is no route context to report. The overlay only reaches a document
   navigation; a route-state fetch, a `curl`, or a test run would otherwise see
-  a 500 and nothing server-side. A body stream that fails after the headers are
-  on the wire is logged there too — destroying the socket is all that is left,
-  so the line is the only signal. Expected 404s are not logged.
+  a 500 and nothing server-side. API failures use the dedicated `onApiError`
+  hook and keep their JSON/plain-text response; only unclaimed page failures
+  use `onRouteError` to opt into the browser overlay. A body stream that fails
+  after the headers are on the wire is logged there too — destroying the socket
+  is all that is left, so the line is the only signal. Expected 404s are not
+  logged.
 - The stack is appended only when the failure names no user module, or under
   `DEBUG` (`shouldIncludeDevErrorStack()`). A route/loader/shell file in
   `RouteErrorContext`, Vite's `id`/`loc.file` on a transform error, or a stack
@@ -856,6 +860,13 @@ own import is still linked. Overlay responses retain the phase timings already
 collected for the dev `Server-Timing` header. Every such failure is also logged
 once to the dev terminal (see "Writing the response" above) — the overlay only
 reaches a browser navigating to a document.
+
+API handler and API middleware failures are already normalized inside the
+runtime, so they cannot reach the dev middleware's outer catch either. The dev
+middleware passes `onApiError` to log them with the same phase, route file, and
+middleware-file context while leaving the API response body and content type
+unchanged. This callback is separate from `onRouteError` so an API failure can
+never satisfy the page-overlay handoff.
 
 Four ergonomics features are built in:
 

--- a/examples/docs/src/routes/docs/api-routes.md
+++ b/examples/docs/src/routes/docs/api-routes.md
@@ -79,6 +79,15 @@ export const app = defineApp({
 
 API middleware runs before the handler, just like page middleware runs before loaders.
 
+## Development Errors
+
+When an API handler or API middleware throws during `pracht dev`, the request
+still receives the normal API error response, and the terminal logs the raw
+failure once. The log identifies the `api` or `middleware` phase together with
+the matched API route or middleware source file, so failures from `fetch()`,
+`curl`, and tests remain visible even though API responses do not use the page
+error overlay.
+
 ---
 
 ## Same-Origin Protection (CSRF)

--- a/packages/capabilities/src/server/middleware.ts
+++ b/packages/capabilities/src/server/middleware.ts
@@ -30,6 +30,8 @@ export async function runMiddlewareChain<TContext>(options: {
   signal: AbortSignal;
   url: URL;
   terminal: () => Promise<Response>;
+  /** @internal Report the middleware where a chain failure originated. */
+  onMiddlewareError?: (error: unknown, file: string) => void;
 }): Promise<Response> {
   const { middlewareFiles, terminal } = options;
 
@@ -56,52 +58,71 @@ export async function runMiddlewareChain<TContext>(options: {
     if (i >= middlewareFiles.length) {
       return terminal();
     }
-    const mwModule = await modulePromises[i];
-    // A registered middleware module that exports nothing usable used to be
-    // skipped silently. That fails *open*: a renamed export or a `default`
-    // export leaves an auth gate wired in the manifest but absent at runtime,
-    // and every static check still passes. Refuse to serve instead.
-    if (typeof mwModule?.middleware !== "function") {
-      const message =
-        `Middleware "${middlewareFiles[i]}" does not export a \`middleware\` function. ` +
-        "Middleware modules must `export const middleware: MiddlewareFn = (args, next) => …` " +
-        "(a default export is not used).";
-      // Failing closed is right, but silently failing closed is an outage a
-      // reviewer has to bisect: the likely trigger is a refactor renaming the
-      // export, which takes down every route carrying this middleware at
-      // deploy time. Sanitized 5xx responses say nothing, so log the cause
-      // once per module — the same treatment capability-registry failures get.
-      warnMissingMiddlewareExport(middlewareFiles[i], message);
-      throw new Error(message);
-    }
+    const middlewareFile = middlewareFiles[i];
+    const noDownstreamError = Symbol("no downstream middleware error");
+    let downstreamError: unknown = noDownstreamError;
 
-    let calledNext = false;
-    const next = (): Promise<Response> => {
-      if (calledNext) {
-        throw new Error(`Middleware "${middlewareFiles[i]}" called next() multiple times`);
+    try {
+      const mwModule = await modulePromises[i];
+      // A registered middleware module that exports nothing usable used to be
+      // skipped silently. That fails *open*: a renamed export or a `default`
+      // export leaves an auth gate wired in the manifest but absent at runtime,
+      // and every static check still passes. Refuse to serve instead.
+      if (typeof mwModule?.middleware !== "function") {
+        const message =
+          `Middleware "${middlewareFile}" does not export a \`middleware\` function. ` +
+          "Middleware modules must `export const middleware: MiddlewareFn = (args, next) => …` " +
+          "(a default export is not used).";
+        // Failing closed is right, but silently failing closed is an outage a
+        // reviewer has to bisect: the likely trigger is a refactor renaming the
+        // export, which takes down every route carrying this middleware at
+        // deploy time. Sanitized 5xx responses say nothing, so log the cause
+        // once per module — the same treatment capability-registry failures get.
+        warnMissingMiddlewareExport(middlewareFile, message);
+        throw new Error(message);
       }
-      calledNext = true;
-      return dispatch(i + 1);
-    };
 
-    const args: MiddlewareArgs<TContext> = {
-      request: options.request,
-      params: options.params,
-      pathname: options.pathname,
-      context: options.context,
-      signal: options.signal,
-      url: options.url,
-      route: options.route,
-    };
+      let calledNext = false;
+      const next = async (): Promise<Response> => {
+        if (calledNext) {
+          throw new Error(`Middleware "${middlewareFile}" called next() multiple times`);
+        }
+        calledNext = true;
+        try {
+          return await dispatch(i + 1);
+        } catch (error: unknown) {
+          downstreamError = error;
+          throw error;
+        }
+      };
 
-    const response = await mwModule.middleware(args, next);
-    if (!(response instanceof Response)) {
-      throw new Error(
-        `Middleware "${middlewareFiles[i]}" did not return a Response. ` +
-          "Middleware must return the result of next() or a short-circuit Response.",
-      );
+      const args: MiddlewareArgs<TContext> = {
+        request: options.request,
+        params: options.params,
+        pathname: options.pathname,
+        context: options.context,
+        signal: options.signal,
+        url: options.url,
+        route: options.route,
+      };
+
+      const response = await mwModule.middleware(args, next);
+      if (!(response instanceof Response)) {
+        throw new Error(
+          `Middleware "${middlewareFile}" did not return a Response. ` +
+            "Middleware must return the result of next() or a short-circuit Response.",
+        );
+      }
+      return response;
+    } catch (error: unknown) {
+      // A downstream failure passes through every upstream middleware frame.
+      // Attribute it only at its origin; if this middleware catches it and
+      // throws a different value, the replacement belongs to this frame.
+      if (downstreamError === noDownstreamError || error !== downstreamError) {
+        options.onMiddlewareError?.(error, middlewareFile);
+      }
+      throw error;
     }
-    return response;
   };
 
   return dispatch(0);

--- a/packages/framework/src/runtime-errors.ts
+++ b/packages/framework/src/runtime-errors.ts
@@ -20,18 +20,20 @@ export interface PrachtRuntimeDiagnostics {
 }
 
 /**
- * Route metadata handed to `onRouteError` alongside the raw error.
+ * Route metadata handed to `onRouteError` or `onApiError` alongside the raw
+ * error.
  *
  * The response body deliberately hides these details outside `debugErrors`,
  * so a caller that owns the surrounding surface — prerendering, the dev
  * server's error overlay — would otherwise have to re-derive which route
- * failed, in which phase, and whether a declared boundary owns the response.
+ * failed, in which phase, and, for a page route, whether a declared boundary
+ * owns the response.
  * Unlike `PrachtRuntimeDiagnostics` it carries no status: the error has not
  * been normalized into a response yet.
  */
 export interface RouteErrorContext {
   phase: PrachtRuntimeDiagnosticPhase;
-  /** Which declared ErrorBoundary will receive the failure, when present. */
+  /** Which declared page ErrorBoundary will receive the failure, when present. */
   errorBoundary?: "route" | "shell";
   routeId?: string;
   routePath?: string;

--- a/packages/framework/src/runtime-page.ts
+++ b/packages/framework/src/runtime-page.ts
@@ -709,6 +709,9 @@ export async function renderPage<TContext>(
       signal: requestSignal,
       url: ctx.url,
       terminal,
+      onMiddlewareError: () => {
+        job.phase = "middleware";
+      },
     });
     if (timings) {
       timings.mw = performance.now() - chainStart - (timings.render ?? 0) - (timings.loader ?? 0);

--- a/packages/framework/src/runtime-request.ts
+++ b/packages/framework/src/runtime-request.ts
@@ -129,6 +129,14 @@ export interface HandlePrachtRequestOptions<TContext = unknown> {
    * passes this so a failing SSG page can name what actually threw.
    */
   onRouteError?: (error: unknown, requestPath: string, context?: RouteErrorContext) => void;
+  /**
+   * Called with the raw error whenever an API handler or app-level API
+   * middleware fails, before it is normalized into a response. The context
+   * uses the same phase and source-file attribution as `onRouteError` so
+   * adapters and development servers can report API failures without parsing
+   * the sanitized response body.
+   */
+  onApiError?: (error: unknown, requestPath: string, context?: RouteErrorContext) => void;
 }
 
 /**
@@ -672,6 +680,9 @@ export async function dispatchApi<TContext>(
       signal: requestSignal,
       url,
       terminal: apiTerminal,
+      onMiddlewareError: () => {
+        currentPhase = "middleware";
+      },
     });
     return withDefaultSecurityHeaders(withEnhancedCapabilityFormRedirect(response, request));
   } catch (error: unknown) {
@@ -687,6 +698,13 @@ export async function dispatchApi<TContext>(
         thrownResponseFailure = normalizeError;
       }
     }
+
+    options.onApiError?.(thrownResponseFailure ?? error, ctx.requestPath, {
+      middlewareFiles: [...apiMiddlewareFiles],
+      phase: currentPhase,
+      routeFile: apiMatch.route.file,
+      routePath: apiMatch.route.path,
+    });
 
     return renderApiErrorResponse({
       error: thrownResponseFailure ?? error,

--- a/packages/framework/test/runtime.test.ts
+++ b/packages/framework/test/runtime.test.ts
@@ -165,6 +165,93 @@ describe("handlePrachtRequest API middleware", () => {
     await expect(response.text()).resolves.not.toContain("reached");
   });
 
+  it("reports thrown handlers with API route attribution", async () => {
+    const app = defineApp({
+      api: { middleware: ["apiAuth"] },
+      middleware: { apiAuth: "./middleware/api-auth.ts" },
+      routes: [route("/", "./routes/home.tsx")],
+    });
+    const failure = new Error("handler exploded");
+    let captured: unknown;
+    let context: Record<string, unknown> | undefined;
+
+    const response = await handlePrachtRequest({
+      apiRoutes: resolveApiRoutes(["/src/api/users/[id].ts"]),
+      app,
+      registry: {
+        apiModules: {
+          "/src/api/users/[id].ts": async () => ({
+            GET: async () => {
+              throw failure;
+            },
+          }),
+        },
+        middlewareModules: {
+          "./middleware/api-auth.ts": async () => ({
+            middleware: (_args: unknown, next: () => Promise<Response>) => next(),
+          }),
+        },
+      },
+      request: new Request("http://localhost/api/users/42?source=test"),
+      onApiError: (error, requestPath, apiContext) => {
+        captured = { error, requestPath };
+        context = apiContext as unknown as Record<string, unknown>;
+      },
+    });
+
+    expect(response.status).toBe(500);
+    expect(captured).toEqual({ error: failure, requestPath: "/api/users/42?source=test" });
+    expect(context).toEqual({
+      middlewareFiles: ["./middleware/api-auth.ts"],
+      phase: "api",
+      routeFile: "/src/api/users/[id].ts",
+      routePath: "/api/users/:id",
+    });
+  });
+
+  it("reports API middleware failures with middleware attribution", async () => {
+    const app = defineApp({
+      api: { middleware: ["apiAuth"] },
+      middleware: { apiAuth: "./middleware/api-auth.ts" },
+      routes: [route("/", "./routes/home.tsx")],
+    });
+    const failure = new Error("middleware exploded");
+    let captured: unknown;
+    let context: Record<string, unknown> | undefined;
+
+    const response = await handlePrachtRequest({
+      apiRoutes: resolveApiRoutes(["/src/api/health.ts"]),
+      app,
+      registry: {
+        apiModules: {
+          "/src/api/health.ts": async () => ({ GET: async () => Response.json({ ok: true }) }),
+        },
+        middlewareModules: {
+          "./middleware/api-auth.ts": async () => ({
+            middleware: async (_args: unknown, next: () => Promise<Response>) => {
+              await next();
+              throw failure;
+            },
+          }),
+        },
+      },
+      request: new Request("http://localhost/api/health"),
+      onApiError: (error, _requestPath, apiContext) => {
+        captured = error;
+        context = apiContext as unknown as Record<string, unknown>;
+      },
+    });
+
+    expect(response.status).toBe(500);
+    expect(captured).toBe(failure);
+    expect(context).toEqual({
+      middlewareFiles: ["./middleware/api-auth.ts"],
+      phase: "middleware",
+      routeFile: "/src/api/health.ts",
+      routePath: "/api/health",
+    });
+  });
+
   it("uses 303 for API middleware redirects on unsafe methods", async () => {
     const app = defineApp({
       api: {

--- a/packages/vite-plugin/src/plugin-dev-ssr.ts
+++ b/packages/vite-plugin/src/plugin-dev-ssr.ts
@@ -254,6 +254,15 @@ export function createDevSSRMiddleware(
             path: requestUrl.pathname,
           });
         },
+        onApiError: (error: unknown, _requestPath: string, context?: RouteErrorContext) => {
+          reportedError = error;
+          hasReportedError = true;
+          logDevRequestError(server, {
+            context,
+            error,
+            path: requestUrl.pathname,
+          });
+        },
         clientEntryUrl: withDevBase(CLIENT_BROWSER_PATH),
         islandsEntryUrl: withDevBase(ISLANDS_CLIENT_BROWSER_PATH),
         islandsBootstrapRequired: serverMod.islandsBootstrapRequired === true,
@@ -442,7 +451,9 @@ function logDevRequestError(
     // context — it happened before anything matched — so without this a route
     // file's syntax error names no file at all on a route-state poll, where
     // there is no overlay to fall back on.
-    file: describeAnnotatedUserModule(error, server.config.root),
+    file:
+      describeAnnotatedUserModule(error, server.config.root) ??
+      describeContextUserModule(options.context),
     message: error instanceof Error ? error.message : String(error),
     path: options.path,
     phase: options.context?.phase,
@@ -460,6 +471,16 @@ function logDevRequestError(
   server.config.logger.error(wantsStack && stack ? `${line}\n${stack}` : line, {
     timestamp: true,
   });
+}
+
+/** Source modules the runtime matched before a handled request failure. */
+function describeContextUserModule(context: RouteErrorContext | undefined): string | undefined {
+  if (!context) return undefined;
+  if (context.phase === "middleware" && context.middlewareFiles?.length) {
+    return context.middlewareFiles.join(", ");
+  }
+  if (context.phase === "loader" && context.loaderFile) return context.loaderFile;
+  return context.routeFile;
 }
 
 /**

--- a/packages/vite-plugin/test/dev-error-overlay.test.ts
+++ b/packages/vite-plugin/test/dev-error-overlay.test.ts
@@ -6,7 +6,7 @@ import { describe, expect, it, vi } from "vitest";
 
 import * as frameworkServer from "../../framework/src/server.ts";
 import * as errorOverlay from "../../framework/src/error-overlay.ts";
-import { defineApp, resolveApp, route } from "../../framework/src/app.ts";
+import { defineApp, resolveApiRoutes, resolveApp, route } from "../../framework/src/app.ts";
 import {
   createDevSSRMiddleware,
   describeAnnotatedUserModule,
@@ -63,6 +63,8 @@ function createResponse() {
 async function render(
   routeModule: Record<string, unknown>,
   options: {
+    apiMiddlewareModule?: Record<string, unknown>;
+    apiModule?: Record<string, unknown>;
     request?: IncomingMessage;
     serverModuleError?: unknown;
     shellModule?: Record<string, unknown>;
@@ -78,9 +80,15 @@ async function render(
       })
     : route("/boom", "./routes/boom.tsx", { id: "boom", render: "ssr" });
   const serverMod = {
-    apiRoutes: [],
+    apiRoutes: options.apiModule ? resolveApiRoutes(["/src/api/boom.ts"]) : [],
     islandsBootstrapRequired: false,
     registry: {
+      apiModules: options.apiModule
+        ? { "/src/api/boom.ts": async () => options.apiModule }
+        : undefined,
+      middlewareModules: options.apiMiddlewareModule
+        ? { "./middleware/api-auth.ts": async () => options.apiMiddlewareModule }
+        : undefined,
       routeModules: { "./routes/boom.tsx": async () => routeModule },
       shellModules: options.shellModule
         ? { "./shells/plain.tsx": async () => options.shellModule }
@@ -88,6 +96,10 @@ async function render(
     },
     resolvedApp: resolveApp(
       defineApp({
+        api: options.apiMiddlewareModule ? { middleware: ["apiAuth"] } : undefined,
+        middleware: options.apiMiddlewareModule
+          ? { apiAuth: "./middleware/api-auth.ts" }
+          : undefined,
         routes: [routeDefinition],
         shells: options.shellModule ? { plain: "./shells/plain.tsx" } : undefined,
       }),
@@ -122,7 +134,11 @@ async function render(
     fellThrough = resolve;
   });
   const next = vi.fn(() => fellThrough());
-  await createDevSSRMiddleware(server)(options.request ?? createRequest("/boom"), res, next);
+  await createDevSSRMiddleware(server)(
+    options.request ?? createRequest(options.apiModule ? "/api/boom" : "/boom"),
+    res,
+    next,
+  );
   await Promise.race([finished, fallthrough]);
   return { ...read(), logger, next };
 }
@@ -368,6 +384,53 @@ describe("dev SSR error overlay", () => {
     } finally {
       vi.unstubAllEnvs();
     }
+  });
+});
+
+describe("dev API error reporting", () => {
+  it("logs thrown API handlers with their phase and route file", async () => {
+    const state = await render(
+      { Component: () => null },
+      {
+        apiModule: {
+          GET: () => {
+            throw new Error("API handler exploded");
+          },
+        },
+      },
+    );
+
+    expect(state.statusCode).toBe(500);
+    expect(state.headers["content-type"]).toContain("application/json");
+    expect(state.body).not.toContain("pracht error");
+    expect(state.logger.error).toHaveBeenCalledTimes(1);
+    const [line] = state.logger.error.mock.calls[0] as [string];
+    expect(line).toContain("[pracht] api error");
+    expect(line).toContain("/src/api/boom.ts");
+    expect(line).toContain("/api/boom");
+    expect(line).toContain("API handler exploded");
+  });
+
+  it("logs API middleware failures with their phase and middleware file", async () => {
+    const state = await render(
+      { Component: () => null },
+      {
+        apiMiddlewareModule: {
+          middleware: async (_args: unknown, next: () => Promise<Response>) => {
+            await next();
+            throw new Error("API middleware exploded");
+          },
+        },
+        apiModule: { GET: () => Response.json({ ok: true }) },
+      },
+    );
+
+    expect(state.statusCode).toBe(500);
+    expect(state.logger.error).toHaveBeenCalledTimes(1);
+    const [line] = state.logger.error.mock.calls[0] as [string];
+    expect(line).toContain("[pracht] middleware error");
+    expect(line).toContain("./middleware/api-auth.ts");
+    expect(line).toContain("API middleware exploded");
   });
 });
 


### PR DESCRIPTION
## Summary

- Log thrown API handlers and API middleware failures once in the dev terminal with phase and source-file attribution.
- Preserve normal API error responses while keeping handler errors distinct from post-`next()` middleware failures.
- Closes #364.

## Testing

- [x] `pnpm run verify -- --check`

## Checklist

- [x] Docs updated if needed
- [x] Skills updated if needed — N/A
- [x] Concise, user-facing changeset added if published packages changed