### PR TITLE
Avoid legacy Suspense warnings on Preact 11

### DIFF
--- a/.changeset/quiet-preact-eleven-suspense.md
+++ b/.changeset/quiet-preact-eleven-suspense.md
@@ -1,0 +1,5 @@
+---
+"@pracht/core": patch
+---
+
+Skip the legacy single-node Suspense hydration warning when an app runs on Preact 11.

--- a/docs/DATA_LOADING.md
+++ b/docs/DATA_LOADING.md
@@ -313,7 +313,8 @@ part of why streaming is opt-in.
   status, or cache headers in the awaited part of the loader.
 - **On Preact 10, a `<Suspense>` boundary that suspends must resolve to exactly
   one DOM element** — not `null`, not a multi-child fragment. This constraint
-  goes away with Preact 11's hydration rework.
+  goes away with Preact 11's hydration rework. Pracht's development diagnostic
+  enforces the single-node rule only when the active Preact runtime is 10.x.
 - Pass the un-awaited call. `defer(await getReviews(id))` throws, because it
   defeats the point silently.
 - Return the marker from an enumerable data property. A deferred value hidden

--- a/e2e/pages-router.test.ts
+++ b/e2e/pages-router.test.ts
@@ -478,3 +478,18 @@ test("Preact 11 hydrates streamed empty and multi-element boundaries", async ({ 
   await expect(page.locator("text=Loading empty boundary")).toHaveCount(0);
   expect(errors).toEqual([]);
 });
+
+test("Preact 11 hydrates client-lazy empty and multi-element boundaries without a legacy warning", async ({
+  page,
+}) => {
+  const errors: string[] = [];
+  page.on("pageerror", (error) => errors.push(error.message));
+  await page.goto("/lazy-boundaries");
+  await expect(page.getByRole("heading", { name: "Lazy hydration boundaries" })).toBeVisible();
+  await expect(page.locator("#lazy-fragment-first")).toHaveText("Lazy fragment first");
+  await expect(page.locator("#lazy-fragment-second")).toHaveText("Lazy fragment second");
+  await expect(page.getByText("Loading lazy empty boundary")).toHaveCount(0);
+  await expect(page.getByText("Loading lazy fragment")).toHaveCount(0);
+  await expect(page.locator("#__pracht_hydration_mismatch__")).toHaveCount(0);
+  expect(errors).toEqual([]);
+});

--- a/examples/docs/src/routes/docs/data-loading.md
+++ b/examples/docs/src/routes/docs/data-loading.md
@@ -217,7 +217,8 @@ Three rules:
   loader.
 - **A suspending `<Suspense>` boundary must resolve to exactly one DOM
   element** on Preact 10 — not `null`, not a multi-child fragment. Preact 11 supports empty and multi-child boundaries; the workspace exercises
-  `11.0.0-rc.1`.
+  `11.0.0-rc.1`, and Pracht skips the legacy single-node development warning
+  when that newer hydration runtime is active.
 - Return `defer()` from an enumerable data property, not from a getter. Pracht
   does not eagerly invoke loader getters to discover hidden deferred values and
   throws instead of silently serializing an unresolved marker.

--- a/examples/pages-router/src/pages/_components/lazy-empty.tsx
+++ b/examples/pages-router/src/pages/_components/lazy-empty.tsx
@@ -1,0 +1,3 @@
+export default function LazyEmpty() {
+  return null;
+}

--- a/examples/pages-router/src/pages/_components/lazy-fragment.tsx
+++ b/examples/pages-router/src/pages/_components/lazy-fragment.tsx
@@ -1,0 +1,8 @@
+export default function LazyFragment() {
+  return (
+    <>
+      <p id="lazy-fragment-first">Lazy fragment first</p>
+      <p id="lazy-fragment-second">Lazy fragment second</p>
+    </>
+  );
+}

--- a/examples/pages-router/src/pages/lazy-boundaries.tsx
+++ b/examples/pages-router/src/pages/lazy-boundaries.tsx
@@ -1,0 +1,20 @@
+import { lazy, Suspense } from "@pracht/core";
+
+export const RENDER_MODE = "ssr";
+
+const LazyEmpty = lazy(() => import("./_components/lazy-empty.tsx"));
+const LazyFragment = lazy(() => import("./_components/lazy-fragment.tsx"));
+
+export function Component() {
+  return (
+    <section>
+      <h1>Lazy hydration boundaries</h1>
+      <Suspense fallback={<p>Loading lazy empty boundary</p>}>
+        <LazyEmpty />
+      </Suspense>
+      <Suspense fallback={<p>Loading lazy fragment</p>}>
+        <LazyFragment />
+      </Suspense>
+    </section>
+  );
+}

--- a/packages/framework/src/hydration-mismatch.ts
+++ b/packages/framework/src/hydration-mismatch.ts
@@ -1,9 +1,17 @@
-import { options as preactOptions } from "preact";
+import * as preactRuntime from "preact";
 import type { VNode } from "preact";
 
 import { installHydrationSuspenseTracking } from "./hydration-suspense.ts";
 
 const HYDRATION_BANNER_ID = "__pracht_hydration_mismatch__";
+
+// Preact 11 initializes a private component bitfield in its base constructor;
+// Preact 10 instances only own `props` and `context`. Probe the shape instead
+// of importing package metadata, because apps commonly alias the bare `preact`
+// specifier to an entry file and those aliases can break package subpaths.
+const PreactComponent = preactRuntime.Component as unknown as new () => Record<string, unknown>;
+const supportsMultiNodeSuspenseHydration = Object.keys(new PreactComponent()).length > 2;
+const preactOptions = preactRuntime.options;
 
 // Preact flag on vnode.__u for vnodes diffing against existing DOM (hydrate path).
 const MODE_HYDRATE = 1 << 5;
@@ -27,16 +35,23 @@ interface InternalComponent {
   __v?: InternalVNode;
 }
 
+interface HydrationMismatchWarningOptions {
+  supportsMultiNodeSuspenseHydration?: boolean;
+}
+
 let installed = false;
 let prevMismatch: PreactOptions["__m"];
 let prevCatchError: PreactOptions["__e"];
 let prevCommit: PreactOptions["__c"];
+let installedLegacySuspenseChecks = false;
 
 // Vnodes that suspended while hydrating, awaiting a post-resolve DOM count.
 const pendingSuspenseChecks = new Set<InternalVNode>();
 let flushScheduled = false;
 
-export function installHydrationMismatchWarning(): void {
+export function installHydrationMismatchWarning(
+  options: HydrationMismatchWarningOptions = {},
+): void {
   if (installed) return;
   installed = true;
 
@@ -48,23 +63,27 @@ export function installHydrationMismatchWarning(): void {
 
   const opts = preactOptions as PreactOptions;
   prevMismatch = opts.__m;
-  prevCatchError = opts.__e;
-  prevCommit = opts.__c;
 
   opts.__m = function (vnode: VNode) {
     appendHydrationWarning(vnode);
     if (prevMismatch) prevMismatch(vnode);
   };
 
-  opts.__e = function (err, newVNode, oldVNode, errorInfo) {
-    trackSuspendingVNode(err, newVNode as InternalVNode);
-    if (prevCatchError) prevCatchError(err, newVNode, oldVNode, errorInfo);
-  };
+  if (!(options.supportsMultiNodeSuspenseHydration ?? supportsMultiNodeSuspenseHydration)) {
+    installedLegacySuspenseChecks = true;
+    prevCatchError = opts.__e;
+    prevCommit = opts.__c;
 
-  opts.__c = function (vnode, commitQueue) {
-    if (prevCommit) prevCommit(vnode, commitQueue);
-    scheduleSuspenseCheckFlush();
-  };
+    opts.__e = function (err, newVNode, oldVNode, errorInfo) {
+      trackSuspendingVNode(err, newVNode as InternalVNode);
+      if (prevCatchError) prevCatchError(err, newVNode, oldVNode, errorInfo);
+    };
+
+    opts.__c = function (vnode, commitQueue) {
+      if (prevCommit) prevCommit(vnode, commitQueue);
+      scheduleSuspenseCheckFlush();
+    };
+  }
 }
 
 function trackSuspendingVNode(err: unknown, vnode: InternalVNode): void {
@@ -223,10 +242,13 @@ export function _resetHydrationMismatchForTesting(): void {
   const opts = preactOptions as PreactOptions;
   if (installed) {
     opts.__m = prevMismatch;
-    opts.__e = prevCatchError;
-    opts.__c = prevCommit;
+    if (installedLegacySuspenseChecks) {
+      opts.__e = prevCatchError;
+      opts.__c = prevCommit;
+    }
   }
   installed = false;
+  installedLegacySuspenseChecks = false;
   prevMismatch = undefined;
   prevCatchError = undefined;
   prevCommit = undefined;

--- a/packages/framework/test/hydration-mismatch.test.ts
+++ b/packages/framework/test/hydration-mismatch.test.ts
@@ -150,7 +150,7 @@ describe("installHydrationMismatchWarning", () => {
   });
 
   it("warns when a component unsuspends during hydration and renders multiple DOM nodes", async () => {
-    installHydrationMismatchWarning();
+    installHydrationMismatchWarning({ supportsMultiNodeSuspenseHydration: false });
 
     scratch.innerHTML = "<div><div>A</div><div>B</div></div>";
 
@@ -185,7 +185,7 @@ describe("installHydrationMismatchWarning", () => {
   });
 
   it("warns when a component unsuspends during hydration and renders zero DOM nodes", async () => {
-    installHydrationMismatchWarning();
+    installHydrationMismatchWarning({ supportsMultiNodeSuspenseHydration: false });
 
     scratch.innerHTML = "<div></div>";
 
@@ -220,7 +220,7 @@ describe("installHydrationMismatchWarning", () => {
   });
 
   it("reports the resolved user component name, not the lazy() wrapper, on offset issues", async () => {
-    installHydrationMismatchWarning();
+    installHydrationMismatchWarning({ supportsMultiNodeSuspenseHydration: false });
 
     scratch.innerHTML = "<div><div>A</div><div>B</div></div>";
 
@@ -253,7 +253,7 @@ describe("installHydrationMismatchWarning", () => {
   });
 
   it("handles wrapper components between the Suspense boundary and the suspending component", async () => {
-    installHydrationMismatchWarning();
+    installHydrationMismatchWarning({ supportsMultiNodeSuspenseHydration: false });
 
     scratch.innerHTML = "<div><div>A</div><div>B</div></div>";
 

--- a/skills/pracht-debug/SKILL.md
+++ b/skills/pracht-debug/SKILL.md
@@ -94,7 +94,10 @@ Work in order; stop at the root cause.
   component (via Preact's `options.__m` hook). Compare server HTML against
   client output. Usual causes: date/time differences, browser-only APIs during
   SSR (`window`, `document`, `localStorage`), conditional rendering on client
-  state — or two copies of `@pracht/core` in the SSR module graph. The tell for
+  state — or, on Preact 10, a suspending boundary resolving to zero or multiple
+  DOM nodes. Preact 11 supports those boundary shapes, so Pracht skips that
+  legacy diagnostic there. Another cause is two copies of `@pracht/core` in
+  the SSR module graph. The tell for
   that last one: in the server-rendered HTML of *every* page, `useLocation()`
   returns `/`, `useParams()` returns `{}`, and `useRouteData()` returns
   `undefined`, while the hydrated client is correct — provider and hooks hold


### PR DESCRIPTION
## Summary

- Skip the legacy single-node Suspense hydration diagnostic on Preact 11 while retaining it on Preact 10.
- Add browser coverage for client-lazy empty and multi-element boundaries, and update contributor docs, public docs, and the debugging skill.
- Fixes #377.

## Testing

- [x] `pnpm run verify` (build, format, lint, typecheck, test, e2e)

## Checklist

- [x] Docs updated if needed
- [x] Skills updated if needed
- [x] Concise, user-facing changeset added if published packages changed
