### PR TITLE
perf(core): compile typed href routes for SSR

### DIFF
--- a/.changeset/faster-link-ssr.md
+++ b/.changeset/faster-link-ssr.md
@@ -1,0 +1,5 @@
+---
+"@pracht/core": patch
+---
+
+Speed up link-heavy server rendering by compiling typed route href lookups once per route table.

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -5,6 +5,22 @@ that promise honest as an app grows: `pracht build --analyze` (visibility),
 per-route client-JS budgets (enforcement), and `pracht({ client })` for
 compiling out router features the app does not use.
 
+## Server-rendered typed links
+
+Server builds compile each immutable href route table on first use. The
+compiled table indexes route ids, records dynamic parameter names, and keeps a
+complete based path for static routes. Subsequent `<Link>` renders,
+`createHref()` calls, typed `navigate()` calls, and typed `prefetch()` calls use
+the same O(1) lookup; static links return their cached path, while dynamic links
+substitute parameters without allocating filtered segment arrays, sets, or a
+normalized parameter object per call. The cache is weakly keyed by the route
+array so short-lived generated or test tables remain collectible.
+
+This compilation is server-only. Browser builds retain the smaller linear
+resolver because route tables there are normally small and the client-byte
+budget is the more important constraint. Keep new typed URL surfaces on the
+shared href builder so they inherit both execution paths.
+
 ## Tree-shaking framework imports
 
 `@pracht/core` is published as unbundled ESM so downstream bundlers can follow

--- a/examples/docs/src/routes/docs/performance.md
+++ b/examples/docs/src/routes/docs/performance.md
@@ -43,6 +43,18 @@ route's chunk list. And
 0.3 KB — small, but it is the entire cost of a feature an app either uses or
 does not.
 
+### Link-heavy server rendering
+
+Typed links do not scan the route list on every server render. The first
+`<Link>` for an app compiles its immutable route table into an id index;
+subsequent links use an O(1) lookup. Static route paths are reused whole, and
+dynamic links validate and substitute their parameters without rebuilding
+intermediate segment arrays, sets, and objects for each link. The same resolver
+backs generated `href()`, typed navigation, and typed prefetch targets.
+
+This optimization is deliberately server-only. Browser builds keep the smaller
+resolver, so faster SSR does not add client JavaScript to hydrated pages.
+
 ### How these numbers are measured
 
 They come from `pnpm bench`, which lives in the repository and anyone can run:

--- a/packages/framework/src/route-matching.ts
+++ b/packages/framework/src/route-matching.ts
@@ -182,6 +182,66 @@ export function buildPathFromSegments(
   return normalizeRoutePath("/" + parts.join("/"));
 }
 
+interface CompiledHrefRoute {
+  segments: readonly RouteSegment[];
+  parameterNames: readonly string[];
+  parameterNameSet?: ReadonlySet<string>;
+  staticPath?: string;
+}
+
+interface CompiledHrefRoutes {
+  byId: ReadonlyMap<string, CompiledHrefRoute>;
+  registeredIds: readonly string[];
+}
+
+// The browser's route table is small enough that retaining the straightforward
+// resolver costs fewer shipped bytes. Server bundles compile instead: the
+// table is shared across requests, where link-heavy renders make repeated
+// scans and path intermediates expensive. Plain Node (tests and custom SSR)
+// has no import.meta.env, so it takes the server path too.
+const COMPILE_HREF_ROUTES = import.meta.env?.SSR !== false;
+let compiledHrefRouteTables:
+  | WeakMap<readonly HrefRouteDefinition[], CompiledHrefRoutes>
+  | undefined;
+
+function getCompiledHrefRoutes(routes: readonly HrefRouteDefinition[]): CompiledHrefRoutes {
+  const cache = (compiledHrefRouteTables ??= new WeakMap());
+  const cached = cache.get(routes);
+  if (cached) return cached;
+
+  const byId = new Map<string, CompiledHrefRoute>();
+  const registeredIds: string[] = [];
+
+  for (const route of routes) {
+    const id = route.id;
+    if (id === undefined) continue;
+    if (id) registeredIds.push(id);
+    // Preserve Array.find()'s first-match behavior for a malformed table with
+    // duplicate ids. Manifest validation normally rejects this earlier.
+    if (byId.has(id)) continue;
+
+    const segments = route.segments ?? parseRouteSegments(route.path);
+    const parameterNames: string[] = [];
+    for (const segment of segments) {
+      if (segment.type !== "static") parameterNames.push(segment.name);
+    }
+
+    byId.set(id, {
+      segments,
+      parameterNames,
+      parameterNameSet: parameterNames.length > 0 ? new Set(parameterNames) : undefined,
+      // Every caller hands this path to a browser, so it carries the deploy
+      // base. Dynamic paths are based after their parameters are substituted.
+      staticPath:
+        parameterNames.length === 0 ? withBase(buildPathFromSegments(segments, {})) : undefined,
+    });
+  }
+
+  const compiled = { byId, registeredIds };
+  cache.set(routes, compiled);
+  return compiled;
+}
+
 export function buildHref<TRoute extends RouteId>(
   routes: readonly HrefRouteDefinition[],
   routeId: TRoute,
@@ -196,6 +256,10 @@ export function buildHrefUntyped(
   routeId: string,
   options: Omit<UntypedRouteTarget, "route"> = {},
 ): string {
+  if (COMPILE_HREF_ROUTES) {
+    return buildCompiledHref(routes, routeId, options.params, options.search, options.hash);
+  }
+
   const route = routes.find((candidate) => candidate.id === routeId);
   if (!route) {
     // The rich "did you mean" error only exists where import.meta.env.DEV is
@@ -221,6 +285,87 @@ export function buildHrefUntyped(
   // paths use `buildPathFromSegments` directly and stay base-free.
   const path = withBase(buildPathFromSegments(segments, params));
   return `${path}${serializeSearch(options.search as SearchParamsInput | undefined)}${serializeHash(options.hash)}`;
+}
+
+function buildCompiledHref(
+  routes: readonly HrefRouteDefinition[],
+  routeId: string,
+  params: Record<string, unknown> | undefined,
+  search: unknown,
+  hash: string | undefined,
+): string {
+  const compiledRoutes = getCompiledHrefRoutes(routes);
+  const route = compiledRoutes.byId.get(routeId);
+  if (!route) throwUnknownRoute(routeId, compiledRoutes.registeredIds);
+  validateCompiledHrefParams(route, params);
+  const path = route.staticPath ?? withBase(buildCompiledHrefPath(route.segments, params!));
+  const searchSuffix = serializeSearch(search as SearchParamsInput | undefined);
+  const hashSuffix = serializeHash(hash);
+  return searchSuffix || hashSuffix ? `${path}${searchSuffix}${hashSuffix}` : path;
+}
+
+function throwUnknownRoute(routeId: string, registeredIds: readonly string[]): never {
+  // The rich "did you mean" error only exists where import.meta.env.DEV is
+  // not statically false (dev server, tests, Node CLI); production builds
+  // constant-fold the guard and tree-shake the error formatting away.
+  if (import.meta.env?.DEV !== false) {
+    throw new Error(
+      formatUnknownNameError({
+        kind: "pracht route id",
+        kindPlural: "route ids",
+        name: routeId,
+        registered: registeredIds,
+      }),
+    );
+  }
+  throw new Error(`Unknown pracht route id "${routeId}".`);
+}
+
+function validateCompiledHrefParams(
+  route: CompiledHrefRoute,
+  params: Record<string, unknown> | undefined,
+): void {
+  for (const name of route.parameterNames) {
+    if (params?.[name] == null) throw new Error(`Missing route param: ${name}.`);
+  }
+
+  if (!params) return;
+  for (const name in params) {
+    if (Object.prototype.hasOwnProperty.call(params, name) && !route.parameterNameSet?.has(name)) {
+      throw new Error(`Unexpected route param: ${name}.`);
+    }
+  }
+}
+
+function buildCompiledHrefPath(
+  segments: readonly RouteSegment[],
+  params: Readonly<Record<string, unknown>>,
+): string {
+  let path = "";
+  for (const segment of segments) {
+    if (segment.type === "static") {
+      path = appendCompiledPathPart(path, segment.value);
+      continue;
+    }
+
+    const raw = String(params[segment.name]);
+    if (segment.type === "param") {
+      path = appendCompiledPathPart(path, encodeDynamicPathSegment(raw));
+      continue;
+    }
+
+    let partStart = 0;
+    for (let index = 0; index <= raw.length; index += 1) {
+      if (index !== raw.length && raw.charCodeAt(index) !== 47) continue;
+      path = appendCompiledPathPart(path, encodeDynamicPathSegment(raw.slice(partStart, index)));
+      partStart = index + 1;
+    }
+  }
+  return path || "/";
+}
+
+function appendCompiledPathPart(path: string, part: string): string {
+  return part ? `${path}/${part}` : path;
 }
 
 export function normalizeHrefParams(

--- a/packages/framework/test/router.test.ts
+++ b/packages/framework/test/router.test.ts
@@ -275,6 +275,31 @@ describe("typed route href helpers", () => {
       "/products/1?tab=details",
     );
   });
+
+  it("compiles each href route table once", () => {
+    let idReads = 0;
+    let pathReads = 0;
+    const routes = [
+      {
+        get id() {
+          idReads += 1;
+          return "home";
+        },
+        get path() {
+          pathReads += 1;
+          return "/";
+        },
+      },
+    ];
+
+    expect(buildHref(routes, "home")).toBe("/");
+    expect(buildHref(routes, "home")).toBe("/");
+    expect({ idReads, pathReads }).toEqual({ idReads: 1, pathReads: 1 });
+  });
+
+  it("preserves explicitly empty ids in low-level href tables", () => {
+    expect(buildHref([{ id: "", path: "/empty" }], "")).toBe("/empty");
+  });
 });
 
 describe("matchRoutePath", () => {


### PR DESCRIPTION
## Summary

- Compile immutable typed-route tables once during server rendering so repeated link generation uses O(1) route-id lookup and cached static paths.
- Keep the browser resolver unchanged to avoid increasing client JavaScript.
- Relevant issue: N/A.

## Testing

- [x] `pnpm run verify` (build, format, lint, typecheck, test, e2e)

## Checklist

- [x] Docs updated if needed
- [x] Skills updated if needed — N/A; no skill changes required
- [x] Concise, user-facing changeset added if published packages changed