### PR TITLE
Publish docs with revision and content verification

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,77 @@
+name: Publish docs
+
+on:
+  workflow_run:
+    workflows: [CI]
+    types: [completed]
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: docs-production
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    if: >-
+      (github.event_name == 'workflow_run' &&
+       github.event.workflow_run.conclusion == 'success' &&
+       github.event.workflow_run.event == 'push') ||
+      (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main')
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    environment:
+      name: docs
+      url: https://pracht.resynapse.dev
+    steps:
+      - name: Checkout verified commit
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
+          persist-credentials: false
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
+        with:
+          version: 11.3.0
+
+      - name: Install Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version-file: .nvmrc
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile --ignore-scripts
+
+      - name: Build workspace and docs
+        run: |
+          pnpm build
+          pnpm --filter @pracht/example-docs build
+          pnpm --dir examples/docs exec node scripts/docs-release.mjs write "$(git rev-parse HEAD)"
+
+      - name: Check that the verified commit is still current
+        id: current
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          latest=$(gh api "repos/$GITHUB_REPOSITORY/commits/main" --jq .sha)
+          if [ "$latest" = "$(git rev-parse HEAD)" ]; then
+            echo 'deploy=true' >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Deploy
+        if: steps.current.outputs.deploy == 'true'
+        working-directory: examples/docs
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: pnpm exec wrangler deploy
+
+      - name: Verify public pages and agent discovery assets
+        if: steps.current.outputs.deploy == 'true'
+        working-directory: examples/docs
+        run: node scripts/docs-release.mjs check

--- a/docs/WORKSPACE.md
+++ b/docs/WORKSPACE.md
@@ -369,3 +369,34 @@ to regress:
 ## Later (Phase 2 remaining)
 
 No Phase 2 adapter ISG items are currently tracked here.
+
+## Publishing the public docs
+
+The `Publish docs` workflow deploys `examples/docs` to the `pracht-docs`
+Cloudflare Worker after the `CI` workflow succeeds for a push to `main`.
+It checks out the verified commit and skips deployment if `main` has advanced.
+A manual run is available on `main` for retrying a failed publication.
+Configure `CLOUDFLARE_API_TOKEN` and `CLOUDFLARE_ACCOUNT_ID` in the GitHub
+`docs` environment (repository secrets also work). The token must be able to
+deploy the existing Worker to that account. The public domain remains
+`https://pracht.resynapse.dev`.
+
+Publication builds the workspace and docs, then writes
+`dist/client/.well-known/pracht-build.json` with the commit SHA and SHA-256
+hashes of the generated HTML, `llms.txt`, and agent-skills assets. After
+`wrangler deploy`, the workflow fetches the public revision marker and compares
+live content with the local build inventory. Missing pages, stale content, and
+an old deployment fail the job, even if the deploy command succeeded.
+
+To prepare and inspect the same release locally, from the repository root:
+
+```sh
+pnpm build
+pnpm --filter @pracht/example-docs build
+pnpm --dir examples/docs exec node scripts/docs-release.mjs write "$(git rev-parse HEAD)"
+pnpm --dir examples/docs exec node scripts/docs-release.mjs check
+```
+
+The final command checks production; it does not publish. Pass another origin
+to `check` to verify a preview deployment. Redirect/fallback documents
+`404.html` and `200.html` are excluded from the successful-page inventory.

--- a/examples/docs/scripts/docs-release.mjs
+++ b/examples/docs/scripts/docs-release.mjs
@@ -1,0 +1,95 @@
+import { createHash } from "node:crypto";
+import { readFile, readdir, mkdir, writeFile } from "node:fs/promises";
+import { resolve, dirname, relative, sep } from "node:path";
+import { pathToFileURL } from "node:url";
+
+export const metadataPath = "/.well-known/pracht-build.json";
+const requiredPaths = [
+  "/docs/why-pracht",
+  "/docs/standalone-capabilities",
+  "/llms.txt",
+  "/.well-known/agent-skills/index.json",
+];
+const digest = (body) => createHash("sha256").update(body).digest("hex");
+
+async function filesIn(directory) {
+  const entries = await readdir(directory, { withFileTypes: true });
+  const nested = await Promise.all(
+    entries.map((entry) => {
+      const path = resolve(directory, entry.name);
+      return entry.isDirectory() ? filesIn(path) : [path];
+    }),
+  );
+  return nested.flat();
+}
+
+export async function writeRelease(directory, revision) {
+  if (!/^[a-f0-9]{40}$/.test(revision ?? "")) throw new Error("A full Git commit SHA is required.");
+  const assets = {};
+  for (const file of (await filesIn(directory)).sort()) {
+    const asset = relative(directory, file).split(sep).join("/");
+    if (asset === "404.html" || asset === "200.html") continue;
+    if (
+      !asset.endsWith(".html") &&
+      asset !== "llms.txt" &&
+      !asset.startsWith(".well-known/agent-skills/") &&
+      !asset.startsWith("skills/")
+    )
+      continue;
+    const path = `/${asset}`.replace(/\/index\.html$/, "").replace(/\.html$/, "") || "/";
+    assets[path] = digest(await readFile(file));
+  }
+  for (const path of requiredPaths) {
+    if (!assets[path]) throw new Error(`The docs build is missing ${path}.`);
+  }
+  const index = JSON.parse(
+    await readFile(resolve(directory, ".well-known/agent-skills/index.json"), "utf8"),
+  );
+  if (!Array.isArray(index.skills)) throw new Error("The docs build has no skill inventory.");
+  for (const skill of index.skills) {
+    const path = new URL(skill.url).pathname;
+    if (!assets[path] || assets[path] !== skill.sha256)
+      throw new Error(`The skill index does not match its built source: ${path}.`);
+  }
+  const release = { revision, assets };
+  const file = resolve(directory, `.${metadataPath}`);
+  await mkdir(dirname(file), { recursive: true });
+  await writeFile(file, `${JSON.stringify(release, null, 2)}\n`);
+  return release;
+}
+
+export async function checkRelease(directory, origin, fetchImpl = fetch) {
+  const expected = JSON.parse(await readFile(resolve(directory, `.${metadataPath}`), "utf8"));
+  const fetchAsset = async (path) => {
+    const url = new URL(path, origin);
+    url.searchParams.set("pracht_revision", expected.revision);
+    const response = await fetchImpl(url, {
+      cache: "no-store",
+      signal: AbortSignal.timeout(15_000),
+    });
+    if (!response.ok) throw new Error(`${path} returned HTTP ${response.status}.`);
+    return Buffer.from(await response.arrayBuffer());
+  };
+  const deployed = JSON.parse((await fetchAsset(metadataPath)).toString("utf8"));
+  if (deployed.revision !== expected.revision)
+    throw new Error(
+      `Stale docs deployment: expected ${expected.revision}, received ${deployed.revision}.`,
+    );
+  // Trust the locally built inventory, never URLs supplied by the deployed site.
+  for (const [path, hash] of Object.entries(expected.assets)) {
+    if (digest(await fetchAsset(path)) !== hash)
+      throw new Error(`Deployed content differs from this build: ${path}.`);
+  }
+  return expected.revision;
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(resolve(process.argv[1])).href) {
+  const [command, argument] = process.argv.slice(2);
+  const directory = resolve("dist/client");
+  if (command === "write") await writeRelease(directory, argument ?? process.env.GITHUB_SHA);
+  else if (command === "check")
+    console.log(
+      `Verified deployed docs at ${await checkRelease(directory, argument ?? "https://pracht.resynapse.dev")}`,
+    );
+  else throw new Error("Usage: node scripts/docs-release.mjs write <commit-sha> | check [origin]");
+}

--- a/examples/docs/scripts/docs-release.test.mjs
+++ b/examples/docs/scripts/docs-release.test.mjs
@@ -1,0 +1,75 @@
+import { createHash } from "node:crypto";
+import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, dirname } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { writeRelease, checkRelease, metadataPath } from "./docs-release.mjs";
+
+const directories = [];
+const revision = "a".repeat(40);
+async function fixture() {
+  const directory = await mkdtemp(join(tmpdir(), "pracht-docs-release-"));
+  directories.push(directory);
+  const files = {
+    "/docs/why-pracht": "<html>islands</html>",
+    "/docs/standalone-capabilities": "<html>standalone</html>",
+    "/llms.txt": "# Docs",
+    "/.well-known/agent-skills/index.json": JSON.stringify({
+      skills: [
+        {
+          url: "https://docs.invalid/skills/demo/SKILL.md",
+          sha256: createHash("sha256").update("Skill source").digest("hex"),
+        },
+      ],
+    }),
+    "/skills/demo/SKILL.md": "Skill source",
+  };
+  for (const [url, body] of Object.entries(files)) {
+    const file = join(directory, url.startsWith("/docs/") ? `${url}/index.html` : url);
+    await mkdir(dirname(file), { recursive: true });
+    await writeFile(file, body);
+  }
+  const release = await writeRelease(directory, revision);
+  files[metadataPath] = JSON.stringify(release);
+  const fetch = async (url) =>
+    new Response(files[url.pathname] ?? "missing", { status: url.pathname in files ? 200 : 404 });
+  return { directory, files, fetch };
+}
+afterEach(async () => {
+  await Promise.all(
+    directories.splice(0).map((directory) => rm(directory, { recursive: true, force: true })),
+  );
+});
+describe("docs publication verification", () => {
+  it("verifies the locally built revision, pages, and agent assets", async () => {
+    const { directory, fetch } = await fixture();
+    await expect(checkRelease(directory, "https://docs.invalid", fetch)).resolves.toBe(revision);
+  });
+  it("rejects a stale release even when its own files are consistent", async () => {
+    const { directory, files, fetch } = await fixture();
+    files[metadataPath] = JSON.stringify({ revision: "b".repeat(40) });
+    await expect(checkRelease(directory, "https://docs.invalid", fetch)).rejects.toThrow(
+      "Stale docs",
+    );
+  });
+  it.each([
+    "/docs/why-pracht",
+    "/llms.txt",
+    "/.well-known/agent-skills/index.json",
+    "/skills/demo/SKILL.md",
+  ])("detects stale content at %s despite a current revision marker", async (path) => {
+    const { directory, files, fetch } = await fixture();
+    files[path] = "old content";
+    await expect(checkRelease(directory, "https://docs.invalid", fetch)).rejects.toThrow(path);
+  });
+  it("refuses an index whose skill source is missing", async () => {
+    const { directory } = await fixture();
+    await rm(join(directory, "skills/demo/SKILL.md"));
+    await expect(writeRelease(directory, revision)).rejects.toThrow("skill index does not match");
+  });
+  it("refuses incomplete local builds", async () => {
+    const { directory } = await fixture();
+    await rm(join(directory, "llms.txt"));
+    await expect(writeRelease(directory, revision)).rejects.toThrow("missing /llms.txt");
+  });
+});

--- a/examples/docs/src/routes/docs/coding-agents.md
+++ b/examples/docs/src/routes/docs/coding-agents.md
@@ -377,3 +377,12 @@ jobs:
 With that in place the review contract is simple: constraints hold (verify passed), the snapshot is fresh (verify passed), and the intent-level diff is sitting in the PR thread. The human review can spend its attention on whether the change is a good idea — the machine already checked whether it is the change it claims to be.
 
 If the app exposes [capabilities](/docs/capabilities), add [`pracht eval`](/docs/agent-trust#pracht-eval-prove-agent-flows-in-ci) to the same workflow. `plan` tells you the agent surface changed; `eval` tells you it still works.
+
+### Published docs revision
+
+The docs site exposes its source commit and content hashes at
+[`.well-known/pracht-build.json`](/.well-known/pracht-build.json).
+Use the revision to check which framework checkout the published guidance
+comes from. Publication verifies the live pages, `llms.txt`, and skill assets
+against the build, so a successful deployment includes the matching agent
+reference material.


### PR DESCRIPTION
## Summary

- Publish the CI-verified main commit to the docs Worker, skip superseded commits, and serialize production deployments.
- Record the source revision and content hashes, then verify live pages, `llms.txt`, the skill index, and every skill source against the local build. A successful deploy command with stale public content fails the job.
- Document the Cloudflare credentials, manual retry/local verification commands, and public revision endpoint.
- Related issue: N/A — follows the framework evaluation's public-docs delivery finding.

## Testing

- [x] `pnpm run verify` (build, format, lint, typecheck, test, e2e)
- Docs production build passed; all 78 built assets, including 33 skills, verified over local HTTP.
- Eight regression tests cover stale revisions/content and incomplete page/skill builds; workflow YAML parsed.
- Adversarial re-review after the skill-file coverage fix found no remaining P1/P2 issues.
- Hosted deployment: N/A. Configure `CLOUDFLARE_API_TOKEN` and `CLOUDFLARE_ACCOUNT_ID` in the `docs` environment or repository secrets.

## Checklist

- [x] Docs updated if needed — internal publishing instructions and public revision reference
- [x] Skills updated if needed — N/A, contributor publishing workflow
- [x] Concise, user-facing changeset added if published packages changed — N/A, private docs app and workflow only
