### PR TITLE
docs(capabilities): type standalone examples

### DIFF
--- a/.changeset/typed-capability-examples.md
+++ b/.changeset/typed-capability-examples.md
@@ -1,0 +1,5 @@
+---
+"@pracht/capabilities": patch
+---
+
+Capability examples now compile with typed run inputs.

--- a/docs/CAPABILITIES.md
+++ b/docs/CAPABILITIES.md
@@ -106,6 +106,10 @@ owns the registered tools' lifetime; abort it when an SPA scope unmounts or is
 replaced. The public setup guide lives at
 <https://pracht.resynapse.dev/docs/standalone-capabilities>.
 
+Standalone capability modules follow the same typing rule as framework-hosted
+ones: annotate `run()` with `CapabilityRunArgs<Input>` to type its input while
+preserving inference for the concrete output.
+
 Skipping this is not a quiet failure but it *is* a confusing one: capability
 dispatch answers `500 internal_error`, and because the modules cannot be
 loaded, every inspection surface reads their metadata as unknown — the dev

--- a/examples/docs/src/routes/docs/standalone-capabilities.md
+++ b/examples/docs/src/routes/docs/standalone-capabilities.md
@@ -25,7 +25,11 @@ npm install @pracht/capabilities
 Wrap an existing service function with the same contract a Pracht app uses:
 
 ```ts [capabilities/notes-search.ts]
-import { defineCapability } from "@pracht/capabilities";
+import { defineCapability, type CapabilityRunArgs } from "@pracht/capabilities";
+
+interface SearchInput {
+  query: string;
+}
 
 export default defineCapability({
   title: "Search notes",
@@ -43,11 +47,13 @@ export default defineCapability({
   },
   effect: "read",
   expose: { http: true, mcp: true },
-  async run({ input }) {
+  async run({ input }: CapabilityRunArgs<SearchInput>) {
     return { notes: await searchNotes(input.query) };
   },
 });
 ```
+
+Annotating `run()` with `CapabilityRunArgs<Input>` types the input while preserving inference for the concrete output. The standalone host uses the same capability object and typing rule as a Pracht app.
 
 ## Mount the Host
 

--- a/packages/capabilities/README.md
+++ b/packages/capabilities/README.md
@@ -8,7 +8,12 @@ class (`read` / `write` / `destructive`), named middleware, and a server-only
 endpoint, a remote MCP tool, and a WebMCP page tool for in-browser agents.
 
 ```ts
-import { defineCapability } from "@pracht/capabilities";
+import { defineCapability, type CapabilityRunArgs } from "@pracht/capabilities";
+
+interface SearchInput {
+  query: string;
+  limit: number;
+}
 
 export default defineCapability({
   title: "Search notes",
@@ -29,7 +34,7 @@ export default defineCapability({
   },
   effect: "read",
   expose: { http: true, webmcp: true },
-  async run({ input, context, request, signal }) {
+  async run({ input, context, request, signal }: CapabilityRunArgs<SearchInput>) {
     return { notes: await searchNotes(input.query, input.limit) };
   },
 });


### PR DESCRIPTION
## Summary

- Make standalone capability examples use `CapabilityRunArgs` so copied examples compile under strict TypeScript.
- Relevant issue: N/A.

## Testing

- [x] `pnpm run verify` (build, format, lint, typecheck, test, e2e)

## Checklist

- [x] Docs updated if needed
- [x] Skills updated if needed — N/A; the existing capability skill already uses `CapabilityRunArgs`.
- [x] Concise, user-facing changeset added if published packages changed
