### PR TITLE
fix(start): typecheck browser-only exports in new apps

### DIFF
--- a/.changeset/browser-types-in-starters.md
+++ b/.changeset/browser-types-in-starters.md
@@ -1,0 +1,5 @@
+---
+"create-pracht": patch
+---
+
+Generated TypeScript configurations now resolve browser-specific package declarations, catching server-only `@pracht/core` root exports before client builds.

--- a/docs/WORKSPACE.md
+++ b/docs/WORKSPACE.md
@@ -13,6 +13,15 @@ described in `VISION_MVP.md`.
 Every published package carries `engines.node: ">=22.18"` too, so an install on
 an older runtime warns instead of failing halfway through a build.
 
+`create-pracht` emits a `tsconfig.client.json` that enables TypeScript's
+`browser` custom condition for routes, shells, islands, and their imports. Root
+imports from `@pracht/core` on those client-facing surfaces therefore use the
+same declarations as a browser bundle and reject server-only exports at
+typecheck time. The base `tsconfig.json` still checks the whole project without
+that condition, preserving server and test resolution; the generated
+`typecheck` script runs both programs. The scaffolder test compiles a
+conditional-exports fixture to guard both halves of the boundary.
+
 **Why 22.18 specifically.** Node enabled type stripping unflagged in 22.18.0.
 `packages/cli/test/fixtures/e2e-port-lease-child.mjs` is spawned with a bare
 `process.execPath` — no `--experimental-strip-types` in `NODE_OPTIONS` — and

--- a/examples/docs/src/routes/docs/reference-api.md
+++ b/examples/docs/src/routes/docs/reference-api.md
@@ -17,8 +17,9 @@ condition, so a client bundle automatically resolves to a client-safe subset of
 the same entry point — you do not pick a different specifier for the browser.
 That condition carries its own type declarations, so a server-only export such
 as `handlePrachtRequest` is a compile error in client code rather than a
-bundling failure. TypeScript only applies the condition when you ask it to, in
-a `tsconfig.json` used for client-only code:
+bundling failure. New `create-pracht` apps enable the condition in their
+generated `tsconfig.client.json`; keep it in custom client TypeScript
+configurations:
 
 ```json [tsconfig.client.json]
 {
@@ -29,8 +30,11 @@ a `tsconfig.json` used for client-only code:
 }
 ```
 
-Without it — and in a project with one `tsconfig.json` covering loaders and
-components alike — types keep resolving to the full entry, exactly as before.
+Without it, TypeScript resolves the root package to the full server-capable
+entry even when Vite will build that module for the browser. The generated base
+`tsconfig.json` deliberately keeps that default for server code and tests; the
+`typecheck` script runs both programs. Explicit `@pracht/core/server` imports
+also keep resolving to the server declarations in either program.
 
 | Specifier | Use |
 | --- | --- |

--- a/packages/start/README.md
+++ b/packages/start/README.md
@@ -17,7 +17,7 @@ npm run dev
 - Detects the active package manager from the current environment.
 - Lets the user choose between the Node.js, Cloudflare, Vercel, Netlify, and static adapters.
 - Optionally wires up Tailwind CSS (`tailwindcss` + `@tailwindcss/vite`, a global stylesheet, and the shell import).
-- Scaffolds a minimal app with a route manifest or pages router, shell, home route, not-found page, a sample API route for serverful adapters, runnable project README, TypeScript typecheck script, and (with agent tooling enabled) agent instructions.
+- Scaffolds a minimal app with a route manifest or pages router, shell, home route, not-found page, a sample API route for serverful adapters, runnable project README, TypeScript typecheck script, browser-aware package resolution that rejects server-only root exports in client code, and (with agent tooling enabled) agent instructions.
 - Manifest scaffolds include a commented-out `constraints` example in `src/routes.ts`, ready for `pracht verify`.
 - The generated `.gitignore` keeps `.pracht/app-graph.json` committable, and the README and agent instructions cover the `pracht verify` / `pracht plan` / `pracht report` loop.
 - Every standalone pnpm scaffold includes a narrow lifecycle-script policy for
@@ -100,7 +100,7 @@ writing it would leave a config in the repo that nothing in the repo reads.
 
 - `dev` -> `pracht dev`
 - `build` -> `pracht build`
-- `typecheck` -> `tsc --noEmit`
+- `typecheck` -> checks the server-capable base TypeScript program, then the browser-conditioned routes, shells, and islands in `tsconfig.client.json`
 
 Node starters also include:
 

--- a/packages/start/src/index.js
+++ b/packages/start/src/index.js
@@ -754,6 +754,7 @@ async function buildProjectFiles({
     }),
     "vite.config.ts": createViteConfig(adapter, router, tailwind),
     "tsconfig.json": createBaseTSConfig(adapter),
+    "tsconfig.client.json": createClientTSConfig(router),
   };
 
   // A static export has no server, so an API route would be a hard build
@@ -871,7 +872,7 @@ function createPackageJson({ adapter, projectName, tailwind, versions }) {
   const scripts = {
     build: "pracht build",
     dev: "pracht dev",
-    typecheck: "tsc --noEmit",
+    typecheck: "tsc --noEmit && tsc --noEmit --project tsconfig.client.json",
   };
 
   if (adapter.id === "node") {
@@ -1161,6 +1162,27 @@ function createBaseTSConfig(_adapter) {
       noEmit: true,
     },
   };
+  return `${JSON.stringify(config, null, 2)}\n`;
+}
+
+function createClientTSConfig(router) {
+  const config = {
+    extends: "./tsconfig.json",
+    compilerOptions: {
+      customConditions: ["browser"],
+    },
+    include:
+      router === "pages"
+        ? ["src/pages/**/*", "src/islands/**/*"]
+        : ["src/routes/**/*", "src/shells/**/*", "src/islands/**/*"],
+  };
+
+  // Pages route modules are shared with the browser, but these two convention
+  // files are server-only. The base program still checks the whole project.
+  if (router === "pages") {
+    config.exclude = ["src/pages/**/_app.config.*", "src/pages/**/_middleware.*"];
+  }
+
   return `${JSON.stringify(config, null, 2)}\n`;
 }
 
@@ -1606,6 +1628,10 @@ function createAgentInstructions({
     lines.push("- `src/api/` — API route handlers");
   }
   lines.push(`- \`vite.config.ts\` — Vite config with the ${adapter.label} adapter`);
+  lines.push("- `tsconfig.json` — server-capable whole-project TypeScript checks");
+  lines.push(
+    "- `tsconfig.client.json` — browser-conditioned checks for routes, shells, islands, and their imports",
+  );
 
   if (tailwind) {
     lines.push("- `src/styles/global.css` — Tailwind CSS entry stylesheet, imported by the shell");
@@ -1780,6 +1806,11 @@ function createReadme({
   if (adapter.id !== "static") {
     lines.push("- `src/api/health.ts` is a sample API route.");
   }
+
+  lines.push("- `tsconfig.json` — server-capable whole-project TypeScript checks.");
+  lines.push(
+    "- `tsconfig.client.json` — browser-conditioned checks for routes, shells, islands, and their imports.",
+  );
 
   if (tailwind) {
     lines.push("- `src/styles/global.css` is the Tailwind CSS entry, imported by the shell.");

--- a/packages/start/test/index.test.js
+++ b/packages/start/test/index.test.js
@@ -1,6 +1,6 @@
-import { execFileSync } from "node:child_process";
+import { execFileSync, spawnSync } from "node:child_process";
 import { existsSync } from "node:fs";
-import { mkdtemp, readFile, readlink, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, readlink, rm, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { fileURLToPath } from "node:url";
@@ -97,7 +97,9 @@ describe("create-pracht", () => {
     expect(parsedPackageJson.pnpm).toBeUndefined();
     expect(packageJson).toContain('"preview": "pracht preview"');
     expect(packageJson).toContain('"start": "node dist/server/server.js"');
-    expect(packageJson).toContain('"typecheck": "tsc --noEmit"');
+    expect(packageJson).toContain(
+      '"typecheck": "tsc --noEmit && tsc --noEmit --project tsconfig.client.json"',
+    );
     expect(packageJson).toMatch(/"typescript": "\^\d+\.\d+\.\d+"/);
     expect(packageJson).not.toContain("wrangler");
     expect(gitignore).toContain(".env*");
@@ -142,6 +144,8 @@ describe("create-pracht", () => {
     expect(readme).toContain("pnpm build");
     expect(readme).toContain("docker build");
     expect(readme).toContain("pnpm typecheck");
+    expect(readme).toContain("`tsconfig.json` — server-capable whole-project TypeScript checks");
+    expect(readme).toContain("`tsconfig.client.json` — browser-conditioned checks");
     expect(readme).toContain("`pracht verify` validates routes and constraints.");
     expect(readme).toContain("`pracht plan --write`");
     expect(readme).toContain("`pracht report`");
@@ -197,6 +201,127 @@ describe("create-pracht", () => {
       }
       "
     `);
+
+    const clientTsconfig = await readFile(join(targetDir, "tsconfig.client.json"), "utf-8");
+    expect(clientTsconfig).toMatchInlineSnapshot(`
+      "{
+        "extends": "./tsconfig.json",
+        "compilerOptions": {
+          "customConditions": [
+            "browser"
+          ]
+        },
+        "include": [
+          "src/routes/**/*",
+          "src/shells/**/*",
+          "src/islands/**/*"
+        ]
+      }
+      "
+    `);
+  });
+
+  it("rejects server-only root exports under the scaffolded browser condition", async () => {
+    const root = await mkdtemp(join(tmpdir(), "pracht-start-browser-types-"));
+    const targetDir = join(root, "my-browser-types-app");
+
+    await scaffoldProject({
+      adapter: NODE_ADAPTER,
+      agentTools: false,
+      packageManager: "pnpm",
+      resolveRemoteVersions: false,
+      targetDir,
+    });
+
+    // Keep the generated tsconfig intact, but replace the application with a
+    // minimal conditional-exports fixture. The framework package tests prove
+    // the real declarations have this shape; this test proves a new app asks
+    // TypeScript for the browser branch while the explicit server subpath is
+    // still available.
+    await rm(join(targetDir, "src"), { force: true, recursive: true });
+    await rm(join(targetDir, "vite.config.ts"), { force: true });
+    await mkdir(join(targetDir, "src/routes"), { recursive: true });
+    await writeFile(
+      join(targetDir, "src/routes/client.ts"),
+      [
+        'import { handlePrachtRequest } from "@pracht/core";',
+        'import { handlePrachtRequest as serverHandle } from "@pracht/core/server";',
+        "void handlePrachtRequest;",
+        "void serverHandle;",
+        "",
+      ].join("\n"),
+    );
+
+    const coreDir = join(targetDir, "node_modules/@pracht/core");
+    await mkdir(coreDir, { recursive: true });
+    await writeFile(
+      join(coreDir, "package.json"),
+      JSON.stringify({
+        name: "@pracht/core",
+        type: "module",
+        exports: {
+          ".": {
+            browser: { types: "./browser.d.ts", default: "./browser.js" },
+            types: "./index.d.ts",
+            default: "./index.js",
+          },
+          "./server": { types: "./server.d.ts", default: "./server.js" },
+        },
+      }),
+    );
+    await writeFile(join(coreDir, "browser.d.ts"), "export declare const Link: unknown;\n");
+    await writeFile(
+      join(coreDir, "index.d.ts"),
+      "export declare function handlePrachtRequest(): Promise<Response>;\n",
+    );
+    await writeFile(
+      join(coreDir, "server.d.ts"),
+      "export declare function handlePrachtRequest(): Promise<Response>;\n",
+    );
+
+    for (const [packageName, subpath] of [
+      ["vite", "client"],
+      ["@pracht/vite-plugin", "virtual"],
+    ]) {
+      const packageDir = join(targetDir, "node_modules", packageName);
+      await mkdir(packageDir, { recursive: true });
+      await writeFile(
+        join(packageDir, "package.json"),
+        JSON.stringify({
+          name: packageName,
+          type: "module",
+          exports: { [`./${subpath}`]: { types: `./${subpath}.d.ts` } },
+        }),
+      );
+      await writeFile(join(packageDir, `${subpath}.d.ts`), "export {};\n");
+    }
+
+    const tscPath = fileURLToPath(
+      new URL("../../../node_modules/typescript/bin/tsc", import.meta.url),
+    );
+    const serverResult = spawnSync(
+      process.execPath,
+      [tscPath, "--project", ".", "--pretty", "false"],
+      {
+        cwd: targetDir,
+        encoding: "utf-8",
+      },
+    );
+    const clientResult = spawnSync(
+      process.execPath,
+      [tscPath, "--project", "tsconfig.client.json", "--pretty", "false"],
+      {
+        cwd: targetDir,
+        encoding: "utf-8",
+      },
+    );
+
+    expect(serverResult.status).toBe(0);
+    expect(clientResult.status).not.toBe(0);
+    expect(clientResult.stdout).toContain(
+      "Module '\"@pracht/core\"' has no exported member 'handlePrachtRequest'",
+    );
+    expect(clientResult.stdout).not.toContain("@pracht/core/server");
   });
 
   it("scaffolds a cloudflare starter", async () => {
@@ -226,7 +351,9 @@ describe("create-pracht", () => {
     expect(packageJson).toMatch(/"@pracht\/adapter-cloudflare": "\^\d+\.\d+\.\d+"/);
 
     expect(packageJson).toContain('"preview": "pracht preview"');
-    expect(packageJson).toContain('"typecheck": "tsc --noEmit"');
+    expect(packageJson).toContain(
+      '"typecheck": "tsc --noEmit && tsc --noEmit --project tsconfig.client.json"',
+    );
     expect(packageJson).toContain('"wrangler": "^4.81.0"');
     // A fixed date, never a generated one: workerd refuses to start when asked
     // for a compatibility date newer than its own binary, so "today" is by
@@ -470,7 +597,9 @@ describe("create-pracht", () => {
     expect(packageJson).toMatch(/"vercel": "\^\d+\.\d+\.\d+"/);
 
     expect(packageJson).toContain('"deploy": "pracht build && vercel deploy --prebuilt"');
-    expect(packageJson).toContain('"typecheck": "tsc --noEmit"');
+    expect(packageJson).toContain(
+      '"typecheck": "tsc --noEmit && tsc --noEmit --project tsconfig.client.json"',
+    );
     expect(packageJson).not.toContain('"preview"');
     expect(readme).toContain("configured for Vercel");
     // `pnpm deploy` is pnpm's own workspace-deploy command and shadows the
@@ -576,6 +705,16 @@ describe("create-pracht", () => {
     expect(agents).toContain("`src/pages/_app.config.ts`");
     expect(agents).toContain("export const REVALIDATE = 3600");
     expect(agents).toContain("pracht generate middleware --name _middleware");
+
+    const clientTsconfig = JSON.parse(
+      await readFile(join(targetDir, "tsconfig.client.json"), "utf-8"),
+    );
+    expect(clientTsconfig).toEqual({
+      extends: "./tsconfig.json",
+      compilerOptions: { customConditions: ["browser"] },
+      include: ["src/pages/**/*", "src/islands/**/*"],
+      exclude: ["src/pages/**/_app.config.*", "src/pages/**/_middleware.*"],
+    });
   });
 
   it("seeds pnpm edge build policy for every router and template permutation", async () => {
@@ -881,6 +1020,7 @@ describe("create-pracht", () => {
     expect(output.files).toContain("src/styles/global.css");
     expect(output.files).toContain(".gitignore");
     expect(output.files).toContain(".mcp.json");
+    expect(output.files).toContain("tsconfig.client.json");
     expect(output.files).toContain(".claude/skills/pracht-scaffold/SKILL.md");
     // The default is a core set, not the whole catalog: an audit skill has
     // nothing to audit in an eight-file starter, and every description it


### PR DESCRIPTION
## Summary

- Generate a browser-conditioned `tsconfig.client.json` while preserving server and test resolution in the base TypeScript program.
- Add scaffold regression coverage and update contributor, public, package, and generated starter documentation.
- Closes #366.

## Testing

- [x] `pnpm run verify` (build, format, lint, typecheck, test, e2e)

## Checklist

- [x] Docs updated if needed
- [x] Skills updated if needed (N/A — no skill behavior changed)
- [x] Concise, user-facing changeset added if published packages changed