### PR TITLE
feat(capabilities): attribute audited MCP calls to OAuth accounts

### DIFF
--- a/.changeset/audit-oauth-account.md
+++ b/.changeset/audit-oauth-account.md
@@ -1,0 +1,7 @@
+---
+"@pracht/capabilities": minor
+"@pracht/core": minor
+"@pracht/vite-plugin": patch
+---
+
+Capability audit events and the dev Agents panel identify the verified OAuth account behind remote MCP calls and nested operations.

--- a/docs/AGENT_TRUST.md
+++ b/docs/AGENT_TRUST.md
@@ -200,11 +200,7 @@ overlay cannot preserve their internal-slot identity. The two identities
 compose: `agent` is the caller's software identity, `tokenAuth` is the account
 it acts for.
 
-`CapabilityAuditEvent` does not yet carry `tokenAuth`, so an audited MCP
-dispatch names the calling software but not the account behind it. Capture the
-principal in named middleware or capability code while request context is
-available and send it to the same audit sink until the event gains a field for
-it.
+`CapabilityAuditEvent.tokenAuth` carries a frozen `{ subject, clientId }` summary of the verified OAuth principal for authenticated MCP calls and their nested server invocations. Other dispatches carry `null`. Tokens, scopes, and arbitrary claims are excluded. Attribution comes from the authenticated transport, so replacement application contexts cannot forge it. The dev Agents panel and the showcase audit table display the account alongside the agent software identity.
 
 Full configuration, the metadata document, the challenge table, the JWKS recipe,
 and the fail-closed rules live in
@@ -810,6 +806,7 @@ const stopAuditLog = addCapabilityAuditListener("audit-log", (event) => {
       status: event.status,
       durationMs: Math.round(event.durationMs),
       agent: event.agent?.agentDomain ?? event.agent?.keyId ?? null,
+      account: event.tokenAuth,
     }),
   );
 });

--- a/docs/REMOTE_MCP.md
+++ b/docs/REMOTE_MCP.md
@@ -617,12 +617,6 @@ format is documented in
 - **Authorization-server duties.** Pracht is the resource server
   ([above](#oauth-resource-server-metadata)); token issuance, dynamic client
   registration (RFC 7591), and consent UI stay with your identity provider.
-- **The OAuth subject in audit events.** `CapabilityAuditEvent` carries the Web
-  Bot Auth `agent`, not `context.tokenAuth`, so an audited MCP dispatch names
-  the calling software but not the account it acted for. Capture the principal
-  in named middleware or capability code while request context is available and
-  send it to the same audit sink until the event gains a field for it — a
-  follow-up.
 - **`resources/*` and `prompts/*`** — only `tools/*` is projected.
 - **The `2026-07-28` wire profile.** It replaces the initialization exchange
   with self-describing requests and requires its own header/result codec; the

--- a/examples/docs/src/routes/docs/agent-trust.md
+++ b/examples/docs/src/routes/docs/agent-trust.md
@@ -128,7 +128,7 @@ export const app = defineApp({
 
 pracht stays the resource server. It does not validate JWTs, fetch JWKS, or issue tokens — the rule is *define the authentication hook first, ship deployment recipes before owning an authorization server*. The verified principal lands on `context.tokenAuth` as a frozen snapshot on a non-writable, non-configurable framework-owned field on a fresh request-local overlay, the same shape as `context.agent`. The adapter-supplied base context remains unchanged even when it is reused, frozen, or sealed, so one request's OAuth principal cannot become another request's identity. Native built-ins such as `Map` and `Date` must be wrapped in an ordinary request context because an overlay cannot preserve their internal-slot identity. The two compose: `agent` is the caller's software identity, `tokenAuth` is the account it acts for.
 
-`CapabilityAuditEvent` does not yet carry `tokenAuth`, so audited MCP dispatches name the calling software but not the account behind it. Capture the principal in named middleware or capability code while request context is available and send it to the same audit sink until the event gains a field for it.
+`CapabilityAuditEvent.tokenAuth` carries a frozen `{ subject, clientId }` summary of the verified OAuth principal for authenticated MCP calls and their nested server invocations. Other dispatches carry `null`. Tokens, scopes, and arbitrary claims are excluded. Attribution comes from the authenticated transport, so replacement application contexts cannot forge it. The dev Agents panel and the showcase audit table display the account alongside the agent software identity.
 
 The full setup — the metadata document, the challenge table, a JWKS `verify` recipe, and the fail-closed rules — is on the [Capabilities page](/docs/capabilities#oauth-letting-a-real-host-connect).
 
@@ -438,6 +438,7 @@ const stopAuditLog = addCapabilityAuditListener("audit-log", (event) => {
       status: event.status,
       durationMs: Math.round(event.durationMs),
       agent: event.agent?.agentDomain ?? event.agent?.keyId ?? null,
+      account: event.tokenAuth,
     }),
   );
 });

--- a/examples/docs/src/routes/docs/recipes-logging.md
+++ b/examples/docs/src/routes/docs/recipes-logging.md
@@ -265,6 +265,7 @@ const stopAuditLog = addCapabilityAuditListener("audit-log", (event) => {
       status: event.status,
       durationMs: Math.round(event.durationMs),
       agent: event.agent?.agentDomain ?? event.agent?.keyId ?? null,
+      account: event.tokenAuth,
     }),
   );
 });

--- a/examples/showcase/src/routes/audit.tsx
+++ b/examples/showcase/src/routes/audit.tsx
@@ -24,6 +24,7 @@ export async function loader(_args: LoaderArgs) {
       status: event.status,
       durationMs: Math.round(event.durationMs),
       agent: event.agent ? (event.agent.agentDomain ?? event.agent.keyId) : null,
+      subject: event.tokenAuth?.subject ?? null,
       ago: Math.max(0, Math.round((now - event.at) / 1000)),
     })),
   };
@@ -67,6 +68,7 @@ export function Component({ data }: RouteComponentProps<typeof loader>) {
                 <th>Outcome</th>
                 <th>Status</th>
                 <th>Agent</th>
+                <th>Account</th>
                 <th>Latency</th>
                 <th>When</th>
               </tr>
@@ -88,6 +90,9 @@ export function Component({ data }: RouteComponentProps<typeof loader>) {
                   </td>
                   <td>{event.status}</td>
                   <td>{event.agent ? <code>{event.agent}</code> : <span class="dim">—</span>}</td>
+                  <td>
+                    {event.subject ? <code>{event.subject}</code> : <span class="dim">—</span>}
+                  </td>
                   <td>{event.durationMs} ms</td>
                   <td class="dim">{event.ago}s ago</td>
                 </tr>

--- a/packages/capabilities/src/server/capabilities.ts
+++ b/packages/capabilities/src/server/capabilities.ts
@@ -549,6 +549,12 @@ function emitCapabilityAudit(event: CapabilityAuditEvent, extra?: CapabilityAudi
   const snapshot = Object.freeze({
     ...event,
     agent: snapshotAgentIdentity(event.agent),
+    tokenAuth: event.tokenAuth
+      ? Object.freeze({
+          subject: event.tokenAuth.subject,
+          clientId: event.tokenAuth.clientId ?? null,
+        })
+      : null,
   });
   // Snapshot every process-wide registration before invoking user code. The
   // single-slot hook can add, replace, or remove an additive sink too; those
@@ -580,6 +586,8 @@ export interface HandleCapabilityRequestOptions<TContext> {
   agent?: PrachtAgentIdentity | null;
   /** Trusted transport selected by an internal framework projection. */
   transport?: "mcp";
+  /** Principal supplied by the authenticated MCP transport, never inferred from app context. */
+  tokenPrincipal?: McpTokenPrincipal;
   onAudit?: CapabilityAuditHook;
 }
 
@@ -615,6 +623,7 @@ export async function handleCapabilityRequest<TContext>(
       status: responseWithEffect.status,
       durationMs: performance.now() - started,
       agent: options.agent ?? null,
+      tokenAuth: options.transport === "mcp" ? (options.tokenPrincipal ?? null) : null,
     },
     options.onAudit,
   );
@@ -1452,6 +1461,7 @@ export async function invokeCapabilityOnHost<T = unknown>(
         status: 500,
         durationMs: performance.now() - started,
         agent: capabilityHostAgent(host, context),
+        tokenAuth: host.via === "mcp" ? (host.tokenAuth ?? null) : null,
       },
       host.onAudit,
     );
@@ -1476,6 +1486,7 @@ export async function invokeCapabilityOnHost<T = unknown>(
       status,
       durationMs: performance.now() - started,
       agent,
+      tokenAuth: host.via === "mcp" ? (host.tokenAuth ?? null) : null,
     },
     host.onAudit,
   );

--- a/packages/capabilities/src/server/mcp.ts
+++ b/packages/capabilities/src/server/mcp.ts
@@ -700,6 +700,7 @@ async function handleToolsCall<TContext>(
       agents: options.agents,
       agent: options.agent ?? null,
       transport: "mcp",
+      tokenPrincipal: options.tokenPrincipal,
       onAudit: options.onAudit,
     });
   } finally {

--- a/packages/capabilities/src/server/types.ts
+++ b/packages/capabilities/src/server/types.ts
@@ -336,6 +336,10 @@ export interface CapabilityAuditEvent {
   /** HTTP status the envelope maps to (also set for server-side invocation). */
   readonly status: number;
   readonly durationMs: number;
+  /** Verified OAuth subject and client, or null outside authenticated MCP dispatch.
+   * Tokens, scopes and arbitrary claims are deliberately excluded from audit events.
+   */
+  readonly tokenAuth: Readonly<Pick<McpTokenPrincipal, "subject" | "clientId">> | null;
   /** Verified agent identity, `null` when unsigned/unverified or Web Bot Auth is off. */
   readonly agent: PrachtAgentIdentity | null;
 }

--- a/packages/capabilities/test/host.test.ts
+++ b/packages/capabilities/test/host.test.ts
@@ -669,3 +669,41 @@ describe("createCapabilityHost composition", () => {
     await expect(response?.json()).resolves.toEqual({ ok: true, data: { notes: ["match:a"] } });
   });
 });
+
+it("audits standalone MCP successes and denials with the verified principal", async () => {
+  const events: { tokenAuth: unknown; outcome: string }[] = [];
+  const host = createCapabilityHost({
+    capabilities: { "notes.search": searchCapability({ expose: { http: true, mcp: true } }) },
+    onAudit: (event) => events.push(event),
+    agents: {
+      mcp: {
+        auth: {
+          resource: `${ORIGIN}/mcp`,
+          authorizationServers: ["https://auth.example"],
+          verify: async () => ({ subject: "user-2", claims: { token: "secret" } }),
+        },
+      },
+    },
+  });
+  for (const query of ["valid", ""]) {
+    await host.fetch(
+      post(
+        "/mcp",
+        {
+          jsonrpc: "2.0",
+          id: 1,
+          method: "tools/call",
+          params: { name: "notes_search", arguments: { query } },
+        },
+        { authorization: "Bearer good" },
+      ),
+    );
+  }
+  expect(events.map((event) => event.tokenAuth)).toEqual([
+    { subject: "user-2", clientId: null },
+    { subject: "user-2", clientId: null },
+  ]);
+  expect(events.map((event) => event.outcome)).toEqual(["ok", "invalid_input"]);
+  await host.fetch(post("/api/capabilities/notes/search", { query: "http" }));
+  expect(events[2].tokenAuth).toBeNull();
+});

--- a/packages/framework/src/devtools.ts
+++ b/packages/framework/src/devtools.ts
@@ -52,6 +52,8 @@ export interface AgentTrafficEvent {
   outcome: string;
   status: number;
   durationMs: number;
+  /** Verified OAuth account behind this dispatch, when present. */
+  tokenAuth?: { readonly subject: string; readonly clientId?: string | null } | null;
   /** Verified agent identity, `null` when unsigned or Web Bot Auth is off. */
   agent: { agentDomain: string | null; keyId: string } | null;
 }
@@ -174,6 +176,7 @@ ${capabilityRows}
         <td>${escapeHtml(formatTransport(event))}</td>
         <td>${escapeHtml(event.effect)}</td>
         <td>${escapeHtml(formatAgent(event.agent))}</td>
+        <td>${escapeHtml(event.tokenAuth?.subject ?? "—")}</td>
         <td class="${agentTrafficSucceeded(event) ? "ok" : "err"}">${escapeHtml(formatOutcome(event))}</td>
         <td class="file">${escapeHtml(formatDuration(event.durationMs))}</td>
       </tr>`,
@@ -192,7 +195,7 @@ ${capabilityRows}
       : "";
 
   const trafficTable = `${composedToggle}<table>
-      <thead><tr><th>Time (UTC)</th><th>Capability</th><th>Transport</th><th>Effect</th><th>Agent</th><th>Outcome</th><th>Duration</th></tr></thead>
+      <thead><tr><th>Time (UTC)</th><th>Capability</th><th>Transport</th><th>Effect</th><th>Agent</th><th>Account</th><th>Outcome</th><th>Duration</th></tr></thead>
       <tbody>
 ${trafficRows}
       </tbody>

--- a/packages/framework/test/remote-mcp-auth.test.ts
+++ b/packages/framework/test/remote-mcp-auth.test.ts
@@ -15,7 +15,12 @@ import {
   mcpResourceMetadataUrl,
 } from "../src/mcp-config.ts";
 import { loadMcpTokenVerifier } from "../src/runtime-mcp-auth.ts";
-import type { McpAuthConfig, McpTokenVerifier, ModuleRegistry } from "../src/types.ts";
+import type {
+  CapabilityAuditEvent,
+  McpAuthConfig,
+  McpTokenVerifier,
+  ModuleRegistry,
+} from "../src/types.ts";
 
 const ORIGIN = "https://app.example";
 const METADATA_PATH = "/.well-known/oauth-protected-resource/mcp";
@@ -159,6 +164,7 @@ function createHarness(options: HarnessOptions = {}) {
 }
 
 interface CallOptions extends HarnessOptions {
+  onAudit?: (event: CapabilityAuditEvent) => void;
   headers?: Record<string, string>;
   method?: string;
   path?: string;
@@ -180,6 +186,7 @@ async function call(body: unknown, options: CallOptions = {}) {
   const response = await handlePrachtRequest({
     app,
     context: options.context,
+    onCapabilityAudit: options.onAudit,
     registry,
     request,
   });
@@ -1095,5 +1102,58 @@ describe("under a deploy base", () => {
     });
     expect(authorized.status).toBe(200);
     expect((await authorized.json()).result.structuredContent).toEqual({ subject: "user-1" });
+  });
+});
+
+describe("OAuth audit attribution", () => {
+  it("attributes nested and outer calls to the verified account without leaking claims", async () => {
+    const events: CapabilityAuditEvent[] = [];
+    await call(
+      {
+        jsonrpc: "2.0",
+        id: 1,
+        method: "tools/call",
+        params: { name: "token_compose", arguments: {} },
+      },
+      {
+        composition: true,
+        headers: { authorization: "Bearer good" },
+        verify: () => ({
+          subject: "user-1",
+          clientId: "assistant-app",
+          scopes: ["notes.read"],
+          claims: { secret: "private" },
+        }),
+        onAudit: (event) => events.push(event),
+      },
+    );
+    expect(events).toHaveLength(2);
+    expect(events.map((event) => event.tokenAuth)).toEqual([
+      { subject: "user-1", clientId: "assistant-app" },
+      { subject: "user-1", clientId: "assistant-app" },
+    ]);
+    expect(events.map((event) => event.outcome)).toEqual(["ok", "ok"]);
+    expect(Object.isFrozen(events[0].tokenAuth)).toBe(true);
+    expect(Reflect.set(events[0].tokenAuth!, "subject", "forged")).toBe(false);
+    expect(JSON.stringify(events)).not.toContain("private");
+  });
+
+  it("does not attribute an unprotected MCP call to an application-supplied principal", async () => {
+    const events: CapabilityAuditEvent[] = [];
+    await call(
+      {
+        jsonrpc: "2.0",
+        id: 1,
+        method: "tools/call",
+        params: { name: "token_probe", arguments: {} },
+      },
+      {
+        auth: null,
+        context: { tokenAuth: { subject: "spoofed" } },
+        onAudit: (event) => events.push(event),
+      },
+    );
+    expect(events).toHaveLength(1);
+    expect(events[0].tokenAuth).toBeNull();
   });
 });

--- a/packages/vite-plugin/src/agent-traffic.ts
+++ b/packages/vite-plugin/src/agent-traffic.ts
@@ -26,6 +26,7 @@ interface AuditEventLike {
   outcome: string;
   status: number;
   durationMs: number;
+  tokenAuth?: { subject: string; clientId?: string | null } | null;
   agent: { agentDomain: string | null; keyId: string } | null;
 }
 
@@ -57,6 +58,9 @@ export function createAgentTrafficBuffer(limit: number = AGENT_TRAFFIC_LIMIT): A
         outcome: event.outcome,
         status: event.status,
         durationMs: event.durationMs,
+        tokenAuth: event.tokenAuth
+          ? { subject: event.tokenAuth.subject, clientId: event.tokenAuth.clientId ?? null }
+          : null,
         // Copied rather than referenced: the audit event's frozen identity is
         // request-scoped, and the panel outlives the request.
         agent: event.agent

--- a/packages/vite-plugin/test/agent-traffic.test.ts
+++ b/packages/vite-plugin/test/agent-traffic.test.ts
@@ -100,3 +100,14 @@ describe("createAgentTrafficBuffer", () => {
     expect(buffer.snapshot().recorded).toBe(1);
   });
 });
+
+it("retains only a copied account summary in the devtools buffer", () => {
+  const buffer = createAgentTrafficBuffer();
+  const tokenAuth = { subject: "user-1", clientId: "client-1", claims: { private: true } };
+  buffer.record(auditEvent({ tokenAuth }));
+  tokenAuth.subject = "changed";
+  expect(buffer.snapshot().events[0].tokenAuth).toEqual({
+    subject: "user-1",
+    clientId: "client-1",
+  });
+});


### PR DESCRIPTION
## Summary

- Capability audit events now identify the verified OAuth account behind MCP calls and nested operations with a frozen `tokenAuth: { subject, clientId }` summary. Tokens, scopes, and arbitrary claims are excluded; HTTP and unauthenticated dispatches report `null`.
- The shared framework/standalone pipeline supplies attribution from authenticated transport state, and the dev Agents panel and showcase display the account.
- Related issue: N/A.

## Testing

- [x] `pnpm run verify` (build, format, lint, typecheck, test, e2e)
- Covers nested context spoofing, unauthenticated context spoofing, standalone successes and denials, immutable account summaries, omitted claims, and copied devtools records.
- Adversarial re-review of the fix diff: no P1/P2 findings.

## Checklist

- [x] Docs updated if needed — internal trust/MCP reference and public trust/logging pages
- [x] Skills updated if needed — N/A; existing observability instructions remain valid
- [x] Concise, user-facing changeset added if published packages changed
