### PR TITLE
Align WebMCP support with the current draft

### DIFF
--- a/.changeset/webmcp-current-draft.md
+++ b/.changeset/webmcp-current-draft.md
@@ -1,0 +1,6 @@
+---
+"@pracht/capabilities": minor
+"@pracht/cli": patch
+---
+
+Standalone WebMCP registration now supports current consequential annotations and opt-in cross-origin exposure, while verify reports Chrome's advisory name budgets.

--- a/docs/CAPABILITIES.md
+++ b/docs/CAPABILITIES.md
@@ -9,7 +9,7 @@ Today those surfaces are:
   routes, and middleware;
 - **an HTTP endpoint** — generated `POST` dispatch when `expose.http` is set;
 - **a WebMCP page tool** — eligible for route-scoped browser registration when
-  `expose.webmcp` is set (ChatGPT desktop browser; Chrome/Edge origin trial);
+  `expose.webmcp` is set (experimental Chrome origin trial);
 - **a remote MCP tool** — served at one Streamable HTTP endpoint when
   `expose.mcp` is set and the app configures `agents.mcp`, for agents that
   never open a browser (see [REMOTE_MCP.md](REMOTE_MCP.md)).
@@ -620,19 +620,30 @@ at all: `callCapability("notes.stats")`.
 With `expose.webmcp: true` (which requires `expose.http`), the client runtime
 can register the capability as a WebMCP page tool for in-browser agents on
 routes that activate its name. The
-shim targets the CG draft API — `document.modelContext.registerTool()` — with
-no `navigator.modelContext` fallback: within the 149–156 origin trial the
-`document` getter landed in Chromium 150 and the deprecated alias was removed
-in 152, so pre-150 trial builds are not targeted and current polyfills install
-the `document` shape. Hosts include the ChatGPT desktop app's built-in browser
-and the Chrome/Edge origin trial (stable-channel visitors need an origin-trial
-token in the page head — see the site docs for the `head()` recipe):
+shim targets the current CG draft API — `document.modelContext.registerTool()`
+— with no `navigator.modelContext` fallback. The spec moved from `navigator`
+to `document` on 2026-07-21; within the 149–156 origin trial the `document`
+getter landed in Chromium 150 and the deprecated alias was removed in 152.
+Pre-150 trial builds are not targeted and current polyfills install the
+`document` shape. Stable-channel visitors need an origin-trial token in the
+page head; see the site docs for the `head()` recipe.
+
+The 2026-09-04 spec snapshot is still a W3C Community Group Draft, explicitly
+not a W3C Standard or Standards Track document. The Web Machine Learning
+Working Group charter lists WebNN, not WebMCP. No mainstream browser agent
+currently consumes arbitrary WebMCP tools in broad production availability;
+Chrome's integration remains preview-only and Anthropic closed support in the
+Claude Chrome extension as not planned. Treat this projection as a progressive
+enhancement and retain HTTP or remote MCP for production agent access:
 
 - one tool per capability: `name`, `title`, `description`, `inputSchema` (the
   capability's JSON Schema), WebMCP's effect-derived `readOnlyHint`, and
   `annotations.untrustedContentHint` when the capability opts in via
-  `expose.webmcp: { untrustedContent: true }`; remote MCP derives its
-  additional MCP-only annotations separately;
+  `expose.webmcp: { untrustedContent: true }`. The draft also defines
+  `consequentialHint`; pracht never infers it because consequential operations
+  belong to the rejected `destructive` page-tool class. Standalone tools may
+  set it explicitly. Remote MCP derives its additional MCP-only annotations
+  separately;
 - `execute()` calls the HTTP projection via `callCapability`, so the user's
   session authenticates the call and validation, middleware, and policy all
   stay server-side — the agent acts as the signed-in user, in their tab. When
@@ -643,8 +654,11 @@ token in the page head — see the site docs for the `head()` recipe):
 - `pracht verify` errors on names outside the spec's tool-name grammar
   (1–128 ASCII `[a-zA-Z0-9_.-]`), warns when a page tool sits behind an
   effective `agentPolicy: "require"` (WebMCP calls are unsigned browser
-  fetches, so every call would 401), and warns when descriptions exceed the
-  published agent-legibility budgets (~500 chars/tool, ~150 chars/parameter);
+  fetches, so every call would 401), and warns when names or descriptions
+  exceed Chrome's advisory budgets (30 chars/tool or parameter name, 500
+  chars/tool description, 150 chars/parameter description). Chrome also
+  recommends at most 1.5K characters per result; pracht preserves validated
+  results, so applications must bound them through inputs and schemas;
 - the shim lives in its own chunk (`virtual:pracht/webmcp`) behind feature
   detection: browsers without the API never download it, and routes with no
   active page tools do not load it;
@@ -653,6 +667,8 @@ token in the page head — see the site docs for the `head()` recipe):
   registers the destination route's set; a route with no tools clears the set;
 - registrations use a caller-owned abort signal, and Vite module replacement
   preserves the active route set while disposing stale registrations;
+- integrated registrations omit `exposedTo`, keeping cross-origin discovery
+  disabled. Standalone callers may pass an explicit secure-origin allowlist;
 - works in full-hydration and islands modes (the islands bootstrap pulls the
   shim in too; `hydration: "none"` pages ship no JS and register no tools).
 

--- a/docs/CAPABILITY_GRAPH.md
+++ b/docs/CAPABILITY_GRAPH.md
@@ -61,7 +61,8 @@ speculative:
   ordinary stateless request handling at the edge.
 - **WebMCP entered Chrome origin trial (Chrome 149, June 2026).** Authored by Google and
   Microsoft in the W3C Web ML CG, it lets a web page register typed tools for in-browser agents —
-  the page itself becomes the tool surface. No framework has integrated it yet.
+  the page itself becomes the tool surface. At the time of this proposal no framework had
+  integrated it yet.
 
 Relevant primary references:
 
@@ -71,6 +72,8 @@ Relevant primary references:
 - [MCP Apps overview](https://modelcontextprotocol.io/extensions/apps/overview)
 - [MCP Apps specification (SEP-1865)](https://modelcontextprotocol.io/seps/1865-mcp-apps-interactive-user-interfaces-for-mcp)
 - [WebMCP origin trial announcement](https://developer.chrome.com/blog/ai-webmcp-origin-trial)
+- [WebMCP Community Group Draft](https://webmachinelearning.github.io/webmcp/)
+- [Web Machine Learning Working Group charter](https://www.w3.org/2025/03/webmachinelearning-charter.html)
 - [Cloudflare remote MCP deployment guide](https://developers.cloudflare.com/agents/model-context-protocol/guides/remote-mcp-server/)
 - [Web Bot Auth / signed agents](https://developers.cloudflare.com/bots/reference/bot-verification/web-bot-auth/)
 
@@ -317,10 +320,11 @@ call only explicitly allowed capabilities.
 ### In-browser agent use (WebMCP)
 
 WebMCP inverts the deployment model: instead of an agent connecting to a remote server, the page
-registers typed tools that an in-browser agent (Gemini in Chrome today; origin trial through
-Chrome 156) can call while the user watches. For a *web* framework this may be the larger prize —
-it is the only emerging standard where the website itself is the tool surface, and no framework
-integrates it yet.
+registers typed tools that a compatible in-browser agent can call while the user watches. Chrome's
+origin trial runs through 156, but no mainstream agent consumes arbitrary WebMCP tools in broad
+production availability as of September 2026. For a *web* framework this may be the larger prize —
+it is the only emerging standard where the website itself is the tool surface, and Pracht can keep
+that experimental projection isolated from its protocol-neutral contract.
 
 With `expose.webmcp` enabled, a manifest route declares the page tool with
 `route(path, file, { capabilities: ["projects.search"] })`; a pages route exports
@@ -332,8 +336,8 @@ is thin: it calls the generated HTTP endpoint, so validation, middleware, policy
 stay server-side. The user's existing session authenticates the call — which is correct for
 WebMCP's model (the agent acts *as the signed-in user, in their tab*) and exactly wrong for remote
 MCP (see the security model: browser cookies must never authenticate the remote transport). Effect
-classes still gate what an in-page agent may do: `destructive` capabilities keep their
-server-verified confirmation flow regardless of who clicks.
+classes still gate what an in-page agent may do: Pracht refuses to register `destructive`
+capabilities because a browser host's confirmation UI is not a server-verified boundary.
 
 The marginal cost on top of the capability graph is small — a client registration shim and typegen —
 and it makes Pracht the first framework where one definition serves human forms, remote agents, and
@@ -961,20 +965,26 @@ WebMCP is not covered by the reversal and is no longer waiting on a mechanism:
 a page host's approval UX is not a security boundary, so there is nothing
 server-verified for the flow to bind to.
 
-### Addendum (2026-08-27 — WebMCP conformance)
+### Addendum (2026-09-07 — WebMCP conformance and availability)
 
 The shim described in spike answer 8 tracked the spec as it stood; the spec
-moved. Chromium removed the deprecated `navigator.modelContext` alias in 152,
-so the shim now targets `document.modelContext` only (the getter landed in
-150; pre-150 origin-trial builds are no longer targeted). `execute()` returns
-the capability envelope as a plain value — the host serializes it per the
-current draft, where the earlier MCP-style content blocks arrived
-double-encoded — and the descriptor gained `title`, the remote projection's
-effect-derived hint set, and an opt-in `untrustedContentHint`
-(`expose.webmcp: { untrustedContent: true }`). ChatGPT's desktop browser
-shipped WebMCP support on 2026-08-25 with no SDK or manifest, which makes the
-"disposable shim over the HTTP projection" design the load-bearing hedge it
-was meant to be.
+moved from `navigator.modelContext` to `document.modelContext` on 2026-07-21.
+Chromium removed the deprecated alias in 152, so the shim now targets
+`document.modelContext` only (the getter landed in 150; pre-150 origin-trial
+builds are no longer targeted). `execute()` returns the capability envelope as
+a plain value — the host serializes it per the current draft, where the earlier
+MCP-style content blocks arrived double-encoded — and the descriptor carries
+`title`, `readOnlyHint`, an opt-in `untrustedContentHint`, and explicit
+`consequentialHint` support for standalone tools. Registrations omit
+`exposedTo` by default, so cross-origin discovery remains opt-in.
+
+The 2026-09-04 snapshot remains a W3C Community Group Draft, explicitly not a
+W3C Standard or Standards Track document. The Web Machine Learning Working
+Group charter lists only WebNN as a normative specification. Adoption also
+lags the API: Chrome's origin trial spans 149–156, its agent integration is
+still preview-only, and Anthropic closed Claude Chrome extension support as
+not planned. That makes the disposable shim and the independent HTTP/remote
+MCP projections the load-bearing hedge they were meant to be.
 
 ## Final Recommendation
 

--- a/examples/docs/src/routes/docs/capabilities.md
+++ b/examples/docs/src/routes/docs/capabilities.md
@@ -279,9 +279,9 @@ Runtime validation is unchanged either way, and it is the runtime — not the co
 
 With `expose.webmcp: true`, the client runtime can register the capability as a [WebMCP](https://webmachinelearning.github.io/webmcp/) page tool via `document.modelContext.registerTool()` on routes that activate its name. Initial hydration installs only the matched route's set. After each SPA navigation commits, pracht aborts the old registrations and installs the destination set; navigating to a route with no tools clears them. The tool's `execute()` dispatches through the HTTP projection, so the agent acts as the signed-in user in their tab while validation, middleware, and policy all stay server-side. If the WebMCP host cancels execution, its `AbortSignal` aborts the capability's HTTP request too, and the returned value is the capability envelope itself (`{ ok, data }` or `{ ok: false, error }`) — the host serializes it per the spec, so there is no extra wrapping for an agent to unpick.
 
-The registered descriptor carries the capability's `title` (hosts show it in their tool UI), its `description`, the input JSON Schema, and WebMCP's effect-derived `readOnlyHint`. Inline JSON Schema stays the non-executing build fast path. Imported and builder-produced Standard JSON Schemas are derived by loading the server-only capability module during code generation; only the resulting JSON is emitted. Keep `expose` and `effect` inline because they still determine the browser endpoint table statically. If a capability module imports an edge-only runtime at the top level, move that import inside `run()` or keep its WebMCP input inline.
+The registered descriptor carries the capability's `title`, its `description`, the input JSON Schema, and WebMCP's effect-derived `readOnlyHint`. Inline JSON Schema stays the non-executing build fast path. Imported and builder-produced Standard JSON Schemas are derived by loading the server-only capability module during code generation; only the resulting JSON is emitted. Keep `expose` and `effect` inline because they still determine the browser endpoint table statically. If a capability module imports an edge-only runtime at the top level, move that import inside `run()` or keep its WebMCP input inline.
 
-Remote MCP derives its additional `destructiveHint` and `idempotentHint` separately because those annotations are not part of WebMCP. Capabilities whose results include user-generated or third-party content can advertise `untrustedContentHint` with the options form:
+Remote MCP derives its additional `destructiveHint` and `idempotentHint` separately because those annotations are not part of WebMCP. WebMCP also defines `consequentialHint`, but pracht does not infer it: consequential operations belong to pracht's `destructive` class, and destructive page tools are rejected instead of relying on a host hint for enforcement. Capabilities whose results include user-generated or third-party content can advertise `untrustedContentHint` with the options form:
 
 ```ts
 expose: {
@@ -296,9 +296,13 @@ The shim ships as its own chunk behind feature detection: browsers without the A
 
 ### Hosts and the origin trial
 
-WebMCP hosts include the ChatGPT desktop app's built-in browser (its "Site tools" surface discovers page tools automatically — no SDK, manifest, or registration) and Chromium browsers running the origin trial (149–156). Within that trial window, the `document.modelContext` getter landed in Chromium 150 and the deprecated `navigator.modelContext` alias was removed in 152, so pracht targets `document.modelContext` only — trial builds older than 150 register no tools, and pre-150 polyfills such as `@mcp-b/webmcp-polyfill` install the `document` shape too.
+WebMCP remains a [W3C Community Group Draft](https://webmachinelearning.github.io/webmcp/), not a W3C Standard or Standards Track deliverable. The [Web Machine Learning Working Group charter](https://www.w3.org/2025/03/webmachinelearning-charter.html) lists WebNN, not WebMCP, so there is no formal commitment to advance this API. Its current imperative surface is `document.modelContext` (`registerTool()`, `getTools()`, and `executeTool()`). The spec moved there from `navigator.modelContext` in July 2026; pracht targets only the current `document` shape.
 
-Agent-embedded browsers enable the API themselves, but for *stable* Chrome and Edge visitors the page must carry an [origin-trial token](https://developer.chrome.com/origintrials/) during the trial window or `document.modelContext` never exists and the tools silently stay off. Register your origin, then emit the token from your shell's `head()`:
+Chrome's origin trial covers versions 149–156. The `document.modelContext` getter landed in Chromium 150 and the deprecated `navigator.modelContext` alias was removed in 152, so trial builds older than 150 register no tools. Polyfills such as `@mcp-b/webmcp-polyfill` install the current `document` shape too.
+
+Treat WebMCP as an experimental progressive enhancement, not your only agent integration. As of September 2026, no mainstream browser agent consumes arbitrary WebMCP page tools in broad production availability. [Chrome's own WebMCP integration](https://developer.chrome.com/docs/ai/webmcp/) remains an early/developer preview (and is separate from the generally available Gemini-in-Chrome surface), while Anthropic has [closed WebMCP support for the Claude Chrome extension as not planned](https://github.com/anthropics/claude-code/issues/30645). Keep the HTTP or remote MCP projection available for agents that need a production transport.
+
+For stable Chrome visitors, the page must carry an [origin-trial token](https://developer.chrome.com/origintrials/) during the trial window or `document.modelContext` never exists and the tools silently stay off. Register your origin, then emit the token from your shell's `head()`:
 
 ```ts [src/shells/app.tsx]
 import { publicEnv } from "@pracht/core";
@@ -314,7 +318,9 @@ The token is origin-bound and public by design, so the [`PRACHT_PUBLIC_` prefix]
 
 For local testing without a token, enable `chrome://flags/#enable-webmcp-testing` (plus `#devtools-webmcp-support` for the DevTools Application-panel WebMCP pane), or fake the API in Playwright — see [Testing](/docs/recipes/testing#faking-webmcp-in-the-browser).
 
-`pracht verify` guards the projection: it errors on tool names the browser would reject and warns when a page tool can never work (a `"require"` agent policy 401s the page's unsigned fetches) or when tool metadata exceeds the published agent-legibility budgets (~500 characters per tool description, ~150 per parameter description).
+`pracht verify` guards the projection: it errors on names outside the draft's hard grammar (1–128 ASCII letters, digits, `_`, `-`, or `.`) and warns when a page tool can never work (a `"require"` agent policy 401s the page's unsigned fetches) or statically readable metadata exceeds [Chrome's advisory budgets](https://developer.chrome.com/docs/ai/webmcp/secure-tools) (30 characters per tool or parameter name, 500 per tool description, and 150 per parameter description). Chrome also recommends no more than 1.5K characters per individual tool result. Pracht does not truncate a validated result — bound arrays and prose through input limits, pagination, and output-schema limits so every transport sees the same value.
+
+Registrations are origin-restrictive by default. The integrated pracht projection does not set `exposedTo`, so cross-origin documents cannot discover or execute its tools. Standalone hosts may pass a deliberate allowlist through `registerWebmcpTools(..., { exposedTo: [...] })`; only list secure origins you trust with the same user data and actions.
 
 ---
 

--- a/examples/docs/src/routes/docs/coding-agents.md
+++ b/examples/docs/src/routes/docs/coding-agents.md
@@ -17,7 +17,7 @@ next:
 | | Audience | When | What it exposes |
 | --- | --- | --- | --- |
 | **`pracht dev-mcp`** (this page) | Your coding agent — Claude Code, Cursor, an MCP client on your machine | **Development** | Your app's *graph*: routes, API endpoints, capabilities, diagnostics, scaffolding |
-| **[Dev page tools](#debugging-in-the-tab-dev-page-tools)** (this page) | An agent-driven browser testing your app — agent-browser, ChatGPT desktop, Chromium under the WebMCP origin trial | **Development** | *This tab*: the matched route, its loader data, islands, the last error, and the app's own page tools — as WebMCP tools on every dev document |
+| **[Dev page tools](#debugging-in-the-tab-dev-page-tools)** (this page) | A WebMCP-compatible agent or test harness driving your app | **Development** | *This tab*: the matched route, its loader data, islands, the last error, and the app's own page tools — as WebMCP tools on every dev document |
 | **[Remote MCP](/docs/capabilities#remote-mcp-tools-for-agents-without-a-browser)** | End-user agents calling your deployed app | **Production** | Your app's *operations*: capabilities served as MCP tools over Streamable HTTP |
 
 `pracht dev-mcp` never ships. It is part of `@pracht/cli`, it runs on your machine, and it is not reachable from your deployed app. Remote MCP is the opposite on every count.
@@ -112,7 +112,7 @@ Tool failures — a missing manifest, an unknown shell, a refusal to overwrite a
 
 ## Debugging in the Tab: Dev Page Tools
 
-An agent that drives a browser against `pracht dev` — agent-browser, ChatGPT desktop's built-in browser, Chromium with the WebMCP origin trial — has the page in front of it but not the framework's view of that page. Which route matched? What did the loader actually return? Did the island hydrate? What was the server error behind this 500? Answering those from the outside means correlating server logs, or finding and configuring a separate MCP server, with the tab under test.
+A WebMCP-compatible agent or test harness driving a browser against `pracht dev` has the page in front of it but not the framework's view of that page. Which route matched? What did the loader actually return? Did the island hydrate? What was the server error behind this 500? Answering those from the outside means correlating server logs, or finding and configuring a separate MCP server, with the tab under test.
 
 So the tab answers them itself. Every document `pracht dev` serves registers five read-only [WebMCP](/docs/capabilities#webmcp-tools-for-in-browser-agents) page tools with the browser's model context, scoped to that document:
 
@@ -126,7 +126,7 @@ So the tab answers them itself. Every document `pracht dev` serves registers fiv
 
 Each resolves to the same `{ ok, data }` / `{ ok: false, error }` envelope as a pracht capability. The tools follow committed client-side navigation, so after an agent clicks a link, `pracht_route` describes the destination.
 
-There is nothing to install. The dev SSR middleware injects one `<script type="module" src="/@pracht/dev-page-tools.js">` into every HTML document it serves — full-hydration routes, islands routes, `hydration: "none"` routes, the dev 404 page, and the error overlay alike. That module feature-detects `document.modelContext` before importing anything, so a browser without the WebMCP API pays for the feature check and nothing else. No build step emits the tag or the module; a production bundle cannot contain them. To turn them off, set `pracht({ devPageTools: false })` in `vite.config.ts`.
+There is nothing to install in the app, but the browser or harness must provide WebMCP; no mainstream browser agent consumes arbitrary page tools in broad production availability yet. The dev SSR middleware injects one `<script type="module" src="/@pracht/dev-page-tools.js">` into every HTML document it serves — full-hydration routes, islands routes, `hydration: "none"` routes, the dev 404 page, and the error overlay alike. That module feature-detects `document.modelContext` before importing anything, so a browser without the WebMCP API pays for the feature check and nothing else. No build step emits the tag or the module; a production bundle cannot contain them. To turn them off, set `pracht({ devPageTools: false })` in `vite.config.ts`.
 
 ```sh
 pracht dev

--- a/examples/docs/src/routes/docs/standalone-capabilities.md
+++ b/examples/docs/src/routes/docs/standalone-capabilities.md
@@ -179,7 +179,9 @@ registerWebmcpTools(
 registrations.abort();
 ```
 
-Registration is a no-op when `document.modelContext` is absent. Each descriptor uses only WebMCP's `readOnlyHint` and optional `untrustedContentHint`; remote MCP derives its additional MCP annotations separately. Destructive page tools are refused because browser registration is not a server-verified confirmation boundary.
+Registration is a no-op when `document.modelContext` is absent. Each descriptor derives WebMCP's `readOnlyHint` and can carry `untrustedContentHint` or an explicit `consequentialHint`; remote MCP derives its additional MCP annotations separately. Destructive page tools are refused because browser registration is not a server-verified confirmation boundary.
+
+The optional registration object also accepts `exposedTo`, but omit it unless a secure cross-origin document genuinely needs access. The default keeps tools restricted to their origin and browser-provided agents. Chrome recommends compact metadata and results: 30 characters per tool or parameter name, 500 per tool description, 150 per parameter description, and 1.5K per result.
 
 ## Moving to Pracht Later
 

--- a/examples/showcase/src/capabilities/projects-search.ts
+++ b/examples/showcase/src/capabilities/projects-search.ts
@@ -14,7 +14,7 @@ interface SearchInput {
  *   /playground      → `useCapability("projects.search")` in the browser
  *   /app             → `invokeCapability()` in the SSR loader
  *   an HTTP agent    → POST /api/capabilities/projects/search
- *   Gemini in Chrome → the same tool, registered on the page via WebMCP
+ *   a WebMCP host    → the same tool, registered on the page
  *   a remote agent   → the `projects_search` tool at POST /mcp
  *
  * One contract, five callers, no duplicated business rules.

--- a/packages/capabilities/README.md
+++ b/packages/capabilities/README.md
@@ -65,6 +65,10 @@ server-side. Validation accepts the dependency-free JSON Schema subset shown
 above, or a Standard Schema validator with Standard JSON Schema support (such
 as Zod 4). The capability projection emits only the derived JSON contract to
 WebMCP; it never adds the validator itself to that client chunk.
+The standalone registrar models the draft's `readOnlyHint`,
+`untrustedContentHint`, and `consequentialHint` annotations. Cross-origin
+discovery remains off unless its third argument explicitly sets a trusted
+`exposedTo` origin allowlist.
 
 See the [Capabilities](https://pracht.resynapse.dev/docs/capabilities) and
 [Standalone Capabilities](https://pracht.resynapse.dev/docs/standalone-capabilities)

--- a/packages/capabilities/src/webmcp.ts
+++ b/packages/capabilities/src/webmcp.ts
@@ -4,11 +4,10 @@
  * The runtime behind pracht's generated `virtual:pracht/webmcp` shim,
  * published so any site — pracht or not — can register page tools with the
  * same registration semantics and annotation policy. Targets the WebMCP CG
- * draft API: `document.modelContext.registerTool()` (ChatGPT desktop's
- * built-in browser; Chromium 150+ within the origin trial — the `document`
- * getter landed in 150 and the deprecated `navigator.modelContext` alias was
- * removed in 152). No-ops when the API is absent, and a failed registration
- * never breaks the page.
+ * draft API: `document.modelContext.registerTool()` (Chromium 150+ within the
+ * 149–156 origin trial — the `document` getter landed in 150 and the
+ * deprecated `navigator.modelContext` alias was removed in 152). No-ops when
+ * the API is absent, and a failed registration never breaks the page.
  *
  * `execute()` returns whatever the dispatch resolves to as a plain value: per
  * the spec the host serializes the returned value itself, so wrapping it in
@@ -23,12 +22,14 @@ import type { JsonSchema } from "./schema.ts";
 export interface WebmcpToolAnnotations {
   readOnlyHint?: boolean;
   untrustedContentHint?: boolean;
+  /** The tool performs a significant real-world or non-reversible action. */
+  consequentialHint?: boolean;
 }
 
 export interface WebmcpTool {
   /** Tool name — for a pracht capability, the registered capability name. */
   name: string;
-  /** Optional display title; feeds host UI (e.g. ChatGPT's "Site tools" list). */
+  /** Optional display title for a host's tool UI. */
   title?: string;
   /** The contract an agent reads. Required — a tool without one is unusable. */
   description: string;
@@ -57,6 +58,12 @@ export interface WebmcpRegistrationOptions {
    * the document's model context, matching the current WebMCP draft.
    */
   signal?: AbortSignal;
+  /**
+   * Secure cross-origin documents that may discover and execute the tools.
+   * Omit this by default: registration then stays restricted to the owning
+   * origin and browser-provided agents.
+   */
+  exposedTo?: readonly string[];
 }
 
 /**
@@ -72,9 +79,11 @@ export type WebmcpDispatch = (
 ) => unknown | Promise<unknown>;
 
 /**
- * The annotation set pracht advertises for an effect class. WebMCP currently
- * standardizes only the read-only and untrusted-content hints; remote MCP has
- * additional effect hints and derives those in its own projection.
+ * The annotation set pracht can derive safely from an effect class. WebMCP
+ * also defines `consequentialHint`, but integrated pracht capabilities never
+ * infer it: operations that require that warning belong to the `destructive`
+ * class, which page-tool exposure rejects. Standalone callers may set the hint
+ * explicitly through `WebmcpTool.annotations`.
  */
 export function webmcpToolAnnotations(
   effect: CapabilityEffect | undefined,

--- a/packages/capabilities/test/webmcp.test.ts
+++ b/packages/capabilities/test/webmcp.test.ts
@@ -13,7 +13,7 @@ interface RegisteredTool {
 
 interface RegistrationCall {
   tool: RegisteredTool;
-  options: { signal?: AbortSignal } | undefined;
+  options: { signal?: AbortSignal; exposedTo?: readonly string[] } | undefined;
 }
 
 function installModelContext(
@@ -22,7 +22,10 @@ function installModelContext(
   const registered: RegistrationCall[] = [];
   (globalThis as { document?: unknown }).document = {
     modelContext: {
-      registerTool(tool: RegisteredTool, options?: { signal?: AbortSignal }) {
+      registerTool(
+        tool: RegisteredTool,
+        options?: { signal?: AbortSignal; exposedTo?: readonly string[] },
+      ) {
         registered.push({ tool, options });
         return registerTool(tool);
       },
@@ -92,9 +95,13 @@ describe("registerWebmcpTools", () => {
 
   it("lets explicit annotations override the derived ones", () => {
     const registered = installModelContext();
-    registerWebmcpTools([{ ...searchTool, annotations: { readOnlyHint: false } }], () => null);
+    registerWebmcpTools(
+      [{ ...searchTool, annotations: { readOnlyHint: false, consequentialHint: true } }],
+      () => null,
+    );
     expect(registered[0].tool.annotations).toEqual({
       readOnlyHint: false,
+      consequentialHint: true,
     });
   });
 
@@ -105,6 +112,18 @@ describe("registerWebmcpTools", () => {
     registerWebmcpTools([searchTool], () => null, { signal: controller.signal });
 
     expect(registered[0].options).toEqual({ signal: controller.signal });
+  });
+
+  it("keeps cross-origin exposure opt-in", () => {
+    const registered = installModelContext();
+
+    registerWebmcpTools([searchTool], () => null);
+    registerWebmcpTools([searchTool], () => null, {
+      exposedTo: ["https://trusted.example"],
+    });
+
+    expect(registered[0].options).toEqual({});
+    expect(registered[1].options).toEqual({ exposedTo: ["https://trusted.example"] });
   });
 
   it("refuses to register destructive tools", () => {

--- a/packages/cli/src/verification-capabilities.ts
+++ b/packages/cli/src/verification-capabilities.ts
@@ -1185,7 +1185,7 @@ function collectSingleCapabilityChecks(
           ),
         );
       }
-      collectWebmcpBudgetChecks(label, description, properties.get("input"), checks);
+      collectWebmcpBudgetChecks(label, name, description, properties.get("input"), checks);
     }
 
     if (effectValue === "destructive") {
@@ -1278,13 +1278,25 @@ function collectSingleCapabilityChecks(
  */
 const WEBMCP_DESCRIPTION_BUDGET = 500;
 const WEBMCP_PARAM_DESCRIPTION_BUDGET = 150;
+const WEBMCP_NAME_BUDGET = 30;
+const WEBMCP_PARAM_NAME_BUDGET = 30;
 
 function collectWebmcpBudgetChecks(
   label: string,
+  name: string,
   description: StaticString,
   inputText: string | undefined,
   checks: Check[],
 ): void {
+  if (name.length > WEBMCP_NAME_BUDGET) {
+    checks.push(
+      createCheck(
+        "warning",
+        `${label} has a ${name.length}-character WebMCP tool name — Chrome recommends no more ` +
+          `than ${WEBMCP_NAME_BUDGET} characters for reliable agent selection.`,
+      ),
+    );
+  }
   if (description.kind === "valid" && description.value.length > WEBMCP_DESCRIPTION_BUDGET) {
     checks.push(
       createCheck(
@@ -1296,6 +1308,21 @@ function collectWebmcpBudgetChecks(
   }
   const schema = inputText ? evaluateLiteral(inputText) : undefined;
   if (!schema || typeof schema !== "object") return;
+  for (const [path, propertyName] of collectSchemaPropertyNames(
+    schema as Record<string, unknown>,
+    "",
+  )) {
+    if (propertyName.length > WEBMCP_PARAM_NAME_BUDGET) {
+      checks.push(
+        createCheck(
+          "warning",
+          `${label} is exposed as a WebMCP page tool and its input parameter at ` +
+            `${JSON.stringify(path)} has a ${propertyName.length}-character name — Chrome ` +
+            `recommends no more than ${WEBMCP_PARAM_NAME_BUDGET} characters per parameter name.`,
+        ),
+      );
+    }
+  }
   for (const [path, text] of collectSchemaDescriptions(schema as Record<string, unknown>, "")) {
     if (text.length > WEBMCP_PARAM_DESCRIPTION_BUDGET) {
       checks.push(
@@ -1308,6 +1335,34 @@ function collectWebmcpBudgetChecks(
       );
     }
   }
+}
+
+/** Every property name in a JSON Schema subtree, reported as a dotted path. */
+function collectSchemaPropertyNames(
+  schema: Record<string, unknown>,
+  path: string,
+): [string, string][] {
+  const found: [string, string][] = [];
+  const properties = schema.properties;
+  if (properties && typeof properties === "object" && !Array.isArray(properties)) {
+    for (const [key, value] of Object.entries(properties)) {
+      const propertyPath = path === "" ? key : `${path}.${key}`;
+      found.push([propertyPath, key]);
+      if (value && typeof value === "object" && !Array.isArray(value)) {
+        found.push(...collectSchemaPropertyNames(value as Record<string, unknown>, propertyPath));
+      }
+    }
+  }
+  const items = schema.items;
+  if (items && typeof items === "object" && !Array.isArray(items)) {
+    found.push(
+      ...collectSchemaPropertyNames(
+        items as Record<string, unknown>,
+        path === "" ? "[]" : `${path}[]`,
+      ),
+    );
+  }
+  return found;
 }
 
 /** Every `description` string in a JSON Schema subtree, except the root's (that is the tool description's job). */

--- a/packages/cli/test/verification-capabilities.test.ts
+++ b/packages/cli/test/verification-capabilities.test.ts
@@ -887,6 +887,33 @@ describe("collectCapabilityChecks", () => {
     expect(checks.some((check) => check.status === "error")).toBe(false);
   });
 
+  it("warns when webmcp tool and parameter names exceed Chrome's advisory budget", () => {
+    const longName = "long." + "x".repeat(30);
+    const longParameter = "parameter".repeat(4);
+    const checks: Check[] = [];
+    collectCapabilityChecks(
+      createProject({
+        capability: capabilitySource(
+          COMPLETE_FIELDS.replace(
+            'query: { type: "string" }',
+            `${JSON.stringify(longParameter)}: { type: "string" }`,
+          ),
+        ),
+        registration: `    ${JSON.stringify(longName)}: () => import("./capabilities/notes-search.ts"),`,
+      }),
+      checks,
+    );
+
+    const warnings = checks
+      .filter((check) => check.status === "warning")
+      .map((check) => check.message);
+    expect(warnings).toContainEqual(expect.stringContaining("35-character WebMCP tool name"));
+    expect(warnings).toContainEqual(
+      expect.stringContaining(`input parameter at ${JSON.stringify(longParameter)}`),
+    );
+    expect(checks.some((check) => check.status === "error")).toBe(false);
+  });
+
   it("fails schemas using unsupported JSON Schema keywords", () => {
     const checks = runChecks(
       capabilitySource(

--- a/packages/framework/src/dev-page-tools.ts
+++ b/packages/framework/src/dev-page-tools.ts
@@ -2,8 +2,7 @@
  * Dev-only WebMCP page tools: the open tab exposes its own debugging surface
  * to an agent-driven browser.
  *
- * An agent testing a page in `pracht dev` (agent-browser, ChatGPT desktop's
- * built-in browser, Chromium under the WebMCP origin trial) can ask the tab
+ * A WebMCP-capable agent or test harness driving a page in `pracht dev` can ask the tab
  * which route matched, what the loader returned, which islands hydrated, and
  * what the last error was — with the context of *this* navigation, instead of
  * correlating server logs or a separately configured MCP server with the page

--- a/packages/vite-plugin/src/plugin-capabilities.ts
+++ b/packages/vite-plugin/src/plugin-capabilities.ts
@@ -580,8 +580,8 @@ export async function createPrachtWebmcpModuleSourceAsync(
 function webmcpTool(capability: ExtractedCapability): Record<string, unknown> {
   return {
     name: capability.name,
-    // The spec's optional `title` feeds host UI (e.g. ChatGPT's "Site tools"
-    // list). Omitted when unavailable rather than guessed.
+    // The spec's optional `title` feeds host UI. Omitted when unavailable
+    // rather than guessed.
     ...(capability.title ? { title: capability.title } : {}),
     description: capability.description,
     inputSchema: capability.inputSchema,

--- a/skills/add-capabilities/SKILL.md
+++ b/skills/add-capabilities/SKILL.md
@@ -385,14 +385,13 @@ same prepare/commit round trip as HTTP, with the token in the call's
 `createCapabilityTestHost()` from `@pracht/core` covers the same pipeline in
 unit tests, without a server.
 
-WebMCP specifics `pracht verify` checks: tool names must fit the spec's
-grammar (1–128 ASCII `[a-zA-Z0-9_.-]`); an effective `agentPolicy: "require"`
-makes a page tool dead (unsigned browser fetches always 401 — warned);
-descriptions have advisory budgets (~500 chars per tool, ~150 per schema
-parameter). Hosts: the ChatGPT desktop browser enables the API itself, but
-stable Chrome/Edge visitors only get `document.modelContext` if the page head
-carries an origin-trial token — the docs site's capabilities page shows the
-shell `head()` recipe.
+WebMCP: names must fit the draft's 1–128 ASCII `[a-zA-Z0-9_.-]` grammar;
+Chrome advises 30 chars/name, 500/tool description, 150/parameter description,
+and 1.5K/result. `pracht verify` checks static limits; bound outputs yourself.
+Stable Chrome needs an origin-trial token. No mainstream production agent
+consumes these tools yet, so retain HTTP or remote MCP. See the capabilities
+site page for current compatibility. An effective `agentPolicy: "require"`
+always 401s unsigned page-tool calls and is warned.
 
 To audit what the whole agent surface exposes, run `/audit-agent-surface`.
 

--- a/skills/audit-agent-surface/SKILL.md
+++ b/skills/audit-agent-surface/SKILL.md
@@ -89,7 +89,8 @@ For every exposed capability, ask whether the exposure is deliberate:
   the tool is dead — every call 401s. Also check that capabilities returning
   user-generated or third-party content set
   `expose.webmcp: { untrustedContent: true }` so hosts treat the output as
-  untrusted.
+  untrusted. Flag `exposedTo` and outputs above 1.5K. Consequential work is
+  `destructive`, so never WebMCP.
 - Private capabilities used as building blocks: `invokeCapability()` runs their
   named middleware but **not** app-level `api.middleware`. Their named
   middleware is the only authorization seam — flag private capabilities with an

--- a/skills/pracht-debug/SKILL.md
+++ b/skills/pracht-debug/SKILL.md
@@ -45,8 +45,8 @@ pracht MCP server is registered (docs/MCP.md), prefer the
 `inspect_routes`/`inspect_api`/`doctor`/`verify` MCP tools — same payloads,
 structured results.
 
-When you are driving a browser against `pracht dev` (agent-browser, a WebMCP
-host), ask the tab before reading logs: every dev document registers read-only
+When you are driving a browser against `pracht dev` with a WebMCP-compatible
+test harness or host, ask the tab before reading logs: every dev document registers read-only
 `pracht_*` page tools with `document.modelContext`. `pracht_route` gives the
 matched route, files, render/hydration mode, and middleware; `pracht_loader_data`
 the data the page holds now (`{ path: "a.0.b" }` narrows it; islands/none routes


### PR DESCRIPTION
## Summary

- Align WebMCP registration and verification with the current draft, including consequential annotations, restrictive cross-origin exposure, and Chrome's advisory naming budgets.
- Correct compatibility guidance across internal docs, public docs, examples, and skills to describe the Community Group status and current adoption gap.
- Issue: N/A.

## Testing

- [x] `pnpm run verify -- --check` (build, format, lint, typecheck, unit tests, byte gate, and e2e)

## Checklist

- [x] Docs updated (internal and public site)
- [x] Skills updated
- [x] Changeset added for `@pracht/capabilities` and `@pracht/cli`
