### PR TITLE
feat: add CSS and Web Vitals performance controls

### DIFF
--- a/.changeset/fast-styles-vitals.md
+++ b/.changeset/fast-styles-vitals.md
@@ -1,0 +1,12 @@
+---
+"@pracht/adapter-cloudflare": patch
+"@pracht/adapter-netlify": patch
+"@pracht/adapter-node": patch
+"@pracht/adapter-static": patch
+"@pracht/adapter-vercel": patch
+"@pracht/cli": patch
+"@pracht/core": patch
+"@pracht/vite-plugin": patch
+---
+
+Add opt-in route CSS inlining across every deployment target and an SSR-safe lazy `useWebVitals()` hook.

--- a/docs/CSP.md
+++ b/docs/CSP.md
@@ -84,15 +84,16 @@ style-src 'self'; style-src-attr 'unsafe-inline'
 Keep `data:` in `img-src` (the starter policy includes it) so the browser may
 load the inline blur image.
 
-## Generated Font Styles
+## Framework-Generated Styles
 
-`defineFont()` emits one inline `<style data-pracht-fonts>` block. For SSR,
-generate a fresh nonce per response, expose it through request context, return
-it from a shared shell head, and include the same value in the response CSP:
+`defineFont()` emits `<style data-pracht-fonts>`, and `pracht({ inlineCss: true })`
+emits `<style data-pracht-inline-css>`. For SSR, generate a fresh nonce per
+response, expose it through request context, return it from a shared shell head,
+and include the same value in the response CSP:
 
 ```ts
 export function head({ context }) {
-  return { fonts: [inter], fontNonce: context.cspNonce };
+  return { fonts: [inter], styleNonce: context.cspNonce };
 }
 
 export function headers({ context }) {
@@ -102,7 +103,9 @@ export function headers({ context }) {
 }
 ```
 
-Pracht keeps the nonce-bearing style element in place when client navigation
+`fontNonce` remains a backwards-compatible font-only override; new code should
+use `styleNonce` so one value covers every framework-generated style. Pracht
+keeps the nonce-bearing font style element in place when client navigation
 updates route fonts. Prefer `font.className` under this policy: `font.style`
 creates a style attribute, which requires a separate CSP allowance. SSG and ISG
 documents cannot safely share a request nonce; use a stable hash that covers the

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -161,6 +161,37 @@ Targeted groups compose cleanly; measured on preact-www, pracht kept its vendor
 chunk while the app's own `manualChunks` function ran for everything else, with
 critical CSS still linked.
 
+## Inlining route CSS
+
+Production documents link the matched route and shell's emitted stylesheets by
+default. Small sites can remove those render-blocking requests by opting into
+full route-CSS inlining:
+
+```ts
+// vite.config.ts
+export default defineConfig({
+  plugins: [pracht({ inlineCss: true })],
+});
+```
+
+The client build's CSS manifest remains the source of truth. The plugin embeds
+the emitted asset contents in the generated server module; the request runtime
+resolves the same route/shell URL set as before and writes it into
+`<style data-pracht-inline-css>`. This one path covers manifest and pages
+routers, SPA shell documents, SSR, SSG/ISG prerendering, error boundaries,
+islands, hydration-none pages, and every built-in adapter. Development keeps
+using Vite-served stylesheet links so HMR is unchanged.
+
+This is whole-file route CSS inlining, not selector-level extraction and not a
+CSS-in-JS render hook. It trades a request for larger HTML and repeats shared
+CSS in every document, so use it for small route styles and measure the result.
+Custom server entries can pass both `cssManifest` and `cssContentManifest`;
+missing content entries deliberately fall back to normal stylesheet links.
+
+With a nonce-based CSP, return `styleNonce` from the active shell or route
+`head()` and include the same nonce in `style-src`. Static SSG/ISG output cannot
+safely reuse a request nonce; prefer linked CSS or a stable hash there.
+
 ## `pracht build --analyze`
 
 After a successful production build, `--analyze` prints a per-route report of
@@ -289,6 +320,37 @@ When a route blows its budget, the usual levers, in order of impact:
    shell; a heavy dependency imported in a shell taxes every page.
 4. **Audit the vendor chunk** — see the `audit-bundles` skill for a guided
    deep-dive into fan-in, heavy dependencies, and prefetch tuning.
+
+## Measuring real-user Web Vitals
+
+`useWebVitals()` reports CLS, FCP, INP, LCP, and TTFB from a client component:
+
+```tsx
+import { useWebVitals } from "@pracht/core";
+
+export function Vitals() {
+  useWebVitals((metric) => {
+    navigator.sendBeacon(
+      "/api/telemetry/vitals",
+      JSON.stringify({
+        name: metric.name,
+        value: metric.value,
+        rating: metric.rating,
+        id: metric.id,
+        path: location.pathname,
+      }),
+    );
+  });
+  return null;
+}
+```
+
+The hook registers from an effect, dynamically imports `web-vitals`, and shares
+one observer set across every mounted caller. It is safe to render on the
+server, does not require `useIsHydrated()`, and adds no metrics code to apps
+that never import the hook. The callback reference stays current across
+re-renders. Mount it once in a shared shell and keep the receiving API route
+small and non-blocking.
 
 ## The benchmark harness
 

--- a/docs/STYLING.md
+++ b/docs/STYLING.md
@@ -31,6 +31,13 @@ stylesheet links to the initial HTML before the client entry. Apps should only
 need to import their CSS from a route, shell, or one of their dependencies — a
 development-only `<link>` in `head()` is unnecessary.
 
+Production links these route-scoped files by default. For small stylesheets,
+`pracht({ inlineCss: true })` instead places the complete matched route and
+shell CSS in the initial document. This removes the parser-blocking stylesheet
+request but repeats shared CSS in every HTML response; see
+[PERFORMANCE.md](PERFORMANCE.md#inlining-route-css) for the trade-off and CSP
+requirements. It does not extract styles produced at render time by CSS-in-JS.
+
 ---
 
 ## CSS-in-JS

--- a/examples/docs/src/routes/docs/fonts.md
+++ b/examples/docs/src/routes/docs/fonts.md
@@ -180,15 +180,19 @@ Pracht deliberately does not read the font binary at build time, so these stay e
 Everything interpolated into the generated CSS is escaped or validated: family names and URLs are CSS-string-escaped (including `<`, so the inline `<style>` can never be closed early), and descriptor values like `weight`, `display`, `unicodeRange`, and the metric overrides are validated against strict grammars — invalid values throw at `defineFont()` time rather than reaching the document.
 
 For a nonce-based Content Security Policy, return the request-specific nonce as
-`fontNonce` from a shared shell `head()` and include the same nonce in
+`styleNonce` from a shared shell `head()` and include the same nonce in
 `style-src`. Pracht places it on the generated font style and preserves that
 style element across client navigation:
 
 ```ts
 export function head({ context }) {
-  return { fonts: [inter], fontNonce: context.cspNonce };
+  return { fonts: [inter], styleNonce: context.cspNonce };
 }
 ```
+
+The older `fontNonce` field remains a font-only override for backwards
+compatibility. Use `styleNonce` in new code so the same nonce also covers
+`pracht({ inlineCss: true })`.
 
 Use `font.className` rather than `font.style` under a strict policy, because
 inline style attributes need a separate CSP allowance. Static SSG/ISG output

--- a/examples/docs/src/routes/docs/performance.md
+++ b/examples/docs/src/routes/docs/performance.md
@@ -202,6 +202,61 @@ critical path.
 
 pracht builds a CSS manifest that maps each source file to its transitive CSS dependencies. At request time, only the CSS needed for the matched route and shell is injected as `<link rel="stylesheet">` tags — no unused CSS is sent.
 
+For a small site, opt into inlining those complete route-scoped files:
+
+```ts [vite.config.ts]
+export default defineConfig({
+  plugins: [pracht({ inlineCss: true })],
+});
+```
+
+Production HTML then contains `<style data-pracht-inline-css>` instead of the
+matched stylesheet links. This works for the manifest and pages routers, every
+render/hydration mode, error boundaries, prerendering, and every built-in
+adapter. Development keeps links so Vite HMR works normally.
+
+Inlining saves a render-blocking request but enlarges every HTML response and
+repeats shared CSS instead of letting one stylesheet cache serve many pages.
+It is whole-file route CSS inlining, not selector-level extraction or runtime
+CSS-in-JS collection. Measure both variants before choosing it.
+
+Under a nonce-based CSP, return `styleNonce` from `head()` and place the same
+nonce in `style-src`. Prefer linked CSS for SSG/ISG pages unless a stable hash
+policy covers the emitted inline block.
+
+---
+
+## Real-User Web Vitals
+
+Mount a small component in a shared shell to receive CLS, FCP, INP, LCP, and
+TTFB:
+
+```tsx [src/components/vitals.tsx]
+import { useWebVitals } from "@pracht/core";
+
+export function Vitals() {
+  useWebVitals((metric) => {
+    navigator.sendBeacon(
+      "/api/telemetry/vitals",
+      JSON.stringify({
+        name: metric.name,
+        value: metric.value,
+        rating: metric.rating,
+        id: metric.id,
+        path: location.pathname,
+      }),
+    );
+  });
+  return null;
+}
+```
+
+The hook is SSR-safe: it starts from an effect and lazy-loads the measurement
+chunk after mount. Multiple callers share one observer set, callbacks can
+change across renders, and apps that never use the hook ship none of that code.
+The browser API may report some metrics only after interaction, visibility
+changes, or page exit, so use `sendBeacon()` or another unload-safe transport.
+
 ---
 
 ## Error Overlay in Dev

--- a/examples/docs/src/routes/docs/recipes-csp.md
+++ b/examples/docs/src/routes/docs/recipes-csp.md
@@ -63,6 +63,28 @@ export function headers() {
 Avoid `'unsafe-eval'`. Avoid `'unsafe-inline'` unless an audited integration
 requires it and the exception is documented.
 
+## Framework-Generated Styles
+
+`defineFont()` and `pracht({ inlineCss: true })` emit inline style elements.
+For SSR, return a request-specific `styleNonce` from the shell head and use the
+same value in `style-src`:
+
+```ts [src/shells/public.tsx]
+export function head({ context }) {
+  return { fonts: [inter], styleNonce: context.cspNonce };
+}
+
+export function headers({ context }) {
+  return {
+    "content-security-policy": `default-src 'self'; style-src 'self' 'nonce-${context.cspNonce}'; font-src 'self'`,
+  };
+}
+```
+
+`fontNonce` remains available as a backwards-compatible font-only override.
+SSG/ISG output cannot safely reuse a request nonce; keep linked CSS and use a
+stable hash or external stylesheet policy for static documents.
+
 ## Inline Script Entries
 
 Pracht does not require app-authored executable inline scripts for normal page

--- a/examples/docs/src/routes/docs/reference-api.md
+++ b/examples/docs/src/routes/docs/reference-api.md
@@ -201,6 +201,14 @@ See [Environment Variables](/docs/env).
 
 ---
 
+## Performance
+
+| Export | Description |
+| --- | --- |
+| `useWebVitals(reporter)` | Lazily report CLS, FCP, INP, LCP, and TTFB from a client component. See [Performance](/docs/performance#real-user-web-vitals) |
+
+---
+
 ## Sessions
 
 From `@pracht/session`. WebCrypto only, so the same build runs on every

--- a/examples/docs/src/routes/docs/reference-config.md
+++ b/examples/docs/src/routes/docs/reference-config.md
@@ -53,6 +53,7 @@ app already follows, so most apps pass only an `adapter`.
 | --- | --- | --- |
 | `prerenderConcurrency` | `10` | Maximum SSG/ISG pages rendered in parallel by `pracht build` |
 | `maxBodySize` | `1048576` (1 MiB) | Largest request body the dev SSR middleware accepts |
+| `inlineCss` | `false` | Inline the complete matched route/shell production CSS in each HTML document instead of linking it. See [Performance](/docs/performance#css-per-page) |
 | `budgets` | `{}` | Per-route gzip client-JS budgets, e.g. `{ "*": "120kb", "/dashboard": "200kb" }`. `"*"` applies everywhere; explicit paths override it. Exceeding one fails the build unless you pass `pracht build --no-budget-fail` |
 | `precompileSsrJsx` | `false` | Precompile safe Preact JSX DOM subtrees in SSR/SSG server bundles. Client bundles keep the normal transform for hydration |
 | `envSafety` | `{}` (enabled) | Fail the build when a production client chunk references a non-public env var. `{ allow: ["NAME"] }` permits specific ones; `false` disables the check. See [Environment Variables](/docs/env) |

--- a/examples/docs/src/routes/docs/styling.md
+++ b/examples/docs/src/routes/docs/styling.md
@@ -41,6 +41,12 @@ See [Performance → CSS Per Page](/docs/performance) for how pracht maps routes
 
 The same behavior applies during development. `pracht dev` discovers the matched route and shell's CSS through Vite's live module graph and places stylesheet links in the initial HTML before the client entry runs. Import the CSS normally from your route or shell; you do not need a development-only `<link>` in `head()`.
 
+Production uses route-scoped links by default. For small emitted stylesheets,
+`pracht({ inlineCss: true })` puts the complete matched route and shell CSS in
+the document instead. That removes a render-blocking request but repeats shared
+CSS in every HTML response, so [measure the trade-off](/docs/performance#css-per-page).
+It does not collect runtime CSS-in-JS output.
+
 ---
 
 ## CSS-in-JS — Use With Care

--- a/packages/adapter-cloudflare/src/index.ts
+++ b/packages/adapter-cloudflare/src/index.ts
@@ -237,6 +237,7 @@ export function createCloudflareServerEntryModule(
     "    islandsEntryUrl: islandsEntryUrl ?? undefined,",
     "    islandsBootstrapRequired,",
     "    cssManifest,",
+    "    cssContentManifest,",
     "    jsManifest,",
     `    assetsBinding: ${JSON.stringify(assetsBinding)},`,
     "    assetsBindingUsesPublicBase: import.meta.env.DEV,",

--- a/packages/adapter-cloudflare/src/runtime.ts
+++ b/packages/adapter-cloudflare/src/runtime.ts
@@ -76,6 +76,7 @@ export interface CloudflareAdapterOptions<
   islandsEntryUrl?: string;
   islandsBootstrapRequired?: boolean;
   cssManifest?: Record<string, string[]>;
+  cssContentManifest?: Record<string, string>;
   jsManifest?: Record<string, string[]>;
   assetsBinding?: string;
   /** @internal Dev asset bindings already return public, base-prefixed redirects. */
@@ -143,6 +144,7 @@ export function createCloudflareFetchHandler<
         islandsEntryUrl: options.islandsEntryUrl,
         islandsBootstrapRequired: options.islandsBootstrapRequired,
         cssManifest: options.cssManifest,
+        cssContentManifest: options.cssContentManifest,
         jsManifest: options.jsManifest,
       } satisfies HandlePrachtRequestOptions<TContext>);
     };
@@ -228,6 +230,7 @@ export function createCloudflareFetchHandler<
       islandsEntryUrl: options.islandsEntryUrl,
       islandsBootstrapRequired: options.islandsBootstrapRequired,
       cssManifest: options.cssManifest,
+      cssContentManifest: options.cssContentManifest,
       jsManifest: options.jsManifest,
     } satisfies HandlePrachtRequestOptions<TContext>);
 

--- a/packages/adapter-cloudflare/test/index.test.ts
+++ b/packages/adapter-cloudflare/test/index.test.ts
@@ -39,6 +39,7 @@ describe("createCloudflareServerEntryModule", () => {
     expect(source).toContain("createCloudflareFetchHandler");
     expect(source).toContain("islandsEntryUrl: islandsEntryUrl ?? undefined");
     expect(source).toContain("islandsBootstrapRequired");
+    expect(source).toContain("cssContentManifest,");
     expect(source).toContain("assetsBindingUsesPublicBase: import.meta.env.DEV");
   });
 

--- a/packages/adapter-netlify/src/index.ts
+++ b/packages/adapter-netlify/src/index.ts
@@ -83,6 +83,7 @@ export interface NetlifyHandlerOptions<
   islandsEntryUrl?: string;
   islandsBootstrapRequired?: boolean;
   cssManifest?: Record<string, string[]>;
+  cssContentManifest?: Record<string, string>;
   jsManifest?: Record<string, string[]>;
   staticDir?: string;
   isgManifest?: Record<string, ISGManifestEntry>;
@@ -237,6 +238,7 @@ export function createNetlifyHandler<
       islandsEntryUrl: options.islandsEntryUrl,
       islandsBootstrapRequired: options.islandsBootstrapRequired,
       cssManifest: options.cssManifest,
+      cssContentManifest: options.cssContentManifest,
       jsManifest: options.jsManifest,
     } satisfies HandlePrachtRequestOptions<TContext>);
 
@@ -318,6 +320,7 @@ export function createNetlifyServerEntryModule(options: NetlifyAdapterOptions = 
     "  islandsEntryUrl: islandsEntryUrl ?? undefined,",
     "  islandsBootstrapRequired,",
     "  cssManifest,",
+    "  cssContentManifest,",
     "  jsManifest,",
     "  staticDir,",
     "  isgManifest,",

--- a/packages/adapter-netlify/test/index.test.ts
+++ b/packages/adapter-netlify/test/index.test.ts
@@ -54,6 +54,7 @@ describe("createNetlifyServerEntryModule", () => {
     expect(source).not.toContain('from "@netlify/functions"');
     expect(source).toContain('"staleWhileRevalidate":60');
     expect(source).toContain("islandsBootstrapRequired");
+    expect(source).toContain("cssContentManifest,");
     expect(source).toContain("finalizePrachtBuild");
     expect(source).toContain("finalizeNetlifyBuild(root,");
     expect(source).toContain("buildBase");

--- a/packages/adapter-node/src/node-entry.ts
+++ b/packages/adapter-node/src/node-entry.ts
@@ -74,6 +74,7 @@ export function createNodeServerEntryModule(options: NodeServerEntryModuleOption
     "  islandsEntryUrl: islandsEntryUrl ?? undefined,",
     "  islandsBootstrapRequired,",
     "  cssManifest,",
+    "  cssContentManifest,",
     "  jsManifest,",
     `  canonicalOrigin: ${JSON.stringify(canonicalOrigin ?? undefined)},`,
     `  basePathStripped: ${JSON.stringify(options.basePathStripped ?? undefined)},`,

--- a/packages/adapter-node/src/node-handler.ts
+++ b/packages/adapter-node/src/node-handler.ts
@@ -78,6 +78,7 @@ export interface NodeAdapterOptions<TContext = unknown> {
   islandsEntryUrl?: string;
   islandsBootstrapRequired?: boolean;
   cssManifest?: Record<string, string[]>;
+  cssContentManifest?: Record<string, string>;
   jsManifest?: Record<string, string[]>;
   headersManifest?: HeadersManifest;
   /** Exact Markdown-capable routes. Omit to preserve negotiation for legacy/custom entries. */
@@ -288,6 +289,7 @@ export function createNodeRequestHandler<TContext = unknown>(
       islandsEntryUrl: options.islandsEntryUrl,
       islandsBootstrapRequired: options.islandsBootstrapRequired,
       cssManifest: options.cssManifest,
+      cssContentManifest: options.cssContentManifest,
       jsManifest: options.jsManifest,
     } satisfies HandlePrachtRequestOptions<TContext>);
 

--- a/packages/adapter-node/src/node-isg.ts
+++ b/packages/adapter-node/src/node-isg.ts
@@ -76,6 +76,7 @@ export async function regenerateISGPage<TContext>(
       islandsEntryUrl: options.islandsEntryUrl,
       islandsBootstrapRequired: options.islandsBootstrapRequired,
       cssManifest: options.cssManifest,
+      cssContentManifest: options.cssContentManifest,
       jsManifest: options.jsManifest,
     });
 

--- a/packages/adapter-node/test/index.test.ts
+++ b/packages/adapter-node/test/index.test.ts
@@ -88,6 +88,7 @@ describe("createNodeServerEntryModule", () => {
     expect(source).toContain(
       'import { createContext as createPrachtContext } from "/src/server/context.ts";',
     );
+    expect(source).toContain("cssContentManifest,");
     expect(source).toContain("createContext: createPrachtContext");
     expect(source).toContain("maxBodySize: 10485760");
     expect(source).toContain("islandsEntryUrl: islandsEntryUrl ?? undefined");

--- a/packages/adapter-static/src/static-entry.ts
+++ b/packages/adapter-static/src/static-entry.ts
@@ -92,6 +92,7 @@ export function createStaticServerEntryModule(options: StaticAdapterOptions = {}
     "    islandsEntryUrl: islandsEntryUrl ?? undefined,",
     "    islandsBootstrapRequired,",
     "    cssManifest,",
+    "    cssContentManifest,",
     "    jsManifest,",
     "    onRouteError: (error) => {",
     "      renderError = error;",

--- a/packages/adapter-static/test/index.test.ts
+++ b/packages/adapter-static/test/index.test.ts
@@ -46,6 +46,7 @@ describe("staticAdapter", () => {
     expect(source).toContain("notFoundData: notFoundState?.data,");
     expect(source).toContain("notFoundError: notFoundState?.error ?? null,");
     expect(source).toContain("createStaticPreviewHandler");
+    expect(source).toContain("cssContentManifest,");
   });
 
   it("defaults to no fallback document", () => {

--- a/packages/adapter-vercel/src/index.ts
+++ b/packages/adapter-vercel/src/index.ts
@@ -46,6 +46,7 @@ export interface VercelAdapterOptions<
   islandsEntryUrl?: string;
   islandsBootstrapRequired?: boolean;
   cssManifest?: Record<string, string[]>;
+  cssContentManifest?: Record<string, string>;
   jsManifest?: Record<string, string[]>;
   createContext?: (args: VercelContextArgs<TVercelContext>) => TContext | Promise<TContext>;
 }
@@ -102,6 +103,7 @@ export function createVercelEdgeHandler<
       islandsEntryUrl: options.islandsEntryUrl,
       islandsBootstrapRequired: options.islandsBootstrapRequired,
       cssManifest: options.cssManifest,
+      cssContentManifest: options.cssContentManifest,
       jsManifest: options.jsManifest,
     } satisfies HandlePrachtRequestOptions<TContext>);
 
@@ -308,6 +310,7 @@ export function createVercelServerEntryModule(
     "    islandsEntryUrl: islandsEntryUrl ?? undefined,",
     "    islandsBootstrapRequired,",
     "    cssManifest,",
+    "    cssContentManifest,",
     "    jsManifest,",
     "    createContext: createPrachtContext,",
     "  });",

--- a/packages/adapter-vercel/test/index.test.ts
+++ b/packages/adapter-vercel/test/index.test.ts
@@ -29,6 +29,7 @@ describe("createVercelServerEntryModule", () => {
     expect(source).toContain("createVercelEdgeHandler");
     expect(source).toContain("islandsEntryUrl: islandsEntryUrl ?? undefined");
     expect(source).toContain("islandsBootstrapRequired");
+    expect(source).toContain("cssContentManifest,");
     expect(source).toContain('export const vercelFunctionName = "app";');
   });
 });

--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -588,6 +588,7 @@ export async function runBuild(root: string, options: BuildOptions = {}): Promis
       islandsEntryUrl: serverMod.islandsEntryUrl ?? undefined,
       islandsBootstrapRequired: serverMod.islandsBootstrapRequired === true,
       cssManifest,
+      cssContentManifest: serverMod.cssContentManifest,
       jsManifest,
       registry: serverMod.registry,
       withISGManifest: true,

--- a/packages/framework/package.json
+++ b/packages/framework/package.json
@@ -100,7 +100,8 @@
   "dependencies": {
     "@pracht/capabilities": "workspace:*",
     "@standard-schema/spec": "^1.0.0",
-    "preact-suspense": "^0.3.0"
+    "preact-suspense": "^0.3.0",
+    "web-vitals": "^6.2.1"
   },
   "peerDependencies": {
     "preact": "^10.0.0 || ^11.0.0-0",

--- a/packages/framework/src/browser.ts
+++ b/packages/framework/src/browser.ts
@@ -121,6 +121,8 @@ export {
 } from "./event-source-hook.ts";
 export { forwardRef } from "./forwardRef.ts";
 export { useIsHydrated } from "./hydration.ts";
+export { useWebVitals } from "./web-vitals-hook.ts";
+export type { WebVitalsMetric, WebVitalsReporter } from "./web-vitals-hook.ts";
 export { Script } from "./script.ts";
 export type { ScriptProps, ScriptStrategy } from "./script.ts";
 export { defer, use } from "./defer.ts";

--- a/packages/framework/src/index.ts
+++ b/packages/framework/src/index.ts
@@ -187,6 +187,8 @@ export {
 } from "./event-source-hook.ts";
 export { forwardRef } from "./forwardRef.ts";
 export { useIsHydrated } from "./hydration.ts";
+export { useWebVitals } from "./web-vitals-hook.ts";
+export type { WebVitalsMetric, WebVitalsReporter } from "./web-vitals-hook.ts";
 export { Script } from "./script.ts";
 export type { ScriptProps, ScriptStrategy } from "./script.ts";
 export { defer, use } from "./defer.ts";

--- a/packages/framework/src/prerender.ts
+++ b/packages/framework/src/prerender.ts
@@ -54,6 +54,8 @@ export interface PrerenderAppOptions {
   islandsBootstrapRequired?: boolean;
   /** Per-source-file CSS map produced by the vite plugin. */
   cssManifest?: Record<string, string[]>;
+  /** Per-public-URL CSS content emitted when route CSS inlining is enabled. */
+  cssContentManifest?: Record<string, string>;
   /** Per-source-file JS map produced by the vite plugin for modulepreload hints. */
   jsManifest?: Record<string, string[]>;
   /** Maximum number of pages rendered concurrently. Defaults to 10. */
@@ -135,6 +137,7 @@ export async function prerenderApp(
             islandsEntryUrl: options.islandsEntryUrl,
             islandsBootstrapRequired: options.islandsBootstrapRequired,
             cssManifest: options.cssManifest,
+            cssContentManifest: options.cssContentManifest,
             jsManifest: options.jsManifest,
             onRouteError: (error) => {
               renderError = error;

--- a/packages/framework/src/runtime-html.ts
+++ b/packages/framework/src/runtime-html.ts
@@ -111,7 +111,11 @@ export function buildHtmlDocument(options: {
    */
   hydrationState?: PrachtHydrationState;
   clientEntryUrl?: string;
+  /** Ordered route CSS assets, optionally carrying content to inline. */
+  cssAssets?: Array<{ content?: string; href: string }>;
   cssUrls?: string[];
+  /** Build-time route CSS to place directly in the document head. */
+  inlineCss?: string[];
   modulePreloadUrls?: string[];
   routeStatePreloadUrl?: string;
   speculationRules?: SpeculationRulesDocument | null;
@@ -121,7 +125,9 @@ export function buildHtmlDocument(options: {
     body,
     hydrationState,
     clientEntryUrl,
+    cssAssets,
     cssUrls = [],
+    inlineCss = [],
     modulePreloadUrls = [],
     routeStatePreloadUrl,
     speculationRules,
@@ -153,9 +159,10 @@ export function buildHtmlDocument(options: {
         .map((attrs) => `<link data-pracht-font-preload ${attrs}>`)
         .join("\n    ")
     : "";
+  const fontNonce = head.fontNonce ?? head.styleNonce;
   const fontStyleTag =
-    fontFragments?.css || head.fontNonce
-      ? `<style data-pracht-fonts${head.fontNonce ? ` nonce="${escapeHtml(head.fontNonce)}"` : ""}>${fontFragments?.css ?? ""}</style>`
+    fontFragments?.css || fontNonce
+      ? `<style data-pracht-fonts${fontNonce ? ` nonce="${escapeHtml(fontNonce)}"` : ""}>${fontFragments?.css ?? ""}</style>`
       : "";
 
   const scriptTags = (head.script ?? [])
@@ -166,9 +173,44 @@ export function buildHtmlDocument(options: {
     })
     .join("\n    ");
 
-  const cssTags = cssUrls
-    .map((url) => `<link rel="stylesheet" href="${escapeHtml(url)}">`)
-    .join("\n    ");
+  // CSS assets are trusted build output, but <style> is a raw-text element:
+  // even a CSS string or URL containing `</style` would otherwise terminate
+  // it at the HTML parser. Escaping the slash preserves the CSS token while
+  // making the closing tag impossible.
+  const renderInlineCss = (css: string[]): string => {
+    const text = css.join("\n").replace(/<\/style/gi, "<\\/style");
+    return text
+      ? `<style data-pracht-inline-css${head.styleNonce ? ` nonce="${escapeHtml(head.styleNonce)}"` : ""}>${text}</style>`
+      : "";
+  };
+  const cssTags = (() => {
+    if (!cssAssets) {
+      return [
+        renderInlineCss(inlineCss),
+        ...cssUrls.map((url) => `<link rel="stylesheet" href="${escapeHtml(url)}">`),
+      ]
+        .filter(Boolean)
+        .join("\n    ");
+    }
+
+    const tags: string[] = [];
+    let pendingInline: string[] = [];
+    const flushInline = () => {
+      const tag = renderInlineCss(pendingInline);
+      if (tag) tags.push(tag);
+      pendingInline = [];
+    };
+    for (const asset of cssAssets) {
+      if (asset.content !== undefined) {
+        pendingInline.push(asset.content);
+      } else {
+        flushInline();
+        tags.push(`<link rel="stylesheet" href="${escapeHtml(asset.href)}">`);
+      }
+    }
+    flushInline();
+    return tags.join("\n    ");
+  })();
 
   const modulePreloadTags = modulePreloadUrls
     .map((url) => `<link rel="modulepreload" href="${escapeHtml(url)}">`)

--- a/packages/framework/src/runtime-manifest.ts
+++ b/packages/framework/src/runtime-manifest.ts
@@ -70,6 +70,26 @@ export function resolvePageCssUrls(
   return resolvePageUrlsFromManifest(cssManifest, shellFile, routeFile);
 }
 
+/**
+ * Split a page's ordered stylesheets into inline payloads and linked fallbacks.
+ * Generated builds populate every URL when inlining is enabled; the fallback
+ * keeps custom server entries safe when their content map is partial or stale.
+ */
+export function resolvePageCssAssets(
+  cssManifest: Record<string, string[]> | undefined,
+  cssContentManifest: Record<string, string> | undefined,
+  shellFile: string | undefined,
+  routeFile: string,
+): Array<{ content?: string; href: string }> {
+  const pageUrls = resolvePageCssUrls(cssManifest, shellFile, routeFile);
+  return pageUrls.map((href) => ({
+    href,
+    ...(cssContentManifest && Object.hasOwn(cssContentManifest, href)
+      ? { content: cssContentManifest[href] }
+      : {}),
+  }));
+}
+
 export function resolvePageJsUrls(
   jsManifest: Record<string, string[]> | undefined,
   shellFile: string | undefined,

--- a/packages/framework/src/runtime-middleware.ts
+++ b/packages/framework/src/runtime-middleware.ts
@@ -165,6 +165,7 @@ function mergeHeadValues(shellHead: HeadMetadata, routeHead: HeadMetadata): Head
     meta: [...(shellHead.meta ?? []), ...(routeHead.meta ?? [])],
     link: [...(shellHead.link ?? []), ...(routeHead.link ?? [])],
     script: [...(shellHead.script ?? []), ...(routeHead.script ?? [])],
+    styleNonce: routeHead.styleNonce ?? shellHead.styleNonce,
     fontNonce: routeHead.fontNonce ?? shellHead.fontNonce,
     // Duplicate registrations (e.g. shell and route both list the same font)
     // are collapsed by the head renderer, not here, so the merge stays a

--- a/packages/framework/src/runtime-page.ts
+++ b/packages/framework/src/runtime-page.ts
@@ -36,7 +36,7 @@ import {
   ISLANDS_ENTRY_MANIFEST_KEY,
   mergeEntryPreloadUrls,
   resolveManifestEntries,
-  resolvePageCssUrls,
+  resolvePageCssAssets,
   resolvePageJsUrls,
   resolveDataFunctions,
   resolveRegistryModule,
@@ -342,13 +342,18 @@ async function resolvePageDocumentMetadata<TContext>(
 
 /** Stylesheet and modulepreload URLs for this route's document. */
 function resolvePageAssets<TContext>(job: PageRenderJob<TContext>): {
-  cssUrls: string[];
+  cssAssets: Array<{ content?: string; href: string }>;
   modulePreloadUrls: string[];
 } {
   const { options } = job.ctx;
   const { route } = job.match;
   return {
-    cssUrls: resolvePageCssUrls(options.cssManifest, route.shellFile, route.file),
+    cssAssets: resolvePageCssAssets(
+      options.cssManifest,
+      options.cssContentManifest,
+      route.shellFile,
+      route.file,
+    ),
     modulePreloadUrls: mergeEntryPreloadUrls(
       options.jsManifest,
       CLIENT_ENTRY_MANIFEST_KEY,
@@ -368,7 +373,7 @@ async function renderSpaDocument<TContext>(
   hasLoader: boolean,
 ): Promise<Response> {
   const { ctx, match, pageOptions } = job;
-  const { cssUrls, modulePreloadUrls } = resolvePageAssets(job);
+  const { cssAssets, modulePreloadUrls } = resolvePageAssets(job);
   // The generated hasLoader hint can be absent for direct runtime
   // callers, but the resolved loader is authoritative here. Route
   // middleware also participates in the route-state request.
@@ -419,7 +424,7 @@ async function renderSpaDocument<TContext>(
         pending: needsRouteState,
       },
       clientEntryUrl: ctx.options.clientEntryUrl,
-      cssUrls,
+      cssAssets,
       modulePreloadUrls,
       // Routes with loader/middleware state preload it. Static exports
       // point this at a serialized file; other adapters use `_data=1`.
@@ -447,7 +452,7 @@ async function renderServerDocument<TContext>(
 ): Promise<Response> {
   const { ctx, match, pageOptions } = job;
   const routeModule = job.routeModule!;
-  const { cssUrls, modulePreloadUrls } = resolvePageAssets(job);
+  const { cssAssets, modulePreloadUrls } = resolvePageAssets(job);
 
   const DefaultComponent =
     typeof routeModule.default === "function" ? routeModule.default : undefined;
@@ -550,7 +555,7 @@ async function renderServerDocument<TContext>(
         head: withCapturedScripts(head, scriptCapture),
         body: ssrContent,
         clientEntryUrl: islandsEntryUrl,
-        cssUrls,
+        cssAssets,
         modulePreloadUrls: islandsEntryUrl
           ? mergeEntryPreloadUrls(ctx.options.jsManifest, ISLANDS_ENTRY_MANIFEST_KEY, [
               ...islandPreloadUrls,
@@ -574,7 +579,7 @@ async function renderServerDocument<TContext>(
         error: null,
       },
       clientEntryUrl: ctx.options.clientEntryUrl,
-      cssUrls,
+      cssAssets,
       modulePreloadUrls,
       speculationRules: getAppSpeculationRules(ctx.resolvedApp),
     }),

--- a/packages/framework/src/runtime-request.ts
+++ b/packages/framework/src/runtime-request.ts
@@ -105,6 +105,8 @@ export interface HandlePrachtRequestOptions<TContext = unknown> {
   islandsBootstrapRequired?: boolean;
   /** Per-source-file CSS map produced by the vite plugin. */
   cssManifest?: Record<string, string[]>;
+  /** Per-public-URL CSS content emitted when the vite plugin inlines route CSS. */
+  cssContentManifest?: Record<string, string>;
   /** Per-source-file JS chunk map produced by the vite plugin for modulepreload hints. */
   jsManifest?: Record<string, string[]>;
   apiRoutes?: ResolvedApiRoute[];

--- a/packages/framework/src/runtime-response.ts
+++ b/packages/framework/src/runtime-response.ts
@@ -21,7 +21,7 @@ import {
   ISLANDS_ENTRY_MANIFEST_KEY,
   mergeEntryPreloadUrls,
   resolveManifestEntries,
-  resolvePageCssUrls,
+  resolvePageCssAssets,
   resolvePageJsUrls,
   resolveRegistryModule,
 } from "./runtime-manifest.ts";
@@ -75,6 +75,7 @@ interface HandleRequestOptionsLike {
   islandsEntryUrl?: string;
   islandsBootstrapRequired?: boolean;
   cssManifest?: Record<string, string[]>;
+  cssContentManifest?: Record<string, string>;
   jsManifest?: Record<string, string[]>;
   registry?: import("./types.ts").ModuleRegistry;
 }
@@ -261,8 +262,9 @@ export async function renderRouteErrorResponse<TContext>(options: {
     options.routeArgs,
     undefined,
   );
-  const cssUrls = resolvePageCssUrls(
+  const cssAssets = resolvePageCssAssets(
     options.options.cssManifest,
+    options.options.cssContentManifest,
     options.shellFile,
     options.routeArgs.route.file,
   );
@@ -346,7 +348,7 @@ export async function renderRouteErrorResponse<TContext>(options: {
         head,
         body,
         clientEntryUrl: islandsEntryUrl,
-        cssUrls,
+        cssAssets,
         modulePreloadUrls: islandsEntryUrl
           ? mergeEntryPreloadUrls(options.options.jsManifest, ISLANDS_ENTRY_MANIFEST_KEY, [
               ...islandPreloadUrls,
@@ -369,7 +371,7 @@ export async function renderRouteErrorResponse<TContext>(options: {
         error: routeErrorWithDiagnostics,
       },
       clientEntryUrl: options.options.clientEntryUrl,
-      cssUrls,
+      cssAssets,
       modulePreloadUrls,
     }),
     routeErrorWithDiagnostics.status,

--- a/packages/framework/src/types.ts
+++ b/packages/framework/src/types.ts
@@ -795,8 +795,13 @@ export interface HeadMetadata {
    */
   fonts?: PrachtFont[];
   /**
-   * CSP nonce for the generated font `<style>`. Put a request-specific nonce
-   * on a shared shell head when using `style-src 'nonce-…'`.
+   * CSP nonce for framework-generated inline styles, including build-time CSS
+   * emitted by `pracht({ inlineCss: true })` and generated font CSS.
+   */
+  styleNonce?: string;
+  /**
+   * CSP nonce for the generated font `<style>`. Prefer `styleNonce`, which
+   * also covers opt-in inlined build CSS. Kept for backwards compatibility.
    */
   fontNonce?: string;
 }

--- a/packages/framework/src/web-vitals-hook.ts
+++ b/packages/framework/src/web-vitals-hook.ts
@@ -1,0 +1,47 @@
+import { useEffect, useRef } from "preact/hooks";
+import type { Metric } from "web-vitals";
+
+export type WebVitalsMetric = Metric;
+export type WebVitalsReporter = (metric: WebVitalsMetric) => void;
+
+const reporters = new Set<WebVitalsReporter>();
+let observers: Promise<void> | undefined;
+
+function publish(metric: WebVitalsMetric): void {
+  for (const report of reporters) report(metric);
+}
+
+function ensureWebVitalsObservers(): Promise<void> {
+  observers ??= import("web-vitals").then(({ onCLS, onFCP, onINP, onLCP, onTTFB }) => {
+    // Register each observer once per document. The package buffers early
+    // performance entries, so loading this chunk after hydration does not
+    // sacrifice initial-navigation measurements.
+    onCLS(publish);
+    onFCP(publish);
+    onINP(publish);
+    onLCP(publish);
+    onTTFB(publish);
+  });
+  return observers;
+}
+
+/**
+ * Report CLS, FCP, INP, LCP, and TTFB from a client component.
+ *
+ * The measurement library is loaded lazily from an effect, so SSR is safe and
+ * applications that do not call this hook ship none of its runtime. Multiple
+ * hook instances share one observer set for the lifetime of the document.
+ */
+export function useWebVitals(report: WebVitalsReporter): void {
+  const reportRef = useRef(report);
+  reportRef.current = report;
+
+  useEffect(() => {
+    const subscriber: WebVitalsReporter = (metric) => reportRef.current(metric);
+    reporters.add(subscriber);
+    void ensureWebVitalsObservers();
+    return () => {
+      reporters.delete(subscriber);
+    };
+  }, []);
+}

--- a/packages/framework/test/critical-css.test.ts
+++ b/packages/framework/test/critical-css.test.ts
@@ -1,0 +1,107 @@
+import { h } from "preact";
+import { describe, expect, it } from "vitest";
+
+import { defineApp, handlePrachtRequest, route } from "../src/index.ts";
+import { buildHtmlDocument } from "../src/runtime-html.ts";
+import { resolvePageCssAssets } from "../src/runtime-manifest.ts";
+
+describe("inlined route CSS", () => {
+  it("partitions inlined assets from linked fallbacks without changing route order", () => {
+    expect(
+      resolvePageCssAssets(
+        {
+          "./shell.tsx": ["/assets/shared.css", "/assets/shell.css"],
+          "./route.tsx": ["/assets/shared.css", "/assets/route.css"],
+        },
+        {
+          "/assets/shared.css": ".shared{}",
+          "/assets/route.css": ".route{}",
+        },
+        "./shell.tsx",
+        "./route.tsx",
+      ),
+    ).toEqual([
+      { content: ".shared{}", href: "/assets/shared.css" },
+      { href: "/assets/shell.css" },
+      { content: ".route{}", href: "/assets/route.css" },
+    ]);
+  });
+
+  it("renders nonce-bearing inline CSS safely and omits its stylesheet link", () => {
+    const html = buildHtmlDocument({
+      head: { styleNonce: 'nonce"value' },
+      body: "<p>hello</p>",
+      cssAssets: [
+        {
+          content: '.hero::after{content:"</style><script>bad()</script>"}',
+          href: "/assets/inline.css",
+        },
+        { href: "/assets/fallback.css" },
+        { content: ".after{display:block}", href: "/assets/after.css" },
+      ],
+    });
+
+    expect(html).toContain(
+      '<style data-pracht-inline-css nonce="nonce&quot;value">.hero::after{content:"<\\/style><script>bad()</script>"}</style>',
+    );
+    expect(html).toContain('<link rel="stylesheet" href="/assets/fallback.css">');
+    expect(html.indexOf("<\\/style><script>bad()")).toBeLessThan(
+      html.indexOf('href="/assets/fallback.css"'),
+    );
+    expect(html.indexOf('href="/assets/fallback.css"')).toBeLessThan(
+      html.indexOf(".after{display:block}"),
+    );
+    expect(html).not.toContain("</style><script>bad()</script>");
+  });
+
+  it.each([
+    ["spa", "full"],
+    ["ssr", "full"],
+    ["ssg", "none"],
+    ["isg", "islands"],
+  ] as const)("uses the same CSS path for %s/%s documents", async (render, hydration) => {
+    const file = "./routes/home.tsx";
+    const response = await handlePrachtRequest({
+      app: defineApp({ routes: [route("/", file, { hydration, render })] }),
+      registry: {
+        routeModules: {
+          [file]: async () => ({ Component: () => h("main", null, "Hello") }),
+        },
+      },
+      request: new Request("http://localhost/"),
+      clientEntryUrl: hydration === "full" ? "/assets/client.js" : undefined,
+      cssManifest: { [file]: ["/assets/home.css"] },
+      cssContentManifest: { "/assets/home.css": ".home{color:rebeccapurple}" },
+    });
+    const html = await response.text();
+
+    expect(response.status).toBe(200);
+    expect(html).toContain("<style data-pracht-inline-css>.home{color:rebeccapurple}</style>");
+    expect(html).not.toContain('rel="stylesheet"');
+  });
+
+  it("keeps inlined CSS on rendered error boundaries", async () => {
+    const file = "./routes/error.tsx";
+    const response = await handlePrachtRequest({
+      app: defineApp({ routes: [route("/", file, { render: "ssr" })] }),
+      registry: {
+        routeModules: {
+          [file]: async () => ({
+            Component: () => {
+              throw new Error("boom");
+            },
+            ErrorBoundary: () => h("main", null, "Recovered"),
+          }),
+        },
+      },
+      request: new Request("http://localhost/"),
+      cssManifest: { [file]: ["/assets/error.css"] },
+      cssContentManifest: { "/assets/error.css": ".error{color:red}" },
+    });
+    const html = await response.text();
+
+    expect(response.status).toBe(500);
+    expect(html).toContain("Recovered");
+    expect(html).toContain("<style data-pracht-inline-css>.error{color:red}</style>");
+  });
+});

--- a/packages/framework/test/font.test.ts
+++ b/packages/framework/test/font.test.ts
@@ -490,6 +490,19 @@ describe("fonts through head merge and document rendering", () => {
     expect(head.fontNonce).toBe("route");
   });
 
+  it("prefers a route style nonce and uses it for generated font CSS", async () => {
+    const head = await mergeHeadMetadata(
+      { Shell: () => null, head: () => ({ styleNonce: "shell" }) },
+      { default: () => null, head: () => ({ fonts: [inter], styleNonce: "route" }) },
+      makeRouteArgs(),
+      undefined,
+    );
+    expect(head.styleNonce).toBe("route");
+    expect(buildHtmlDocument({ head, body: "" })).toContain(
+      '<style data-pracht-fonts nonce="route">',
+    );
+  });
+
   it("emits one preload and one @font-face when shell and route register the same font", async () => {
     const head = await mergeHeadMetadata(
       {

--- a/packages/framework/test/package-tree-shaking.test.ts
+++ b/packages/framework/test/package-tree-shaking.test.ts
@@ -108,6 +108,11 @@ async function bundleExport(
           /^preact\//,
           "preact-render-to-string",
           "preact-suspense",
+          // The harness copies @pracht/core's dist files into a temporary
+          // directory without installing package dependencies beside them.
+          // Apps receive web-vitals through @pracht/core; keep the lazy import
+          // external here so unrelated export checks model that resolution.
+          "web-vitals",
         ],
         input: publicId,
       },
@@ -163,6 +168,13 @@ describe("published package tree shaking", () => {
     ["Script", 2_400],
   ])("keeps a named %s import below %i gzip bytes", async (exportName, maxGzipBytes) => {
     expect((await bundleExport(exportName)).gzipBytes).toBeLessThanOrEqual(maxGzipBytes);
+  });
+
+  it("drops Web Vitals when another browser export is used", async () => {
+    const { code } = await bundleExport("createHref");
+
+    expect(code).not.toContain("web-vitals");
+    expect(code).not.toContain("onCLS");
   });
 
   // The generated client entry (`@pracht/core/client`) is what every hydrating

--- a/packages/framework/test/web-vitals-hook.test.ts
+++ b/packages/framework/test/web-vitals-hook.test.ts
@@ -1,0 +1,72 @@
+// @vitest-environment jsdom
+import { h, render } from "preact";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => {
+  const callbacks = new Map<string, (metric: unknown) => void>();
+  return {
+    callbacks,
+    onCLS: vi.fn((callback: (metric: unknown) => void) => callbacks.set("CLS", callback)),
+    onFCP: vi.fn((callback: (metric: unknown) => void) => callbacks.set("FCP", callback)),
+    onINP: vi.fn((callback: (metric: unknown) => void) => callbacks.set("INP", callback)),
+    onLCP: vi.fn((callback: (metric: unknown) => void) => callbacks.set("LCP", callback)),
+    onTTFB: vi.fn((callback: (metric: unknown) => void) => callbacks.set("TTFB", callback)),
+  };
+});
+
+vi.mock("web-vitals", () => mocks);
+
+import { useWebVitals, type WebVitalsMetric } from "../src/web-vitals-hook.ts";
+
+async function flushEffects(): Promise<void> {
+  await Promise.resolve();
+  await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
+  await Promise.resolve();
+  await new Promise<void>((resolve) => setTimeout(resolve, 0));
+}
+
+describe("useWebVitals", () => {
+  const roots: HTMLDivElement[] = [];
+
+  afterEach(() => {
+    for (const root of roots) {
+      render(null, root);
+      root.remove();
+    }
+    roots.length = 0;
+  });
+
+  it("lazily shares one observer set and always calls the latest reporters", async () => {
+    const first = vi.fn();
+    const second = vi.fn();
+    const latest = vi.fn();
+    const root = document.createElement("div");
+    roots.push(root);
+    document.body.appendChild(root);
+
+    function Probe({ report }: { report: (metric: WebVitalsMetric) => void }) {
+      useWebVitals(report);
+      return null;
+    }
+
+    render(h("div", null, h(Probe, { report: first }), h(Probe, { report: second })), root);
+    expect(mocks.onCLS).not.toHaveBeenCalled();
+    await flushEffects();
+
+    for (const observe of [mocks.onCLS, mocks.onFCP, mocks.onINP, mocks.onLCP, mocks.onTTFB]) {
+      expect(observe).toHaveBeenCalledTimes(1);
+    }
+
+    const metric = { name: "LCP", value: 123 } as WebVitalsMetric;
+    mocks.callbacks.get("LCP")?.(metric);
+    expect(first).toHaveBeenCalledWith(metric);
+    expect(second).toHaveBeenCalledWith(metric);
+
+    render(h("div", null, h(Probe, { report: latest }), h(Probe, { report: second })), root);
+    await flushEffects();
+    mocks.callbacks.get("CLS")?.({ name: "CLS", value: 0.01 } as WebVitalsMetric);
+    expect(latest).toHaveBeenCalledTimes(1);
+    expect(first).toHaveBeenCalledTimes(1);
+    expect(second).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/vite-plugin/src/plugin-assets.ts
+++ b/packages/vite-plugin/src/plugin-assets.ts
@@ -1,5 +1,5 @@
 import { existsSync, readFileSync } from "node:fs";
-import { resolve } from "node:path";
+import { dirname, resolve } from "node:path";
 import { stripPrachtClientModuleQuery } from "./client-module-query.ts";
 
 export const PRACHT_CLIENT_MODULE_ID = "virtual:pracht/client";
@@ -26,6 +26,7 @@ export interface ClientBuildAssets {
   clientEntryUrl: string | null;
   islandsEntryUrl: string | null;
   cssManifest: Record<string, string[]>;
+  cssContentManifest: Record<string, string>;
   jsManifest: Record<string, string[]>;
 }
 
@@ -38,12 +39,22 @@ function assetUrl(file: string, base: string): string {
   return `${base}${file}`;
 }
 
-export function readClientBuildAssets(root = process.cwd(), base = "/"): ClientBuildAssets {
+export function readClientBuildAssets(
+  root = process.cwd(),
+  base = "/",
+  inlineCss = false,
+): ClientBuildAssets {
   const manifestPath = ["dist/client/.vite/manifest.json", "dist/.vite/manifest.json"]
     .map((candidate) => resolve(root, candidate))
     .find((candidate) => existsSync(candidate));
   if (!manifestPath) {
-    return { clientEntryUrl: null, islandsEntryUrl: null, cssManifest: {}, jsManifest: {} };
+    return {
+      clientEntryUrl: null,
+      islandsEntryUrl: null,
+      cssManifest: {},
+      cssContentManifest: {},
+      jsManifest: {},
+    };
   }
 
   const rawManifest = readFileSync(manifestPath, "utf-8");
@@ -52,13 +63,21 @@ export function readClientBuildAssets(root = process.cwd(), base = "/"): ClientB
   const islandsEntry = manifest[PRACHT_ISLANDS_CLIENT_MODULE_ID];
 
   const cssManifest: Record<string, string[]> = {};
+  const cssContentManifest: Record<string, string> = {};
   const jsManifest: Record<string, string[]> = {};
+  const clientOutDir = dirname(dirname(manifestPath));
   for (const [key, entry] of Object.entries(manifest)) {
     if (!entry.src) continue;
     const deps = collectTransitiveDeps(manifest, key);
     const manifestKey = stripPrachtClientModuleQuery(entry.src);
     if (deps.css.length > 0) {
       cssManifest[manifestKey] = deps.css.map((f) => assetUrl(f, base));
+      if (inlineCss) {
+        for (const file of deps.css) {
+          const url = assetUrl(file, base);
+          cssContentManifest[url] ??= readFileSync(resolve(clientOutDir, file), "utf-8");
+        }
+      }
     }
     if (deps.js.length > 0) {
       jsManifest[manifestKey] = deps.js.map((f) => assetUrl(f, base));
@@ -77,6 +96,7 @@ export function readClientBuildAssets(root = process.cwd(), base = "/"): ClientB
     clientEntryUrl: clientEntry ? assetUrl(clientEntry.file, base) : null,
     islandsEntryUrl: islandsEntry ? assetUrl(islandsEntry.file, base) : null,
     cssManifest,
+    cssContentManifest,
     jsManifest,
   };
 }

--- a/packages/vite-plugin/src/plugin-codegen.ts
+++ b/packages/vite-plugin/src/plugin-codegen.ts
@@ -541,8 +541,14 @@ export function createPrachtServerModuleSource(
   const routeHeadHints = routeHints.head;
   const routeStaticPathsHints = routeHints.staticPaths;
   const clientBuild = buildOptions.isBuild
-    ? readClientBuildAssets(buildOptions.root, buildOptions.base ?? "/")
-    : { clientEntryUrl: null, islandsEntryUrl: null, cssManifest: {}, jsManifest: {} };
+    ? readClientBuildAssets(buildOptions.root, buildOptions.base ?? "/", resolved.inlineCss)
+    : {
+        clientEntryUrl: null,
+        islandsEntryUrl: null,
+        cssManifest: {},
+        cssContentManifest: {},
+        jsManifest: {},
+      };
   const adapter = resolved.adapter;
   const llmsTxtConfig = resolveLlmsTxtConfig(resolved, buildOptions.root);
   const islandsBootstrapRequired = hasWebmcpCapabilities(resolved, buildOptions.root);
@@ -611,6 +617,7 @@ export function createPrachtServerModuleSource(
     `export const islandsEntryUrl = ${JSON.stringify(islandsEntryUrl ?? null)};`,
     `export const islandsBootstrapRequired = ${JSON.stringify(islandsBootstrapRequired)};`,
     `export const cssManifest = ${JSON.stringify(clientBuild.cssManifest)};`,
+    `export const cssContentManifest = ${JSON.stringify(clientBuild.cssContentManifest)};`,
     `export const jsManifest = ${JSON.stringify(clientBuild.jsManifest)};`,
     `export const prerenderConcurrency = ${JSON.stringify(resolved.prerenderConcurrency)};`,
     `export const budgets = ${JSON.stringify(resolved.budgets)};`,

--- a/packages/vite-plugin/src/plugin-options.ts
+++ b/packages/vite-plugin/src/plugin-options.ts
@@ -89,6 +89,12 @@ export interface PrachtPluginOptions {
    * Preact merged into its own chunks.
    */
   vendorChunk?: boolean;
+  /**
+   * Inline the matched route and shell's emitted production CSS in the HTML
+   * head instead of linking those assets. Defaults to `false`; enable it for
+   * small critical stylesheets after accounting for HTML/cache duplication.
+   */
+  inlineCss?: boolean;
   appFile?: string;
   routesDir?: string;
   shellsDir?: string;
@@ -160,6 +166,7 @@ export const CLIENT_FEATURE_DEFAULTS: Required<PrachtClientOptions> = {
 const DEFAULTS: ResolvedPrachtPluginOptions = {
   client: CLIENT_FEATURE_DEFAULTS,
   vendorChunk: true,
+  inlineCss: false,
   appFile: "/src/routes.ts",
   middlewareDir: "/src/middleware",
   routesDir: "/src/routes",
@@ -194,6 +201,11 @@ export function resolveOptions(options: PrachtPluginOptions): ResolvedPrachtPlug
   if (typeof resolved.vendorChunk !== "boolean") {
     throw new Error(
       `pracht({ vendorChunk }) expects a boolean, got ${JSON.stringify(resolved.vendorChunk)}.`,
+    );
+  }
+  if (typeof resolved.inlineCss !== "boolean") {
+    throw new Error(
+      `pracht({ inlineCss }) expects a boolean, got ${JSON.stringify(resolved.inlineCss)}.`,
     );
   }
   resolved.additionalExtensions = normalizeAdditionalExtensions(resolved.additionalExtensions);

--- a/packages/vite-plugin/test/default-adapter.test.ts
+++ b/packages/vite-plugin/test/default-adapter.test.ts
@@ -14,6 +14,7 @@ describe("createDefaultNodeAdapter", () => {
     );
     expect(source).toContain("headersManifest,");
     expect(source).toContain("markdownManifest,");
+    expect(source).toContain("cssContentManifest,");
     expect(source).toContain("createNodeRequestHandler");
   });
 });

--- a/packages/vite-plugin/test/plugin-assets.test.ts
+++ b/packages/vite-plugin/test/plugin-assets.test.ts
@@ -1,0 +1,47 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { readClientBuildAssets } from "../src/plugin-assets.ts";
+
+const roots: string[] = [];
+
+afterEach(() => {
+  for (const root of roots) rmSync(root, { force: true, recursive: true });
+  roots.length = 0;
+});
+
+function fixture(): string {
+  const root = mkdtempSync(join(tmpdir(), "pracht-inline-css-"));
+  roots.push(root);
+  mkdirSync(join(root, "dist/client/.vite"), { recursive: true });
+  mkdirSync(join(root, "dist/client/assets"), { recursive: true });
+  writeFileSync(join(root, "dist/client/assets/home.css"), ".home{color:purple}");
+  writeFileSync(
+    join(root, "dist/client/.vite/manifest.json"),
+    JSON.stringify({
+      "src/routes/home.tsx": {
+        file: "assets/home.js",
+        src: "src/routes/home.tsx",
+        css: ["assets/home.css"],
+      },
+    }),
+  );
+  return root;
+}
+
+describe("readClientBuildAssets inlineCss", () => {
+  it("leaves CSS content out by default", () => {
+    const assets = readClientBuildAssets(fixture(), "/app/");
+    expect(assets.cssManifest["src/routes/home.tsx"]).toEqual(["/app/assets/home.css"]);
+    expect(assets.cssContentManifest).toEqual({});
+  });
+
+  it("keys emitted CSS content by its public base-prefixed URL", () => {
+    const assets = readClientBuildAssets(fixture(), "/app/", true);
+    expect(assets.cssContentManifest).toEqual({
+      "/app/assets/home.css": ".home{color:purple}",
+    });
+  });
+});

--- a/packages/vite-plugin/test/plugin-options.test.ts
+++ b/packages/vite-plugin/test/plugin-options.test.ts
@@ -64,6 +64,18 @@ describe("resolveOptions client", () => {
   });
 });
 
+describe("resolveOptions inlineCss", () => {
+  it("defaults to linked stylesheets and accepts explicit inlining", () => {
+    expect(resolveOptions({}).inlineCss).toBe(false);
+    expect(resolveOptions({ inlineCss: true }).inlineCss).toBe(true);
+  });
+
+  it("rejects non-boolean values", () => {
+    // @ts-expect-error — inlineCss is a boolean.
+    expect(() => resolveOptions({ inlineCss: "yes" })).toThrow(/inlineCss.*expects a boolean/);
+  });
+});
+
 describe("resolveOptions budgets", () => {
   it("defaults to no budgets", () => {
     expect(resolveOptions({}).budgets).toEqual({});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -482,6 +482,9 @@ importers:
       preact-suspense:
         specifier: ^0.3.0
         version: 0.3.0(preact@10.29.1)
+      web-vitals:
+        specifier: ^6.2.1
+        version: 6.2.1
 
   packages/i18n:
     dependencies:
@@ -3409,6 +3412,9 @@ packages:
     resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
     engines: {node: '>=18'}
 
+  web-vitals@6.2.1:
+    resolution: {integrity: sha512-rLcLXA2sx6+9dE88NHFubwTtGxpK4yYBLj6qHPdFoCaLr0cXGb4efOqtKLlm4loGA4OEKHIQKMKzZkKyOh5ctw==}
+
   webidl-conversions@3.0.1:
     resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
 
@@ -5985,6 +5991,8 @@ snapshots:
   w3c-xmlserializer@5.0.0:
     dependencies:
       xml-name-validator: 5.0.0
+
+  web-vitals@6.2.1: {}
 
   webidl-conversions@3.0.1: {}
 

--- a/skills/add-observability/SKILL.md
+++ b/skills/add-observability/SKILL.md
@@ -169,53 +169,26 @@ slowest loaders (cross-reference with `audit-bundles` perf hotspots).
 
 ## Step 4: Web Vitals on the client
 
-```bash
-pnpm add web-vitals
-```
-
-Create `src/client/vitals.ts` — export a function, **no module-level
-side effects**:
-
-```ts
-import { onCLS, onINP, onLCP, onFCP, onTTFB, type Metric } from "web-vitals";
-
-function send(metric: Metric) {
-  navigator.sendBeacon?.(
-    "/api/telemetry/vitals",
-    JSON.stringify({ name: metric.name, value: metric.value, id: metric.id, path: location.pathname }),
-  );
-}
-
-export function reportVitals() {
-  onCLS(send);
-  onINP(send);
-  onLCP(send);
-  onFCP(send);
-  onTTFB(send);
-}
-```
-
-Do NOT import this statically from a shell: shells render on the **server**
-too, so module-level `onCLS(...)` calls would execute during SSR. The primary
-pattern is a lazy `import()` inside an effect, guarded by `useIsHydrated`
-(exported from `@pracht/core`), placed in a shell or top-level component:
+Use the framework hook from a component mounted by a shared shell:
 
 ```tsx
-import { useIsHydrated } from "@pracht/core";
-import { useEffect } from "preact/hooks";
+import { useWebVitals } from "@pracht/core";
 
 export function Vitals() {
-  const hydrated = useIsHydrated();
-  useEffect(() => {
-    if (!hydrated) return;
-    void import("../client/vitals").then((m) => m.reportVitals());
-  }, [hydrated]);
+  useWebVitals((metric) => {
+    navigator.sendBeacon?.(
+      "/api/telemetry/vitals",
+      JSON.stringify({ name: metric.name, value: metric.value, id: metric.id, path: location.pathname }),
+    );
+  });
   return null;
 }
 ```
 
-This keeps `web-vitals` out of the critical bundle (lazy chunk) and only
-starts observers after hydration has fully settled.
+The hook is safe during SSR, lazy-loads `web-vitals` after mount, and shares a
+single observer set across callers. No separate dependency, hydration guard,
+or client-only module is needed, and apps that never call it ship no metrics
+runtime.
 
 ## Step 5: Beacon endpoint
 


### PR DESCRIPTION
## Summary

- Add opt-in route and shell CSS inlining across every deployment adapter, including CSP nonce support and linked-asset fallback behavior.
- Add an SSR-safe, lazily loaded `useWebVitals()` hook for CLS, FCP, INP, LCP, and TTFB reporting.
- Relevant issue: N/A.

## Testing

- [ ] `pnpm run verify` (build, format, lint, typecheck, test, e2e)
  - Build, format, lint, typecheck, and generated-type checks passed. Two full unit-suite attempts encountered unrelated peak-load flakes: one late jsdom animation-frame cleanup error after all 3,795 assertions passed, then two unchanged CLI timeouts while system load exceeded 196.
- [x] `pnpm exec vitest run packages/framework/test/router-static-fallback.test.ts packages/framework/test/web-vitals-hook.test.ts` (5 passed)
- [x] `VITEST_MAX_WORKERS=1 pnpm exec vitest run packages/cli/test/cli-inspect.test.js` (3 passed)
- [x] `pnpm run bench:check`
- [x] `pnpm exec playwright test --workers=1` (180 passed)

## Checklist

- [x] Docs updated if needed
- [x] Skills updated if needed
- [x] Concise, user-facing changeset added if published packages changed